### PR TITLE
refactor(query): make segment compaction commit through CommitSink

### DIFF
--- a/src/query/catalog/src/table.rs
+++ b/src/query/catalog/src/table.rs
@@ -399,9 +399,10 @@ pub trait Table: Sync + Send {
     async fn compact_segments(
         &self,
         ctx: Arc<dyn TableContext>,
+        pipeline: &mut Pipeline,
         limit: Option<usize>,
     ) -> Result<()> {
-        let (_, _) = (ctx, limit);
+        let (_, _, _) = (ctx, pipeline, limit);
 
         Err(ErrorCode::Unimplemented(format!(
             "The operation 'compact_segments' is not supported for the table '{}', which is using the '{}' engine.",

--- a/src/query/service/src/interpreters/interpreter_optimize_compact_segment.rs
+++ b/src/query/service/src/interpreters/interpreter_optimize_compact_segment.rs
@@ -69,11 +69,20 @@ impl Interpreter for OptimizeCompactSegmentInterpreter {
         // check mutability
         table.check_mutable()?;
 
+        let mut build_res = PipelineBuildResult::create();
         table
-            .compact_segments(self.ctx.clone(), self.plan.num_segment_limit)
+            .compact_segments(
+                self.ctx.clone(),
+                &mut build_res.main_pipeline,
+                self.plan.num_segment_limit,
+            )
             .await?;
 
-        drop(lock_guard);
-        Ok(PipelineBuildResult::create())
+        if build_res.main_pipeline.is_empty() {
+            drop(lock_guard);
+        } else {
+            build_res.main_pipeline.add_lock_guard(lock_guard);
+        }
+        Ok(build_res)
     }
 }

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
@@ -29,6 +29,7 @@ use databend_common_expression::SendableDataBlockStream;
 use databend_common_expression::Value;
 use databend_common_expression::types::number::NumberColumn;
 use databend_common_expression::types::number::NumberScalar;
+use databend_common_pipeline::core::Pipeline;
 use databend_common_storage::DataOperator;
 use databend_common_storages_fuse::FuseStorageFormat;
 use databend_common_storages_fuse::FuseTable;
@@ -43,12 +44,12 @@ use databend_common_storages_fuse::operations::CompactOptions;
 use databend_common_storages_fuse::operations::SegmentCompactMutator;
 use databend_common_storages_fuse::operations::SegmentCompactionState;
 use databend_common_storages_fuse::operations::SegmentCompactor;
-use databend_common_pipeline::core::Pipeline;
-use databend_query::pipelines::executor::ExecutorSettings;
-use databend_query::pipelines::executor::PipelineCompleteExecutor;use databend_common_storages_fuse::statistics::RowOrientedSegmentBuilder;
+use databend_common_storages_fuse::statistics::RowOrientedSegmentBuilder;
 use databend_common_storages_fuse::statistics::gen_columns_statistics;
 use databend_common_storages_fuse::statistics::reducers::merge_statistics_mut;
 use databend_common_storages_fuse::statistics::sort_by_cluster_stats;
+use databend_query::pipelines::executor::ExecutorSettings;
+use databend_query::pipelines::executor::PipelineCompleteExecutor;
 use databend_query::sessions::QueryContext;
 use databend_query::sessions::TableContext;
 use databend_query::sessions::TableContextSettings;
@@ -207,20 +208,12 @@ async fn test_compact_segment_unresolvable_conflict() -> anyhow::Result<()> {
 
 #[async_trait::async_trait]
 trait TryCommitCompact {
-    async fn try_commit_compact(
-        self,
-        table: &FuseTable,
-        ctx: Arc<QueryContext>,
-    ) -> Result<()>;
+    async fn try_commit_compact(self, table: &FuseTable, ctx: Arc<QueryContext>) -> Result<()>;
 }
 
 #[async_trait::async_trait]
 impl TryCommitCompact for SegmentCompactMutator {
-    async fn try_commit_compact(
-        self,
-        table: &FuseTable,
-        ctx: Arc<QueryContext>,
-    ) -> Result<()> {
+    async fn try_commit_compact(self, table: &FuseTable, ctx: Arc<QueryContext>) -> Result<()> {
         let base_snapshot = self.base_snapshot().clone();
         let table_meta_timestamps =
             ctx.get_table_meta_timestamps(table, Some(base_snapshot.clone()))?;
@@ -237,8 +230,7 @@ impl TryCommitCompact for SegmentCompactMutator {
             table_meta_timestamps,
         )?;
         let executor_settings = ExecutorSettings::try_create(ctx.clone())?;
-        let executor =
-            PipelineCompleteExecutor::from_pipelines(vec![pipeline], executor_settings)?;
+        let executor = PipelineCompleteExecutor::from_pipelines(vec![pipeline], executor_settings)?;
         ctx.set_executor(executor.get_inner())?;
         executor.execute().await?;
         Ok(())

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
@@ -43,7 +43,9 @@ use databend_common_storages_fuse::operations::CompactOptions;
 use databend_common_storages_fuse::operations::SegmentCompactMutator;
 use databend_common_storages_fuse::operations::SegmentCompactionState;
 use databend_common_storages_fuse::operations::SegmentCompactor;
-use databend_common_storages_fuse::statistics::RowOrientedSegmentBuilder;
+use databend_common_pipeline::core::Pipeline;
+use databend_query::pipelines::executor::ExecutorSettings;
+use databend_query::pipelines::executor::PipelineCompleteExecutor;use databend_common_storages_fuse::statistics::RowOrientedSegmentBuilder;
 use databend_common_storages_fuse::statistics::gen_columns_statistics;
 use databend_common_storages_fuse::statistics::reducers::merge_statistics_mut;
 use databend_common_storages_fuse::statistics::sort_by_cluster_stats;
@@ -51,6 +53,7 @@ use databend_query::sessions::QueryContext;
 use databend_query::sessions::TableContext;
 use databend_query::sessions::TableContextSettings;
 use databend_query::sessions::TableContextTableAccess;
+use databend_query::sessions::TableContextTableManagement;
 use databend_query::sessions::TableContextTelemetry;
 use databend_query::test_kits::*;
 use databend_storages_common_cache::LoadParams;
@@ -90,7 +93,7 @@ async fn test_compact_segment_normal_case() -> anyhow::Result<()> {
     let mutator = build_mutator(fuse_table, ctx.clone(), None).await?;
     assert!(mutator.is_some());
     let mutator = mutator.unwrap();
-    mutator.try_commit(fuse_table).await?;
+    mutator.try_commit_compact(fuse_table, ctx.clone()).await?;
 
     // check segment count
     let qry = "select segment_count as count from fuse_snapshot('default', 't') limit 1";
@@ -135,7 +138,7 @@ async fn test_compact_segment_resolvable_conflict() -> anyhow::Result<()> {
     let num_inserts = 9;
     fixture.append_rows(num_inserts).await?;
 
-    mutator.try_commit(fuse_table).await?;
+    mutator.try_commit_compact(fuse_table, ctx.clone()).await?;
 
     // check segment count
     let count_seg = "select segment_count as count from fuse_snapshot('default', 't') limit 1";
@@ -195,11 +198,51 @@ async fn test_compact_segment_unresolvable_conflict() -> anyhow::Result<()> {
     }
 
     // the compact operation committed latter should be failed.
-    let r = mutator.try_commit(fuse_table).await;
+    let r: Result<()> = mutator.try_commit_compact(fuse_table, ctx.clone()).await;
     assert!(r.is_err());
     assert_eq!(r.err().unwrap().code(), ErrorCode::UNRESOLVABLE_CONFLICT);
 
     Ok(())
+}
+
+#[async_trait::async_trait]
+trait TryCommitCompact {
+    async fn try_commit_compact(
+        self,
+        table: &FuseTable,
+        ctx: Arc<QueryContext>,
+    ) -> Result<()>;
+}
+
+#[async_trait::async_trait]
+impl TryCommitCompact for SegmentCompactMutator {
+    async fn try_commit_compact(
+        self,
+        table: &FuseTable,
+        ctx: Arc<QueryContext>,
+    ) -> Result<()> {
+        let base_snapshot = self.base_snapshot().clone();
+        let table_meta_timestamps =
+            ctx.get_table_meta_timestamps(table, Some(base_snapshot.clone()))?;
+        let compaction = self.into_compaction_state();
+        if compaction.new_segment_paths.is_empty() {
+            return Ok(());
+        }
+        let mut pipeline = Pipeline::create();
+        table.build_compact_segment_pipeline(
+            ctx.clone(),
+            &mut pipeline,
+            compaction,
+            base_snapshot,
+            table_meta_timestamps,
+        )?;
+        let executor_settings = ExecutorSettings::try_create(ctx.clone())?;
+        let executor =
+            PipelineCompleteExecutor::from_pipelines(vec![pipeline], executor_settings)?;
+        ctx.set_executor(executor.get_inner())?;
+        executor.execute().await?;
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]
@@ -233,7 +276,7 @@ async fn check_count(result_stream: SendableDataBlockStream) -> Result<u64> {
 pub async fn compact_segment(ctx: Arc<QueryContext>, table: &Arc<dyn Table>) -> Result<()> {
     let fuse_table = FuseTable::try_from_table(table.as_ref())?;
     let mutator = build_mutator(fuse_table, ctx.clone(), None).await?.unwrap();
-    mutator.try_commit(fuse_table).await
+    mutator.try_commit_compact(fuse_table, ctx).await
 }
 
 async fn build_mutator(

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -1376,10 +1376,11 @@ impl Table for FuseTable {
     async fn compact_segments(
         &self,
         ctx: Arc<dyn TableContext>,
+        pipeline: &mut Pipeline,
         limit: Option<usize>,
     ) -> Result<()> {
         self.check_format_supported()?;
-        self.do_compact_segments(ctx, limit).await
+        self.do_compact_segments(ctx, pipeline, limit).await
     }
 
     #[async_backtrace::framed]

--- a/src/query/storages/fuse/src/operations/commit.rs
+++ b/src/query/storages/fuse/src/operations/commit.rs
@@ -16,15 +16,11 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use backoff::backoff::Backoff;
 use chrono::Utc;
 use databend_common_catalog::catalog::Catalog;
 use databend_common_catalog::table::Table;
-use databend_common_catalog::table::TableExt;
 use databend_common_catalog::table_context::TableContext;
-use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
-use databend_common_expression::TableSchemaRef;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::TableMeta;
 use databend_common_meta_app::schema::TableStatistics;
@@ -33,7 +29,6 @@ use databend_common_meta_app::schema::UpdateStreamMetaReq;
 use databend_common_meta_app::schema::UpdateTableMetaReq;
 use databend_common_meta_app::schema::UpdateTempTableReq;
 use databend_common_meta_app::schema::UpsertTableCopiedFileReq;
-use databend_common_metrics::storage::*;
 use databend_common_pipeline::core::Pipeline;
 use databend_common_pipeline_transforms::TransformPipelineHelper;
 use databend_common_sql::executor::physical_plans::MutationKind;
@@ -42,8 +37,6 @@ use databend_storages_common_cache::CacheAccessor;
 use databend_storages_common_cache::CachedObject;
 use databend_storages_common_cache::LoadParams;
 use databend_storages_common_table_meta::meta::BlockHLL;
-use databend_storages_common_table_meta::meta::Location;
-use databend_storages_common_table_meta::meta::SegmentInfo;
 use databend_storages_common_table_meta::meta::SnapshotId;
 use databend_storages_common_table_meta::meta::Statistics;
 use databend_storages_common_table_meta::meta::TableMetaTimestamps;
@@ -56,25 +49,19 @@ use databend_storages_common_table_meta::readers::snapshot_reader::TableSnapshot
 use databend_storages_common_table_meta::table::OPT_KEY_LEGACY_SNAPSHOT_LOC;
 use databend_storages_common_table_meta::table::OPT_KEY_SNAPSHOT_LOCATION;
 use databend_storages_common_table_meta::table::OPT_KEY_TEMP_PREFIX;
-use log::debug;
 use log::info;
 use opendal::Operator;
 
 use super::TableMutationAggregator;
-use super::decorate_snapshot;
 use super::new_serialize_segment_processor;
 use crate::FuseTable;
 use crate::io::MetaReaders;
 use crate::io::MetaWriter;
-use crate::io::SegmentsIO;
 use crate::io::TableMetaLocationGenerator;
 use crate::operations::SnapshotHintWriter;
 use crate::operations::common::AppendGenerator;
 use crate::operations::common::CommitSink;
-use crate::operations::common::ConflictResolveContext;
-use crate::operations::set_backoff;
 use crate::statistics::TableStatsGenerator;
-use crate::statistics::merge_statistics;
 
 impl FuseTable {
     #[async_backtrace::framed]
@@ -317,195 +304,6 @@ impl FuseTable {
         SnapshotHintWriter::new(ctx, operator)
             .write_last_snapshot_hint(location_generator, last_snapshot_path, new_table_meta)
             .await
-    }
-
-    // TODO use commit sink instead
-    #[async_backtrace::framed]
-    pub async fn commit_mutation(
-        &self,
-        ctx: &Arc<dyn TableContext>,
-        base_snapshot: Arc<TableSnapshot>,
-        base_segments: &[Location],
-        base_summary: Statistics,
-        table_meta_timestamps: TableMetaTimestamps,
-    ) -> Result<()> {
-        let mut retries = 0;
-        let mut backoff = set_backoff(None, None, None);
-
-        let mut latest_snapshot = base_snapshot.clone();
-        let mut latest_table_info = &self.table_info;
-        let default_cluster_key_id = self.cluster_key_id();
-        let base_schema = self.schema();
-
-        // holding the reference of latest table during retries
-        let mut latest_table_ref: Arc<dyn Table>;
-
-        // potentially concurrently appended segments, init it to empty
-        let mut concurrently_appended_segment_locations: &[Location] = &[];
-
-        // Status
-        ctx.set_status_info("mutation: begin try to commit");
-
-        loop {
-            let mut snapshot_tobe_committed = TableSnapshot::try_from_previous(
-                latest_snapshot.clone(),
-                Some(latest_table_info.ident.seq),
-                table_meta_timestamps,
-            )?;
-
-            if base_schema != latest_table_info.schema() {
-                return Err(ErrorCode::StorageOther(
-                    "The schema of the table has changed",
-                ));
-            }
-            let (segments_tobe_committed, statistics_tobe_committed) = Self::merge_with_base(
-                ctx.clone(),
-                self.operator.clone(),
-                base_segments,
-                &base_summary,
-                concurrently_appended_segment_locations,
-                base_schema.clone(),
-                default_cluster_key_id,
-            )
-            .await?;
-            snapshot_tobe_committed.segments = segments_tobe_committed;
-            snapshot_tobe_committed.summary = statistics_tobe_committed;
-            snapshot_tobe_committed.summary.additional_stats_meta = latest_snapshot
-                .summary
-                .additional_stats_meta
-                .as_ref()
-                .cloned();
-
-            decorate_snapshot(
-                &mut snapshot_tobe_committed,
-                ctx.txn_mgr(),
-                Some(base_snapshot.clone()),
-                self.get_id(),
-            )?;
-
-            match self
-                .commit_to_meta_server(
-                    ctx.as_ref(),
-                    latest_table_info,
-                    &self.meta_location_generator,
-                    snapshot_tobe_committed,
-                    None,
-                    &None,
-                    &self.operator,
-                )
-                .await
-            {
-                Err(e) if e.code() == ErrorCode::TABLE_VERSION_MISMATCHED => {
-                    match backoff.next_backoff() {
-                        Some(d) => {
-                            let name = self.table_info.name.clone();
-                            debug!(
-                                "got error TableVersionMismatched, tx will be retried {} ms later. table name {}, identity {}",
-                                d.as_millis(),
-                                name.as_str(),
-                                self.table_info.ident
-                            );
-
-                            tokio::time::sleep(d).await;
-                            latest_table_ref = self.refresh(ctx.as_ref()).await?;
-                            let latest_fuse_table =
-                                FuseTable::try_from_table(latest_table_ref.as_ref())?;
-                            latest_snapshot =
-                                latest_fuse_table
-                                    .read_table_snapshot()
-                                    .await?
-                                    .ok_or_else(|| {
-                                        ErrorCode::Internal(
-                                            "mutation meets empty snapshot during conflict reconciliation",
-                                        )
-                                    })?;
-                            latest_table_info = &latest_fuse_table.table_info;
-
-                            // Check if there is only insertion during the operation.
-                            if let Some(range_of_newly_append) =
-                                ConflictResolveContext::is_latest_snapshot_append_only(
-                                    &base_snapshot,
-                                    &latest_snapshot,
-                                )
-                            {
-                                info!("resolvable conflicts detected");
-                                metrics_inc_commit_mutation_latest_snapshot_append_only();
-                                concurrently_appended_segment_locations =
-                                    &latest_snapshot.segments[range_of_newly_append];
-                            } else {
-                                metrics_inc_commit_mutation_unresolvable_conflict();
-                                break Err(ErrorCode::UnresolvableConflict(
-                                    "segment compact conflict with other operations",
-                                ));
-                            }
-
-                            retries += 1;
-                            metrics_inc_commit_mutation_retry();
-                            continue;
-                        }
-                        None => {
-                            // Commit not fulfilled, abort.
-                            //
-                            // Note that, here the last error we have seen is TableVersionMismatched,
-                            // otherwise we should have been returned, thus it is safe to abort the operation here.
-                            break Err(ErrorCode::StorageOther(format!(
-                                "commit mutation failed after {} retries",
-                                retries
-                            )));
-                        }
-                    }
-                }
-                Err(e) => {
-                    // we are not sure about if the table state has been modified or not, just propagate the error
-                    // and return, without aborting anything.
-                    break Err(e);
-                }
-                Ok(_) => {
-                    break {
-                        metrics_inc_commit_mutation_success();
-                        Ok(())
-                    };
-                }
-            }
-        }
-    }
-
-    #[async_backtrace::framed]
-    async fn merge_with_base(
-        ctx: Arc<dyn TableContext>,
-        operator: Operator,
-        base_segments: &[Location],
-        base_summary: &Statistics,
-        concurrently_appended_segment_locations: &[Location],
-        schema: TableSchemaRef,
-        default_cluster_key_id: Option<u32>,
-    ) -> Result<(Vec<Location>, Statistics)> {
-        if concurrently_appended_segment_locations.is_empty() {
-            Ok((base_segments.to_owned(), base_summary.clone()))
-        } else {
-            // place the concurrently appended segments at the head of segment list
-            let new_segments = concurrently_appended_segment_locations
-                .iter()
-                .chain(base_segments.iter())
-                .cloned()
-                .collect();
-
-            let fuse_segment_io = SegmentsIO::create(ctx, operator, schema);
-            let concurrent_appended_segment_infos = fuse_segment_io
-                .read_segments::<SegmentInfo>(concurrently_appended_segment_locations, true)
-                .await?;
-
-            let mut new_statistics = base_summary.clone();
-            for result in concurrent_appended_segment_infos.into_iter() {
-                let concurrent_appended_segment = result?;
-                new_statistics = merge_statistics(
-                    new_statistics.clone(),
-                    &concurrent_appended_segment.summary,
-                    default_cluster_key_id,
-                );
-            }
-            Ok((new_segments, new_statistics))
-        }
     }
 
     // check if there are any fuse table legacy options

--- a/src/query/storages/fuse/src/operations/compact.rs
+++ b/src/query/storages/fuse/src/operations/compact.rs
@@ -12,22 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use databend_common_catalog::plan::Partitions;
 use databend_common_catalog::table::CompactionLimits;
 use databend_common_exception::Result;
 use databend_common_expression::ComputedExpr;
+use databend_common_expression::DataBlock;
 use databend_common_expression::FieldIndex;
 use databend_common_io::constants::DEFAULT_BLOCK_PER_SEGMENT;
+use databend_common_pipeline::core::Pipeline;
+use databend_common_pipeline::sources::OneBlockSource;
+use databend_common_sql::executor::physical_plans::MutationKind;
+use databend_storages_common_table_meta::meta::SegmentInfo;
 use databend_storages_common_table_meta::meta::TableSnapshot;
+use databend_storages_common_table_meta::meta::Versioned;
 
 use crate::FUSE_OPT_KEY_BLOCK_PER_SEGMENT;
 use crate::FuseTable;
 use crate::Table;
 use crate::TableContext;
+use crate::operations::common::CommitMeta;
+use crate::operations::common::CommitSink;
+use crate::operations::common::ConflictResolveContext;
+use crate::operations::common::MutationGenerator;
+use crate::operations::common::SnapshotChanges;
+use crate::operations::VirtualSchemaMode;
 use crate::operations::mutation::BlockCompactMutator;
 use crate::operations::mutation::SegmentCompactMutator;
+use crate::operations::mutation::SegmentCompactionState;
 
 #[derive(Clone)]
 pub struct CompactOptions {
@@ -43,6 +58,7 @@ impl FuseTable {
     pub(crate) async fn do_compact_segments(
         &self,
         ctx: Arc<dyn TableContext>,
+        pipeline: &mut Pipeline,
         num_segment_limit: Option<usize>,
     ) -> Result<()> {
         let compact_options = if let Some(v) = self
@@ -70,7 +86,82 @@ impl FuseTable {
             return Ok(());
         }
 
-        segment_compactor.try_commit(self).await
+        let base_snapshot = segment_compactor.base_snapshot().clone();
+        let compaction = segment_compactor.into_compaction_state();
+        self.build_compact_segment_pipeline(
+            ctx,
+            pipeline,
+            compaction,
+            base_snapshot,
+            table_meta_timestamps,
+        )
+    }
+
+    pub fn build_compact_segment_pipeline(
+        &self,
+        ctx: Arc<dyn TableContext>,
+        pipeline: &mut Pipeline,
+        compaction: SegmentCompactionState,
+        base_snapshot: Arc<TableSnapshot>,
+        table_meta_timestamps: databend_storages_common_table_meta::meta::TableMetaTimestamps,
+    ) -> Result<()> {
+        let base_segments = &base_snapshot.segments;
+        let final_segments_set: HashSet<&_> = compaction.segments_locations.iter().collect();
+
+        let removed_segment_indexes: Vec<usize> = base_segments
+            .iter()
+            .enumerate()
+            .filter(|(_, loc)| !final_segments_set.contains(loc))
+            .map(|(idx, _)| idx)
+            .collect();
+
+        let appended_segments: Vec<_> = compaction
+            .new_segment_paths
+            .iter()
+            .map(|p| (p.clone(), SegmentInfo::VERSION))
+            .collect();
+
+        let snapshot_changes = SnapshotChanges {
+            appended_segments,
+            replaced_segments: HashMap::new(),
+            removed_segment_indexes,
+            merged_statistics: compaction.removed_statistics.clone(),
+            removed_statistics: compaction.removed_statistics,
+        };
+
+        let conflict_resolve_ctx =
+            ConflictResolveContext::ModifiedSegmentExistsInLatest(snapshot_changes);
+        let meta = CommitMeta::new(
+            conflict_resolve_ctx,
+            vec![],
+            self.get_id(),
+            0,
+            None,
+            VirtualSchemaMode::Merge,
+            HashMap::new(),
+        );
+        let block = DataBlock::empty_with_meta(Box::new(meta));
+
+        pipeline.add_source(
+            |output| OneBlockSource::create(output, block.clone()),
+            1,
+        )?;
+
+        let snapshot_gen = MutationGenerator::new(Some(base_snapshot), MutationKind::Compact);
+        pipeline.add_sink(|input| {
+            CommitSink::try_create(
+                self,
+                ctx.clone(),
+                None,
+                vec![],
+                snapshot_gen.clone(),
+                input,
+                None,
+                None,
+                None,
+                table_meta_timestamps,
+            )
+        })
     }
 
     #[async_backtrace::framed]

--- a/src/query/storages/fuse/src/operations/compact.rs
+++ b/src/query/storages/fuse/src/operations/compact.rs
@@ -34,12 +34,12 @@ use crate::FUSE_OPT_KEY_BLOCK_PER_SEGMENT;
 use crate::FuseTable;
 use crate::Table;
 use crate::TableContext;
+use crate::operations::VirtualSchemaMode;
 use crate::operations::common::CommitMeta;
 use crate::operations::common::CommitSink;
 use crate::operations::common::ConflictResolveContext;
 use crate::operations::common::MutationGenerator;
 use crate::operations::common::SnapshotChanges;
-use crate::operations::VirtualSchemaMode;
 use crate::operations::mutation::BlockCompactMutator;
 use crate::operations::mutation::SegmentCompactMutator;
 use crate::operations::mutation::SegmentCompactionState;
@@ -142,10 +142,7 @@ impl FuseTable {
         );
         let block = DataBlock::empty_with_meta(Box::new(meta));
 
-        pipeline.add_source(
-            |output| OneBlockSource::create(output, block.clone()),
-            1,
-        )?;
+        pipeline.add_source(|output| OneBlockSource::create(output, block.clone()), 1)?;
 
         let snapshot_gen = MutationGenerator::new(Some(base_snapshot), MutationKind::Compact);
         pipeline.add_sink(|input| {

--- a/src/query/storages/fuse/src/operations/mutation/mutator/segment_compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/segment_compact_mutator.rs
@@ -23,11 +23,11 @@ use databend_storages_common_table_meta::meta::Location;
 use databend_storages_common_table_meta::meta::SegmentInfo;
 use databend_storages_common_table_meta::meta::Statistics;
 use databend_storages_common_table_meta::meta::TableMetaTimestamps;
+use databend_storages_common_table_meta::meta::TableSnapshot;
 use databend_storages_common_table_meta::meta::Versioned;
 use log::info;
 use opendal::Operator;
 
-use crate::FuseTable;
 use crate::TableContext;
 use crate::io::CachedMetaWriter;
 use crate::io::SegmentsIO;
@@ -45,6 +45,8 @@ pub struct SegmentCompactionState {
     pub new_segment_paths: Vec<String>,
     // number of fragmented segments compacted
     pub num_fragments_compacted: usize,
+    // statistics of segments that were consumed by compaction
+    pub removed_statistics: Statistics,
 }
 
 pub struct SegmentCompactMutator {
@@ -79,6 +81,14 @@ impl SegmentCompactMutator {
 
     fn has_compaction(&self) -> bool {
         !self.compaction.new_segment_paths.is_empty()
+    }
+
+    pub fn into_compaction_state(self) -> SegmentCompactionState {
+        self.compaction
+    }
+
+    pub fn base_snapshot(&self) -> &Arc<TableSnapshot> {
+        &self.compact_params.base_snapshot
     }
 
     #[async_backtrace::framed]
@@ -128,27 +138,6 @@ impl SegmentCompactMutator {
         metrics_set_compact_segments_select_duration_second(select_begin.elapsed());
 
         Ok(self.has_compaction())
-    }
-
-    #[async_backtrace::framed]
-    pub async fn try_commit(&self, table: &FuseTable) -> Result<()> {
-        if !self.has_compaction() {
-            // defensive checking
-            return Ok(());
-        }
-
-        // summary of snapshot is unchanged for compact segments.
-        let statistics = self.compact_params.base_snapshot.summary.clone();
-
-        table
-            .commit_mutation(
-                &self.ctx,
-                self.compact_params.base_snapshot.clone(),
-                &self.compaction.segments_locations,
-                statistics,
-                self.table_meta_timestamps,
-            )
-            .await
     }
 }
 
@@ -367,6 +356,12 @@ impl<'a> SegmentCompactor<'a> {
                 None => hlls_has_none = true,
             }
         }
+
+        merge_statistics_mut(
+            &mut self.compacted_state.removed_statistics,
+            &new_statistics,
+            self.default_cluster_key_id,
+        );
 
         let location = self
             .location_generator


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Replace the standalone `commit_mutation` OCC retry loop with the unified `CommitSink<MutationGenerator>` pipeline path for segment compaction. This removes ~200 lines of duplicated commit logic and unifies all write operations under the same commit framework.

All other write operations (INSERT, DELETE, UPDATE, block compaction, truncate, etc.) already commit through `CommitSink`. Segment compaction was the only path using a standalone async retry loop. Unifying gives segment compaction:
- Richer conflict resolution (`ModifiedSegmentExistsInLatest` instead of append-only detection)
- Auto-vacuum and purge support
- Unified metrics and observability

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20114)
<!-- Reviewable:end -->
