### PR TITLE
fix(meta): skip unrecognized table index type in TableMeta deserialization

### DIFF
--- a/src/meta/proto-conv/src/impls/table.rs
+++ b/src/meta/proto-conv/src/impls/table.rs
@@ -184,6 +184,10 @@ impl FromToProto for mt::TableMeta {
         let indexes = p
             .indexes
             .into_iter()
+            // Skip indexes whose type this binary does not recognize, so a table
+            // that enables a newer index type can still be read by an older binary
+            // instead of failing to deserialize the whole TableMeta (#20113).
+            .filter(|(_, index)| mt::TableIndexType::from_i32(index.index_type).is_some())
             .map(|(name, index)| Ok((name, mt::TableIndex::from_pb(index)?)))
             .collect::<Result<BTreeMap<_, _>, _>>()?;
 

--- a/src/meta/proto-conv/tests/it/proto_conv.rs
+++ b/src/meta/proto-conv/tests/it/proto_conv.rs
@@ -330,6 +330,35 @@ fn new_table_index() -> databend_common_meta_app::schema::TableIndex {
 }
 
 #[test]
+fn test_table_meta_skips_unknown_index_type() -> anyhow::Result<()> {
+    // A TableMeta that contains an index whose type was written by a newer binary
+    // (an unrecognized `TableIndexType` discriminant) must still deserialize: the
+    // unknown index is skipped rather than failing the whole TableMeta with
+    // `Incompatible`, so an older binary can still read the table. See #20113.
+    let valid = new_table_index().to_pb();
+    let mut unknown = valid.clone();
+    unknown.name = "future_idx".to_string();
+    unknown.index_type = 9999; // not a known TableIndexType value
+
+    let tbl = new_table_meta();
+    let mut p = tbl.to_pb();
+    p.indexes.clear();
+    p.indexes.insert("idx1".to_string(), valid);
+    p.indexes.insert("future_idx".to_string(), unknown);
+
+    let got = mt::TableMeta::from_pb(p)?;
+    assert!(
+        got.indexes.contains_key("idx1"),
+        "index with a known type must be preserved"
+    );
+    assert!(
+        !got.indexes.contains_key("future_idx"),
+        "index with an unknown type must be skipped, not fail the whole TableMeta"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_pb_from_to() -> anyhow::Result<()> {
     let db = new_db_meta();
     let p = db.to_pb();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

`TableMeta::from_pb` deserializes every index eagerly, and `TableIndex::from_pb`
returns `Incompatible` when `TableIndexType::from_i32` does not recognize the
stored discriminant (`src/meta/proto-conv/src/impls/table.rs`). So once a table
enables an index type that a given binary does not know about — e.g. a table
created by a newer version that added a new index type — that binary can no
longer read the **entire** table metadata, not just the unknown index.

This skips indexes whose type is not recognized so the rest of the metadata
still loads and the table stays readable. Recognized indexes and any other
incompatibilities are unaffected.

Reproduced with `test_table_meta_skips_unknown_index_type`: a `TableMeta` with a
valid index plus one carrying an unrecognized `index_type` fails `from_pb` with
`invalid IndexType: 9999` before the change; after it, deserialization succeeds
and only the unknown index is dropped.

- Close #20113

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20115)
<!-- Reviewable:end -->
