### PR TITLE
fix(query): recheck function after cast elimination

### DIFF
--- a/src/query/storages/common/index/src/eliminate_cast.rs
+++ b/src/query/storages/common/index/src/eliminate_cast.rs
@@ -57,7 +57,22 @@ impl ExprVisitor<String> for RewriteVisitor<'_> {
                 return Ok(result);
             }
         }
-        Self::visit_function_call(call, self)
+        match Self::visit_function_call(call, self)? {
+            Some(Expr::FunctionCall(func)) => {
+                let name = func.id.name();
+                match check_function(
+                    func.span,
+                    name.as_ref(),
+                    func.id.params(),
+                    &func.args,
+                    self.fn_registry,
+                ) {
+                    Ok(expr) => Ok(Some(expr)),
+                    Err(_) => Ok(None),
+                }
+            }
+            result => Ok(result),
+        }
     }
 }
 

--- a/src/query/storages/common/index/tests/it/range_pruner.rs
+++ b/src/query/storages/common/index/tests/it/range_pruner.rs
@@ -17,18 +17,25 @@ use std::io::Write;
 use std::sync::Arc;
 
 use databend_common_base::base::OrderedFloat;
+use databend_common_expression::Cast;
+use databend_common_expression::ColumnRef;
+use databend_common_expression::Constant;
 use databend_common_expression::ConstantFolder;
+use databend_common_expression::Domain;
+use databend_common_expression::Expr;
 use databend_common_expression::FunctionContext;
 use databend_common_expression::Scalar;
 use databend_common_expression::TableDataType;
 use databend_common_expression::TableField;
 use databend_common_expression::TableSchema;
+use databend_common_expression::type_check::check_function;
 use databend_common_expression::types::ArgType;
 use databend_common_expression::types::DataType;
 use databend_common_expression::types::Int32Type;
 use databend_common_expression::types::NumberDataType;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_storages_common_index::RangeIndex;
+use databend_storages_common_index::eliminate_cast;
 use databend_storages_common_table_meta::meta::ColumnStatistics;
 use databend_storages_common_table_meta::meta::SpatialStatistics;
 use databend_storages_common_table_meta::meta::StatisticsOfColumns;
@@ -127,6 +134,61 @@ fn test_range_index_prunes_nullable_integer_column_eq_numeric_string_literal() {
     let index = RangeIndex::try_create(func_ctx, &expr, schema, Default::default()).unwrap();
 
     assert!(!index.apply(&stats, None, |_| false).unwrap());
+}
+
+#[test]
+fn test_range_index_keeps_nullable_boolean_cast_under_is_true() {
+    let func_ctx = FunctionContext::default();
+    let schema = Arc::new(TableSchema::new(vec![TableField::new(
+        "b",
+        TableDataType::Boolean,
+    )]));
+    let stats = create_stats(
+        &[("b", Scalar::Boolean(false), Scalar::Boolean(true))],
+        &schema,
+    );
+    let nullable_boolean = DataType::Boolean.wrap_nullable();
+    let column = Expr::ColumnRef(ColumnRef {
+        span: None,
+        id: "b".to_string(),
+        data_type: DataType::Boolean,
+        display_name: "b".to_string(),
+    });
+    let cast = Expr::Cast(Cast {
+        span: None,
+        is_try: false,
+        expr: Box::new(column),
+        dest_type: nullable_boolean.clone(),
+    });
+    let constant = Expr::Constant(Constant {
+        span: None,
+        scalar: Scalar::Boolean(true),
+        data_type: nullable_boolean,
+    });
+    let eq_expr = check_function(None, "eq", &[], &[cast, constant], &BUILTIN_FUNCTIONS).unwrap();
+    let expr = check_function(None, "is_true", &[], &[eq_expr], &BUILTIN_FUNCTIONS).unwrap();
+    let inverted_expr = check_function(
+        None,
+        "not",
+        &[],
+        std::slice::from_ref(&expr),
+        &BUILTIN_FUNCTIONS,
+    )
+    .unwrap();
+    let input_domains = [("b".to_string(), Domain::full(&DataType::Boolean))]
+        .into_iter()
+        .collect();
+
+    let rewritten_expr = eliminate_cast(&expr, input_domains).unwrap();
+    assert_eq!(rewritten_expr.data_type(), &DataType::Boolean);
+    let index = RangeIndex::try_create(func_ctx.clone(), &expr, schema.clone(), Default::default())
+        .unwrap();
+
+    assert!(index.apply(&stats, None, |_| false).unwrap());
+
+    let inverted_index =
+        RangeIndex::try_create(func_ctx, &inverted_expr, schema, Default::default()).unwrap();
+    assert!(inverted_index.apply(&stats, None, |_| false).unwrap());
 }
 
 #[test]

--- a/tests/sqllogictests/suites/query/union.test
+++ b/tests/sqllogictests/suites/query/union.test
@@ -365,6 +365,46 @@ select a, typeof(a), cast(a as string) as s from (select '1' as a union all sele
 1.00000 DECIMAL(38, 5) 1.00000
 
 statement ok
+drop table if exists tmp_union_bool_nn;
+
+statement ok
+drop table if exists tmp_union_bool_null;
+
+statement ok
+create table tmp_union_bool_nn(b boolean not null);
+
+statement ok
+create table tmp_union_bool_null(b boolean null);
+
+statement ok
+insert into tmp_union_bool_nn values (true), (false);
+
+statement ok
+insert into tmp_union_bool_null values (null), (true);
+
+statement ok
+analyze table tmp_union_bool_nn;
+
+statement ok
+analyze table tmp_union_bool_null;
+
+query B rowsort
+select b from (
+  select b from tmp_union_bool_nn
+  union all
+  select b from tmp_union_bool_null
+) where b = true;
+----
+1
+1
+
+statement ok
+drop table tmp_union_bool_nn;
+
+statement ok
+drop table tmp_union_bool_null;
+
+statement ok
 create or replace table t1 (a int, b int);
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR fixes a range pruning panic after filter pushdown through `UNION ALL` preserves nullable coercion. When `eliminate_cast` rewrites a child expression, the parent `FunctionCall` now re-runs function resolution so its overload metadata matches the rewritten argument types.

It also adds regression coverage for a nullable/non-null boolean union filter.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Commands run:

```bash
cargo test -p databend-storages-common-index test_range_index_keeps_nullable_boolean_cast_under_is_true -- --nocapture
cargo build -p databend-binaries --bin databend-query
target/debug/databend-sqllogictests --handlers http --run_file union.test --enable_sandbox --parallel 1 --port 8000 --no-fail-fast
```

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20102)
<!-- Reviewable:end -->
