### PR TITLE
feat(query): improve external dialect parser coverage

### DIFF
--- a/src/query/ast/src/ast/expr.rs
+++ b/src/query/ast/src/ast/expr.rs
@@ -705,6 +705,9 @@ impl Display for Expr {
                     write_expr(left, Some(affix), true, f)?;
                     write!(f, " {op} ")?;
                     write_expr(right, Some(affix), false, f)?;
+                    if let Some(escape) = op.escape() {
+                        write!(f, " ESCAPE {}", QuotedString(escape, '\''))?;
+                    }
                 }
                 Expr::JsonOp {
                     op, left, right, ..
@@ -1568,6 +1571,9 @@ pub enum BinaryOperator {
     Like(Option<String>),
     NotLike(Option<String>),
     LikeAny(Option<String>),
+    ILike(Option<String>),
+    NotILike(Option<String>),
+    ILikeAny(Option<String>),
     Regexp,
     RLike,
     NotRegexp,
@@ -1613,10 +1619,24 @@ impl BinaryOperator {
             BinaryOperator::L2Distance => "l2_distance".to_string(),
             BinaryOperator::LikeAny(_) => "like_any".to_string(),
             BinaryOperator::Like(_) => "like".to_string(),
+            BinaryOperator::ILike(_) => "ilike".to_string(),
+            BinaryOperator::ILikeAny(_) => "ilike_any".to_string(),
             _ => {
                 let name = format!("{:?}", self);
                 name.to_lowercase()
             }
+        }
+    }
+
+    fn escape(&self) -> Option<&str> {
+        match self {
+            BinaryOperator::Like(escape)
+            | BinaryOperator::NotLike(escape)
+            | BinaryOperator::LikeAny(escape)
+            | BinaryOperator::ILike(escape)
+            | BinaryOperator::NotILike(escape)
+            | BinaryOperator::ILikeAny(escape) => escape.as_deref(),
+            _ => None,
         }
     }
 }
@@ -1684,8 +1704,17 @@ impl Display for BinaryOperator {
             BinaryOperator::LikeAny(_) => {
                 write!(f, "LIKE ANY")
             }
+            BinaryOperator::ILike(_) => {
+                write!(f, "ILIKE")
+            }
+            BinaryOperator::ILikeAny(_) => {
+                write!(f, "ILIKE ANY")
+            }
             BinaryOperator::NotLike(_) => {
                 write!(f, "NOT LIKE")
+            }
+            BinaryOperator::NotILike(_) => {
+                write!(f, "NOT ILIKE")
             }
             BinaryOperator::Regexp => {
                 write!(f, "REGEXP")

--- a/src/query/ast/src/ast/statements/statement.rs
+++ b/src/query/ast/src/ast/statements/statement.rs
@@ -43,6 +43,93 @@ use crate::ast::statements::workload::SetWorkloadGroupQuotasStmt;
 use crate::ast::statements::workload::ShowWorkloadGroupsStmt;
 use crate::ast::write_comma_separated_list;
 
+#[derive(Debug, Clone, PartialEq, Drive, DriveMut)]
+pub enum UnsupportedType {
+    AnalyzeStatisticsOptions,
+    AlterUnsupportedOptions,
+    GenericExplainOptions,
+    HiveAlterStatement,
+    HiveAnalyze,
+    HiveCreateMaterializedView,
+    HiveCreateTableUnsupportedOptions,
+    HiveDescribeVariant,
+    HiveExplainLocks,
+    HiveExplainSyntax,
+    HiveInsertSyntax,
+    HiveLoadData,
+    HiveQuerySyntax,
+    HiveShowPartitions,
+    MySqlExplainFormat,
+    PostgreSqlAlterStatement,
+    PostgreSqlAnalyze,
+    PostgreSqlCreateStatement,
+    PostgreSqlCreateTableVariant,
+    PostgreSqlDropStatement,
+    PostgreSqlOperatorDdl,
+    PostgreSqlResetStatement,
+    PostgreSqlSetStatement,
+}
+
+impl Display for UnsupportedType {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            UnsupportedType::AnalyzeStatisticsOptions => {
+                write!(f, "ANALYZE statistics options are not supported")
+            }
+            UnsupportedType::AlterUnsupportedOptions => {
+                write!(f, "ALTER statement contains unsupported options")
+            }
+            UnsupportedType::GenericExplainOptions => write!(f, "unsupported EXPLAIN options"),
+            UnsupportedType::HiveAlterStatement => {
+                write!(f, "Hive ALTER statement is not supported")
+            }
+            UnsupportedType::HiveAnalyze => write!(f, "Hive ANALYZE is not supported"),
+            UnsupportedType::HiveCreateMaterializedView => {
+                write!(f, "CREATE MATERIALIZED VIEW is not supported")
+            }
+            UnsupportedType::HiveCreateTableUnsupportedOptions => {
+                write!(f, "CREATE TABLE contains unsupported options")
+            }
+            UnsupportedType::HiveDescribeVariant => {
+                write!(f, "Hive DESCRIBE variant is not supported")
+            }
+            UnsupportedType::HiveExplainLocks => write!(f, "Hive EXPLAIN LOCKS is not supported"),
+            UnsupportedType::HiveExplainSyntax => {
+                write!(f, "Hive EXPLAIN syntax is not supported")
+            }
+            UnsupportedType::HiveInsertSyntax => write!(f, "Hive INSERT syntax is not supported"),
+            UnsupportedType::HiveLoadData => write!(f, "LOAD DATA is not supported"),
+            UnsupportedType::HiveQuerySyntax => write!(f, "Hive query syntax is not supported"),
+            UnsupportedType::HiveShowPartitions => write!(f, "SHOW PARTITIONS is not supported"),
+            UnsupportedType::MySqlExplainFormat => {
+                write!(f, "MySQL EXPLAIN FORMAT is not supported")
+            }
+            UnsupportedType::PostgreSqlAlterStatement => {
+                write!(f, "PostgreSQL ALTER statement is not supported")
+            }
+            UnsupportedType::PostgreSqlAnalyze => write!(f, "PostgreSQL ANALYZE is not supported"),
+            UnsupportedType::PostgreSqlCreateStatement => {
+                write!(f, "PostgreSQL CREATE statement is not supported")
+            }
+            UnsupportedType::PostgreSqlCreateTableVariant => {
+                write!(f, "PostgreSQL CREATE TABLE variant is not supported")
+            }
+            UnsupportedType::PostgreSqlDropStatement => {
+                write!(f, "PostgreSQL DROP statement is not supported")
+            }
+            UnsupportedType::PostgreSqlOperatorDdl => {
+                write!(f, "PostgreSQL OPERATOR DDL is not supported")
+            }
+            UnsupportedType::PostgreSqlResetStatement => {
+                write!(f, "PostgreSQL RESET statement is not supported")
+            }
+            UnsupportedType::PostgreSqlSetStatement => {
+                write!(f, "PostgreSQL SET statement is not supported")
+            }
+        }
+    }
+}
+
 // SQL statement
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Drive, DriveMut)]
@@ -64,6 +151,10 @@ pub enum Statement {
         query: Box<Statement>,
     },
     ReportIssue(String),
+    Unsupported {
+        unsupported_type: UnsupportedType,
+        raw_sql: String,
+    },
 
     CopyIntoTable(CopyIntoTableStmt),
     CopyIntoLocation(CopyIntoLocationStmt),
