### PR TITLE
refactor(query): reduce parser success path overhead

### DIFF
--- a/src/query/ast/src/parser/error.rs
+++ b/src/query/ast/src/parser/error.rs
@@ -65,14 +65,25 @@ impl ErrorKind {
 ///
 /// This is similar to the `Error`, but the information will not get lost
 /// even the error is from a optional branch.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct Backtrace {
+    enabled: bool,
     inner: RefCell<Option<BacktraceInner>>,
 }
 
 impl Backtrace {
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            enabled: true,
+            inner: RefCell::new(None),
+        }
+    }
+
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            inner: RefCell::new(None),
+        }
     }
 
     pub fn clear(&self) {
@@ -85,6 +96,12 @@ impl Backtrace {
     /// particularly when the furthest path is reached but considered invalid.
     pub fn restore(&self, other: Backtrace) {
         *self.inner.borrow_mut() = other.inner.into_inner();
+    }
+}
+
+impl Default for Backtrace {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -139,25 +156,27 @@ impl<'a> nom::error::ContextError<Input<'a>> for Error<'a> {
 
 impl<'a> Error<'a> {
     pub fn from_error_kind(input: Input<'a>, kind: ErrorKind) -> Self {
-        let mut inner = input.backtrace.inner.borrow_mut();
-        if let Some(ref mut inner) = *inner {
-            match input.tokens[0].span.start.cmp(&inner.span.start) {
-                Ordering::Equal => {
-                    inner.errors.push(kind.clone());
+        if input.backtrace.enabled {
+            let mut inner = input.backtrace.inner.borrow_mut();
+            if let Some(ref mut inner) = *inner {
+                match input.tokens[0].span.start.cmp(&inner.span.start) {
+                    Ordering::Equal => {
+                        inner.errors.push(kind.clone());
+                    }
+                    Ordering::Less => (),
+                    Ordering::Greater => {
+                        *inner = BacktraceInner {
+                            span: transform_span(&input.tokens[..1]).unwrap(),
+                            errors: vec![kind.clone()],
+                        };
+                    }
                 }
-                Ordering::Less => (),
-                Ordering::Greater => {
-                    *inner = BacktraceInner {
-                        span: transform_span(&input.tokens[..1]).unwrap(),
-                        errors: vec![kind.clone()],
-                    };
-                }
-            }
-        } else {
-            *inner = Some(BacktraceInner {
-                span: transform_span(&input.tokens[..1]).unwrap(),
-                errors: vec![kind.clone()],
-            })
+            } else {
+                *inner = Some(BacktraceInner {
+                    span: transform_span(&input.tokens[..1]).unwrap(),
+                    errors: vec![kind.clone()],
+                })
+            };
         }
 
         Error {

--- a/src/query/ast/src/parser/parser.rs
+++ b/src/query/ast/src/parser/parser.rs
@@ -40,7 +40,11 @@ use crate::parser::token::TokenKind;
 use crate::parser::token::Tokenizer;
 
 pub fn tokenize_sql(sql: &str) -> Result<Vec<Token<'_>>> {
-    Tokenizer::new(sql).collect::<Result<Vec<_>>>()
+    let mut tokens = Vec::with_capacity((sql.len() / 4).clamp(4, 256));
+    for token in Tokenizer::new(sql) {
+        tokens.push(token?);
+    }
+    Ok(tokens)
 }
 
 /// Parse a SQL string into `Statement`s.
@@ -160,7 +164,7 @@ pub fn run_parser<O>(
     allow_partial: bool,
     mut parser: impl FnMut(Input) -> IResult<O>,
 ) -> Result<O> {
-    let backtrace = Backtrace::new();
+    let backtrace = Backtrace::disabled();
     let input = Input {
         tokens,
         dialect,
@@ -184,6 +188,18 @@ pub fn run_parser<O>(
         }
         Err(nom::Err::Error(err) | nom::Err::Failure(err)) => {
             let source = tokens[0].source;
+            let backtrace = Backtrace::new();
+            let input = Input {
+                tokens,
+                dialect,
+                mode,
+                backtrace: &backtrace,
+            };
+            let err = match parser(input) {
+                Err(nom::Err::Error(err) | nom::Err::Failure(err)) => err,
+                Ok(_) => err,
+                Err(nom::Err::Incomplete(_)) => unreachable!(),
+            };
             Err(ParseError(None, display_parser_error(err, source)))
         }
         Err(nom::Err::Incomplete(_)) => unreachable!(),

--- a/src/query/ast/src/parser/query.rs
+++ b/src/query/ast/src/parser/query.rs
@@ -46,7 +46,19 @@ pub fn query(i: Input) -> IResult<Query> {
 }
 
 pub fn set_operation(i: Input) -> IResult<SetExpr> {
-    let (rest, set_operation_elements) = rule! { #set_operation_element+ }.parse(i)?;
+    let (rest, mut set_operation_elements) = rule! { #set_operation_element+ }.parse(i)?;
+    if set_operation_elements.len() == 1 {
+        let elem = set_operation_elements.pop().unwrap();
+        if matches!(
+            &elem.elem,
+            SetOperationElement::Group(_)
+                | SetOperationElement::SelectStmt { .. }
+                | SetOperationElement::Values(_)
+        ) {
+            return Ok((rest, set_operation_primary(elem)));
+        }
+        set_operation_elements.push(elem);
+    }
     run_pratt_parser(SetOperationParser, set_operation_elements, rest, i)
 }
 
@@ -237,6 +249,45 @@ pub fn set_operation_element(i: Input) -> IResult<WithSpan<SetOperationElement>>
 
 struct SetOperationParser;
 
+fn set_operation_primary(input: WithSpan<SetOperationElement>) -> SetExpr {
+    match input.elem {
+        SetOperationElement::Group(expr) => {
+            let mut query = expr.into_query();
+            query.span = transform_span(input.span.tokens);
+            SetExpr::Query(Box::new(query))
+        }
+        SetOperationElement::SelectStmt {
+            hints,
+            distinct,
+            top_n,
+            select_list,
+            from,
+            selection,
+            group_by,
+            having,
+            window_list,
+            qualify,
+        } => SetExpr::Select(Box::new(SelectStmt {
+            span: transform_span(input.span.tokens),
+            hints,
+            top_n,
+            distinct,
+            select_list,
+            from,
+            selection,
+            group_by,
+            having,
+            window_list,
+            qualify,
+        })),
+        SetOperationElement::Values(values) => SetExpr::Values {
+            span: transform_span(input.span.tokens),
+            values,
+        },
+        _ => unreachable!(),
+    }
+}
+
 impl<'a, I: Iterator<Item = WithSpan<'a, SetOperationElement>>> PrattParser<I>
     for SetOperationParser
 {
@@ -268,43 +319,7 @@ impl<'a, I: Iterator<Item = WithSpan<'a, SetOperationElement>>> PrattParser<I>
     }
 
     fn primary(&mut self, input: Self::Input) -> Result<Self::Output, &'static str> {
-        let set_expr = match input.elem {
-            SetOperationElement::Group(expr) => {
-                let mut query = expr.into_query();
-                query.span = transform_span(input.span.tokens);
-                SetExpr::Query(Box::new(query))
-            }
-            SetOperationElement::SelectStmt {
-                hints,
-                distinct,
-                top_n,
-                select_list,
-                from,
-                selection,
-                group_by,
-                having,
-                window_list,
-                qualify,
-            } => SetExpr::Select(Box::new(SelectStmt {
-                span: transform_span(input.span.tokens),
-                hints,
-                top_n,
-                distinct,
-                select_list,
-                from,
-                selection,
-                group_by,
-                having,
-                window_list,
-                qualify,
-            })),
-            SetOperationElement::Values(values) => SetExpr::Values {
-                span: transform_span(input.span.tokens),
-                values,
-            },
-            _ => unreachable!(),
-        };
-        Ok(set_expr)
+        Ok(set_operation_primary(input))
     }
 
     fn infix(
@@ -790,7 +805,21 @@ pub fn order_by_expr(i: Input) -> IResult<OrderByExpr> {
 }
 
 pub fn table_reference(i: Input) -> IResult<TableReference> {
-    let (rest, table_reference_elements) = rule! { #table_reference_element+ }.parse(i)?;
+    let (rest, mut table_reference_elements) = rule! { #table_reference_element+ }.parse(i)?;
+    if table_reference_elements.len() == 1 {
+        let elem = table_reference_elements.pop().unwrap();
+        if matches!(
+            &elem.elem,
+            TableReferenceElement::Group(_)
+                | TableReferenceElement::Table { .. }
+                | TableReferenceElement::TableFunction { .. }
+                | TableReferenceElement::Subquery { .. }
+                | TableReferenceElement::Stage { .. }
+        ) {
+            return Ok((rest, table_reference_primary(elem)));
+        }
+        table_reference_elements.push(elem);
+    }
     run_pratt_parser(TableReferenceParser, table_reference_elements, rest, i)
 }
 
@@ -1066,6 +1095,89 @@ fn get_table_sample(
 
 struct TableReferenceParser;
 
+fn table_reference_primary(input: WithSpan<TableReferenceElement>) -> TableReference {
+    match input.elem {
+        TableReferenceElement::Group(table_ref) => table_ref,
+        TableReferenceElement::Table {
+            table,
+            alias,
+            temporal,
+            with_options,
+            pivot,
+            unpivot,
+            sample,
+        } => TableReference::Table {
+            span: transform_span(input.span.tokens),
+            table,
+            alias,
+            temporal,
+            with_options,
+            pivot,
+            unpivot,
+            sample,
+        },
+        TableReferenceElement::TableFunction {
+            lateral,
+            name,
+            params,
+            alias,
+            sample,
+        } => {
+            let normal_params = params
+                .iter()
+                .filter_map(|p| match p {
+                    TableFunctionParam::Normal(p) => Some(p.clone()),
+                    _ => None,
+                })
+                .collect();
+            let named_params = params
+                .into_iter()
+                .filter_map(|p| match p {
+                    TableFunctionParam::Named { name, value } => Some((name, value)),
+                    _ => None,
+                })
+                .collect();
+            TableReference::TableFunction {
+                span: transform_span(input.span.tokens),
+                lateral,
+                name,
+                params: normal_params,
+                named_params,
+                alias,
+                sample,
+            }
+        }
+        TableReferenceElement::Subquery {
+            lateral,
+            subquery,
+            alias,
+            pivot,
+            unpivot,
+        } => TableReference::Subquery {
+            span: transform_span(input.span.tokens),
+            lateral,
+            subquery,
+            alias,
+            pivot,
+            unpivot,
+        },
+        TableReferenceElement::Stage {
+            location,
+            options,
+            alias,
+        } => {
+            let options = SelectStageOptions::from(options);
+            TableReference::Location {
+                span: transform_span(input.span.tokens),
+                location,
+                options,
+                alias,
+            }
+        }
+        _ => unreachable!(),
+    }
+}
+
 impl<'a, I: Iterator<Item = WithSpan<'a, TableReferenceElement>>> PrattParser<I>
     for TableReferenceParser
 {
@@ -1083,87 +1195,7 @@ impl<'a, I: Iterator<Item = WithSpan<'a, TableReferenceElement>>> PrattParser<I>
     }
 
     fn primary(&mut self, input: Self::Input) -> Result<Self::Output, &'static str> {
-        let table_ref = match input.elem {
-            TableReferenceElement::Group(table_ref) => table_ref,
-            TableReferenceElement::Table {
-                table,
-                alias,
-                temporal,
-                with_options,
-                pivot,
-                unpivot,
-                sample,
-            } => TableReference::Table {
-                span: transform_span(input.span.tokens),
-                table,
-                alias,
-                temporal,
-                with_options,
-                pivot,
-                unpivot,
-                sample,
-            },
-            TableReferenceElement::TableFunction {
-                lateral,
-                name,
-                params,
-                alias,
-                sample,
-            } => {
-                let normal_params = params
-                    .iter()
-                    .filter_map(|p| match p {
-                        TableFunctionParam::Normal(p) => Some(p.clone()),
-                        _ => None,
-                    })
-                    .collect();
-                let named_params = params
-                    .into_iter()
-                    .filter_map(|p| match p {
-                        TableFunctionParam::Named { name, value } => Some((name, value)),
-                        _ => None,
-                    })
-                    .collect();
-                TableReference::TableFunction {
-                    span: transform_span(input.span.tokens),
-                    lateral,
-                    name,
-                    params: normal_params,
-                    named_params,
-                    alias,
-                    sample,
-                }
-            }
-            TableReferenceElement::Subquery {
-                lateral,
-                subquery,
-                alias,
-                pivot,
-                unpivot,
-            } => TableReference::Subquery {
-                span: transform_span(input.span.tokens),
-                lateral,
-                subquery,
-                alias,
-                pivot,
-                unpivot,
-            },
-            TableReferenceElement::Stage {
-                location,
-                options,
-                alias,
-            } => {
-                let options = SelectStageOptions::from(options);
-                TableReference::Location {
-                    span: transform_span(input.span.tokens),
-                    location,
-                    options,
-                    alias,
-                }
-            }
-            _ => unreachable!(),
-        };
-        Ok(table_ref)
+        Ok(table_reference_primary(input))
     }
 
     fn infix(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Reduce `databend-common-ast` parser success-path overhead without adding a second statement-level parser implementation.

This is a lower-risk replacement for the previous aggressive AST parser fast-path PR. It keeps the existing nom parser as the single source of grammar behavior and only applies small structural optimizations:

- avoid building parser error backtrace state on successful parses; rerun with backtrace enabled only when parsing fails
- pre-allocate token vectors in `tokenize_sql`
- skip Pratt parser setup for single-primary `set_operation` and `table_reference` cases while reusing the same AST construction helpers as the Pratt path

This PR intentionally does not add `fast_path.rs` or handwritten parsers for statements like `SELECT`, `INSERT`, `CREATE`, etc.

## Compatibility Checks

Compared this branch against `origin/main` over the SQL AST benchmark PostgreSQL and Hive corpora:

```text
PostgreSQL: main OK / PR ERR = 0, display_diff = 0
Hive:       main OK / PR ERR = 0, display_diff = 0
```

No golden testdata changes.

## Benchmarks

### `/workspace/sql_ast_benchmark`

Same machine, same command, patching `databend-common-ast` to each local tree:

```text
cargo bench --bench parsing --config 'patch.crates-io.databend-common-ast.path=".../src/query/ast"'
```

| Dialect | Main median | PR median | Main p90 | PR p90 | Change |
|---|---:|---:|---:|---:|---:|
| PostgreSQL | 7860.1 ns | 5466.1 ns | 20622.8 ns | 13701.3 ns | +30.5% median |
| MySQL | 6872.2 ns | 5746.1 ns | 20756.2 ns | 17390.6 ns | +16.4% median |
| Hive | 10856.2 ns | 10986.4 ns | 34241.3 ns | 35189.0 ns | -1.2% median |

Current PR rows:

```text
postgresql,databend-common-ast,29384,13195,143.0,1740.6,3105.5,5466.1,7998.1,13701.3,40973.7,1066569.7,7866.3,99.8
mysql,databend-common-ast,30214,16598,160.2,1589.5,2794.5,5746.1,10045.1,17390.6,84621.3,4507116.7,15273.0,100.0
hive,databend-common-ast,41293,21362,240.2,910.9,4987.9,10986.4,20021.5,35189.0,122688.0,603481805.0,46130.3,100.0
```

### `src/query/ast/benches/bench.rs`

Same machine, same command:

```text
cargo bench -p databend-common-ast --bench bench
```

| Benchmark | Main median | PR median | Change |
|---|---:|---:|---:|
| `parse_extra_star_comment_block` | 32.41 us | 26.13 us | +19.4% |
| `tokenize_extra_star_comment_block` | 6.099 us | 5.894 us | +3.4% |
| `tokenize_normal_comment_block` | 2.17 us | 2.096 us | +3.4% |
| `deep_function_call` | 99.69 us | 81.72 us | +18.0% |
| `deep_query` | 280.3 us | 223.7 us | +20.2% |
| `large_query` | 168.6 us | 138.4 us | +17.9% |
| `large_statement` | 168.7 us | 139.9 us | +17.1% |
| `wide_embedding` | 2.805 ms | 2.533 ms | +9.7% |
| `wide_expr` | 32.11 us | 30.45 us | +5.2% |

## Tests

- [x] Unit Test
- [ ] Logic Test
- [x] Benchmark Test
- [ ] No Test - _Explain why_

Validated with:

```text
cargo test -p databend-common-ast --all-targets
cargo clippy -p databend-common-ast --all-targets -- -D warnings
git diff --check
git diff -- src/query/ast/tests/it/testdata
cargo bench -p databend-common-ast --bench bench
cargo bench --bench parsing --config 'patch.crates-io.databend-common-ast.path="/home/sundy/workspace/databend/src/query/ast"'
```

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20119)
<!-- Reviewable:end -->
