### PR TITLE
fix(query): set variable to NULL when subquery returns empty result

### DIFF
--- a/src/query/service/src/interpreters/interpreter_set.rs
+++ b/src/query/service/src/interpreters/interpreter_set.rs
@@ -212,6 +212,14 @@ impl Interpreter for SetInterpreter {
                 let num_rows: usize = datablocks.iter().map(|b| b.num_rows()).sum();
                 if num_rows == 0 {
                     if matches!(self.set.set_type, SetType::Variable) {
+                        let num_columns = bind_context.columns.len();
+                        if num_columns != self.set.idents.len() {
+                            return Err(ErrorCode::BadArguments(format!(
+                                "Expect {} column in set query result, but got {} columns",
+                                self.set.idents.len(),
+                                num_columns
+                            )));
+                        }
                         self.execute_variables(vec![Scalar::Null; self.set.idents.len()])
                             .await?;
                         return Ok(PipelineBuildResult::create());

--- a/src/query/service/src/interpreters/interpreter_set.rs
+++ b/src/query/service/src/interpreters/interpreter_set.rs
@@ -209,17 +209,17 @@ impl Interpreter for SetInterpreter {
                     .execute_with_hooks(self.ctx.clone(), QueryFinishHooks::nested_with_hooks())
                     .await?;
                 let datablocks: Vec<DataBlock> = stream.try_collect::<Vec<_>>().await?;
+                let num_columns = bind_context.columns.len();
+                if num_columns != self.set.idents.len() {
+                    return Err(ErrorCode::BadArguments(format!(
+                        "Expect {} column in set query result, but got {} columns",
+                        self.set.idents.len(),
+                        num_columns
+                    )));
+                }
                 let num_rows: usize = datablocks.iter().map(|b| b.num_rows()).sum();
                 if num_rows == 0 {
                     if matches!(self.set.set_type, SetType::Variable) {
-                        let num_columns = bind_context.columns.len();
-                        if num_columns != self.set.idents.len() {
-                            return Err(ErrorCode::BadArguments(format!(
-                                "Expect {} column in set query result, but got {} columns",
-                                self.set.idents.len(),
-                                num_columns
-                            )));
-                        }
                         self.execute_variables(vec![Scalar::Null; self.set.idents.len()])
                             .await?;
                         return Ok(PipelineBuildResult::create());
@@ -234,13 +234,6 @@ impl Interpreter for SetInterpreter {
                     return Err(ErrorCode::BadArguments(format!(
                         "Expect scalar result in set query result, but got {} rows",
                         datablock.num_rows()
-                    )));
-                }
-                if datablock.num_columns() != self.set.idents.len() {
-                    return Err(ErrorCode::BadArguments(format!(
-                        "Expect {} column in set query result, but got {} columns",
-                        self.set.idents.len(),
-                        datablock.num_columns()
                     )));
                 }
                 datablock

--- a/src/query/service/src/interpreters/interpreter_set.rs
+++ b/src/query/service/src/interpreters/interpreter_set.rs
@@ -209,6 +209,17 @@ impl Interpreter for SetInterpreter {
                     .execute_with_hooks(self.ctx.clone(), QueryFinishHooks::nested_with_hooks())
                     .await?;
                 let datablocks: Vec<DataBlock> = stream.try_collect::<Vec<_>>().await?;
+                let num_rows: usize = datablocks.iter().map(|b| b.num_rows()).sum();
+                if num_rows == 0 {
+                    if matches!(self.set.set_type, SetType::Variable) {
+                        self.execute_variables(vec![Scalar::Null; self.set.idents.len()])
+                            .await?;
+                        return Ok(PipelineBuildResult::create());
+                    }
+                    return Err(ErrorCode::BadArguments(
+                        "Subquery in SET statement returned 0 rows, expected exactly 1 row",
+                    ));
+                }
                 let datablock = DataBlock::concat(&datablocks)?;
 
                 if datablock.num_rows() != 1 {

--- a/tests/sqllogictests/suites/query/show_variables.test
+++ b/tests/sqllogictests/suites/query/show_variables.test
@@ -30,3 +30,12 @@ query TTT
 select name, value, type from show_variables() where name='a';
 ----
 a 3 UInt8
+
+statement ok
+set variable x = (select 1 where 1 = 0)
+
+skipif mysql
+query T
+select getvariable('x')
+----
+NULL

--- a/tests/sqllogictests/suites/query/show_variables.test
+++ b/tests/sqllogictests/suites/query/show_variables.test
@@ -39,3 +39,9 @@ query T
 select getvariable('x')
 ----
 NULL
+
+statement error Expect 2 column in set query result, but got 1 columns
+set variable (a, b) = (select 1 where 1 = 0)
+
+statement error Expect 1 column in set query result, but got 2 columns
+set variable x = (select 1, 2 where 1 = 0)

--- a/tests/sqllogictests/suites/query/show_variables.test
+++ b/tests/sqllogictests/suites/query/show_variables.test
@@ -34,7 +34,6 @@ a 3 UInt8
 statement ok
 set variable x = (select 1 where 1 = 0)
 
-skipif mysql
 query T
 select getvariable('x')
 ----


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

When `SET VARIABLE x = (SELECT ... WHERE ...)` subquery returns 0 rows, the interpreter previously called `DataBlock::concat(&[])` which threw an internal error: `code: 1016, message: Can't concat empty blocks`.

This PR fixes the behavior to align with Snowflake: when the subquery returns no rows, the variable is set to NULL instead of erroring. For non-variable SET statements (settings), a clear error message is returned: "Subquery in SET statement returned 0 rows, expected exactly 1 row".

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20118)
<!-- Reviewable:end -->
