### PR TITLE
fix(storage): refresh stats after txn retry

### DIFF
--- a/src/query/storages/fuse/src/retry/commit.rs
+++ b/src/query/storages/fuse/src/retry/commit.rs
@@ -26,6 +26,7 @@ use databend_common_meta_app::schema::UpdateTableMetaReq;
 use databend_meta_client::types::MatchSeq;
 use databend_storages_common_cache::Table;
 use databend_storages_common_cache::TableSnapshot;
+use databend_storages_common_table_meta::meta::Statistics;
 use databend_storages_common_table_meta::meta::Versioned;
 use databend_storages_common_table_meta::meta::decode_column_hll;
 use databend_storages_common_table_meta::meta::encode_column_hll;
@@ -161,10 +162,6 @@ async fn try_rebuild_req(
         "try_rebuild_req: update_failed_tbls={:?}",
         update_failed_tbls
     );
-    let insert_rows = {
-        let txn_mgr = ctx.txn_mgr();
-        txn_mgr.lock().multi_table_insert_rows()
-    };
     let txn_mgr = ctx.txn_mgr();
     for (tid, seq, table_meta) in update_failed_tbls {
         if table_meta.engine == "STREAM" {
@@ -222,19 +219,18 @@ async fn try_rebuild_req(
             })?
             .clone();
 
-        let s = merge_statistics(
-            new_snapshot.summary(),
-            &latest_snapshot.summary(),
-            default_cluster_key_id,
-        );
-        let mut merged_summary = deduct_statistics(&s, &base_snapshot.summary());
+        let base_summary = base_snapshot.summary();
+        let new_summary = new_snapshot.summary();
+        let latest_summary = latest_snapshot.summary();
+        let s = merge_statistics(new_summary.clone(), &latest_summary, default_cluster_key_id);
+        let mut merged_summary = deduct_statistics(&s, &base_summary);
         let mut additional_stats_meta = latest_snapshot.additional_stats_meta();
-        let insert_row = insert_rows.get(&tid).cloned().unwrap_or(0);
+        let stats_row_delta = insert_stats_row_delta(&base_summary, &new_summary);
         let new_hll = new_snapshot
             .as_ref()
             .and_then(|v| v.summary.additional_stats_meta.as_ref())
             .and_then(|m| m.hll.as_ref());
-        if insert_row > 0 && new_hll.is_some_and(|v| !v.is_empty()) {
+        if stats_row_delta > 0 && new_hll.is_some_and(|v| !v.is_empty()) {
             if let Some(ref mut latest_metas) = additional_stats_meta {
                 let new_hll = decode_column_hll(new_hll.unwrap())?.unwrap();
                 let latest_hll = latest_metas
@@ -247,7 +243,7 @@ async fn try_rebuild_req(
                 let merged = merge_column_hll(new_hll, latest_hll);
                 if !merged.is_empty() {
                     latest_metas.hll = Some(encode_column_hll(&merged)?);
-                    latest_metas.row_count += insert_row;
+                    latest_metas.row_count += stats_row_delta;
                 }
             }
         }
@@ -350,6 +346,25 @@ async fn try_rebuild_req(
     Ok(())
 }
 
+fn insert_stats_row_delta(base_summary: &Statistics, new_summary: &Statistics) -> u64 {
+    let inserted_rows = new_summary.row_count.saturating_sub(base_summary.row_count);
+    if inserted_rows == 0 {
+        return 0;
+    }
+
+    let Some(new_stats_meta) = new_summary.additional_stats_meta.as_ref() else {
+        return 0;
+    };
+
+    match base_summary.additional_stats_meta.as_ref() {
+        Some(base_stats_meta) => new_stats_meta
+            .row_count
+            .saturating_sub(base_stats_meta.row_count)
+            .min(inserted_rows),
+        None => new_stats_meta.row_count.min(inserted_rows),
+    }
+}
+
 fn retry_too_many_msg(
     retries: u32,
     start_time: Instant,
@@ -364,4 +379,62 @@ fn retry_too_many_msg(
             .map(|(tid, _, _)| tid)
             .collect::<Vec<_>>()
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_storages_common_table_meta::meta::AdditionalStatsMeta;
+
+    use super::*;
+
+    fn summary(row_count: u64, stats_row_count: Option<u64>) -> Statistics {
+        Statistics {
+            row_count,
+            additional_stats_meta: stats_row_count.map(|row_count| AdditionalStatsMeta {
+                row_count,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_insert_stats_row_delta_from_stats_meta() {
+        let base_summary = summary(100, Some(100));
+        let new_summary = summary(110, Some(110));
+
+        assert_eq!(insert_stats_row_delta(&base_summary, &new_summary), 10);
+    }
+
+    #[test]
+    fn test_insert_stats_row_delta_without_base_stats_meta() {
+        let base_summary = summary(100, None);
+        let new_summary = summary(110, Some(110));
+
+        assert_eq!(insert_stats_row_delta(&base_summary, &new_summary), 10);
+    }
+
+    #[test]
+    fn test_insert_stats_row_delta_without_new_stats_meta() {
+        let base_summary = summary(100, Some(100));
+        let new_summary = summary(110, None);
+
+        assert_eq!(insert_stats_row_delta(&base_summary, &new_summary), 0);
+    }
+
+    #[test]
+    fn test_insert_stats_row_delta_ignores_stats_refresh_without_insert() {
+        let base_summary = summary(100, Some(100));
+        let new_summary = summary(100, Some(130));
+
+        assert_eq!(insert_stats_row_delta(&base_summary, &new_summary), 0);
+    }
+
+    #[test]
+    fn test_insert_stats_row_delta_capped_by_inserted_rows() {
+        let base_summary = summary(100, Some(100));
+        let new_summary = summary(110, Some(130));
+
+        assert_eq!(insert_stats_row_delta(&base_summary, &new_summary), 10);
+    }
 }

--- a/tests/suites/0_stateless/01_transaction/01_04_txn_snapshot_retry.py
+++ b/tests/suites/0_stateless/01_transaction/01_04_txn_snapshot_retry.py
@@ -10,6 +10,8 @@ from mysql.connector import errors as mysql_errors
 
 
 TABLE_NAME = "txn_snapshot_retry_concurrency"
+STATS_DATABASE = "txn_snapshot_retry_stats_db"
+STATS_TABLE = "txn_snapshot_retry_stats"
 NUM_THREADS = 8
 TRANSACTIONS_PER_THREAD = 3
 ROWS_PER_TRANSACTION = 2
@@ -23,9 +25,9 @@ USER = os.getenv("QUERY_MYSQL_HANDLER_USER", "root")
 PASSWORD = os.getenv("QUERY_MYSQL_HANDLER_PASSWORD", "root")
 
 
-def create_connection():
+def create_connection(autocommit=False):
     conn = mysql.connector.connect(
-        host=HOST, port=PORT, user=USER, passwd=PASSWORD, autocommit=False
+        host=HOST, port=PORT, user=USER, passwd=PASSWORD, autocommit=autocommit
     )
     cursor = conn.cursor()
     return conn, cursor
@@ -36,6 +38,47 @@ def drain(cursor):
         cursor.fetchall()
     except mysql_errors.InterfaceError:
         pass
+
+
+def execute(cursor, sql: str) -> None:
+    cursor.execute(sql)
+    drain(cursor)
+
+
+def fetch_one(cursor, sql: str):
+    cursor.execute(sql)
+    rows = cursor.fetchall()
+    if len(rows) != 1:
+        raise AssertionError(f"Expected one row for {sql}, got {rows}")
+    return rows[0]
+
+
+def fetch_stats(cursor):
+    return fetch_one(
+        cursor,
+        f"""
+        SELECT stats_row_count, actual_row_count, distinct_count
+        FROM system.statistics
+        WHERE database = '{STATS_DATABASE}'
+          AND table = '{STATS_TABLE}'
+          AND column_name = 'a'
+        """,
+    )
+
+
+def assert_stats(cursor, expected_rows: int) -> None:
+    stats_row_count, actual_row_count, distinct_count = fetch_stats(cursor)
+    if stats_row_count != expected_rows or actual_row_count != expected_rows:
+        raise AssertionError(
+            "Expected stats_row_count and actual_row_count "
+            f"to be {expected_rows}; got stats_row_count={stats_row_count}, "
+            f"actual_row_count={actual_row_count}, distinct_count={distinct_count}"
+        )
+
+
+def use_stats_database(cursor) -> None:
+    execute(cursor, f"USE {STATS_DATABASE}")
+    execute(cursor, "SET enable_table_snapshot_stats = 1")
 
 
 def run_transaction_batch(thread_id: int) -> None:
@@ -82,13 +125,11 @@ def run_transaction_batch(thread_id: int) -> None:
         conn.close()
 
 
-def main() -> None:
+def verify_concurrent_transaction_retry() -> None:
     setup_conn, setup_cursor = create_connection()
     try:
-        setup_cursor.execute(f"DROP TABLE IF EXISTS {TABLE_NAME}")
-        drain(setup_cursor)
-        setup_cursor.execute(f"CREATE TABLE {TABLE_NAME} (id BIGINT)")
-        drain(setup_cursor)
+        execute(setup_cursor, f"DROP TABLE IF EXISTS {TABLE_NAME}")
+        execute(setup_cursor, f"CREATE TABLE {TABLE_NAME} (id BIGINT)")
     finally:
         setup_cursor.close()
         setup_conn.close()
@@ -123,12 +164,83 @@ def main() -> None:
         if duplicates:
             raise AssertionError(f"found duplicated segments: {duplicates}")
 
-        verify_cursor.execute(f"DROP TABLE IF EXISTS {TABLE_NAME}")
-        drain(verify_cursor)
+        execute(verify_cursor, f"DROP TABLE IF EXISTS {TABLE_NAME}")
     finally:
         verify_cursor.close()
         verify_conn.close()
 
+
+def verify_snapshot_stats_after_retry() -> None:
+    setup_conn, setup_cursor = create_connection(autocommit=True)
+    conn_a = cursor_a = conn_b = cursor_b = None
+    try:
+        execute(setup_cursor, f"DROP DATABASE IF EXISTS {STATS_DATABASE}")
+        execute(setup_cursor, f"CREATE DATABASE {STATS_DATABASE}")
+        use_stats_database(setup_cursor)
+        execute(setup_cursor, f"CREATE TABLE {STATS_TABLE}(a INT)")
+        execute(
+            setup_cursor,
+            f"INSERT INTO {STATS_TABLE} SELECT number::int FROM numbers(100)",
+        )
+        execute(setup_cursor, f"ANALYZE TABLE {STATS_TABLE}")
+        assert_stats(setup_cursor, 100)
+
+        conn_a, cursor_a = create_connection(autocommit=True)
+        conn_b, cursor_b = create_connection(autocommit=True)
+        use_stats_database(cursor_a)
+        use_stats_database(cursor_b)
+
+        execute(cursor_a, "BEGIN")
+        execute(
+            cursor_a,
+            f"INSERT INTO {STATS_TABLE} "
+            "SELECT (1000 + number)::int FROM numbers(10)",
+        )
+        count_in_a = fetch_one(
+            cursor_a,
+            f"SELECT count(*) FROM {STATS_TABLE}",
+        )[0]
+        if count_in_a != 110:
+            raise AssertionError(f"Expected session A to see 110 rows, got {count_in_a}")
+
+        execute(
+            cursor_b,
+            f"INSERT INTO {STATS_TABLE} "
+            "SELECT (2000 + number)::int FROM numbers(5)",
+        )
+        count_in_b = fetch_one(
+            cursor_b,
+            f"SELECT count(*) FROM {STATS_TABLE}",
+        )[0]
+        if count_in_b != 105:
+            raise AssertionError(f"Expected session B to see 105 rows, got {count_in_b}")
+        assert_stats(cursor_b, 105)
+
+        execute(cursor_a, "COMMIT")
+        count_after_commit = fetch_one(
+            cursor_a,
+            f"SELECT count(*) FROM {STATS_TABLE}",
+        )[0]
+        if count_after_commit != 115:
+            raise AssertionError(
+                f"Expected 115 rows after session A commit, got {count_after_commit}"
+            )
+        assert_stats(cursor_a, 115)
+    finally:
+        for cursor in (cursor_a, cursor_b):
+            if cursor is not None:
+                cursor.close()
+        for conn in (conn_a, conn_b):
+            if conn is not None:
+                conn.close()
+        execute(setup_cursor, f"DROP DATABASE IF EXISTS {STATS_DATABASE}")
+        setup_cursor.close()
+        setup_conn.close()
+
+
+def main() -> None:
+    verify_concurrent_transaction_retry()
+    verify_snapshot_stats_after_retry()
     print("Transaction snapshot retry looks good")
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Fix explicit transaction commit retry so snapshot statistics row count is merged from the transaction-generated snapshot metadata instead of the multi-table-insert-only row buffer.
- Preserve HLL merge behavior while using the additional stats row delta as the source of truth for retried commits.
- Add a stateless regression that reproduces the concurrent commit sequence from the issue and verifies `system.statistics.stats_row_count` matches `actual_row_count` after retry.

- fixes: #20007

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation run locally:

- `cargo fmt -p databend-common-storages-fuse --check`
- `git diff --check`
- `python3 -m py_compile tests/suites/0_stateless/01_transaction/01_04_txn_snapshot_retry.py`
- `cargo test -p databend-common-storages-fuse additional_stats_row_delta`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20098)
<!-- Reviewable:end -->
