### PR TITLE
fix(query): resolve physical column name for runtime filter probe target

### DIFF
--- a/src/query/service/src/physical_plans/physical_hash_join.rs
+++ b/src/query/service/src/physical_plans/physical_hash_join.rs
@@ -751,11 +751,17 @@ impl PhysicalPlanBuilder {
                             // with another column in the same table.
                             let entry = metadata.column(col.index);
                             if let ColumnEntry::BaseTableColumn(base_col) = entry {
-                                let table = metadata.table(base_col.table_index);
-                                let schema = table.table().schema();
-                                if let Ok(field) = schema.field_of_column_id(base_col.column_id) {
-                                    return Ok(field.name().clone());
+                                if base_col.path_indices.is_none() {
+                                    let table = metadata.table(base_col.table_index);
+                                    let schema = table.table().schema_with_stream();
+                                    if let Ok(field) = schema.field_of_column_id(base_col.column_id)
+                                    {
+                                        return Ok(field.name().clone());
+                                    }
                                 }
+                                // For nested/path columns, or when schema lookup
+                                // fails, use the stable metadata-level column name.
+                                return Ok(base_col.column_name.clone());
                             }
                             Ok(col.column_name.clone())
                         })?,

--- a/src/query/service/src/physical_plans/physical_hash_join.rs
+++ b/src/query/service/src/physical_plans/physical_hash_join.rs
@@ -739,11 +739,26 @@ impl PhysicalPlanBuilder {
                     .base_column_scan_id(*column_idx)
                     .unwrap();
 
+                let metadata = self.metadata.read();
                 return Ok(Some((
                     left_condition
                         .as_raw_expr()
-                        .type_check(&*self.metadata.read())?
-                        .project_column_ref(|col| Ok(col.column_name.clone()))?,
+                        .type_check(&*metadata)?
+                        .project_column_ref(|col| {
+                            // Use the physical column name from the table schema
+                            // (looked up by column_id) rather than the binding's
+                            // context name, which can be an alias that collides
+                            // with another column in the same table.
+                            let entry = metadata.column(col.index);
+                            if let ColumnEntry::BaseTableColumn(base_col) = entry {
+                                let table = metadata.table(base_col.table_index);
+                                let schema = table.table().schema();
+                                if let Ok(field) = schema.field_of_column_id(base_col.column_id) {
+                                    return Ok(field.name().clone());
+                                }
+                            }
+                            Ok(col.column_name.clone())
+                        })?,
                     scan_id,
                     table_index,
                     *column_idx,

--- a/src/query/service/src/physical_plans/runtime_filter/builder.rs
+++ b/src/query/service/src/physical_plans/runtime_filter/builder.rs
@@ -288,11 +288,14 @@ fn scalar_to_remote_expr(
             .project_column_ref(|col| {
                 let entry = md.column(col.index);
                 if let ColumnEntry::BaseTableColumn(base_col) = entry {
-                    let table = md.table(base_col.table_index);
-                    let schema = table.table().schema();
-                    if let Ok(field) = schema.field_of_column_id(base_col.column_id) {
-                        return Ok(field.name().clone());
+                    if base_col.path_indices.is_none() {
+                        let table = md.table(base_col.table_index);
+                        let schema = table.table().schema_with_stream();
+                        if let Ok(field) = schema.field_of_column_id(base_col.column_id) {
+                            return Ok(field.name().clone());
+                        }
                     }
+                    return Ok(base_col.column_name.clone());
                 }
                 Ok(col.column_name.clone())
             })?

--- a/src/query/service/src/physical_plans/runtime_filter/builder.rs
+++ b/src/query/service/src/physical_plans/runtime_filter/builder.rs
@@ -280,11 +280,24 @@ fn scalar_to_remote_expr(
         return Ok(None);
     };
 
-    let remote_expr = scalar
-        .as_raw_expr()
-        .type_check(&*metadata.read())?
-        .project_column_ref(|col| Ok(col.column_name.clone()))?
-        .as_remote_expr();
+    let remote_expr = {
+        let md = metadata.read();
+        scalar
+            .as_raw_expr()
+            .type_check(&*md)?
+            .project_column_ref(|col| {
+                let entry = md.column(col.index);
+                if let ColumnEntry::BaseTableColumn(base_col) = entry {
+                    let table = md.table(base_col.table_index);
+                    let schema = table.table().schema();
+                    if let Ok(field) = schema.field_of_column_id(base_col.column_id) {
+                        return Ok(field.name().clone());
+                    }
+                }
+                Ok(col.column_name.clone())
+            })?
+            .as_remote_expr()
+    };
 
     if supported_probe_key_for_runtime_filter(&remote_expr) {
         return Ok(Some((remote_expr, scan_id, column_idx)));

--- a/tests/sqllogictests/suites/ee/06_ee_stream/06_0015_stream_rf_alias_collision.test
+++ b/tests/sqllogictests/suites/ee/06_ee_stream/06_0015_stream_rf_alias_collision.test
@@ -1,0 +1,129 @@
+## Copyright 2023 Databend Cloud
+##
+## Licensed under the Elastic License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     https://www.elastic.co/licensing/elastic-license
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+## Test: runtime filter must resolve hidden stream columns by schema_with_stream().
+## Mutations populate _origin_block_row_num; plain inserts leave it NULL.
+## The subquery aliases _origin_block_row_num as row_num, colliding with a physical column.
+## Bug scenario: RF resolves row_num to the physical column instead of the hidden stream column.
+## Expected: 3 matches.
+
+statement ok
+DROP DATABASE IF EXISTS test_stream_rf_alias_collision
+
+statement ok
+CREATE DATABASE test_stream_rf_alias_collision
+
+statement ok
+USE test_stream_rf_alias_collision
+
+statement ok
+CREATE TABLE t_stream_probe(row_num UInt64, val UInt64) ROW_PER_BLOCK = 10
+
+statement ok
+ALTER TABLE t_stream_probe SET OPTIONS(change_tracking = true)
+
+statement ok
+INSERT INTO t_stream_probe VALUES (100, 1), (101, 2), (102, 3), (103, 4), (104, 5), (105, 6), (106, 7), (107, 8)
+
+statement ok
+DELETE FROM t_stream_probe WHERE val >= 7
+
+statement ok
+CREATE TABLE t_stream_build(row_num UInt64)
+
+statement ok
+INSERT INTO t_stream_build VALUES (0), (1), (2)
+
+## Sanity check: the mutation rewrites the surviving rows with origin row numbers.
+query II
+SELECT row_num, _origin_block_row_num FROM t_stream_probe ORDER BY row_num
+----
+100 0
+101 1
+102 2
+103 3
+104 4
+105 5
+
+query T
+EXPLAIN SELECT count()
+FROM t_stream_build AS b
+INNER JOIN (
+    SELECT _origin_block_row_num AS row_num
+    FROM t_stream_probe
+    WHERE _origin_block_row_num IS NOT NULL
+) AS p
+ON b.row_num = p.row_num
+----
+AggregateFinal
+├── output columns: [count() (#6)]
+├── group by: []
+├── aggregate functions: [count()]
+├── estimated rows: 1.00
+└── AggregatePartial
+    ├── group by: []
+    ├── aggregate functions: [count()]
+    ├── estimated rows: 1.00
+    └── HashJoin
+        ├── output columns: []
+        ├── join type: INNER
+        ├── build keys: [b.row_num (#0)]
+        ├── probe keys: [p.row_num (#5)]
+        ├── keys is null equal: [false]
+        ├── filters: []
+        ├── build join filters:
+        │   └── filter id:0, build key:b.row_num (#0), probe targets:[p.row_num (#5)@scan1], filter type:bloom,inlist,min_max
+        ├── estimated rows: 3.00
+        ├── TableScan(Build)
+        │   ├── table: default.test_stream_rf_alias_collision.t_stream_build
+        │   ├── scan id: 0
+        │   ├── output columns: [row_num (#0)]
+        │   ├── read rows: 3
+        │   ├── read size: < 1 KiB
+        │   ├── partitions total: 1
+        │   ├── partitions scanned: 1
+        │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+        │   ├── push downs: [filters: [is_not_null(t_stream_build.row_num (#0))], limit: NONE]
+        │   └── estimated rows: 3.00
+        └── Filter(Probe)
+            ├── output columns: [t_stream_probe._origin_block_row_num (#5)]
+            ├── filters: [is_not_null(t_stream_probe._origin_block_row_num (#5))]
+            ├── estimated rows: 6.00
+            └── TableScan
+                ├── table: default.test_stream_rf_alias_collision.t_stream_probe
+                ├── scan id: 1
+                ├── output columns: [_origin_block_row_num (#5)]
+                ├── read rows: 6
+                ├── read size: < 1 KiB
+                ├── partitions total: 1
+                ├── partitions scanned: 1
+                ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+                ├── push downs: [filters: [is_not_null(t_stream_probe._origin_block_row_num (#5))], limit: NONE]
+                ├── apply join filters: [#0]
+                └── estimated rows: 6.00
+
+query I
+SELECT count()
+FROM t_stream_build AS b
+INNER JOIN (
+    SELECT _origin_block_row_num AS row_num
+    FROM t_stream_probe
+    WHERE _origin_block_row_num IS NOT NULL
+) AS p
+ON b.row_num = p.row_num
+----
+3
+
+statement ok
+DROP DATABASE test_stream_rf_alias_collision

--- a/tests/sqllogictests/suites/query/join/runtime_filter_column_name_alias.test
+++ b/tests/sqllogictests/suites/query/join/runtime_filter_column_name_alias.test
@@ -28,3 +28,63 @@ DROP TABLE t_probe;
 
 statement ok
 DROP TABLE t_build;
+
+# Test: runtime filter on a tuple inner field must still work correctly.
+# The path_indices guard should not break nested column RF behavior.
+# t_nested has a Tuple column with named field "key". We join on t:key.
+# Expected: 3 matches.
+
+statement ok
+CREATE OR REPLACE TABLE t_nested(id INT NOT NULL, t TUPLE(key INT, name VARCHAR) NOT NULL) row_per_block = 5;
+
+statement ok
+CREATE OR REPLACE TABLE t_lookup(key INT NOT NULL);
+
+statement ok
+INSERT INTO t_nested VALUES (1,(10,'a')),(2,(20,'b')),(3,(30,'c')),(4,(40,'d')),(5,(50,'e')),(6,(60,'f')),(7,(70,'g')),(8,(80,'h')),(9,(90,'i')),(10,(100,'j'));
+
+statement ok
+INSERT INTO t_lookup VALUES (10),(20),(30);
+
+query I
+SELECT count() FROM t_lookup AS b INNER JOIN t_nested AS p ON b.key = p.t:key;
+----
+3
+
+statement ok
+DROP TABLE t_nested;
+
+statement ok
+DROP TABLE t_lookup;
+
+# Test: tuple inner field aliased to collide with a top-level column.
+#
+# t_data has both a top-level "key" (values 100..109) and a tuple field
+# t:key (values 1..10). Subquery aliases t:key AS key, which collides
+# with the physical top-level "key" column.
+# Bug scenario: RF resolves "key" to the physical top-level column
+# (100..109) instead of the tuple leaf t:key (1..10), bloom rejects all.
+# Expected: 3
+
+statement ok
+CREATE OR REPLACE TABLE t_data(key INT NOT NULL, t TUPLE(key INT, name VARCHAR) NOT NULL) row_per_block = 5;
+
+statement ok
+CREATE OR REPLACE TABLE t_dim(key INT NOT NULL);
+
+statement ok
+INSERT INTO t_data VALUES (100,(1,'a')),(101,(2,'b')),(102,(3,'c')),(103,(4,'d')),(104,(5,'e')),(105,(6,'f')),(106,(7,'g')),(107,(8,'h')),(108,(9,'i')),(109,(10,'j'));
+
+statement ok
+INSERT INTO t_dim VALUES (1),(2),(3);
+
+query I
+SELECT count() FROM t_dim AS d INNER JOIN (SELECT t:key AS key FROM t_data) AS p ON d.key = p.key;
+----
+3
+
+statement ok
+DROP TABLE t_data;
+
+statement ok
+DROP TABLE t_dim;

--- a/tests/sqllogictests/suites/query/join/runtime_filter_column_name_alias.test
+++ b/tests/sqllogictests/suites/query/join/runtime_filter_column_name_alias.test
@@ -1,0 +1,30 @@
+# Test: bloom runtime filter must resolve the physical column name, not an alias.
+#
+# t_probe has col_a (values 100..404) and col_b (values 1..20).
+# Subquery aliases col_b AS col_a, then joins with t_build(col_a = 1,2,3).
+# Bug: RF resolves "col_a" to the physical col_a (100..404) instead of
+# the aliased source col_b (1..20), bloom rejects all rows → returns 0.
+# Expected: 3
+
+statement ok
+CREATE OR REPLACE TABLE t_probe(col_a INT NOT NULL, col_b INT NOT NULL) row_per_block = 5;
+
+statement ok
+CREATE OR REPLACE TABLE t_build(col_a INT NOT NULL);
+
+statement ok
+INSERT INTO t_probe VALUES (100,1),(101,2),(102,3),(103,4),(104,5),(200,6),(201,7),(202,8),(203,9),(204,10),(300,11),(301,12),(302,13),(303,14),(304,15),(400,16),(401,17),(402,18),(403,19),(404,20);
+
+statement ok
+INSERT INTO t_build VALUES (1),(2),(3);
+
+query I
+SELECT count() FROM t_build AS b INNER JOIN (SELECT col_b AS col_a FROM t_probe) AS p ON b.col_a = p.col_a;
+----
+3
+
+statement ok
+DROP TABLE t_probe;
+
+statement ok
+DROP TABLE t_build;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

The bloom runtime filter's probe-side column reference was resolved using the `ColumnBinding.column_name`, which is the query-context name and can be an alias. When a column alias collides with another physical column name in the same table, `schema.index_of(name)` finds the wrong column. This causes the bloom filter to read unrelated data (default-filled zeros or wrong column values), reject all probe rows, and produce incorrect join results.

**Minimal reproduction:**

```sql
CREATE OR REPLACE TABLE t_probe(col_a INT NOT NULL, col_b INT NOT NULL) row_per_block = 5;
CREATE OR REPLACE TABLE t_build(col_a INT NOT NULL);

INSERT INTO t_probe VALUES (100,1),(101,2),(102,3),(103,4),(104,5),(200,6),(201,7),(202,8),(203,9),(204,10),(300,11),(301,12),(302,13),(303,14),(304,15),(400,16),(401,17),(402,18),(403,19),(404,20);
INSERT INTO t_build VALUES (1),(2),(3);

SET enable_join_runtime_filter = 1;
SELECT count()
FROM t_build AS b
INNER JOIN (SELECT col_b AS col_a FROM t_probe) AS p
ON b.col_a = p.col_a;
-- Expected: 3
-- Bug:      0 (bloom RF resolves "col_a" to the physical col_a instead of the aliased col_b)
```

**Fix:** In `project_column_ref`, look up the physical column name from the table schema via `column_id` instead of using the binding's context name.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20105)
<!-- Reviewable:end -->