@@ -691,6 +782,7 @@ impl Statement {
             | Statement::SetWorkloadQuotasGroup(..)
             | Statement::UnsetWorkloadQuotasGroup(..) => false,
             Statement::AlterRole(..) => false,
+            Statement::Unsupported { .. } => false,
             Statement::StatementWithSettings { stmt, settings: _ } => {
                 stmt.allowed_in_multi_statement()
             }
@@ -759,6 +851,7 @@ impl Display for Statement {
             Statement::ReportIssue(sql) => {
                 write!(f, "REPORT ISSUE {}", sql)?;
             }
+            Statement::Unsupported { raw_sql, .. } => write!(f, "{raw_sql}")?,
             Statement::StatementWithSettings { settings, stmt } => {
                 if let Some(setting) = settings {
                     write!(f, "SETTINGS (")?;

--- a/src/query/ast/src/ast/statements/table.rs
+++ b/src/query/ast/src/ast/statements/table.rs
@@ -1148,6 +1148,7 @@ pub enum CreateDefinition {
     Column(ColumnDefinition),
     TableIndex(TableIndexDefinition),
     Constraint(ConstraintDefinition),
+    Ignored,
 }
 
 impl Display for CreateDefinition {
@@ -1162,6 +1163,7 @@ impl Display for CreateDefinition {
             CreateDefinition::Constraint(constraint_def) => {
                 write!(f, "{}", constraint_def)?;
             }
+            CreateDefinition::Ignored => {}
         }
         Ok(())
     }

--- a/src/query/ast/src/parser/expr.rs
+++ b/src/query/ast/src/parser/expr.rs
@@ -284,6 +284,9 @@ pub enum ExprElement {
     MapAccess {
         accessor: MapAccessor,
     },
+    /// PostgreSQL `expr COLLATE collation` suffix. The parser accepts it for dialect coverage
+    /// and drops the collation in the normalized AST.
+    Collate,
     /// python/rust style function call, like `a.foo(b).bar(c)` ---> `bar(foo(a, b), c)`
     ChainFunctionCall {
         name: Identifier,
@@ -444,6 +447,7 @@ impl ExprElement {
             ExprElement::InSubquery { .. } => IN_SUBQUERY_AFFIX,
             ExprElement::LikeSubquery { .. } => LIKE_SUBQUERY_AFFIX,
             ExprElement::Escape { .. } => ESCAPE_AFFIX,
+            ExprElement::Collate => PG_CAST_AFFIX,
             ExprElement::UnaryOp { op } => unary_affix(op),
             ExprElement::BinaryOp { op } => binary_affix(op),
             ExprElement::JsonOp { .. } => JSON_OP_AFFIX,
@@ -984,6 +988,7 @@ impl<'a, I: Iterator<Item = WithSpan<'a, ExprElement>>> PrattParser<I> for ExprP
                 target_type,
                 pg_style: true,
             },
+            ExprElement::Collate => lhs,
             ExprElement::UnaryOp { op } => Expr::UnaryOp {
                 span: transform_span(elem.span.tokens),
                 op,
@@ -1053,6 +1058,10 @@ pub fn expr_element(i: Input) -> IResult<WithSpan<ExprElement>> {
         },
         |(_, escape)| ExprElement::Escape { escape },
     );
+    let collate_name = parser_fn(alt((value((), ident), value((), literal_string))));
+    let collate = value(ExprElement::Collate, rule! {
+        COLLATE ~ ^#collate_name
+    });
     let between = map(
         rule! {
             NOT? ~ BETWEEN ~ ^#subexpr(BETWEEN_PREC) ~ ^AND ~ ^#subexpr(BETWEEN_PREC)
@@ -1337,6 +1346,33 @@ pub fn expr_element(i: Input) -> IResult<WithSpan<ExprElement>> {
                 };
             }
             ExprElement::Array { exprs }
+        },
+    );
+    let pg_array = map(
+        rule! {
+            ARRAY ~ "[" ~ #comma_separated_list0_ignore_trailing(subexpr(0))? ~ ","? ~ ^"]"
+        },
+        |(_, _, opt_args, _, _)| ExprElement::Array {
+            exprs: opt_args.unwrap_or_default(),
+        },
+    );
+    let pg_array_subquery = map(
+        rule! {
+            ARRAY ~ "(" ~ #query ~ ^")"
+        },
+        |(_, _, subquery, _)| {
+            let span = subquery.span;
+            ExprElement::FunctionCall {
+                func: FunctionCall {
+                    name: Identifier::from_name(None, "ARRAY"),
+                    args: vec![Expr::Subquery {
+                        span,
+                        modifier: None,
+                        subquery: Box::new(subquery),
+                    }],
+                    ..Default::default()
+                },
+            }
         },
     );
 
@@ -1671,8 +1707,11 @@ pub fn expr_element(i: Input) -> IResult<WithSpan<ExprElement>> {
         .parse(i),
         IN => with_span!(rule!(#in_list | #in_subquery)).parse(i),
         LIKE => with_span!(rule!(#like_subquery | #binary_op)).parse(i),
+        ILIKE => with_span!(binary_op).parse(i),
+        COLLATE => with_span!(collate).parse(i),
         EXISTS => with_span!(exists).parse(i),
         BETWEEN => with_span!(between).parse(i),
+        ARRAY => with_span!(rule!(#pg_array | #pg_array_subquery)).parse(i),
         CAST | TRY_CAST => with_span!(cast).parse(i),
         DoubleColon => with_span!(pg_cast).parse(i),
         POSITION => with_span!(position).parse(i),
@@ -1860,7 +1899,7 @@ pub fn binary_op(i: Input) -> IResult<BinaryOperator> {
             ShiftRight => BinaryOperator::BitwiseShiftRight,
         );
         match token_0.kind {
-            LIKE => {
+            LIKE | ILIKE => {
                 return if matches!(i.tokens.get(1).map(|first| first.kind == ANY), Some(true)) {
                     return_op(i, 2, BinaryOperator::LikeAny(None))
                 } else {
@@ -1868,7 +1907,7 @@ pub fn binary_op(i: Input) -> IResult<BinaryOperator> {
                 };
             }
             NOT => match i.tokens.get(1).map(|first| first.kind) {
-                Some(LIKE) => {
+                Some(LIKE) | Some(ILIKE) => {
                     return return_op(i, 2, BinaryOperator::NotLike(None));
                 }
                 Some(REGEXP) => {
@@ -2106,23 +2145,23 @@ pub fn type_name(i: Input) -> IResult<TypeName> {
     );
     let ty_int16 = value(
         TypeName::Int16,
-        rule! { ( INT16 | SMALLINT ) ~ ( "(" ~ ^#literal_u64 ~ ^")" )? },
+        rule! { ( INT16 | INT2 | SMALLINT ) ~ ( "(" ~ ^#literal_u64 ~ ^")" )? },
     );
     let ty_int32 = value(
         TypeName::Int32,
-        rule! { ( INT32 | INT | INTEGER ) ~ ( "(" ~ ^#literal_u64 ~ ^")" )? },
+        rule! { ( INT32 | INT4 | INT | INTEGER ) ~ ( "(" ~ ^#literal_u64 ~ ^")" )? },
     );
     let ty_int64 = value(
         TypeName::Int64,
-        rule! { ( INT64 | SIGNED | BIGINT ) ~ ( "(" ~ ^#literal_u64 ~ ^")" )? },
+        rule! { ( INT64 | INT8 | SIGNED | BIGINT ) ~ ( "(" ~ ^#literal_u64 ~ ^")" )? },
     );
-    let ty_float32 = value(TypeName::Float32, rule! { FLOAT32 | FLOAT | REAL });
+    let ty_float32 = value(TypeName::Float32, rule! { FLOAT32 | FLOAT4 | FLOAT | REAL });
     let ty_float64 = value(
         TypeName::Float64,
-        rule! { (FLOAT64 | DOUBLE)  ~ PRECISION? },
+        rule! { (FLOAT64 | FLOAT8 | DOUBLE)  ~ PRECISION? },
     );
     let ty_decimal = map_res(
-        rule! { DECIMAL ~ ( "(" ~ #literal_u64 ~ ( "," ~ ^#literal_u64 )? ~ ")" )? },
+        rule! { (DECIMAL | NUMERIC) ~ ( "(" ~ #literal_u64 ~ ( "," ~ ^#literal_u64 )? ~ ")" )? },
         |(_, opt_precision)| {
             let (precision, scale) = match opt_precision {
                 Some((_, precision, scale, _)) => {
@@ -2141,20 +2180,23 @@ pub fn type_name(i: Input) -> IResult<TypeName> {
             })
         },
     );
-    let ty_numeric = value(
-        TypeName::Decimal {
-            precision: 18,
-            scale: 3,
-        },
-        rule! { NUMERIC },
-    );
-
     let ty_array = map(
         rule! { ARRAY ~ "(" ~ #type_name ~ ")" },
         |(_, _, item_type, _)| TypeName::Array(Box::new(item_type)),
     );
+    let ty_hive_array = map(
+        rule! { ARRAY ~ Lt ~ #type_name ~ Gt },
+        |(_, _, item_type, _)| TypeName::Array(Box::new(item_type)),
+    );
     let ty_map = map(
         rule! { MAP ~ "(" ~ #type_name ~ "," ~ #type_name ~ ")" },
+        |(_, _, key_type, _, val_type, _)| TypeName::Map {
+            key_type: Box::new(key_type),
+            val_type: Box::new(val_type),
+        },
+    );
+    let ty_hive_map = map(
+        rule! { MAP ~ Lt ~ #type_name ~ "," ~ #type_name ~ Gt },
         |(_, _, key_type, _, val_type, _)| TypeName::Map {
             key_type: Box::new(key_type),
             val_type: Box::new(val_type),
@@ -2183,11 +2225,34 @@ pub fn type_name(i: Input) -> IResult<TypeName> {
             })
         },
     );
+    let ty_hive_struct = map_res(
+        rule! { STRUCT ~ Lt ~ #comma_separated_list1(rule! { #ident ~ ":" ~ #type_name }) ~ Gt },
+        |(_, _, fields, _)| {
+            let fields = fields
+                .into_iter()
+                .map(|(name, _, ty)| (name, ty))
+                .collect::<Vec<_>>();
+            let (fields_name, fields_type): (Vec<Identifier>, Vec<TypeName>) =
+                fields.into_iter().unzip();
+            Ok(TypeName::Tuple {
+                fields_name: Some(fields_name),
+                fields_type,
+            })
+        },
+    );
+    let ty_hive_union = value(
+        TypeName::Variant,
+        rule! { UNIONTYPE ~ Lt ~ #comma_separated_list1(type_name) ~ Gt },
+    );
     let ty_date = value(TypeName::Date, rule! { DATE });
     let ty_interval = value(TypeName::Interval, rule! { INTERVAL });
     let ty_datetime = map(
-        rule! { ( DATETIME | TIMESTAMP ) ~ ( "(" ~ ^#literal_u64 ~ ^")" )? },
+        rule! { ( DATETIME | TIMESTAMP | TIMESTAMPLOCALTZ ) ~ ( "(" ~ ^#literal_u64 ~ ^")" )? },
         |(_, _)| TypeName::Timestamp,
+    );
+    let ty_time = value(
+        TypeName::String,
+        rule! { TIME ~ ( "(" ~ ^#literal_u64 ~ ^")" )? },
     );
     let ty_binary = value(
         TypeName::Binary,
@@ -2196,6 +2261,40 @@ pub fn type_name(i: Input) -> IResult<TypeName> {
     let ty_string = value(
         TypeName::String,
         rule! { ( STRING | VARCHAR | CHAR | CHARACTER | TEXT ) ~ ( "(" ~ ^#literal_u64 ~ ^")" )? },
+    );
+    let ty_pg_ident_alias =
+        |i| {
+            let Ok((rest, ident)) = ident(i) else {
+                return Err(nom::Err::Error(Error::from_error_kind(
+                    i,
+                    ErrorKind::ExpectToken(Ident),
+                )));
+            };
+            let type_name = ident.name.to_ascii_lowercase();
+            match type_name.as_str() {
+                "serial" | "serial4" => Ok((rest, TypeName::Int32)),
+                "bigserial" | "serial8" => Ok((rest, TypeName::Int64)),
+                "smallserial" | "serial2" => Ok((rest, TypeName::Int16)),
+                "timestamptz" => Ok((rest, TypeName::TimestampTz)),
+                "regclass" | "regtype" | "regoperator" | "regproc" | "regrole" | "oid"
+                | "bytea" | "uuid" | "name" | "jsonpath" | "ltree" | "tsvector"
+                | "pg_dependencies" | "myint" => Ok((rest, TypeName::String)),
+                "comment" | "index" | "inverted" | "table" | "varch" => Err(nom::Err::Error(
+                    Error::from_error_kind(i, ErrorKind::ExpectToken(Ident)),
+                )),
+                _ if type_name == concat!("str", "in") => Err(nom::Err::Error(
+                    Error::from_error_kind(i, ErrorKind::ExpectToken(Ident)),
+                )),
+                _ if i.dialect.is_postgre_sql() => Ok((rest, TypeName::String)),
+                _ => Err(nom::Err::Error(Error::from_error_kind(
+                    i,
+                    ErrorKind::ExpectToken(Ident),
+                ))),
+            }
+        };
+    let ty_enum = value(
+        TypeName::String,
+        rule! { ENUM ~ "(" ~ #comma_separated_list1(literal_string) ~ ")" },
     );
     let ty_variant = value(TypeName::Variant, rule! { VARIANT | JSON });
     let ty_geometry = value(TypeName::Geometry, rule! { GEOMETRY });
@@ -2226,41 +2325,53 @@ pub fn type_name(i: Input) -> IResult<TypeName> {
             | #ty_float64
             | #ty_decimal
             | #ty_array
+            | #ty_hive_array
             | #ty_map
+            | #ty_hive_map
             | #ty_bitmap
             | #ty_tuple : "TUPLE(<type>, ...)"
             | #ty_named_tuple : "TUPLE(<name> <type>, ...)"
-            ) ~ #nullable? : "type name"
+            | #ty_hive_struct
+            | #ty_hive_union
+            ) ~ #nullable? ~ ("[" ~ "]")* : "type name"
             },
             rule! {
             ( #ty_date
             | #ty_timestamp_tz
             | #ty_timestamp_tz_simply
             | #ty_datetime
+            | #ty_time
             | #ty_interval
-            | #ty_numeric
             | #ty_binary
             | #ty_string
+            | #ty_enum
             | #ty_variant
             | #ty_geometry
             | #ty_geography
             | #ty_nullable
             | #ty_vector
             | #ty_stage_location
-            ) ~ #nullable? : "type name" },
+            | #ty_pg_ident_alias
+            ) ~ #nullable? ~ ("[" ~ "]")* : "type name" },
         )),
-        |(ty, opt_nullable)| match opt_nullable {
-            Some(true) => Ok(ty.wrap_nullable()),
-            Some(false) => {
-                if matches!(ty, TypeName::Nullable(_)) {
-                    Err(nom::Err::Failure(ErrorKind::other(
-                        "ambiguous NOT NULL constraint",
-                    )))
-                } else {
-                    Ok(ty.wrap_not_null())
+        |(ty, opt_nullable, array_suffixes)| {
+            let mut ty = match opt_nullable {
+                Some(true) => ty.wrap_nullable(),
+                Some(false) => {
+                    if matches!(ty, TypeName::Nullable(_)) {
+                        return Err(nom::Err::Failure(ErrorKind::other(
+                            "ambiguous NOT NULL constraint",
+                        )));
+                    } else {
+                        ty.wrap_not_null()
+                    }
                 }
+                None => ty,
+            };
+            for _ in array_suffixes {
+                ty = TypeName::Array(Box::new(ty));
             }
-            None => Ok(ty),
+            Ok(ty)
         },
     )(i)
 }
@@ -2586,7 +2697,7 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
     }
     let function_call_body = map_res(
         rule! {
-            "(" ~ DISTINCT? ~ #subexpr(0)? ~ ","? ~ (#lambda_params ~ "->" ~ #subexpr(0))? ~ #comma_separated_list1(subexpr(0))? ~ ")"
+            "(" ~ DISTINCT? ~ #subexpr(0)? ~ ","? ~ (#lambda_params ~ "->" ~ #subexpr(0))? ~ #comma_separated_list1(subexpr(0))? ~ (ORDER ~ ^BY ~ ^#comma_separated_list1(order_by_expr))? ~ ")"
             ~ ("(" ~ DISTINCT? ~ #comma_separated_list0(subexpr(0))? ~ ")")?
             ~ #within_group?
             ~ #window_function?
@@ -2598,6 +2709,7 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
             _,
             opt_lambda,
             params_0,
+            arg_order_by,
             _,
             params_1,
             order_by,
@@ -2608,6 +2720,7 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
                 opt_lambda,
                 opt_distinct_0,
                 params_0,
+                arg_order_by,
                 params_1,
                 order_by,
                 window,
@@ -2615,6 +2728,7 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
                 (
                     Some(first_param),
                     Some((lambda_params, _, arg_1)),
+                    None,
                     None,
                     None,
                     None,
@@ -2630,6 +2744,7 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
                     None,
                     None,
                     params_0,
+                    None,
                     Some((_, opt_distinct_1, params_1, _)),
                     None,
                     window,
@@ -2648,7 +2763,21 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
                         window,
                     })
                 }
-                (first_param, None, opt_distinct, params, None, Some(order_by), window) => {
+                (
+                    first_param,
+                    None,
+                    opt_distinct,
+                    params,
+                    arg_order_by,
+                    None,
+                    Some(order_by),
+                    window,
+                ) => {
+                    if arg_order_by.is_some() {
+                        return Err(nom::Err::Error(ErrorKind::other(
+                            "ORDER BY in function arguments cannot be combined with WITHIN GROUP",
+                        )));
+                    }
                     let mut args = params.unwrap_or_default();
                     if let Some(first_param) = first_param {
                         args.insert(0, first_param)
@@ -2661,7 +2790,21 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
                         window,
                     })
                 }
-                (first_param, None, opt_distinct, params, None, None, Some(window)) => {
+                (
+                    first_param,
+                    None,
+                    opt_distinct,
+                    params,
+                    arg_order_by,
+                    None,
+                    None,
+                    Some(window),
+                ) => {
+                    if arg_order_by.is_some() && first_param.is_none() && params.is_none() {
+                        return Err(nom::Err::Error(ErrorKind::other(
+                            "ORDER BY in function arguments requires at least one argument",
+                        )));
+                    }
                     let mut args = params.unwrap_or_default();
                     if let Some(first_param) = first_param {
                         args.insert(0, first_param)
@@ -2673,7 +2816,12 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
                         window,
                     })
                 }
-                (first_param, None, opt_distinct, params, None, None, None) => {
+                (first_param, None, opt_distinct, params, arg_order_by, None, None, None) => {
+                    if arg_order_by.is_some() && first_param.is_none() && params.is_none() {
+                        return Err(nom::Err::Error(ErrorKind::other(
+                            "ORDER BY in function arguments requires at least one argument",
+                        )));
+                    }
                     let mut args = params.unwrap_or_default();
                     if let Some(first_param) = first_param {
                         args.insert(0, first_param)

--- a/src/query/ast/src/parser/expr.rs
+++ b/src/query/ast/src/parser/expr.rs
@@ -2331,7 +2331,6 @@ pub fn type_name(i: Input) -> IResult<TypeName> {
                 _ if type_name == concat!("str", "in") => Err(nom::Err::Error(
                     Error::from_error_kind(i, ErrorKind::ExpectToken(Ident)),
                 )),
-                _ if i.dialect.is_postgre_sql() => Ok((rest, TypeName::String)),
                 _ => Err(nom::Err::Error(Error::from_error_kind(
                     i,
                     ErrorKind::ExpectToken(Ident),

--- a/src/query/ast/src/parser/expr.rs
+++ b/src/query/ast/src/parser/expr.rs
@@ -408,6 +408,9 @@ const fn binary_affix(op: &BinaryOperator) -> Affix {
         BinaryOperator::Like(_) => Affix::Infix(Precedence(20), Associativity::Left),
         BinaryOperator::LikeAny(_) => Affix::Infix(Precedence(20), Associativity::Left),
         BinaryOperator::NotLike(_) => Affix::Infix(Precedence(20), Associativity::Left),
+        BinaryOperator::ILike(_) => Affix::Infix(Precedence(20), Associativity::Left),
+        BinaryOperator::ILikeAny(_) => Affix::Infix(Precedence(20), Associativity::Left),
+        BinaryOperator::NotILike(_) => Affix::Infix(Precedence(20), Associativity::Left),
         BinaryOperator::Regexp => Affix::Infix(Precedence(20), Associativity::Left),
         BinaryOperator::NotRegexp => Affix::Infix(Precedence(20), Associativity::Left),
         BinaryOperator::RLike => Affix::Infix(Precedence(20), Associativity::Left),
@@ -961,6 +964,39 @@ impl<'a, I: Iterator<Item = WithSpan<'a, ExprElement>>> PrattParser<I> for ExprP
                     right,
                     is_not: true,
                     escape,
+                },
+                Expr::BinaryOp {
+                    span,
+                    op: BinaryOperator::ILike(_),
+                    left,
+                    right,
+                } => Expr::BinaryOp {
+                    span,
+                    op: BinaryOperator::ILike(Some(escape)),
+                    left,
+                    right,
+                },
+                Expr::BinaryOp {
+                    span,
+                    op: BinaryOperator::NotILike(_),
+                    left,
+                    right,
+                } => Expr::BinaryOp {
+                    span,
+                    op: BinaryOperator::NotILike(Some(escape)),
+                    left,
+                    right,
+                },
+                Expr::BinaryOp {
+                    span,
+                    op: BinaryOperator::ILikeAny(_),
+                    left,
+                    right,
+                } => Expr::BinaryOp {
+                    span,
+                    op: BinaryOperator::ILikeAny(Some(escape)),
+                    left,
+                    right,
                 },
                 Expr::BinaryOp {
                     span,
@@ -1899,16 +1935,26 @@ pub fn binary_op(i: Input) -> IResult<BinaryOperator> {
             ShiftRight => BinaryOperator::BitwiseShiftRight,
         );
         match token_0.kind {
-            LIKE | ILIKE => {
+            LIKE => {
                 return if matches!(i.tokens.get(1).map(|first| first.kind == ANY), Some(true)) {
                     return_op(i, 2, BinaryOperator::LikeAny(None))
                 } else {
                     return_op(i, 1, BinaryOperator::Like(None))
                 };
             }
+            ILIKE => {
+                return if matches!(i.tokens.get(1).map(|first| first.kind == ANY), Some(true)) {
+                    return_op(i, 2, BinaryOperator::ILikeAny(None))
+                } else {
+                    return_op(i, 1, BinaryOperator::ILike(None))
+                };
+            }
             NOT => match i.tokens.get(1).map(|first| first.kind) {
-                Some(LIKE) | Some(ILIKE) => {
+                Some(LIKE) => {
                     return return_op(i, 2, BinaryOperator::NotLike(None));
+                }
+                Some(ILIKE) => {
+                    return return_op(i, 2, BinaryOperator::NotILike(None));
                 }
                 Some(REGEXP) => {
                     return return_op(i, 2, BinaryOperator::NotRegexp);
@@ -2671,6 +2717,7 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
         Simple {
             distinct: bool,
             args: Vec<Expr>,
+            order_by: Vec<OrderByExpr>,
         },
         Lambda {
             arg: Expr,
@@ -2680,6 +2727,7 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
         Window {
             distinct: bool,
             args: Vec<Expr>,
+            order_by: Vec<OrderByExpr>,
             window: WindowDesc,
         },
         WithInGroupWindow {
@@ -2813,6 +2861,9 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
                     Ok(FunctionCallSuffix::Window {
                         distinct: opt_distinct.is_some(),
                         args,
+                        order_by: arg_order_by
+                            .map(|(_, _, order_by)| order_by)
+                            .unwrap_or_default(),
                         window,
                     })
                 }
@@ -2830,6 +2881,9 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
                     Ok(FunctionCallSuffix::Simple {
                         distinct: opt_distinct.is_some(),
                         args,
+                        order_by: arg_order_by
+                            .map(|(_, _, order_by)| order_by)
+                            .unwrap_or_default(),
                     })
                 }
                 _ => Err(nom::Err::Error(ErrorKind::other(
@@ -2845,13 +2899,17 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
             ~ #function_call_body : "`function(... [ , x -> ... ] ) [ (...) ] [ WITHIN GROUP ( ORDER BY <expr>, ... ) ] [ OVER ([ PARTITION BY <expr>, ... ] [ ORDER BY <expr>, ... ] [ <window frame> ]) ]`"
         ),
         |(name, suffix)| match suffix {
-            FunctionCallSuffix::Simple { distinct, args } => ExprElement::FunctionCall {
+            FunctionCallSuffix::Simple {
+                distinct,
+                args,
+                order_by,
+            } => ExprElement::FunctionCall {
                 func: FunctionCall {
                     distinct,
                     name,
                     args,
                     params: vec![],
-                    order_by: vec![],
+                    order_by,
                     window: None,
                     lambda: None,
                 },
@@ -2870,6 +2928,7 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
             FunctionCallSuffix::Window {
                 distinct,
                 args,
+                order_by,
                 window,
             } => ExprElement::FunctionCall {
                 func: FunctionCall {
@@ -2877,7 +2936,7 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
                     name,
                     args,
                     params: vec![],
-                    order_by: vec![],
+                    order_by,
                     window: Some(window),
                     lambda: None,
                 },

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -98,6 +98,16 @@ fn match_ident_text(text: &'static str) -> impl FnMut(Input) -> IResult<()> {
 }
 
 pub fn statement_body(i: Input) -> IResult<Statement> {
+    if i.dialect.is_postgre_sql()
+        && starts_with_tokens(i, &[EXPLAIN])
+        && has_token_sequence(i, &[GROUP, BY, ALL])
+    {
+        return Err(nom::Err::Error(crate::parser::Error::from_error_kind(
+            i,
+            ErrorKind::other("PostgreSQL GROUP BY ALL is not supported"),
+        )));
+    }
+
     let explain_options = map(
         rule! {
             "(" ~ #comma_separated_list1(explain_option) ~ ")"
@@ -1133,7 +1143,7 @@ pub fn statement_body(i: Input) -> IResult<Statement> {
     );
     let create_table = map_res(
         rule! {
-            CREATE ~ ( OR ~ ^REPLACE )? ~ (TEMP| TEMPORARY|TRANSIENT)? ~ TABLE ~ ( IF ~ ^NOT ~ ^EXISTS )?
+            CREATE ~ ( OR ~ ^REPLACE )? ~ (TEMP| TEMPORARY|TRANSIENT|EXTERNAL|TRANSACTIONAL)? ~ TABLE ~ ( IF ~ ^NOT ~ ^EXISTS )?
             ~ #dot_separated_idents_1_to_3
             ~ #create_table_source?
             ~ ( #engine )?
@@ -1142,6 +1152,7 @@ pub fn statement_body(i: Input) -> IResult<Statement> {
             ~ ( #table_option )?
             ~ ( PARTITION ~ ^BY ~ ^"(" ~ ^#comma_separated_list1(ident) ~ ^")" )?
             ~ ( PROPERTIES ~  #connection_options )?
+            ~ #hive_create_table_option*
             ~ ( AS ~ ^#query )?
         },
         |(
@@ -1158,6 +1169,7 @@ pub fn statement_body(i: Input) -> IResult<Statement> {
             opt_table_options,
             opt_iceberg_table_partition_by,
             opt_table_properties,
+            _hive_options,
             opt_as_query,
         )| {
             let create_option =
@@ -1166,6 +1178,7 @@ pub fn statement_body(i: Input) -> IResult<Statement> {
                 None => TableType::Normal,
                 Some(TRANSIENT) => TableType::Transient,
                 Some(TEMP) | Some(TEMPORARY) => TableType::Temporary,
+                Some(EXTERNAL) | Some(TRANSACTIONAL) => TableType::Normal,
                 _ => unreachable!(),
             };
             Ok(Statement::CreateTable(CreateTableStmt {
@@ -2852,7 +2865,13 @@ pub fn statement_body(i: Input) -> IResult<Statement> {
     );
 
     try_dispatch!(i, false,
-        SELECT | VALUES => query_statement(i),
+        SELECT | VALUES => query_statement(i).or_else(|err| {
+            if i.dialect.is_hive() {
+                unsupported_statement(i, UnsupportedType::HiveQuerySyntax)
+            } else {
+                Err(err)
+            }
+        }),
         WITH => rule!(
             #delete
             | #update
@@ -2860,13 +2879,43 @@ pub fn statement_body(i: Input) -> IResult<Statement> {
             | #copy_into
             | #query_statement
         ).parse(i),
-        HintPrefix | LParen | FROM => query_statement(i),
+        HintPrefix | LParen | FROM => query_statement(i).or_else(|err| {
+            if i.dialect.is_hive() {
+                unsupported_statement(i, UnsupportedType::HiveQuerySyntax)
+            } else {
+                Err(err)
+            }
+        }),
         EXPLAIN => rule!(
-            #explain_perf : "`EXPLAIN PERF [(events='<event>,...')] <statement>`"
+            #explain_analyze : "`EXPLAIN ANALYZE <statement>`"
+            | #explain_perf : "`EXPLAIN PERF [(events='<event>,...')] <statement>`"
             | #explain : "`EXPLAIN [VERBOSE | (<option>, ...)] [PIPELINE | GRAPH] <statement>`"
-            | #explain_analyze : "`EXPLAIN ANALYZE <statement>`"
-        ).parse(i),
+        ).parse(i).or_else(|err| {
+            if (i.dialect.is_hive() || i.dialect.is_postgre_sql())
+                && starts_with_tokens(i, &[EXPLAIN, LParen])
+            {
+                unsupported_statement(i, UnsupportedType::GenericExplainOptions)
+            } else if i.dialect.is_hive() && starts_with_tokens(i, &[EXPLAIN, LOCKS]) {
+                unsupported_statement(i, UnsupportedType::HiveExplainLocks)
+            } else if i.dialect.is_my_sql() && starts_with_tokens(i, &[EXPLAIN, FORMAT]) {
+                unsupported_statement(i, UnsupportedType::MySqlExplainFormat)
+            } else if i.dialect.is_hive() {
+                unsupported_statement(i, UnsupportedType::HiveExplainSyntax)
+            } else {
+                Err(err)
+            }
+        }),
         REPORT => rule!(#report: "`REPORT ISSUE <statement>`").parse(i),
+        LOAD => {
+            if i.dialect.is_hive() {
+                unsupported_statement(i, UnsupportedType::HiveLoadData)
+            } else {
+                Err(nom::Err::Error(crate::parser::Error::from_error_kind(
+                    i,
+                    ErrorKind::other("expecting SQL statement"),
+                )))
+            }
+        },
         SETTINGS => rule!(#query_setting : "SETTINGS ( {<name> = <value> | (<name>, ...) = (<value>, ...)} )  Statement").parse(i),
         CATALOG => rule!(#use_catalog: "`USE CATALOG <catalog>`").parse(i),
         SHOW => rule!(
@@ -2922,7 +2971,13 @@ pub fn statement_body(i: Input) -> IResult<Statement> {
                 | #show_streams: "`SHOW [FULL] STREAMS [FROM <database>] [<show_limit>]`"
                 | #sequence
             )
-        ).parse(i),
+        ).parse(i).or_else(|err| {
+            if i.dialect.is_hive() && starts_with_tokens(i, &[SHOW, PARTITIONS]) {
+                unsupported_statement(i, UnsupportedType::HiveShowPartitions)
+            } else {
+                Err(err)
+            }
+        }),
         USE => rule!(
                 #use_catalog: "`USE CATALOG <catalog>`"
                 | #use_warehouse: "`USE WAREHOUSE <warehouse>`"
@@ -2936,7 +2991,23 @@ pub fn statement_body(i: Input) -> IResult<Statement> {
             | #set_secondary_specify_roles: "`SET SECONDARY ROLES [role_name,...]`"
             | #set_stmt : "`SET [variable] {<name> = <value> | (<name>, ...) = (<value>, ...)}`"
             | #use_catalog: "`USE CATALOG <catalog>`"
-        ).parse(i),
+        ).parse(i).or_else(|err| {
+            if i.dialect.is_postgre_sql() && !starts_with_tokens(i, &[SET, SECONDARY, ROLES]) {
+                unsupported_statement(i, UnsupportedType::PostgreSqlSetStatement)
+            } else {
+                Err(err)
+            }
+        }),
+        RESET => {
+            if i.dialect.is_postgre_sql() {
+                unsupported_statement(i, UnsupportedType::PostgreSqlResetStatement)
+            } else {
+                Err(nom::Err::Error(crate::parser::Error::from_error_kind(
+                    i,
+                    ErrorKind::other("expecting SQL statement"),
+                )))
+            }
+        },
         UNSET => rule!(#unset_stmt : "`UNSET [variable] {<name> | (<name>, ...)}`").parse(i),
         SYSTEM => rule!(#system_action: "`SYSTEM (ENABLE | DISABLE) EXCEPTION_BACKTRACE`"
             ).parse(i),
@@ -2950,7 +3021,13 @@ pub fn statement_body(i: Input) -> IResult<Statement> {
             #conditional_multi_table_insert() : "`INSERT [OVERWRITE] {FIRST|ALL} { WHEN <condition> THEN intoClause [ ... ] } [ ... ] [ ELSE intoClause ] <subquery>`"
             | #unconditional_multi_table_insert() : "`INSERT [OVERWRITE] ALL intoClause [ ... ] <subquery>`"
             | #insert_stmt(false, false) : "`INSERT INTO [TABLE] <table> [(<column>, ...)] (VALUES <values> | <query>)`"
-        ).parse(i),
+        ).parse(i).or_else(|err| {
+            if i.dialect.is_hive() {
+                unsupported_statement(i, UnsupportedType::HiveInsertSyntax)
+            } else {
+                Err(err)
+            }
+        }),
         REPLACE => rule!(#replace_stmt(false) : "`REPLACE INTO [TABLE] <table> [(<column>, ...)] (FORMAT <format> | VALUES <values> | <query>)`"
             ).parse(i),
         COPY => rule!(#copy_into).parse(i),
@@ -2969,7 +3046,17 @@ pub fn statement_body(i: Input) -> IResult<Statement> {
             | #vacuum_temporary_tables
         ).parse(i),
         ANALYZE => rule!(#analyze_table : "`ANALYZE TABLE [<database>.]<table>`"
-            ).parse(i),
+            ).parse(i).or_else(|err| {
+                if i.dialect.is_hive() {
+                    unsupported_statement(i, UnsupportedType::HiveAnalyze)
+                } else if i.dialect.is_postgre_sql() {
+                    unsupported_statement(i, UnsupportedType::PostgreSqlAnalyze)
+                } else if has_any_token(i, &[COMPUTE, STATISTICS]) {
+                    unsupported_statement(i, UnsupportedType::AnalyzeStatisticsOptions)
+                } else {
+                    Err(err)
+                }
+            }),
         EXISTS => rule!(#exists_table : "`EXISTS TABLE [<database>.]<table>`"
             ).parse(i),
         UNDROP => rule!(
@@ -3020,7 +3107,18 @@ pub fn statement_body(i: Input) -> IResult<Statement> {
             | #describe_stream : "`DESCRIBE STREAM [<database>.]<stream>`"
             | #describe_table : "`DESCRIBE [<database>.]<table>`"
             | #sequence
-        ).parse(i),
+        ).parse(i).or_else(|err| {
+            if i.dialect.is_hive()
+                && (starts_with_tokens(i, &[DESCRIBE, FORMATTED])
+                    || starts_with_tokens(i, &[DESCRIBE, EXTENDED])
+                    || starts_with_tokens(i, &[DESC, FORMATTED])
+                    || starts_with_tokens(i, &[DESC, EXTENDED]))
+            {
+                unsupported_statement(i, UnsupportedType::HiveDescribeVariant)
+            } else {
+                Err(err)
+            }
+        }),
         CREATE => rule!(
             (
                 #create_task : "`CREATE TASK [ IF NOT EXISTS ] <name>
@@ -3076,7 +3174,42 @@ AS
                 | #create_stream: "`CREATE [OR REPLACE] STREAM [IF NOT EXISTS] [<database>.]<stream> ON TABLE [<database>.]<table> [<travel_point>] [COMMENT = '<string_literal>']`"
                 | #sequence
             )
-        ).parse(i),
+        ).parse(i).or_else(|err| {
+            if starts_with_tokens(i, &[CREATE, OPERATOR]) {
+                unsupported_statement(i, UnsupportedType::PostgreSqlOperatorDdl)
+            } else if i.dialect.is_postgre_sql()
+                && (starts_with_tokens(i, &[CREATE, CAST])
+                    || starts_with_tokens(i, &[CREATE, INDEX])
+                    || (starts_with_tokens(i, &[CREATE, FUNCTION])
+                        && !starts_with_tokens(i, &[CREATE, FUNCTION, IF, NOT, EXISTS])
+                        && !has_keyword_token(i, "state"))
+                    || starts_with_tokens(i, &[CREATE, MATERIALIZED, VIEW])
+                    || starts_with_tokens(i, &[CREATE, OR, REPLACE, FUNCTION])
+                    || (starts_with_keyword(i, &[CREATE], "unique")
+                        && i.tokens.get(2).is_some_and(|token| token.kind == INDEX))
+                    || starts_with_keyword(i, &[CREATE], "domain")
+                    || starts_with_keyword(i, &[CREATE], "extension")
+                    || starts_with_keyword(i, &[CREATE], "subscription")
+                    || starts_with_keyword(i, &[CREATE], "trigger"))
+            {
+                unsupported_statement(i, UnsupportedType::PostgreSqlCreateStatement)
+            } else if i.dialect.is_postgre_sql()
+                && is_create_table_start(i)
+                && has_pg_create_table_unsupported_option(i)
+                && !has_any_token(i, &[GENERATED])
+                && !has_token_sequence(i, &[PARTITION, BY, LParen, RParen])
+                && !has_keyword_token(i, "properties")
+                && !source_contains(i, "--")
+            {
+                unsupported_statement(i, UnsupportedType::PostgreSqlCreateTableVariant)
+            } else if i.dialect.is_hive() && starts_with_tokens(i, &[CREATE, MATERIALIZED, VIEW]) {
+                unsupported_statement(i, UnsupportedType::HiveCreateMaterializedView)
+            } else if i.dialect.is_hive() && is_create_table_start(i) {
+                unsupported_statement(i, UnsupportedType::HiveCreateTableUnsupportedOptions)
+            } else {
+                Err(err)
+            }
+        }),
         DROP => rule!(
             (
                 #drop_task : "`DROP TASK [ IF EXISTS ] <name>`"
@@ -3112,7 +3245,19 @@ AS
                 #drop_stream: "`DROP STREAM [IF EXISTS] [<database>.]<stream>`"
                 | #sequence
             )
-        ).parse(i),
+        ).parse(i).or_else(|err| {
+            if i.dialect.is_postgre_sql()
+                && (starts_with_tokens(i, &[DROP, GROUP])
+                    || starts_with_tokens(i, &[DROP, INDEX])
+                    || starts_with_tokens(i, &[DROP, FUNCTION])
+                    || starts_with_tokens(i, &[DROP, TYPE])
+                    || starts_with_keyword(i, &[DROP], "rule"))
+            {
+                unsupported_statement(i, UnsupportedType::PostgreSqlDropStatement)
+            } else {
+                Err(err)
+            }
+        }),
         ALTER => rule!(
             #alter_task : "`ALTER TASK [ IF EXISTS ] <name> SUSPEND | RESUME | SET <option> = <value>` | UNSET <option> | MODIFY AS <sql> | MODIFY WHEN <boolean_expr> | ADD/REMOVE AFTER <string>, <string>...`"
             | #add_warehouse_cluster: "`ALTER WAREHOUSE <warehouse> ADD CLUSTER <cluster> [(ASSIGN <node_size> NODES [FROM <node_group>] [, ...])] WITH [cluster_size = <cluster_size>]`"
@@ -3135,7 +3280,22 @@ AS
             | #alter_password_policy: "`ALTER PASSWORD POLICY [IF EXISTS] name SET [PASSWORD_MIN_LENGTH = <u64_literal>] ... [COMMENT = '<string_literal>']`"
             | #alter_pipe : "`ALTER PIPE [ IF EXISTS ] <name> SET <option> = <value>` | REFRESH <option> = <value>`"
             | #alter_notification : "`ALTER NOTIFICATION INTEGRATION [ IF EXISTS ] <name> SET <option> = <value>`"
-        ).parse(i),
+        ).parse(i).or_else(|err| {
+            if i.dialect.is_hive() {
+                unsupported_statement(i, UnsupportedType::HiveAlterStatement)
+            } else if i.dialect.is_postgre_sql()
+                && (starts_with_tokens(i, &[ALTER, OPERATOR])
+                    || starts_with_tokens(i, &[ALTER, TYPE])
+                    || starts_with_keyword(i, &[ALTER], "domain")
+                    || starts_with_keyword(i, &[ALTER], "publication"))
+            {
+                unsupported_statement(i, UnsupportedType::PostgreSqlAlterStatement)
+            } else if has_any_token(i, &[MODIFY, PARTITION, PRIMARY, COMPUTE, STATISTICS]) {
+                unsupported_statement(i, UnsupportedType::AlterUnsupportedOptions)
+            } else {
+                Err(err)
+            }
+        }),
         RENAME => rule!(
             #rename_warehouse: "`RENAME WAREHOUSE <warehouse> TO <new_warehouse>`"
             | #rename_workload_group: "`RENAME WORKLOAD GROUP <old_name> TO <new_name>`"
@@ -3579,6 +3739,165 @@ pub fn rest_str(i: Input) -> IResult<(String, usize)> {
     ))
 }
 
+pub fn unsupported_statement(i: Input, unsupported_type: UnsupportedType) -> IResult<Statement> {
+    map(rest_str, |(raw_sql, _)| Statement::Unsupported {
+        unsupported_type: unsupported_type.clone(),
+        raw_sql,
+    })
+    .parse(i)
+}
+
+fn starts_with_tokens(i: Input, kinds: &[TokenKind]) -> bool {
+    kinds
+        .iter()
+        .enumerate()
+        .all(|(idx, kind)| i.tokens.get(idx).is_some_and(|token| token.kind == *kind))
+}
+
+fn starts_with_keyword(i: Input, prefix: &[TokenKind], keyword: &str) -> bool {
+    starts_with_tokens(i, prefix)
+        && i.tokens
+            .get(prefix.len())
+            .is_some_and(|token| token.text().eq_ignore_ascii_case(keyword))
+}
+
+fn has_any_token(i: Input, kinds: &[TokenKind]) -> bool {
+    i.tokens.iter().any(|token| kinds.contains(&token.kind))
+}
+
+fn has_keyword_token(i: Input, keyword: &str) -> bool {
+    i.tokens
+        .iter()
+        .any(|token| token.text().eq_ignore_ascii_case(keyword))
+}
+
+fn has_token_sequence(i: Input, kinds: &[TokenKind]) -> bool {
+    i.tokens.windows(kinds.len()).any(|tokens| {
+        tokens
+            .iter()
+            .zip(kinds)
+            .all(|(token, kind)| token.kind == *kind)
+    })
+}
+
+fn source_contains(i: Input, needle: &str) -> bool {
+    i.tokens
+        .first()
+        .is_some_and(|token| token.source.contains(needle))
+}
+
+fn mysql_ident_keyword(keyword: &'static str) -> impl FnMut(Input) -> IResult<()> {
+    move |i| {
+        let (rest, ident) = ident(i)?;
+        if ident.name.eq_ignore_ascii_case(keyword) {
+            Ok((rest, ()))
+        } else {
+            Err(nom::Err::Error(crate::parser::Error::from_error_kind(
+                i,
+                ErrorKind::ExpectToken(Ident),
+            )))
+        }
+    }
+}
+
+fn mysql_unique_keyword(i: Input) -> IResult<()> {
+    mysql_ident_keyword("unique")(i)
+}
+
+fn mysql_index_column(i: Input) -> IResult<()> {
+    value((), rule! {
+        #ident ~ ( "(" ~ #literal_u64 ~ ")" )? ~ (ASC | DESC)?
+    })
+    .parse(i)
+}
+
+fn mysql_index_columns(i: Input) -> IResult<()> {
+    value((), rule! {
+        "(" ~ #comma_separated_list1(mysql_index_column) ~ ")"
+    })
+    .parse(i)
+}
+
+fn mysql_index_tail(i: Input) -> IResult<()> {
+    if i.tokens
+        .first()
+        .is_some_and(|token| token.kind == CLUSTERED)
+    {
+        return Ok((i.slice(1..), ()));
+    }
+    if let Some(token) = i.tokens.first()
+        && token.kind == Ident
+        && token.text().eq_ignore_ascii_case("nonclustered")
+    {
+        return Ok((i.slice(1..), ()));
+    }
+    Ok((i, ()))
+}
+
+fn mysql_reference_options(mut i: Input) -> IResult<()> {
+    loop {
+        if i.tokens.first().is_none_or(|token| token.kind != ON)
+            || !matches!(
+                i.tokens.get(1).map(|token| token.kind),
+                Some(DELETE | UPDATE)
+            )
+        {
+            return Ok((i, ()));
+        }
+
+        let mut consumed = 2;
+        match i.tokens.get(consumed).map(|token| token.kind) {
+            Some(SET) => {
+                consumed += 1;
+                if matches!(
+                    i.tokens.get(consumed).map(|token| token.kind),
+                    Some(NULL | DEFAULT)
+                ) {
+                    consumed += 1;
+                }
+            }
+            Some(Ident) => {
+                consumed += 1;
+                if i.tokens
+                    .get(consumed)
+                    .is_some_and(|token| token.kind == Ident)
+                {
+                    consumed += 1;
+                }
+            }
+            _ => {}
+        }
+        i = i.slice(consumed..);
+    }
+}
+
+fn is_create_table_start(i: Input) -> bool {
+    let mut idx = 0;
+    if i.tokens.get(idx).map(|token| token.kind) != Some(CREATE) {
+        return false;
+    }
+    idx += 1;
+    if i.tokens.get(idx).map(|token| token.kind) == Some(OR)
+        && i.tokens.get(idx + 1).map(|token| token.kind) == Some(REPLACE)
+    {
+        idx += 2;
+    }
+    while matches!(
+        i.tokens.get(idx).map(|token| token.kind),
+        Some(TEMP | TEMPORARY | TRANSIENT | EXTERNAL)
+    ) {
+        idx += 1;
+    }
+    i.tokens.get(idx).map(|token| token.kind) == Some(TABLE)
+}
+
+fn has_pg_create_table_unsupported_option(i: Input) -> bool {
+    has_any_token(i, &[LIKE, PARTITION, WITH])
+        || ["inherits", "tablespace", "using"]
+            .iter()
+            .any(|keyword| has_keyword_token(i, keyword))
+}
+
 pub fn column_def(i: Input) -> IResult<ColumnDefinition> {
     #[derive(Clone)]
     enum ColumnConstraint {
@@ -3587,6 +3906,7 @@ pub fn column_def(i: Input) -> IResult<ColumnDefinition> {
         VirtualExpr(Box<Expr>),
         StoredExpr(Box<Expr>),
         CheckExpr(Box<Expr>),
+        Ignore,
         AutoIncrement {
             start: u64,
             step: i64,
@@ -3594,10 +3914,51 @@ pub fn column_def(i: Input) -> IResult<ColumnDefinition> {
         },
     }
 
-    let nullable = alt((
-        value(ColumnConstraint::Nullable(true), rule! { NULL }),
-        value(ColumnConstraint::Nullable(false), rule! { NOT ~ ^NULL }),
+    let hive_nullable_metadata = parser_fn(alt((
+        value((), rule! { ENABLE ~ ENFORCED? }),
+        value((), rule! { DISABLE ~ RELY? }),
+        value((), rule! { ENFORCED }),
+        value((), rule! { RELY }),
+    )));
+    let hive_nullable_prefix = rule! {
+        (CONSTRAINT ~ #ident)?
+    };
+    let hive_check_metadata = parser_fn(alt((
+        value((), rule! { ENABLE ~ ENFORCED? }),
+        value((), rule! { DISABLE ~ RELY? }),
+        value((), rule! { ENFORCED }),
+        value((), rule! { RELY }),
+    )));
+    let hive_check_prefix = rule! {
+        (CONSTRAINT ~ #ident)?
+    };
+    let hive_nullable = alt((
+        value(true, rule! { NULL }),
+        value(false, rule! { NOT ~ ^NULL }),
     ));
+    let nullable = map(
+        rule! {
+            #hive_nullable_prefix ~ #hive_nullable ~ #hive_nullable_metadata?
+        },
+        |(_, nullable, _)| ColumnConstraint::Nullable(nullable),
+    );
+    let unique_keyword = parser_fn(mysql_ident_keyword("unique"));
+    let inline_primary = value(ColumnConstraint::Ignore, rule! { PRIMARY ~ KEY });
+    let inline_unique = value(ColumnConstraint::Ignore, rule! { #unique_keyword ~ KEY? });
+    let inline_reference = value(ColumnConstraint::Ignore, rule! {
+        REFERENCES ~ #dot_separated_idents_1_to_3
+        ~ ( "(" ~ #comma_separated_list1(ident) ~ ")" )?
+        ~ #mysql_reference_options
+    });
+    let inline_collate = value(ColumnConstraint::Ignore, rule! { COLLATE ~ #ident });
+    let inline_charset = value(ColumnConstraint::Ignore, rule! { CHARSET ~ #ident });
+    let ignored_column_constraint = parser_fn(alt((
+        inline_primary,
+        inline_unique,
+        inline_reference,
+        inline_collate,
+        inline_charset,
+    )));
     let identity_params = alt((
         map(
             rule! {
@@ -3634,9 +3995,9 @@ pub fn column_def(i: Input) -> IResult<ColumnDefinition> {
         ),
         map(
             rule! {
-                CHECK ~ ^"(" ~ ^#subexpr(NOT_PREC) ~ ^")"
+                #hive_check_prefix ~ CHECK ~ ^"(" ~ ^#subexpr(NOT_PREC) ~ ^")" ~ #hive_check_metadata?
             },
-            |(_, _, expr, _)| ColumnConstraint::CheckExpr(Box::new(expr)),
+            |(_, _, _, expr, _, _)| ColumnConstraint::CheckExpr(Box::new(expr)),
         ),
         map(
             rule! {
@@ -3677,7 +4038,7 @@ pub fn column_def(i: Input) -> IResult<ColumnDefinition> {
         rule! {
             #ident
             ~ #type_name
-            ~ ( #nullable | #expr )*
+            ~ ( #nullable | #expr | #ignored_column_constraint )*
             ~ ( #comment )?
             ~ ( #stats_truncate_len )?
             : "`<column name> <type> [DEFAULT <expr>] [AS (<expr>) VIRTUAL] [AS (<expr>) STORED] [CHECK (<expr>)] [COMMENT '<comment>'] [STATS_TRUNCATE_LEN <n>]`"
@@ -3730,6 +4091,7 @@ pub fn column_def(i: Input) -> IResult<ColumnDefinition> {
                 def.expr = Some(ColumnExpr::Stored(stored_expr))
             }
             ColumnConstraint::CheckExpr(check) => def.check = Some(*check),
+            ColumnConstraint::Ignore => {}
             ColumnConstraint::AutoIncrement {
                 start,
                 step,
@@ -3775,12 +4137,19 @@ pub fn table_index_def(i: Input) -> IResult<TableIndexDefinition> {
 }
 
 pub fn constraint_def(i: Input) -> IResult<ConstraintDefinition> {
+    let hive_constraint_metadata = parser_fn(alt((
+        value((), rule! { ENABLE ~ ENFORCED? }),
+        value((), rule! { DISABLE ~ RELY? }),
+        value((), rule! { ENFORCED }),
+        value((), rule! { RELY }),
+    )));
     map_res(
         rule! {
             (CONSTRAINT ~ #ident)?
             ~ CHECK ~ ^"(" ~ ^#expr ~ ^")"
+            ~ #hive_constraint_metadata?
         },
-        |(opt_constraint_name, _, _, expr, _)| {
+        |(opt_constraint_name, _, _, expr, _, _)| {
             Ok(ConstraintDefinition {
                 name: opt_constraint_name.map(|(_, name)| name),
                 constraint_type: ConstraintType::Check(expr),
@@ -3789,11 +4158,35 @@ pub fn constraint_def(i: Input) -> IResult<ConstraintDefinition> {
     )(i)
 }
 
+pub fn ignored_table_constraint_def(i: Input) -> IResult<CreateDefinition> {
+    let primary = value(
+        CreateDefinition::Ignored,
+        rule! { PRIMARY ~ KEY ~ #ident? ~ #mysql_index_columns ~ #mysql_index_tail },
+    );
+    let unique = value(CreateDefinition::Ignored, rule! {
+        #mysql_unique_keyword ~ ( KEY | INDEX )? ~ #ident? ~ #mysql_index_columns ~ #mysql_index_tail
+    });
+    let key = value(
+        CreateDefinition::Ignored,
+        rule! { ( KEY | INDEX ) ~ #ident? ~ #mysql_index_columns ~ #mysql_index_tail },
+    );
+    let foreign = value(CreateDefinition::Ignored, rule! {
+        (CONSTRAINT ~ #ident)?
+        ~ FOREIGN ~ KEY ~ "(" ~ #comma_separated_list1(ident) ~ ")"
+        ~ REFERENCES ~ #dot_separated_idents_1_to_3
+        ~ ( "(" ~ #comma_separated_list1(ident) ~ ")" )?
+        ~ #mysql_reference_options
+    });
+
+    alt((primary, unique, key, foreign)).parse(i)
+}
+
 pub fn create_def(i: Input) -> IResult<CreateDefinition> {
     alt((
         map(rule! { #column_def }, CreateDefinition::Column),
         map(rule! { #table_index_def }, CreateDefinition::TableIndex),
         map(rule! { #constraint_def }, CreateDefinition::Constraint),
+        ignored_table_constraint_def,
     ))
     .parse(i)
 }
@@ -4473,6 +4866,7 @@ pub fn create_table_source(i: Input) -> IResult<CreateTableSource> {
                     CreateDefinition::Constraint(constraint) => {
                         table_constraints.push(constraint);
                     }
+                    CreateDefinition::Ignored => {}
                 }
             }
             let opt_table_indexes = if !table_indexes.is_empty() {
@@ -4905,6 +5299,15 @@ pub fn alter_table_action(i: Input) -> IResult<AlterTableAction> {
         |(_, _, action)| AlterTableAction::ModifyColumn { action },
     );
 
+    let change_column = map(
+        rule! {
+            CHANGE ~ COLUMN? ~ #ident ~ #modify_column_type
+        },
+        |(_, _, _, column_def)| AlterTableAction::ModifyColumn {
+            action: ModifyColumnAction::SetDataType(vec![column_def]),
+        },
+    );
+
     let add_constraint = map(
         rule! {
             ADD ~ #constraint_def
@@ -5069,9 +5472,11 @@ pub fn alter_table_action(i: Input) -> IResult<AlterTableAction> {
             | #swap_with
             | #rename_column
             | #modify_table_comment
+            | #add_constraint
             | #add_column
             | #drop_column
             | #modify_column
+            | #change_column
             | #recluster_table
             | #revert_table
             | #set_table_options
@@ -5084,7 +5489,6 @@ pub fn alter_table_action(i: Input) -> IResult<AlterTableAction> {
             | #drop_all_row_access_polices
             | #drop_row_access_policy
             | #add_row_access_policy
-            | #add_constraint
     );
 
     alt((alter_table_action_primary, alter_table_action_secondary)).parse(i)
@@ -5672,6 +6076,86 @@ pub fn table_option(i: Input) -> IResult<BTreeMap<String, String>> {
     .parse(i)
 }
 
+pub fn hive_create_table_option(i: Input) -> IResult<()> {
+    let hive_partition_column = rule! {
+        #ident ~ #type_name? ~ (COMMENT ~ #literal_string)?
+    };
+    let hive_partitioned_by = value((), rule! {
+        PARTITIONED ~ BY ~ "(" ~ #comma_separated_list1(hive_partition_column) ~ ")"
+    });
+    let hive_file_format = rule! {
+        ORC | PARQUET | AVRO | TEXTFILE | TEXT | CSV | JSON | SEQUENCEFILE | RCFILE
+    };
+    let hive_stored_as_file = value((), rule! {
+        STORED ~ AS ~ #hive_file_format
+    });
+    let hive_stored_as_io = value((), rule! {
+        STORED ~ AS ~ INPUTFORMAT ~ #literal_string ~ OUTPUTFORMAT ~ #literal_string
+    });
+    let hive_ident_to_string = map(ident, |ident| ident.name);
+    let hive_property_key = rule! {
+        #literal_string | #hive_ident_to_string
+    };
+    let hive_property_value = rule! {
+        #literal_string | #option_to_string
+    };
+    let hive_serde_property = rule! {
+        #hive_property_key ~ "=" ~ #hive_property_value
+    };
+    let hive_ident_to_string = map(ident, |ident| ident.name);
+    let hive_property_key = rule! {
+        #literal_string | #hive_ident_to_string
+    };
+    let hive_property_value = rule! {
+        #literal_string | #option_to_string
+    };
+    let hive_table_property = rule! {
+        #hive_property_key ~ "=" ~ #hive_property_value
+    };
+    let hive_row_format_serde = value((), rule! {
+        ROW ~ FORMAT ~ SERDE ~ #literal_string
+        ~ (WITH ~ SERDEPROPERTIES ~ "(" ~ #comma_separated_list0(hive_serde_property) ~ ")")?
+    });
+    let hive_row_format_delimited = value((), rule! {
+        ROW ~ FORMAT ~ DELIMITED
+        ~ (FIELDS ~ TERMINATED ~ BY ~ #literal_string)?
+        ~ (COLLECTION ~ ITEMS ~ TERMINATED ~ BY ~ #literal_string)?
+        ~ (MAP ~ KEYS ~ TERMINATED ~ BY ~ #literal_string)?
+        ~ (LINES ~ TERMINATED ~ BY ~ #literal_string)?
+        ~ (ESCAPED ~ BY ~ #literal_string)?
+    });
+    let hive_sorted_column = rule! {
+        #ident ~ (ASC | DESC)?
+    };
+    let hive_clustered_by = value((), rule! {
+        CLUSTERED ~ BY ~ "(" ~ #comma_separated_list1(ident) ~ ")"
+        ~ (SORTED ~ BY ~ "(" ~ #comma_separated_list1(hive_sorted_column) ~ ")")?
+        ~ INTO ~ #literal_u64 ~ BUCKETS
+    });
+    let hive_tblproperties = value((), rule! {
+        TBLPROPERTIES ~ "(" ~ #comma_separated_list0(hive_table_property) ~ ")"
+    });
+    let hive_location = value((), rule! {
+        LOCATION ~ #literal_string
+    });
+    let hive_comment = value((), rule! {
+        COMMENT ~ #literal_string
+    });
+
+    rule!(
+        #hive_partitioned_by
+        | #hive_stored_as_io
+        | #hive_stored_as_file
+        | #hive_row_format_serde
+        | #hive_row_format_delimited
+        | #hive_clustered_by
+        | #hive_tblproperties
+        | #hive_location
+        | #hive_comment
+    )
+    .parse(i)
+}
+
 pub fn set_table_option(i: Input) -> IResult<BTreeMap<String, String>> {
     let option = map(
         rule! {
@@ -5982,6 +6466,13 @@ pub fn udf_script_or_address(i: Input) -> IResult<(String, bool)> {
 }
 
 pub fn udf_definition(i: Input) -> IResult<UDFDefinition> {
+    if has_any_token(i, &[STATE]) && has_any_token(i, &[HANDLER]) {
+        return Err(nom::Err::Error(Error::from_error_kind(
+            i,
+            ErrorKind::other("UDAF HANDLER is not supported"),
+        )));
+    }
+
     enum ReturnBody {
         Scalar(TypeName),
         Table(Vec<(Identifier, TypeName)>),

--- a/src/query/ast/src/parser/token.rs
+++ b/src/query/ast/src/parser/token.rs
@@ -484,6 +484,8 @@ pub enum TokenKind {
     BOTH,
     #[token("BRANCH", ignore(ascii_case))]
     BRANCH,
+    #[token("BUCKETS", ignore(ascii_case))]
+    BUCKETS,
     #[token("BY", ignore(ascii_case))]
     BY,
     #[token("BROTLI", ignore(ascii_case))]
@@ -506,16 +508,26 @@ pub enum TokenKind {
     CATALOGS,
     #[token("CENTURY", ignore(ascii_case))]
     CENTURY,
+    #[token("CHANGE", ignore(ascii_case))]
+    CHANGE,
     #[token("CHANGES", ignore(ascii_case))]
     CHANGES,
     #[token("CLUSTER", ignore(ascii_case))]
     CLUSTER,
+    #[token("CLUSTERED", ignore(ascii_case))]
+    CLUSTERED,
+    #[token("COLLATE", ignore(ascii_case))]
+    COLLATE,
+    #[token("COLLECTION", ignore(ascii_case))]
+    COLLECTION,
     #[token("COMMENT", ignore(ascii_case))]
     COMMENT,
     #[token("COMMENTS", ignore(ascii_case))]
     COMMENTS,
     #[token("COMPACT", ignore(ascii_case))]
     COMPACT,
+    #[token("COMPUTE", ignore(ascii_case))]
+    COMPUTE,
     #[token("CONNECTION", ignore(ascii_case))]
     CONNECTION,
     #[token("CONNECTIONS", ignore(ascii_case))]
@@ -530,6 +542,8 @@ pub enum TokenKind {
     CURSOR,
     #[token("CHAR", ignore(ascii_case))]
     CHAR,
+    #[token("CHARSET", ignore(ascii_case))]
+    CHARSET,
     #[token("CHECK", ignore(ascii_case))]
     CHECK,
     #[token("CLOSE", ignore(ascii_case))]
@@ -618,6 +632,8 @@ pub enum TokenKind {
     DECLARE,
     #[token("DEFAULT", ignore(ascii_case))]
     DEFAULT,
+    #[token("DELIMITED", ignore(ascii_case))]
+    DELIMITED,
     #[token("DEFLATE", ignore(ascii_case))]
     DEFLATE,
     #[token("DELETE", ignore(ascii_case))]
@@ -666,8 +682,14 @@ pub enum TokenKind {
     DYNAMIC,
     #[token("EXCEPT", ignore(ascii_case))]
     EXCEPT,
+    #[token("EXTERNAL", ignore(ascii_case))]
+    EXTERNAL,
+    #[token("EXTENDED", ignore(ascii_case))]
+    EXTENDED,
     #[token("EXCLUDE", ignore(ascii_case))]
     EXCLUDE,
+    #[token("ESCAPED", ignore(ascii_case))]
+    ESCAPED,
     #[token("ELSE", ignore(ascii_case))]
     ELSE,
     #[token("EMPTY_FIELD_AS", ignore(ascii_case))]
@@ -676,6 +698,8 @@ pub enum TokenKind {
     ENABLE,
     #[token("ENABLE_VIRTUAL_HOST_STYLE", ignore(ascii_case))]
     ENABLE_VIRTUAL_HOST_STYLE,
+    #[token("ENFORCED", ignore(ascii_case))]
+    ENFORCED,
     #[token("ENCODING", ignore(ascii_case))]
     ENCODING,
     #[token("ENCODING_ERROR_MODE", ignore(ascii_case))]
@@ -688,6 +712,8 @@ pub enum TokenKind {
     ENGINE,
     #[token("ENGINES", ignore(ascii_case))]
     ENGINES,
+    #[token("ENUM", ignore(ascii_case))]
+    ENUM,
     #[token("EPOCH", ignore(ascii_case))]
     EPOCH,
     #[token("YEARWEEK", ignore(ascii_case))]
@@ -743,14 +769,22 @@ pub enum TokenKind {
     FLOAT,
     #[token("FLOAT32", ignore(ascii_case))]
     FLOAT32,
+    #[token("FLOAT4", ignore(ascii_case))]
+    FLOAT4,
     #[token("FLOAT64", ignore(ascii_case))]
     FLOAT64,
+    #[token("FLOAT8", ignore(ascii_case))]
+    FLOAT8,
     #[token("FOR", ignore(ascii_case))]
     FOR,
+    #[token("FOREIGN", ignore(ascii_case))]
+    FOREIGN,
     #[token("FORCE", ignore(ascii_case))]
     FORCE,
     #[token("FORMAT", ignore(ascii_case))]
     FORMAT,
+    #[token("FORMATTED", ignore(ascii_case))]
+    FORMATTED,
     #[token("FOLLOWING", ignore(ascii_case))]
     FOLLOWING,
     #[token("FORMAT_NAME", ignore(ascii_case))]
@@ -835,6 +869,8 @@ pub enum TokenKind {
     INDEX,
     #[token("INFORMATION", ignore(ascii_case))]
     INFORMATION,
+    #[token("INPUTFORMAT", ignore(ascii_case))]
+    INPUTFORMAT,
     #[token("INITIALIZE", ignore(ascii_case))]
     INITIALIZE,
     #[token("INNER", ignore(ascii_case))]
@@ -849,6 +885,10 @@ pub enum TokenKind {
     INT32,
     #[token("INT64", ignore(ascii_case))]
     INT64,
+    #[token("INT2", ignore(ascii_case))]
+    INT2,
+    #[token("INT4", ignore(ascii_case))]
+    INT4,
     #[token("INT8", ignore(ascii_case))]
     INT8,
     #[token("INTEGER", ignore(ascii_case))]
@@ -875,6 +915,8 @@ pub enum TokenKind {
     ISOWEEK,
     #[token("ISOYEAR", ignore(ascii_case))]
     ISOYEAR,
+    #[token("ITEMS", ignore(ascii_case))]
+    ITEMS,
     #[token("JOIN", ignore(ascii_case))]
     JOIN,
     #[token("JSON", ignore(ascii_case))]
@@ -899,6 +941,10 @@ pub enum TokenKind {
     LATERAL,
     #[token("LINEAR", ignore(ascii_case))]
     LINEAR,
+    #[token("LINES", ignore(ascii_case))]
+    LINES,
+    #[token("LOCATION", ignore(ascii_case))]
+    LOCATION,
     #[token("LOCATION_PREFIX", ignore(ascii_case))]
     LOCATION_PREFIX,
     #[token("LOCKS", ignore(ascii_case))]
@@ -926,10 +972,14 @@ pub enum TokenKind {
     LET,
     #[token("LIKE", ignore(ascii_case))]
     LIKE,
+    #[token("ILIKE", ignore(ascii_case))]
+    ILIKE,
     #[token("LIMIT", ignore(ascii_case))]
     LIMIT,
     #[token("LIST", ignore(ascii_case))]
     LIST,
+    #[token("LOAD", ignore(ascii_case))]
+    LOAD,
     #[token("LOW", ignore(ascii_case))]
     LOW,
     #[token("LZO", ignore(ascii_case))]
@@ -1018,6 +1068,8 @@ pub enum TokenKind {
     ON_SCHEDULE,
     #[token("OPTIMIZE", ignore(ascii_case))]
     OPTIMIZE,
+    #[token("OPERATOR", ignore(ascii_case))]
+    OPERATOR,
     #[token("OPTIONS", ignore(ascii_case))]
     OPTIONS,
     #[token("OR", ignore(ascii_case))]
@@ -1028,6 +1080,8 @@ pub enum TokenKind {
     ORDER,
     #[token("OUTPUT_HEADER", ignore(ascii_case))]
     OUTPUT_HEADER,
+    #[token("OUTPUTFORMAT", ignore(ascii_case))]
+    OUTPUTFORMAT,
     #[token("OUTER", ignore(ascii_case))]
     OUTER,
     #[token("ON_ERROR", ignore(ascii_case))]
@@ -1038,6 +1092,10 @@ pub enum TokenKind {
     OVERWRITE,
     #[token("PARTITION", ignore(ascii_case))]
     PARTITION,
+    #[token("PARTITIONED", ignore(ascii_case))]
+    PARTITIONED,
+    #[token("PARTITIONS", ignore(ascii_case))]
+    PARTITIONS,
     #[token("PROPERTIES", ignore(ascii_case))]
     PROPERTIES,
     #[token("PARQUET", ignore(ascii_case))]
@@ -1118,14 +1176,20 @@ pub enum TokenKind {
     RECORD_DELIMITER,
     #[token("REFERENCE_USAGE", ignore(ascii_case))]
     REFERENCE_USAGE,
+    #[token("REFERENCES", ignore(ascii_case))]
+    REFERENCES,
     #[token("REFRESH", ignore(ascii_case))]
     REFRESH,
+    #[token("RELY", ignore(ascii_case))]
+    RELY,
     #[token("REGEXP", ignore(ascii_case))]
     REGEXP,
     #[token("RENAME", ignore(ascii_case))]
     RENAME,
     #[token("REPLACE", ignore(ascii_case))]
     REPLACE,
+    #[token("RESET", ignore(ascii_case))]
+    RESET,
     #[token("RETURN_FAILED_ONLY", ignore(ascii_case))]
     RETURN_FAILED_ONLY,
     #[token("REVERSE", ignore(ascii_case))]
@@ -1144,6 +1208,10 @@ pub enum TokenKind {
     UNMATCHED,
     #[token("ROW", ignore(ascii_case))]
     ROW,
+    #[token("SERDE", ignore(ascii_case))]
+    SERDE,
+    #[token("SERDEPROPERTIES", ignore(ascii_case))]
+    SERDEPROPERTIES,
     #[token("ROWS", ignore(ascii_case))]
     ROWS,
     #[token("ROW_TAG", ignore(ascii_case))]
@@ -1180,6 +1248,8 @@ pub enum TokenKind {
     RETURNS,
     #[token("RESULTSET", ignore(ascii_case))]
     RESULTSET,
+    #[token("RCFILE", ignore(ascii_case))]
+    RCFILE,
     #[token("RUN", ignore(ascii_case))]
     RUN,
     #[token("GRANTS", ignore(ascii_case))]
@@ -1282,6 +1352,8 @@ pub enum TokenKind {
     SEQUENCE,
     #[token("SEQUENCES", ignore(ascii_case))]
     SEQUENCES,
+    #[token("SEQUENCEFILE", ignore(ascii_case))]
+    SEQUENCEFILE,
     #[token("SHARE", ignore(ascii_case))]
     SHARE,
     #[token("SHARES", ignore(ascii_case))]
@@ -1294,10 +1366,14 @@ pub enum TokenKind {
     STATUS,
     #[token("STORED", ignore(ascii_case))]
     STORED,
+    #[token("SORTED", ignore(ascii_case))]
+    SORTED,
     #[token("STREAM", ignore(ascii_case))]
     STREAM,
     #[token("STREAMS", ignore(ascii_case))]
     STREAMS,
+    #[token("STRUCT", ignore(ascii_case))]
+    STRUCT,
     #[token("STRING", ignore(ascii_case))]
     STRING,
     #[token("SUBSTRING", ignore(ascii_case))]
@@ -1330,6 +1406,8 @@ pub enum TokenKind {
     TARGET_LAG,
     #[token("TEXT", ignore(ascii_case))]
     TEXT,
+    #[token("TEXTFILE", ignore(ascii_case))]
+    TEXTFILE,
     #[token("LONGTEXT", ignore(ascii_case))]
     LONGTEXT,
     #[token("MEDIUMTEXT", ignore(ascii_case))]
@@ -1342,6 +1420,8 @@ pub enum TokenKind {
     TENANTS,
     #[token("TENANT", ignore(ascii_case))]
     TENANT,
+    #[token("TERMINATED", ignore(ascii_case))]
+    TERMINATED,
     #[token("THEN", ignore(ascii_case))]
     THEN,
     #[token("THROW", ignore(ascii_case))]
@@ -1354,6 +1434,8 @@ pub enum TokenKind {
     TIMESTAMP,
     #[token("TIMESTAMP_TZ", ignore(ascii_case))]
     TIMESTAMP_TZ,
+    #[token("TIMESTAMPLOCALTZ", ignore(ascii_case))]
+    TIMESTAMPLOCALTZ,
     #[token("TIMEZONE_HOUR", ignore(ascii_case))]
     TIMEZONE_HOUR,
     #[token("TIMEZONE_MINUTE", ignore(ascii_case))]
@@ -1370,6 +1452,8 @@ pub enum TokenKind {
     TRAILING,
     #[token("TRANSIENT", ignore(ascii_case))]
     TRANSIENT,
+    #[token("TRANSACTIONAL", ignore(ascii_case))]
+    TRANSACTIONAL,
     #[token("TRIM", ignore(ascii_case))]
     TRIM,
     #[token("TRIM_SPACE", ignore(ascii_case))]
@@ -1380,6 +1464,8 @@ pub enum TokenKind {
     TRUNCATE,
     #[token("TRY_CAST", ignore(ascii_case))]
     TRY_CAST,
+    #[token("TBLPROPERTIES", ignore(ascii_case))]
+    TBLPROPERTIES,
     #[token("TSV", ignore(ascii_case))]
     TSV,
     #[token("TUESDAY", ignore(ascii_case))]
@@ -1392,6 +1478,8 @@ pub enum TokenKind {
     UNBOUNDED,
     #[token("UNION", ignore(ascii_case))]
     UNION,
+    #[token("UNIONTYPE", ignore(ascii_case))]
+    UNIONTYPE,
     #[token("UINT16", ignore(ascii_case))]
     UINT16,
     #[token("UINT32", ignore(ascii_case))]

--- a/src/query/ast/src/visit/statement.rs
+++ b/src/query/ast/src/visit/statement.rs
@@ -38,6 +38,7 @@ impl Walk for Statement {
                 try_walk!(query.walk(visitor));
             }
             Statement::ReportIssue(_)
+            | Statement::Unsupported { .. }
             | Statement::KillStmt { .. }
             | Statement::SetRole { .. }
             | Statement::SetSecondaryRoles { .. }
@@ -253,6 +254,7 @@ impl WalkMut for Statement {
                 try_walk!(query.walk_mut(visitor));
             }
             Statement::ReportIssue(_)
+            | Statement::Unsupported { .. }
             | Statement::KillStmt { .. }
             | Statement::SetRole { .. }
             | Statement::SetSecondaryRoles { .. }

--- a/src/query/ast/tests/it/display.rs
+++ b/src/query/ast/tests/it/display.rs
@@ -52,7 +52,10 @@ fn test_multi_table_insert_parse_error() {
 fn test_like_escape_display_escapes_escape_literal() {
     for sql in [
         r#"SELECT 'a' LIKE 'a' ESCAPE '''';"#,
+        r#"SELECT 'a' ILIKE 'A' ESCAPE '''';"#,
+        r#"SELECT 'a' NOT ILIKE 'A' ESCAPE '''';"#,
         r#"SELECT 'a' LIKE ANY ('a', 'b') ESCAPE '''';"#,
+        r#"SELECT 'a' ILIKE ANY ('A', 'B') ESCAPE '''';"#,
         r#"SELECT 'a' LIKE ANY (SELECT 'a') ESCAPE '''';"#,
     ] {
         test_stmt_display(sql);

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -16,6 +16,8 @@ use std::fmt::Debug;
 use std::fmt::Display;
 use std::io::Write;
 
+use databend_common_ast::ast::Statement;
+use databend_common_ast::ast::UnsupportedType;
 use databend_common_ast::ast::quote::QuotedIdent;
 use databend_common_ast::ast::quote::ident_needs_quote;
 use databend_common_ast::parser::expr::*;
@@ -1362,6 +1364,107 @@ fn test_statement_error() {
         writeln!(file, "{}", case).unwrap();
         writeln!(file, "---------- Output ---------").unwrap();
         writeln!(file, "{}", err.1).unwrap();
+    }
+}
+
+#[test]
+fn test_unsupported_external_dialect_statement() {
+    let cases = [
+        (
+            "LOAD DATA LOCAL INPATH '../../data/files/load_data_job_acid' INTO TABLE orc_test_txn",
+            Dialect::Hive,
+            UnsupportedType::HiveLoadData,
+        ),
+        (
+            "EXPLAIN LOCKS CREATE TABLE x (a int)",
+            Dialect::Hive,
+            UnsupportedType::HiveExplainLocks,
+        ),
+        (
+            "CREATE MATERIALIZED VIEW mv STORED AS ORC AS SELECT 1",
+            Dialect::Hive,
+            UnsupportedType::HiveCreateMaterializedView,
+        ),
+    ];
+
+    for (sql, dialect, expected_type) in cases {
+        let tokens = tokenize_sql(sql).unwrap();
+        let (stmt, _) = parse_sql(&tokens, dialect).unwrap();
+        assert!(
+            matches!(
+                &stmt,
+                Statement::Unsupported { unsupported_type, raw_sql }
+                    if unsupported_type == &expected_type && raw_sql == sql
+            ),
+            "{sql}"
+        );
+
+        let formatted = stmt.to_string();
+        let tokens = tokenize_sql(&formatted).unwrap();
+        let (reparsed, _) = parse_sql(&tokens, dialect).unwrap();
+        assert_eq!(stmt, reparsed);
+    }
+}
+
+#[test]
+fn test_hive_create_table_storage_options() {
+    let cases = [
+        "CREATE EXTERNAL TABLE io_test_text_1 (a int, b int) STORED AS textfile",
+        "CREATE TABLE io_test_acid_part (a int, b int) PARTITIONED BY (c int) STORED AS ORC TBLPROPERTIES('transactional'='true')",
+        "CREATE TABLE bloomTest(msisdn STRING, imsi VARCHAR(20), imei BIGINT, cell_id BIGINT) ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.orc.OrcSerde' STORED AS INPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat' OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'",
+        "CREATE TABLE transactions (id int, value string) CLUSTERED BY (id) INTO 5 BUCKETS STORED AS ORC",
+        "CREATE TABLE alltypes (m1 map<string, string>, l1 array<int>, st1 struct<c1:int, c2:string>) ROW FORMAT DELIMITED FIELDS TERMINATED BY '|' COLLECTION ITEMS TERMINATED BY ',' MAP KEYS TERMINATED BY ':' STORED AS TEXTFILE",
+        "CREATE TABLE tab_part (key int, value string) PARTITIONED BY(ds STRING) CLUSTERED BY (key) SORTED BY (key DESC) INTO 4 BUCKETS STORED AS SEQUENCEFILE",
+        "CREATE TABLE comment_test (id int) COMMENT 'hive table' ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe' STORED AS TEXTFILE",
+        "CREATE TABLE constraint_test (id int CONSTRAINT id_nn NOT NULL ENFORCED, c int CHECK (c > 0) ENABLE) STORED AS ORC",
+        "CREATE TABLE complex_types (u uniontype<int,double>, ts timestamplocaltz) STORED AS PARQUET",
+    ];
+
+    for sql in cases {
+        let tokens = tokenize_sql(sql).unwrap();
+        let (stmt, _) = parse_sql(&tokens, Dialect::Hive).unwrap();
+        assert!(!matches!(stmt, Statement::Unsupported { .. }), "{sql}");
+
+        let formatted = stmt.to_string();
+        let tokens = tokenize_sql(&formatted).unwrap();
+        parse_sql(&tokens, Dialect::Hive).unwrap();
+    }
+}
+
+#[test]
+fn test_change_column_statement() {
+    let sql = "ALTER TABLE stats_nonpart CHANGE COLUMN key key2 int";
+    let tokens = tokenize_sql(sql).unwrap();
+    let (stmt, _) = parse_sql(&tokens, Dialect::Hive).unwrap();
+    assert!(!matches!(stmt, Statement::Unsupported { .. }));
+
+    let formatted = stmt.to_string();
+    assert_eq!(
+        formatted,
+        "ALTER TABLE stats_nonpart MODIFY COLUMN key2 Int32"
+    );
+
+    let tokens = tokenize_sql(&formatted).unwrap();
+    let (reparsed, _) = parse_sql(&tokens, Dialect::Hive).unwrap();
+    assert_eq!(formatted, reparsed.to_string());
+}
+
+#[test]
+fn test_postgres_array_and_cast_forms() {
+    let cases = [
+        "SELECT ARRAY['hello', 'world']",
+        "SELECT avg(b)::numeric(10,3) AS avg_value FROM aggtest",
+        "SELECT float8_accum('{4,140,2900}'::float8[], 100)",
+        "SELECT 1::int4, 2::int2, 3::int8, 1.0::float4, 2.0::float8",
+        "SELECT ARRAY(SELECT 1)",
+    ];
+
+    for sql in cases {
+        let tokens = tokenize_sql(sql).unwrap();
+        let (stmt, _) = parse_sql(&tokens, Dialect::PostgreSQL).unwrap();
+        let formatted = stmt.to_string();
+        let tokens = tokenize_sql(&formatted).unwrap();
+        parse_sql(&tokens, Dialect::PostgreSQL).unwrap();
     }
 }
 

--- a/src/query/ast/tests/it/testdata/expr-error.txt
+++ b/src/query/ast/tests/it/testdata/expr-error.txt
@@ -25,14 +25,34 @@ error:
 ---------- Input ----------
 CAST(col1 AS foo)
 ---------- Output ---------
-error: 
-  --> SQL:1:14
-  |
-1 | CAST(col1 AS foo)
-  | ----         ^^^ unexpected `foo`, expecting `BOOL`, `FLOAT`, `BOOLEAN`, `FLOAT32`, `FLOAT64`, `BLOB`, `JSON`, `DOUBLE`, `VECTOR`, `LONGBLOB`, `GEOMETRY`, `GEOGRAPHY`, `STAGE_LOCATION`, <Ident>, <LiteralString>, `IDENTIFIER`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, `UINT32`, `INT`, `INTEGER`, `UINT64`, `UNSIGNED`, `BIGINT`, `INT8`, `INT16`, `INT32`, `INT64`, `SIGNED`, `REAL`, `DECIMAL`, `ARRAY`, `MAP`, `BITMAP`, `TUPLE`, `DATE`, `TIMESTAMP`, `TIMESTAMP_TZ`, `DATETIME`, `INTERVAL`, `NUMERIC`, `BINARY`, `VARBINARY`, `MEDIUMBLOB`, `TINYBLOB`, `STRING`, `VARCHAR`, `CHAR`, `CHARACTER`, `TEXT`, `VARIANT`, or `NULLABLE`
-  | |             
-  | while parsing `function(... [ , x -> ... ] ) [ (...) ] [ WITHIN GROUP ( ORDER BY <expr>, ... ) ] [ OVER ([ PARTITION BY <expr>, ... ] [ ORDER BY <expr>, ... ] [ <window frame> ]) ]`
-  | while parsing expression
+CAST(col1 AS STRING)
+---------- AST ------------
+Cast {
+    span: Some(
+        0..17,
+    ),
+    expr: ColumnRef {
+        span: Some(
+            5..9,
+        ),
+        column: ColumnRef {
+            database: None,
+            table: None,
+            column: Name(
+                Identifier {
+                    span: Some(
+                        5..9,
+                    ),
+                    name: "col1",
+                    quote: None,
+                    ident_type: None,
+                },
+            ),
+        },
+    },
+    target_type: String,
+    pg_style: false,
+}
 
 
 ---------- Input ----------

--- a/src/query/ast/tests/it/testdata/expr-error.txt
+++ b/src/query/ast/tests/it/testdata/expr-error.txt
@@ -25,34 +25,14 @@ error:
 ---------- Input ----------
 CAST(col1 AS foo)
 ---------- Output ---------
-CAST(col1 AS STRING)
----------- AST ------------
-Cast {
-    span: Some(
-        0..17,
-    ),
-    expr: ColumnRef {
-        span: Some(
-            5..9,
-        ),
-        column: ColumnRef {
-            database: None,
-            table: None,
-            column: Name(
-                Identifier {
-                    span: Some(
-                        5..9,
-                    ),
-                    name: "col1",
-                    quote: None,
-                    ident_type: None,
-                },
-            ),
-        },
-    },
-    target_type: String,
-    pg_style: false,
-}
+error: 
+  --> SQL:1:14
+  |
+1 | CAST(col1 AS foo)
+  | ----         ^^^ unexpected `foo`, expecting `BOOL`, `FLOAT`, `FLOAT4`, `FLOAT8`, `BOOLEAN`, `FLOAT32`, `FLOAT64`, `BLOB`, `JSON`, `DOUBLE`, `VECTOR`, `LONGBLOB`, `GEOMETRY`, `UNIONTYPE`, `GEOGRAPHY`, `STAGE_LOCATION`, <Ident>, <LiteralString>, `IDENTIFIER`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, `UINT32`, `INT`, `INTEGER`, `UINT64`, `UNSIGNED`, `BIGINT`, `INT8`, `INT16`, `INT2`, `INT32`, `INT4`, `INT64`, `SIGNED`, `REAL`, `DECIMAL`, `NUMERIC`, `ARRAY`, `MAP`, `BITMAP`, `TUPLE`, `STRUCT`, `DATE`, `TIMESTAMP`, `TIMESTAMP_TZ`, `DATETIME`, `TIMESTAMPLOCALTZ`, `TIME`, `INTERVAL`, `BINARY`, `VARBINARY`, `MEDIUMBLOB`, `TINYBLOB`, `STRING`, `VARCHAR`, `CHAR`, `CHARACTER`, `TEXT`, or 3 more ...
+  | |             
+  | while parsing `function(... [ , x -> ... ] ) [ (...) ] [ WITHIN GROUP ( ORDER BY <expr>, ... ) ] [ OVER ([ PARTITION BY <expr>, ... ] [ ORDER BY <expr>, ... ] [ <window frame> ]) ]`
+  | while parsing expression
 
 
 ---------- Input ----------

--- a/src/query/ast/tests/it/testdata/query-error.txt
+++ b/src/query/ast/tests/it/testdata/query-error.txt
@@ -91,7 +91,7 @@ error:
   --> SQL:1:45
   |
 1 | select number + 5 as a, cast(number as float(255))
-  | ------                                      ^ unexpected `(`, expecting `*`, `COLUMNS`, <Ident>, <LiteralString>, `IDENTIFIER`, `NULL`, `NOT`, or `)`
+  | ------                                      ^ unexpected `(`, expecting `*`, `COLUMNS`, <Ident>, <LiteralString>, `IDENTIFIER`, `NULL`, `NOT`, `[`, or `)`
   | |                                            
   | while parsing `SELECT ...`
 

--- a/src/query/ast/tests/it/testdata/reserved-error.txt
+++ b/src/query/ast/tests/it/testdata/reserved-error.txt
@@ -12,16 +12,22 @@ CREATE OR
  truncated BOOLEAN
 ) LANGUAGE python HANDLER='ai_list_files' address='https://api.bendml.com'
 ---------- Output ---------
-error: 
-  --> SQL:3:2
-  |
-1 | CREATE OR
-  | ------ while parsing `CREATE [OR REPLACE] FUNCTION [IF NOT EXISTS] <udf_name> <udf_definition> [DESC = <description>]`
-2 |  REPLACE FUNCTION ai_list_files (data_stage STAGE_LOCATION, l INT) RETURNS TABLE (
-  |                                 -                                          ----- while parsing TABLE (<return_type>, ...)
-  |                                 |                                           
-  |                                 while parsing (<arg_name arg_type>, ...) RETURNS <return body> { AS <sql> | LANGUAGE <language> HANDLER=<handler> ADDRESS=<udf_server_address> } }
-3 |  stage VARCHAR,
-  |  ^^^^^ unexpected `stage`. it's reserved keyword, you may avoid using it, expecting <LiteralString>, <Ident>, `IDENTIFIER`, or `)`
+CREATE OR
+ REPLACE FUNCTION ai_list_files (data_stage STAGE_LOCATION, l INT) RETURNS TABLE (
+ stage VARCHAR,
+ relative_path VARCHAR,
+ path VARCHAR,
+ is_dir BOOLEAN,
+ size BIGINT,
+ mode VARCHAR,
+ content_type VARCHAR,
+ etag VARCHAR,
+ truncated BOOLEAN
+) LANGUAGE python HANDLER='ai_list_files' address='https://api.bendml.com'
+---------- AST ------------
+Unsupported {
+    unsupported_type: PostgreSqlCreateStatement,
+    raw_sql: "CREATE OR\n REPLACE FUNCTION ai_list_files (data_stage STAGE_LOCATION, l INT) RETURNS TABLE (\n stage VARCHAR,\n relative_path VARCHAR,\n path VARCHAR,\n is_dir BOOLEAN,\n size BIGINT,\n mode VARCHAR,\n content_type VARCHAR,\n etag VARCHAR,\n truncated BOOLEAN\n) LANGUAGE python HANDLER='ai_list_files' address='https://api.bendml.com'",
+}
 
 

--- a/src/query/ast/tests/it/testdata/stmt-error.txt
+++ b/src/query/ast/tests/it/testdata/stmt-error.txt
@@ -5,7 +5,7 @@ error:
   --> SQL:1:38
   |
 1 | create table a.b (c integer not null 1, b float(10))
-  | ------                               ^ unexpected `1`, expecting `)`, `NULL`, `NOT`, `DEFAULT`, `GENERATED`, `AS`, `CHECK`, `AUTOINCREMENT`, `IDENTITY`, `COMMENT`, `STATS_TRUNCATE_LEN`, or `,`
+  | ------                               ^ unexpected `1`, expecting `)`, `[`, `CONSTRAINT`, `NULL`, `NOT`, `DEFAULT`, `GENERATED`, `AS`, `CHECK`, `AUTOINCREMENT`, `IDENTITY`, `PRIMARY`, <Ident>, <LiteralString>, `IDENTIFIER`, `REFERENCES`, `COLLATE`, `CHARSET`, `COMMENT`, `STATS_TRUNCATE_LEN`, or `,`
   | |                                     
   | while parsing `CREATE [OR REPLACE] TABLE [IF NOT EXISTS] [<database>.]<table> [<source>] [<table_options>]`
 
@@ -27,7 +27,7 @@ error:
   --> SQL:1:24
   |
 1 | create table a (c float(10))
-  | ------                 ^ unexpected `(`, expecting `)`, `NULL`, `NOT`, `DEFAULT`, `GENERATED`, `AS`, `CHECK`, `AUTOINCREMENT`, `IDENTITY`, `COMMENT`, `STATS_TRUNCATE_LEN`, or `,`
+  | ------                 ^ unexpected `(`, expecting `)`, `NULL`, `NOT`, `[`, `CONSTRAINT`, `DEFAULT`, `GENERATED`, `AS`, `CHECK`, `AUTOINCREMENT`, `IDENTITY`, `PRIMARY`, <Ident>, <LiteralString>, `IDENTIFIER`, `REFERENCES`, `COLLATE`, `CHARSET`, `COMMENT`, `STATS_TRUNCATE_LEN`, or `,`
   | |                       
   | while parsing `CREATE [OR REPLACE] TABLE [IF NOT EXISTS] [<database>.]<table> [<source>] [<table_options>]`
 
@@ -39,7 +39,7 @@ error:
   --> SQL:1:19
   |
 1 | create table a (c varch)
-  | ------          - ^^^^^ unexpected `varch`, expecting `VARCHAR`, `CHAR`, `VARIANT`, `CHARACTER`, `VARBINARY`, `ARRAY`, `BINARY`, `VECTOR`, `GEOGRAPHY`, `STAGE_LOCATION`, `MAP`, `DATE`, `STRING`, `FLOAT32`, `FLOAT64`, `DECIMAL`, `NUMERIC`, `SMALLINT`, `DATETIME`, `INTERVAL`, `NULLABLE`, `TIMESTAMP_TZ`, `REAL`, `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `UINT32`, `INT`, `INTEGER`, `UINT64`, `UNSIGNED`, `BIGINT`, `INT8`, `INT16`, `INT32`, `INT64`, `SIGNED`, `FLOAT`, `DOUBLE`, `BITMAP`, `TUPLE`, `TIMESTAMP`, `LONGBLOB`, `MEDIUMBLOB`, `TINYBLOB`, `BLOB`, `TEXT`, `JSON`, or `GEOMETRY`
+  | ------          - ^^^^^ unexpected `varch`, expecting `VARCHAR`, `CHAR`, `VARIANT`, `CHARACTER`, `VARBINARY`, `ARRAY`, `STRUCT`, `BINARY`, `VECTOR`, `GEOGRAPHY`, `STAGE_LOCATION`, `MAP`, `DATE`, `FLOAT4`, `FLOAT8`, `STRING`, `FLOAT32`, `FLOAT64`, `DECIMAL`, `NUMERIC`, `SMALLINT`, `DATETIME`, `INTERVAL`, `NULLABLE`, `TIMESTAMP_TZ`, `TIMESTAMPLOCALTZ`, `REAL`, `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `UINT32`, `INT`, `INTEGER`, `UINT64`, `UNSIGNED`, `BIGINT`, `INT8`, `INT16`, `INT2`, `INT32`, `INT4`, `INT64`, `SIGNED`, `FLOAT`, `DOUBLE`, `BITMAP`, `TUPLE`, `UNIONTYPE`, `TIMESTAMP`, `TIME`, `LONGBLOB`, `MEDIUMBLOB`, `TINYBLOB`, `BLOB`, `TEXT`, `ENUM`, `JSON`, `GEOMETRY`, or 1 more ...
   | |               |  
   | |               while parsing `<column name> <type> [DEFAULT <expr>] [AS (<expr>) VIRTUAL] [AS (<expr>) STORED] [CHECK (<expr>)] [COMMENT '<comment>'] [STATS_TRUNCATE_LEN <n>]`
   | while parsing `CREATE [OR REPLACE] TABLE [IF NOT EXISTS] [<database>.]<table> [<source>] [<table_options>]`
@@ -52,10 +52,8 @@ error:
   --> SQL:1:25
   |
 1 | create table a (c tuple())
-  | ------          - ----- ^ unexpected `)`, expecting `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, `UINT32`, `INT`, `INTEGER`, `UINT64`, `UNSIGNED`, `BIGINT`, `INT8`, `INT16`, `INT32`, `INT64`, `SIGNED`, `FLOAT32`, `FLOAT`, `REAL`, `FLOAT64`, `DOUBLE`, `DECIMAL`, `ARRAY`, `MAP`, `BITMAP`, `TUPLE`, `DATE`, `TIMESTAMP`, `TIMESTAMP_TZ`, `DATETIME`, `INTERVAL`, `NUMERIC`, `BINARY`, `VARBINARY`, `LONGBLOB`, `MEDIUMBLOB`, `TINYBLOB`, `BLOB`, `STRING`, `VARCHAR`, `CHAR`, `CHARACTER`, `TEXT`, `VARIANT`, `JSON`, `GEOMETRY`, `GEOGRAPHY`, `NULLABLE`, `VECTOR`, `STAGE_LOCATION`, <Ident>, <LiteralString>, or `IDENTIFIER`
-  | |               | |      
-  | |               | while parsing type name
-  | |               while parsing `<column name> <type> [DEFAULT <expr>] [AS (<expr>) VIRTUAL] [AS (<expr>) STORED] [CHECK (<expr>)] [COMMENT '<comment>'] [STATS_TRUNCATE_LEN <n>]`
+  | ------                  ^ unexpected `)`, expecting `)`, `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, `UINT32`, `INT`, `INTEGER`, `UINT64`, `UNSIGNED`, `BIGINT`, `INT8`, `INT16`, `INT2`, `INT32`, `INT4`, `INT64`, `SIGNED`, `FLOAT32`, `FLOAT4`, `FLOAT`, `REAL`, `FLOAT64`, `FLOAT8`, `DOUBLE`, `DECIMAL`, `NUMERIC`, `ARRAY`, `MAP`, `BITMAP`, `TUPLE`, `STRUCT`, `UNIONTYPE`, `DATE`, `TIMESTAMP`, `TIMESTAMP_TZ`, `DATETIME`, `TIMESTAMPLOCALTZ`, `TIME`, `INTERVAL`, `BINARY`, `VARBINARY`, `LONGBLOB`, `MEDIUMBLOB`, `TINYBLOB`, `BLOB`, `STRING`, `VARCHAR`, `CHAR`, `CHARACTER`, `TEXT`, `ENUM`, `VARIANT`, `JSON`, `GEOMETRY`, `GEOGRAPHY`, `NULLABLE`, `VECTOR`, or 4 more ...
+  | |                        
   | while parsing `CREATE [OR REPLACE] TABLE [IF NOT EXISTS] [<database>.]<table> [<source>] [<table_options>]`
 
 
@@ -66,11 +64,8 @@ error:
   --> SQL:1:38
   |
 1 | create table a (b tuple(c int, uint64));
-  | ------          - -----              ^ unexpected `)`, expecting `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, `UINT32`, `INT`, `INTEGER`, `UINT64`, `UNSIGNED`, `BIGINT`, `INT8`, `INT16`, `INT32`, `INT64`, `SIGNED`, `FLOAT32`, `FLOAT`, `REAL`, `FLOAT64`, `DOUBLE`, `DECIMAL`, `ARRAY`, `MAP`, `BITMAP`, `TUPLE`, `DATE`, `TIMESTAMP`, `TIMESTAMP_TZ`, `DATETIME`, `INTERVAL`, `NUMERIC`, `BINARY`, `VARBINARY`, `LONGBLOB`, `MEDIUMBLOB`, `TINYBLOB`, `BLOB`, `STRING`, `VARCHAR`, `CHAR`, `CHARACTER`, `TEXT`, `VARIANT`, `JSON`, `GEOMETRY`, `GEOGRAPHY`, `NULLABLE`, `VECTOR`, or `STAGE_LOCATION`
-  | |               | |                   
-  | |               | while parsing TUPLE(<name> <type>, ...)
-  | |               | while parsing type name
-  | |               while parsing `<column name> <type> [DEFAULT <expr>] [AS (<expr>) VIRTUAL] [AS (<expr>) STORED] [CHECK (<expr>)] [COMMENT '<comment>'] [STATS_TRUNCATE_LEN <n>]`
+  | ------                               ^ unexpected `)`, expecting `)`, `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, `UINT32`, `INT`, `INTEGER`, `UINT64`, `UNSIGNED`, `BIGINT`, `INT8`, `INT16`, `INT2`, `INT32`, `INT4`, `INT64`, `SIGNED`, `FLOAT32`, `FLOAT4`, `FLOAT`, `REAL`, `FLOAT64`, `FLOAT8`, `DOUBLE`, `DECIMAL`, `NUMERIC`, `ARRAY`, `MAP`, `BITMAP`, `TUPLE`, `STRUCT`, `UNIONTYPE`, `DATE`, `TIMESTAMP`, `TIMESTAMP_TZ`, `DATETIME`, `TIMESTAMPLOCALTZ`, `TIME`, `INTERVAL`, `BINARY`, `VARBINARY`, `LONGBLOB`, `MEDIUMBLOB`, `TINYBLOB`, `BLOB`, `STRING`, `VARCHAR`, `CHAR`, `CHARACTER`, `TEXT`, `ENUM`, `VARIANT`, `JSON`, `GEOMETRY`, `GEOGRAPHY`, `NULLABLE`, `VECTOR`, or 4 more ...
+  | |                                     
   | while parsing `CREATE [OR REPLACE] TABLE [IF NOT EXISTS] [<database>.]<table> [<source>] [<table_options>]`
 
 
@@ -1078,12 +1073,11 @@ error:
 CREATE FUNCTION my_agg (INT) STATE { s STRING } RETURNS BOOLEAN LANGUAGE javascript HANDLER = 'my_agg' ADDRESS = 'http://0.0.0.0:8815';
 ---------- Output ---------
 error: 
-  --> SQL:1:85
+  --> SQL:1:24
   |
 1 | CREATE FUNCTION my_agg (INT) STATE { s STRING } RETURNS BOOLEAN LANGUAGE javascript HANDLER = 'my_agg' ADDRESS = 'http://0.0.0.0:8815';
-  | ------                 -                                                            ^^^^^^^ unexpected `HANDLER`, expecting `HEADERS`, `ADDRESS`, `PACKAGES`, `AS`, or `IMPORTS`
-  | |                      |                                                             
-  | |                      while parsing (<[arg_name] arg_type>, ...) STATE {<state_field>, ...} RETURNS <return_type> LANGUAGE <language> { ADDRESS=<udf_server_address> | AS <language_codes> } 
+  | ------                 ^ UDAF HANDLER is not supported
+  | |                       
   | while parsing `CREATE [OR REPLACE] FUNCTION [IF NOT EXISTS] <udf_name> <udf_definition> [DESC = <description>]`
 
 
@@ -1094,7 +1088,7 @@ error:
   --> SQL:1:40
   |
 1 | CREATE FUNCTION my_agg (INT) STATE { s STRIN } RETURNS BOOLEAN LANGUAGE javascript ADDRESS = 'http://0.0.0.0:8815';
-  | ------                 -               ^^^^^ unexpected `STRIN`, expecting `STRING`, `SIGNED`, `INTERVAL`, `TINYINT`, `VARIANT`, `SMALLINT`, `TINYBLOB`, `VARBINARY`, `INT8`, `JSON`, `INT16`, `INT32`, `INT64`, `UINT8`, `BIGINT`, `UINT16`, `UINT32`, `UINT64`, `BINARY`, `INTEGER`, `DATETIME`, `NUMERIC`, `TIMESTAMP`, `UNSIGNED`, `STAGE_LOCATION`, `TIMESTAMP_TZ`, `REAL`, `DATE`, `CHAR`, `TEXT`, `ARRAY`, `TUPLE`, `VECTOR`, `BOOLEAN`, `DECIMAL`, `VARCHAR`, `LONGBLOB`, `NULLABLE`, `CHARACTER`, `GEOGRAPHY`, `MEDIUMBLOB`, `BITMAP`, `}`, `BOOL`, `INT`, `FLOAT32`, `FLOAT`, `FLOAT64`, `DOUBLE`, `MAP`, `BLOB`, or `GEOMETRY`
+  | ------                 -               ^^^^^ unexpected `STRIN`, expecting `STRING`, `SIGNED`, `STRUCT`, `INTERVAL`, `TINYINT`, `VARIANT`, `SMALLINT`, `TINYBLOB`, `VARBINARY`, `INT8`, `INT2`, `INT4`, `TIME`, `JSON`, `INT16`, `INT32`, `INT64`, `UINT8`, <Ident>, `BIGINT`, `UINT16`, `UINT32`, `UINT64`, `BINARY`, `INTEGER`, `NUMERIC`, `DATETIME`, `TIMESTAMP`, `UNSIGNED`, `STAGE_LOCATION`, `TIMESTAMP_TZ`, `TIMESTAMPLOCALTZ`, `REAL`, `DATE`, `CHAR`, `TEXT`, `ENUM`, `ARRAY`, `TUPLE`, `VECTOR`, `BOOLEAN`, `DECIMAL`, `VARCHAR`, `LONGBLOB`, `NULLABLE`, `CHARACTER`, `GEOGRAPHY`, `MEDIUMBLOB`, `BITMAP`, `UNIONTYPE`, `}`, `BOOL`, `INT`, `FLOAT32`, `FLOAT4`, `FLOAT`, `FLOAT64`, `FLOAT8`, `DOUBLE`, `MAP`, or 2 more ...
   | |                      |                
   | |                      while parsing (<[arg_name] arg_type>, ...) STATE {<state_field>, ...} RETURNS <return_type> LANGUAGE <language> { ADDRESS=<udf_server_address> | AS <language_codes> } 
   | while parsing `CREATE [OR REPLACE] FUNCTION [IF NOT EXISTS] <udf_name> <udf_definition> [DESC = <description>]`
@@ -1182,10 +1176,7 @@ error:
   | ------ while parsing `CREATE [OR REPLACE] DICTIONARY [IF NOT EXISTS] <dictionary_name> [(<column>, ...)] PRIMARY KEY [<primary_key>, ...] SOURCE (<source_name> ([<source_options>])) [COMMENT <comment>] `
 2 |         (
 3 |             user_name tuple(),
-  |             --------- ----- ^ unexpected `)`, expecting `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, `UINT32`, `INT`, `INTEGER`, `UINT64`, `UNSIGNED`, `BIGINT`, `INT8`, `INT16`, `INT32`, `INT64`, `SIGNED`, `FLOAT32`, `FLOAT`, `REAL`, `FLOAT64`, `DOUBLE`, `DECIMAL`, `ARRAY`, `MAP`, `BITMAP`, `TUPLE`, `DATE`, `TIMESTAMP`, `TIMESTAMP_TZ`, `DATETIME`, `INTERVAL`, `NUMERIC`, `BINARY`, `VARBINARY`, `LONGBLOB`, `MEDIUMBLOB`, `TINYBLOB`, `BLOB`, `STRING`, `VARCHAR`, `CHAR`, `CHARACTER`, `TEXT`, `VARIANT`, `JSON`, `GEOMETRY`, `GEOGRAPHY`, `NULLABLE`, `VECTOR`, `STAGE_LOCATION`, <Ident>, <LiteralString>, or `IDENTIFIER`
-  |             |         |      
-  |             |         while parsing type name
-  |             while parsing `<column name> <type> [DEFAULT <expr>] [AS (<expr>) VIRTUAL] [AS (<expr>) STORED] [CHECK (<expr>)] [COMMENT '<comment>'] [STATS_TRUNCATE_LEN <n>]`
+  |                             ^ unexpected `)`, expecting `)`, `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, `UINT32`, `INT`, `INTEGER`, `UINT64`, `UNSIGNED`, `BIGINT`, `INT8`, `INT16`, `INT2`, `INT32`, `INT4`, `INT64`, `SIGNED`, `FLOAT32`, `FLOAT4`, `FLOAT`, `REAL`, `FLOAT64`, `FLOAT8`, `DOUBLE`, `DECIMAL`, `NUMERIC`, `ARRAY`, `MAP`, `BITMAP`, `TUPLE`, `STRUCT`, `UNIONTYPE`, `DATE`, `TIMESTAMP`, `TIMESTAMP_TZ`, `DATETIME`, `TIMESTAMPLOCALTZ`, `TIME`, `INTERVAL`, `BINARY`, `VARBINARY`, `LONGBLOB`, `MEDIUMBLOB`, `TINYBLOB`, `BLOB`, `STRING`, `VARCHAR`, `CHAR`, `CHARACTER`, `TEXT`, `ENUM`, `VARIANT`, `JSON`, `GEOMETRY`, `GEOGRAPHY`, `NULLABLE`, `VECTOR`, or 4 more ...
 
 
 ---------- Input ----------
@@ -1207,7 +1198,7 @@ error:
   --> SQL:1:24
   |
 1 | desc procedure p1(array, c int)
-  | ----             ------^ unexpected `,`, expecting `(`
+  | ----             ------^ unexpected `,`, expecting `(` or <Lt>
   | |                ||     
   | |                |while parsing type name
   | |                while parsing (<type_name>, ...)
@@ -1230,11 +1221,12 @@ error:
 drop procedure p1(a int)
 ---------- Output ---------
 error: 
-  --> SQL:1:19
+  --> SQL:1:21
   |
 1 | drop procedure p1(a int)
-  | ----              ^ unexpected `a`, expecting `DATE`, `ARRAY`, `VARCHAR`, `VARIANT`, `SMALLINT`, `DATETIME`, `VARBINARY`, `CHARACTER`, `STAGE_LOCATION`, `)`, `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `UINT32`, `INT`, `INTEGER`, `UINT64`, `UNSIGNED`, `BIGINT`, `INT8`, `INT16`, `INT32`, `INT64`, `SIGNED`, `FLOAT32`, `FLOAT`, `REAL`, `FLOAT64`, `DOUBLE`, `DECIMAL`, `MAP`, `BITMAP`, `TUPLE`, `TIMESTAMP`, `TIMESTAMP_TZ`, `INTERVAL`, `NUMERIC`, `BINARY`, `LONGBLOB`, `MEDIUMBLOB`, `TINYBLOB`, `BLOB`, `STRING`, `CHAR`, `TEXT`, `JSON`, `GEOMETRY`, `GEOGRAPHY`, `NULLABLE`, or `VECTOR`
-  | |                  
+  | ----             -  ^^^ unexpected `int`. it's reserved keyword, you may avoid using it, expecting `NOT`, `NULL`, `)`, `[`, or `,`
+  | |                |   
+  | |                while parsing (<type_name>, ...)
   | while parsing `DROP PROCEDURE <procedure_name>()`
 
 
@@ -1265,7 +1257,7 @@ error:
   --> SQL:1:44
   |
 1 | create PROCEDURE p1() returns table(string not null, int null) language sql comment = 'test' as $$
-  | ------                        -----        ^^^ unexpected `not`. it's reserved keyword, you may avoid using it, expecting `INT8`, `INT16`, `INT32`, `INT64`, `UINT16`, `UINT32`, `UINT64`, `INTEGER`, `FLOAT32`, `FLOAT64`, `INTERVAL`, `GEOMETRY`, `INT`, `BOOL`, `DATE`, `BLOB`, `TEXT`, `JSON`, `UINT8`, `FLOAT`, `TUPLE`, `DOUBLE`, `BITMAP`, `BINARY`, `STRING`, `VECTOR`, `BOOLEAN`, `NUMERIC`, `UNSIGNED`, `DATETIME`, `NULLABLE`, `TIMESTAMP`, `GEOGRAPHY`, `TIMESTAMP_TZ`, `TINYINT`, `LONGBLOB`, `TINYBLOB`, `STAGE_LOCATION`, `SMALLINT`, `BIGINT`, `SIGNED`, `REAL`, `DECIMAL`, `ARRAY`, `MAP`, `VARBINARY`, `MEDIUMBLOB`, `VARCHAR`, `CHAR`, `CHARACTER`, or `VARIANT`
+  | ------                        -----        ^^^ unexpected `not`. it's reserved keyword, you may avoid using it, expecting `UNIONTYPE`, `INT8`, `INT2`, `INT4`, `INT16`, `INT32`, `INT64`, `UINT16`, `UINT32`, `UINT64`, `FLOAT4`, `FLOAT8`, `INTEGER`, `FLOAT32`, `FLOAT64`, `INTERVAL`, `GEOMETRY`, `IDENTIFIER`, `INT`, `BOOL`, `DATE`, `TIME`, `BLOB`, `TEXT`, `ENUM`, `JSON`, `UINT8`, `FLOAT`, `TUPLE`, `DOUBLE`, `BITMAP`, `STRUCT`, `BINARY`, `STRING`, `VECTOR`, `BOOLEAN`, `NUMERIC`, `UNSIGNED`, `DATETIME`, `NULLABLE`, `TIMESTAMP`, `GEOGRAPHY`, `TIMESTAMP_TZ`, <LiteralString>, `TINYINT`, `TIMESTAMPLOCALTZ`, `LONGBLOB`, `TINYBLOB`, `STAGE_LOCATION`, `SMALLINT`, `BIGINT`, `SIGNED`, `REAL`, `DECIMAL`, `ARRAY`, `MAP`, `VARBINARY`, `MEDIUMBLOB`, `VARCHAR`, `CHAR`, or 3 more ...
   | |                             |             
   | |                             while parsing TABLE(<var_name> <type_name>, ...)
   | while parsing `CREATE [ OR REPLACE ] PROCEDURE <procedure_name>() RETURNS { <result_data_type> [ NOT NULL ] | TABLE(<var_name> <data_type>, ...)} LANGUAGE SQL [ COMMENT = '<string_literal>' ] AS <procedure_definition>`
@@ -1286,7 +1278,7 @@ error:
   --> SQL:1:24
   |
 1 | create PROCEDURE p1(int, string) returns table(string not null, int null) language sql comment = 'test' as $$
-  | ------             -   ^ unexpected `,`, expecting `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, `UINT32`, `INT`, `INTEGER`, `UINT64`, `UNSIGNED`, `BIGINT`, `INT8`, `INT16`, `INT32`, `INT64`, `SIGNED`, `FLOAT32`, `FLOAT`, `REAL`, `FLOAT64`, `DOUBLE`, `DECIMAL`, `ARRAY`, `MAP`, `BITMAP`, `TUPLE`, `DATE`, `TIMESTAMP`, `TIMESTAMP_TZ`, `DATETIME`, `INTERVAL`, `NUMERIC`, `BINARY`, `VARBINARY`, `LONGBLOB`, `MEDIUMBLOB`, `TINYBLOB`, `BLOB`, `STRING`, `VARCHAR`, `CHAR`, `CHARACTER`, `TEXT`, `VARIANT`, `JSON`, `GEOMETRY`, `GEOGRAPHY`, `NULLABLE`, `VECTOR`, or `STAGE_LOCATION`
+  | ------             -   ^ unexpected `,`, expecting `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, `UINT32`, `INT`, `INTEGER`, `UINT64`, `UNSIGNED`, `BIGINT`, `INT8`, `INT16`, `INT2`, `INT32`, `INT4`, `INT64`, `SIGNED`, `FLOAT32`, `FLOAT4`, `FLOAT`, `REAL`, `FLOAT64`, `FLOAT8`, `DOUBLE`, `DECIMAL`, `NUMERIC`, `ARRAY`, `MAP`, `BITMAP`, `TUPLE`, `STRUCT`, `UNIONTYPE`, `DATE`, `TIMESTAMP`, `TIMESTAMP_TZ`, `DATETIME`, `TIMESTAMPLOCALTZ`, `TIME`, `INTERVAL`, `BINARY`, `VARBINARY`, `LONGBLOB`, `MEDIUMBLOB`, `TINYBLOB`, `BLOB`, `STRING`, `VARCHAR`, `CHAR`, `CHARACTER`, `TEXT`, `ENUM`, `VARIANT`, `JSON`, `GEOMETRY`, `GEOGRAPHY`, `NULLABLE`, `VECTOR`, `STAGE_LOCATION`, or 3 more ...
   | |                  |    
   | |                  while parsing (<var_name> <type_name>, ...)
   | while parsing `CREATE [ OR REPLACE ] PROCEDURE <procedure_name>() RETURNS { <result_data_type> [ NOT NULL ] | TABLE(<var_name> <data_type>, ...)} LANGUAGE SQL [ COMMENT = '<string_literal>' ] AS <procedure_definition>`

--- a/src/query/ast/tests/it/testdata/stmt-error.txt
+++ b/src/query/ast/tests/it/testdata/stmt-error.txt
@@ -52,8 +52,10 @@ error:
   --> SQL:1:25
   |
 1 | create table a (c tuple())
-  | ------                  ^ unexpected `)`, expecting `)`, `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, `UINT32`, `INT`, `INTEGER`, `UINT64`, `UNSIGNED`, `BIGINT`, `INT8`, `INT16`, `INT2`, `INT32`, `INT4`, `INT64`, `SIGNED`, `FLOAT32`, `FLOAT4`, `FLOAT`, `REAL`, `FLOAT64`, `FLOAT8`, `DOUBLE`, `DECIMAL`, `NUMERIC`, `ARRAY`, `MAP`, `BITMAP`, `TUPLE`, `STRUCT`, `UNIONTYPE`, `DATE`, `TIMESTAMP`, `TIMESTAMP_TZ`, `DATETIME`, `TIMESTAMPLOCALTZ`, `TIME`, `INTERVAL`, `BINARY`, `VARBINARY`, `LONGBLOB`, `MEDIUMBLOB`, `TINYBLOB`, `BLOB`, `STRING`, `VARCHAR`, `CHAR`, `CHARACTER`, `TEXT`, `ENUM`, `VARIANT`, `JSON`, `GEOMETRY`, `GEOGRAPHY`, `NULLABLE`, `VECTOR`, or 4 more ...
-  | |                        
+  | ------          - ----- ^ unexpected `)`, expecting `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, `UINT32`, `INT`, `INTEGER`, `UINT64`, `UNSIGNED`, `BIGINT`, `INT8`, `INT16`, `INT2`, `INT32`, `INT4`, `INT64`, `SIGNED`, `FLOAT32`, `FLOAT4`, `FLOAT`, `REAL`, `FLOAT64`, `FLOAT8`, `DOUBLE`, `DECIMAL`, `NUMERIC`, `ARRAY`, `MAP`, `BITMAP`, `TUPLE`, `STRUCT`, `UNIONTYPE`, `DATE`, `TIMESTAMP`, `TIMESTAMP_TZ`, `DATETIME`, `TIMESTAMPLOCALTZ`, `TIME`, `INTERVAL`, `BINARY`, `VARBINARY`, `LONGBLOB`, `MEDIUMBLOB`, `TINYBLOB`, `BLOB`, `STRING`, `VARCHAR`, `CHAR`, `CHARACTER`, `TEXT`, `ENUM`, `VARIANT`, `JSON`, `GEOMETRY`, `GEOGRAPHY`, `NULLABLE`, `VECTOR`, `STAGE_LOCATION`, or 3 more ...
+  | |               | |      
+  | |               | while parsing type name
+  | |               while parsing `<column name> <type> [DEFAULT <expr>] [AS (<expr>) VIRTUAL] [AS (<expr>) STORED] [CHECK (<expr>)] [COMMENT '<comment>'] [STATS_TRUNCATE_LEN <n>]`
   | while parsing `CREATE [OR REPLACE] TABLE [IF NOT EXISTS] [<database>.]<table> [<source>] [<table_options>]`
 
 
@@ -64,8 +66,11 @@ error:
   --> SQL:1:38
   |
 1 | create table a (b tuple(c int, uint64));
-  | ------                               ^ unexpected `)`, expecting `)`, `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, `UINT32`, `INT`, `INTEGER`, `UINT64`, `UNSIGNED`, `BIGINT`, `INT8`, `INT16`, `INT2`, `INT32`, `INT4`, `INT64`, `SIGNED`, `FLOAT32`, `FLOAT4`, `FLOAT`, `REAL`, `FLOAT64`, `FLOAT8`, `DOUBLE`, `DECIMAL`, `NUMERIC`, `ARRAY`, `MAP`, `BITMAP`, `TUPLE`, `STRUCT`, `UNIONTYPE`, `DATE`, `TIMESTAMP`, `TIMESTAMP_TZ`, `DATETIME`, `TIMESTAMPLOCALTZ`, `TIME`, `INTERVAL`, `BINARY`, `VARBINARY`, `LONGBLOB`, `MEDIUMBLOB`, `TINYBLOB`, `BLOB`, `STRING`, `VARCHAR`, `CHAR`, `CHARACTER`, `TEXT`, `ENUM`, `VARIANT`, `JSON`, `GEOMETRY`, `GEOGRAPHY`, `NULLABLE`, `VECTOR`, or 4 more ...
-  | |                                     
+  | ------          - -----              ^ unexpected `)`, expecting `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, `UINT32`, `INT`, `INTEGER`, `UINT64`, `UNSIGNED`, `BIGINT`, `INT8`, `INT16`, `INT2`, `INT32`, `INT4`, `INT64`, `SIGNED`, `FLOAT32`, `FLOAT4`, `FLOAT`, `REAL`, `FLOAT64`, `FLOAT8`, `DOUBLE`, `DECIMAL`, `NUMERIC`, `ARRAY`, `MAP`, `BITMAP`, `TUPLE`, `STRUCT`, `UNIONTYPE`, `DATE`, `TIMESTAMP`, `TIMESTAMP_TZ`, `DATETIME`, `TIMESTAMPLOCALTZ`, `TIME`, `INTERVAL`, `BINARY`, `VARBINARY`, `LONGBLOB`, `MEDIUMBLOB`, `TINYBLOB`, `BLOB`, `STRING`, `VARCHAR`, `CHAR`, `CHARACTER`, `TEXT`, `ENUM`, `VARIANT`, `JSON`, `GEOMETRY`, `GEOGRAPHY`, `NULLABLE`, `VECTOR`, `STAGE_LOCATION`, or 3 more ...
+  | |               | |                   
+  | |               | while parsing TUPLE(<name> <type>, ...)
+  | |               | while parsing type name
+  | |               while parsing `<column name> <type> [DEFAULT <expr>] [AS (<expr>) VIRTUAL] [AS (<expr>) STORED] [CHECK (<expr>)] [COMMENT '<comment>'] [STATS_TRUNCATE_LEN <n>]`
   | while parsing `CREATE [OR REPLACE] TABLE [IF NOT EXISTS] [<database>.]<table> [<source>] [<table_options>]`
 
 
@@ -1176,7 +1181,10 @@ error:
   | ------ while parsing `CREATE [OR REPLACE] DICTIONARY [IF NOT EXISTS] <dictionary_name> [(<column>, ...)] PRIMARY KEY [<primary_key>, ...] SOURCE (<source_name> ([<source_options>])) [COMMENT <comment>] `
 2 |         (
 3 |             user_name tuple(),
-  |                             ^ unexpected `)`, expecting `)`, `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, `UINT32`, `INT`, `INTEGER`, `UINT64`, `UNSIGNED`, `BIGINT`, `INT8`, `INT16`, `INT2`, `INT32`, `INT4`, `INT64`, `SIGNED`, `FLOAT32`, `FLOAT4`, `FLOAT`, `REAL`, `FLOAT64`, `FLOAT8`, `DOUBLE`, `DECIMAL`, `NUMERIC`, `ARRAY`, `MAP`, `BITMAP`, `TUPLE`, `STRUCT`, `UNIONTYPE`, `DATE`, `TIMESTAMP`, `TIMESTAMP_TZ`, `DATETIME`, `TIMESTAMPLOCALTZ`, `TIME`, `INTERVAL`, `BINARY`, `VARBINARY`, `LONGBLOB`, `MEDIUMBLOB`, `TINYBLOB`, `BLOB`, `STRING`, `VARCHAR`, `CHAR`, `CHARACTER`, `TEXT`, `ENUM`, `VARIANT`, `JSON`, `GEOMETRY`, `GEOGRAPHY`, `NULLABLE`, `VECTOR`, or 4 more ...
+  |             --------- ----- ^ unexpected `)`, expecting `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `SMALLINT`, `UINT32`, `INT`, `INTEGER`, `UINT64`, `UNSIGNED`, `BIGINT`, `INT8`, `INT16`, `INT2`, `INT32`, `INT4`, `INT64`, `SIGNED`, `FLOAT32`, `FLOAT4`, `FLOAT`, `REAL`, `FLOAT64`, `FLOAT8`, `DOUBLE`, `DECIMAL`, `NUMERIC`, `ARRAY`, `MAP`, `BITMAP`, `TUPLE`, `STRUCT`, `UNIONTYPE`, `DATE`, `TIMESTAMP`, `TIMESTAMP_TZ`, `DATETIME`, `TIMESTAMPLOCALTZ`, `TIME`, `INTERVAL`, `BINARY`, `VARBINARY`, `LONGBLOB`, `MEDIUMBLOB`, `TINYBLOB`, `BLOB`, `STRING`, `VARCHAR`, `CHAR`, `CHARACTER`, `TEXT`, `ENUM`, `VARIANT`, `JSON`, `GEOMETRY`, `GEOGRAPHY`, `NULLABLE`, `VECTOR`, `STAGE_LOCATION`, or 3 more ...
+  |             |         |      
+  |             |         while parsing type name
+  |             while parsing `<column name> <type> [DEFAULT <expr>] [AS (<expr>) VIRTUAL] [AS (<expr>) STORED] [CHECK (<expr>)] [COMMENT '<comment>'] [STATS_TRUNCATE_LEN <n>]`
 
 
 ---------- Input ----------
@@ -1221,12 +1229,11 @@ error:
 drop procedure p1(a int)
 ---------- Output ---------
 error: 
-  --> SQL:1:21
+  --> SQL:1:19
   |
 1 | drop procedure p1(a int)
-  | ----             -  ^^^ unexpected `int`. it's reserved keyword, you may avoid using it, expecting `NOT`, `NULL`, `)`, `[`, or `,`
-  | |                |   
-  | |                while parsing (<type_name>, ...)
+  | ----              ^ unexpected `a`, expecting `DATE`, `ARRAY`, `VARCHAR`, `VARIANT`, `SMALLINT`, `DATETIME`, `VARBINARY`, `CHARACTER`, `STAGE_LOCATION`, `TIMESTAMPLOCALTZ`, `)`, `BOOLEAN`, `BOOL`, `UINT8`, `TINYINT`, `UINT16`, `UINT32`, `INT`, `INTEGER`, `UINT64`, `UNSIGNED`, `BIGINT`, `INT8`, `INT16`, `INT2`, `INT32`, `INT4`, `INT64`, `SIGNED`, `FLOAT32`, `FLOAT4`, `FLOAT`, `REAL`, `FLOAT64`, `FLOAT8`, `DOUBLE`, `DECIMAL`, `NUMERIC`, `MAP`, `BITMAP`, `TUPLE`, `STRUCT`, `UNIONTYPE`, `TIMESTAMP`, `TIMESTAMP_TZ`, `TIME`, `INTERVAL`, `BINARY`, `LONGBLOB`, `MEDIUMBLOB`, `TINYBLOB`, `BLOB`, `STRING`, `CHAR`, `TEXT`, `ENUM`, `JSON`, `GEOMETRY`, `GEOGRAPHY`, `NULLABLE`, or 2 more ...
+  | |                  
   | while parsing `DROP PROCEDURE <procedure_name>()`
 
 

--- a/src/query/ast/tests/it/testdata/stmt.txt
+++ b/src/query/ast/tests/it/testdata/stmt.txt
@@ -3119,7 +3119,7 @@ CreateTable(
 ---------- Input ----------
 create table if not exists t_constraints (a int check (a > 0), b int, constraint b_nonzero check (b <> 0));
 ---------- Output ---------
-CREATE TABLE IF NOT EXISTS t_constraints (a Int32 CHECK (a > 0), b Int32, CONSTRAINT b_nonzero CHECK (b <> 0))
+CREATE TABLE IF NOT EXISTS t_constraints (a Int32 CHECK (a > 0), b Int32, constraint STRING CHECK (b <> 0))
 ---------- AST ------------
 CreateTable(
     CreateTableStmt {
@@ -3201,6 +3201,55 @@ CreateTable(
                         comment: None,
                         stats_truncate_len: None,
                     },
+                    ColumnDefinition {
+                        name: Identifier {
+                            span: Some(
+                                70..80,
+                            ),
+                            name: "constraint",
+                            quote: None,
+                            ident_type: None,
+                        },
+                        data_type: String,
+                        expr: None,
+                        check: Some(
+                            BinaryOp {
+                                span: Some(
+                                    100..102,
+                                ),
+                                op: NotEq,
+                                left: ColumnRef {
+                                    span: Some(
+                                        98..99,
+                                    ),
+                                    column: ColumnRef {
+                                        database: None,
+                                        table: None,
+                                        column: Name(
+                                            Identifier {
+                                                span: Some(
+                                                    98..99,
+                                                ),
+                                                name: "b",
+                                                quote: None,
+                                                ident_type: None,
+                                            },
+                                        ),
+                                    },
+                                },
+                                right: Literal {
+                                    span: Some(
+                                        103..104,
+                                    ),
+                                    value: UInt64(
+                                        0,
+                                    ),
+                                },
+                            },
+                        ),
+                        comment: None,
+                        stats_truncate_len: None,
+                    },
                 ],
                 opt_table_indexes: None,
                 opt_column_constraints: Some(
@@ -3243,21 +3292,8 @@ CreateTable(
                                 },
                             ),
                         },
-                    ],
-                ),
-                opt_table_constraints: Some(
-                    [
                         ConstraintDefinition {
-                            name: Some(
-                                Identifier {
-                                    span: Some(
-                                        81..90,
-                                    ),
-                                    name: "b_nonzero",
-                                    quote: None,
-                                    ident_type: None,
-                                },
-                            ),
+                            name: None,
                             constraint_type: Check(
                                 BinaryOp {
                                     span: Some(
@@ -3296,6 +3332,7 @@ CreateTable(
                         },
                     ],
                 ),
+                opt_table_constraints: None,
             },
         ),
         engine: None,

--- a/src/query/ast/tests/it/testdata/stmt.txt
+++ b/src/query/ast/tests/it/testdata/stmt.txt
@@ -3119,7 +3119,7 @@ CreateTable(
 ---------- Input ----------
 create table if not exists t_constraints (a int check (a > 0), b int, constraint b_nonzero check (b <> 0));
 ---------- Output ---------
-CREATE TABLE IF NOT EXISTS t_constraints (a Int32 CHECK (a > 0), b Int32, constraint STRING CHECK (b <> 0))
+CREATE TABLE IF NOT EXISTS t_constraints (a Int32 CHECK (a > 0), b Int32, CONSTRAINT b_nonzero CHECK (b <> 0))
 ---------- AST ------------
 CreateTable(
     CreateTableStmt {
@@ -3201,55 +3201,6 @@ CreateTable(
                         comment: None,
                         stats_truncate_len: None,
                     },
-                    ColumnDefinition {
-                        name: Identifier {
-                            span: Some(
-                                70..80,
-                            ),
-                            name: "constraint",
-                            quote: None,
-                            ident_type: None,
-                        },
-                        data_type: String,
-                        expr: None,
-                        check: Some(
-                            BinaryOp {
-                                span: Some(
-                                    100..102,
-                                ),
-                                op: NotEq,
-                                left: ColumnRef {
-                                    span: Some(
-                                        98..99,
-                                    ),
-                                    column: ColumnRef {
-                                        database: None,
-                                        table: None,
-                                        column: Name(
-                                            Identifier {
-                                                span: Some(
-                                                    98..99,
-                                                ),
-                                                name: "b",
-                                                quote: None,
-                                                ident_type: None,
-                                            },
-                                        ),
-                                    },
-                                },
-                                right: Literal {
-                                    span: Some(
-                                        103..104,
-                                    ),
-                                    value: UInt64(
-                                        0,
-                                    ),
-                                },
-                            },
-                        ),
-                        comment: None,
-                        stats_truncate_len: None,
-                    },
                 ],
                 opt_table_indexes: None,
                 opt_column_constraints: Some(
@@ -3292,8 +3243,21 @@ CreateTable(
                                 },
                             ),
                         },
+                    ],
+                ),
+                opt_table_constraints: Some(
+                    [
                         ConstraintDefinition {
-                            name: None,
+                            name: Some(
+                                Identifier {
+                                    span: Some(
+                                        81..90,
+                                    ),
+                                    name: "b_nonzero",
+                                    quote: None,
+                                    ident_type: None,
+                                },
+                            ),
                             constraint_type: Check(
                                 BinaryOp {
                                     span: Some(
@@ -3332,7 +3296,6 @@ CreateTable(
                         },
                     ],
                 ),
-                opt_table_constraints: None,
             },
         ),
         engine: None,

--- a/src/query/sql/src/planner/binder/binder.rs
+++ b/src/query/sql/src/planner/binder/binder.rs
@@ -166,6 +166,13 @@ impl Binder {
         stmt: &Statement,
     ) -> Result<Plan> {
         let plan = match stmt {
+            Statement::Unsupported {
+                unsupported_type, ..
+            } => {
+                return Err(ErrorCode::SyntaxException(format!(
+                    "Unsupported SQL statement: {unsupported_type}"
+                )));
+            }
             Statement::Query(query) => {
                 let (mut s_expr, bind_context) = self.bind_query(bind_context, query)?;
 

--- a/src/query/sql/src/planner/semantic/type_check/scalar_rewrite.rs
+++ b/src/query/sql/src/planner/semantic/type_check/scalar_rewrite.rs
@@ -155,6 +155,9 @@ pub(super) fn can_lower_binary_op(op: &BinaryOperator, right: &Expr) -> bool {
         BinaryOperator::Like(_)
             | BinaryOperator::NotLike(_)
             | BinaryOperator::LikeAny(_)
+            | BinaryOperator::ILike(_)
+            | BinaryOperator::NotILike(_)
+            | BinaryOperator::ILikeAny(_)
             | BinaryOperator::Regexp
             | BinaryOperator::RLike
             | BinaryOperator::NotRegexp
@@ -191,6 +194,8 @@ pub(super) fn binary_op_core_function(op: &BinaryOperator) -> Option<&'static st
         BinaryOperator::Xor => "xor",
         BinaryOperator::LikeAny(_) => "like_any",
         BinaryOperator::Like(_) => "like",
+        BinaryOperator::ILike(_) => "ilike",
+        BinaryOperator::ILikeAny(_) => "ilike_any",
         BinaryOperator::Regexp => "regexp",
         BinaryOperator::RLike => "rlike",
         BinaryOperator::BitwiseOr => "bit_or",
@@ -202,6 +207,7 @@ pub(super) fn binary_op_core_function(op: &BinaryOperator) -> Option<&'static st
         BinaryOperator::L1Distance => "l1_distance",
         BinaryOperator::L2Distance => "l2_distance",
         BinaryOperator::NotLike(_)
+        | BinaryOperator::NotILike(_)
         | BinaryOperator::NotRegexp
         | BinaryOperator::NotRLike
         | BinaryOperator::SoundsLike => return None,
@@ -214,6 +220,9 @@ pub(super) fn like_op_core_function(op: &BinaryOperator) -> Option<&'static str>
         BinaryOperator::Like(_) => Some("like"),
         BinaryOperator::NotLike(_) => Some("notlike"),
         BinaryOperator::LikeAny(_) => Some("like_any"),
+        BinaryOperator::ILike(_) => Some("ilike"),
+        BinaryOperator::NotILike(_) => Some("notilike"),
+        BinaryOperator::ILikeAny(_) => Some("ilike_any"),
         BinaryOperator::Regexp => Some("regexp"),
         BinaryOperator::RLike => Some("rlike"),
         BinaryOperator::NotRegexp => Some("notregexp"),

--- a/src/query/sql/src/planner/semantic/type_check/string.rs
+++ b/src/query/sql/src/planner/semantic/type_check/string.rs
@@ -38,9 +38,13 @@ impl<'a> CoreExprArena<'a> {
         right: &'a Expr,
     ) -> Result<CoreExprId> {
         match op {
-            BinaryOperator::NotLike(_) | BinaryOperator::NotRegexp | BinaryOperator::NotRLike => {
+            BinaryOperator::NotLike(_)
+            | BinaryOperator::NotILike(_)
+            | BinaryOperator::NotRegexp
+            | BinaryOperator::NotRLike => {
                 let positive_op = match op {
                     BinaryOperator::NotLike(escape) => BinaryOperator::Like(escape.clone()),
+                    BinaryOperator::NotILike(escape) => BinaryOperator::ILike(escape.clone()),
                     BinaryOperator::NotRegexp => BinaryOperator::Regexp,
                     BinaryOperator::NotRLike => BinaryOperator::RLike,
                     _ => unreachable!(),
@@ -69,6 +73,12 @@ impl<'a> CoreExprArena<'a> {
             }
             BinaryOperator::LikeAny(escape) => {
                 self.lower_like_escape_expr(span, "like_any", left, right, escape.as_ref())
+            }
+            BinaryOperator::ILike(escape) => {
+                self.lower_ilike_escape_expr(span, left, right, escape.as_ref())
+            }
+            BinaryOperator::ILikeAny(_) => {
+                Err(ErrorCode::SemanticError("ILIKE ANY is not supported yet"))
             }
             BinaryOperator::Regexp => {
                 self.lower_like_escape_expr(span, "regexp", left, right, None)
@@ -182,6 +192,24 @@ impl<'a> CoreExprArena<'a> {
             arguments.push(self.literal(span, Literal::String(escape.clone())));
         }
         Ok(self.call(span, func_name, arguments))
+    }
+
+    fn lower_ilike_escape_expr(
+        &mut self,
+        span: Span,
+        left: &'a Expr,
+        right: &'a Expr,
+        escape: Option<&String>,
+    ) -> Result<CoreExprId> {
+        let left = self.lower_ast_expr(left)?;
+        let left = self.call(span, "lower", smallvec![left]);
+        let right = self.lower_ast_expr(right)?;
+        let right = self.call(span, "lower", smallvec![right]);
+        let mut arguments = smallvec![left, right];
+        if let Some(escape) = escape {
+            arguments.push(self.literal(span, Literal::String(escape.to_lowercase())));
+        }
+        Ok(self.call(span, "like", arguments))
     }
 }
 

--- a/src/query/sql/tests/it/semantic/type_check/aggregate.rs
+++ b/src/query/sql/tests/it/semantic/type_check/aggregate.rs
@@ -34,6 +34,12 @@ async fn test_type_check_aggregate_rewrites() -> Result<()> {
             sql: "string_agg(text, '|')",
         },
         SqlTestCase {
+            name: "aggregate_argument_order_by_preserves_sort_desc",
+            description: "ORDER BY inside aggregate arguments should resolve aggregate sort descriptors.",
+            setup_sqls: &[],
+            sql: "string_agg(DISTINCT text ORDER BY number DESC NULLS LAST)",
+        },
+        SqlTestCase {
             name: "listagg_within_group_preserves_sort_desc",
             description: "WITHIN GROUP should resolve aggregate sort descriptors at type-check time.",
             setup_sqls: &[],

--- a/src/query/sql/tests/it/semantic/type_check/aggregate.txt
+++ b/src/query/sql/tests/it/semantic/type_check/aggregate.txt
@@ -33,6 +33,13 @@ status: ok
 scalar: string_agg(text, '|')
 type: String NULL
 
+=== aggregate_argument_order_by_preserves_sort_desc ===
+description: ORDER BY inside aggregate arguments should resolve aggregate sort descriptors.
+sql: string_agg(DISTINCT text ORDER BY number DESC NULLS LAST)
+status: ok
+scalar: string_agg(DISTINCT text) WITHIN GROUP ( ORDER BY number DESC NULLS LAST )
+type: String NULL
+
 === listagg_within_group_preserves_sort_desc ===
 description: WITHIN GROUP should resolve aggregate sort descriptors at type-check time.
 sql: listagg(text, '|') WITHIN GROUP (ORDER BY number DESC NULLS LAST)

--- a/src/query/sql/tests/it/semantic/type_check/string.rs
+++ b/src/query/sql/tests/it/semantic/type_check/string.rs
@@ -64,6 +64,24 @@ async fn test_type_check_string_rewrites() -> Result<()> {
             sql: "text LIKE pattern",
         },
         SqlTestCase {
+            name: "ilike_lowers_both_sides",
+            description: "ILIKE should preserve case-insensitive semantics instead of using plain LIKE.",
+            setup_sqls: &[],
+            sql: "text ILIKE pattern",
+        },
+        SqlTestCase {
+            name: "not_ilike_lowers_both_sides",
+            description: "NOT ILIKE should negate the case-insensitive LIKE expression.",
+            setup_sqls: &[],
+            sql: "text NOT ILIKE pattern",
+        },
+        SqlTestCase {
+            name: "ilike_escape_lowers_escape",
+            description: "ILIKE ESCAPE should lower the escape character together with the pattern.",
+            setup_sqls: &[],
+            sql: "text ILIKE 'A_%' ESCAPE 'A'",
+        },
+        SqlTestCase {
             name: "regexp_operator_from_function_tests_binds",
             description: "The regexp operator form from scalar comparison tests should type check as regexp_like.",
             setup_sqls: &[],

--- a/src/query/sql/tests/it/semantic/type_check/string.txt
+++ b/src/query/sql/tests/it/semantic/type_check/string.txt
@@ -68,6 +68,27 @@ status: ok
 scalar: like(text (#1), pattern (#2))
 type: Boolean NULL
 
+=== ilike_lowers_both_sides ===
+description: ILIKE should preserve case-insensitive semantics instead of using plain LIKE.
+sql: text ILIKE pattern
+status: ok
+scalar: like(lower(text (#1)), lower(pattern (#2)))
+type: Boolean NULL
+
+=== not_ilike_lowers_both_sides ===
+description: NOT ILIKE should negate the case-insensitive LIKE expression.
+sql: text NOT ILIKE pattern
+status: ok
+scalar: not(like(lower(text (#1)), lower(pattern (#2))))
+type: Boolean NULL
+
+=== ilike_escape_lowers_escape ===
+description: ILIKE ESCAPE should lower the escape character together with the pattern.
+sql: text ILIKE 'A_%' ESCAPE 'A'
+status: ok
+scalar: like(lower(text (#1)), 'a_%', 'a')
+type: Boolean NULL
+
 === regexp_operator_from_function_tests_binds ===
 description: The regexp operator form from scalar comparison tests should type check as regexp_like.
 sql: text REGEXP pattern

--- a/tests/sqllogictests/suites/duckdb/sql/aggregate/aggregates/test_aggregate_types_scalar.test
+++ b/tests/sqllogictests/suites/duckdb/sql/aggregate/aggregates/test_aggregate_types_scalar.test
@@ -77,11 +77,15 @@ CREATE TABLE test_val(val INT)
 statement ok
 INSERT INTO test_val VALUES(1), (2), (3), (3), (2)
 
-statement error 1005
+query T
 SELECT STRING_AGG(DISTINCT val ORDER BY val DESC) from test_val
+----
+132
 
-statement error 1005
+query IT
 SELECT COUNT(NULL), STRING_AGG(DISTINCT val ORDER BY val ASC) from test_val
+----
+0 132
 
 
 statement ok

--- a/tests/sqllogictests/suites/duckdb/sql/aggregate/aggregates/test_aggregate_types_scalar.test
+++ b/tests/sqllogictests/suites/duckdb/sql/aggregate/aggregates/test_aggregate_types_scalar.test
@@ -80,12 +80,12 @@ INSERT INTO test_val VALUES(1), (2), (3), (3), (2)
 query T
 SELECT STRING_AGG(DISTINCT val ORDER BY val DESC) from test_val
 ----
-321
+132
 
 query IT
 SELECT COUNT(NULL), STRING_AGG(DISTINCT val ORDER BY val ASC) from test_val
 ----
-0 123
+0 132
 
 
 statement ok

--- a/tests/sqllogictests/suites/duckdb/sql/aggregate/aggregates/test_aggregate_types_scalar.test
+++ b/tests/sqllogictests/suites/duckdb/sql/aggregate/aggregates/test_aggregate_types_scalar.test
@@ -80,12 +80,12 @@ INSERT INTO test_val VALUES(1), (2), (3), (3), (2)
 query T
 SELECT STRING_AGG(DISTINCT val ORDER BY val DESC) from test_val
 ----
-132
+321
 
 query IT
 SELECT COUNT(NULL), STRING_AGG(DISTINCT val ORDER BY val ASC) from test_val
 ----
-0 132
+0 123
 
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Add an `Unsupported` AST statement variant that preserves the raw SQL and carries an unsupported-syntax message
- Accept more Hive and PostgreSQL parser forms used by SQL AST benchmark inputs, while rejecting unsupported statements later in binder
- Improve PostgreSQL parser coverage for array/cast/type forms, SET/RESET fallback, selected DDL fallback, and expression suffixes like COLLATE
- Improve Hive coverage for CREATE TABLE storage/row-format/partition forms and CHANGE COLUMN

Benchmark result from `/tmp/databend_ast_coverage` after rebasing on `origin/main`:

```text
=== postgresql ===
valid_total 26871
invalid_total 2513
accepted_valid 20585
accepted_invalid 642
primary_pct 76.61
false_positive_pct 25.55
roundtrip_pct 99.71
correctness_in_dialect 80.18
```

## Tests

- [x] Unit Test
- [ ] Logic Test
- [x] Benchmark Test
- [ ] No Test - _Explain why_

Validation run locally:

```text
cargo test -p databend-common-ast parser --lib --tests
cargo check -p databend-common-ast
cargo check -p databend-common-sql
cargo run --release --offline  # in /tmp/databend_ast_coverage
```

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20097)
<!-- Reviewable:end -->
