### PR TITLE
fix(query): trigger all ready task successors

### DIFF
--- a/src/query/service/src/task/service.rs
+++ b/src/query/service/src/task/service.rs
@@ -770,10 +770,24 @@ WHERE ta.task_name = {task_name}
         OR (nt.completed_at IS NOT NULL AND tr.completed_at <= nt.completed_at)
       )
   );");
-            if let Some(next_task) = self.execute_sql(None, &check).await?.first().and_then(|block| block.columns()[0].index(0).and_then(|scalar| { scalar.as_string().map(|s| s.to_string()) })) {
+            let blocks = self.execute_sql(None, &check).await?;
+            for next_task in Self::next_task_names_from_blocks(&blocks) {
                 yield Result::Ok(next_task);
             }
         }
+    }
+
+    fn next_task_names_from_blocks(blocks: &[DataBlock]) -> impl Iterator<Item = String> + '_ {
+        blocks.iter().flat_map(|block| {
+            let column = block.columns().first();
+            (0..block.num_rows()).filter_map(move |row| {
+                column.and_then(|column| {
+                    column
+                        .index(row)
+                        .and_then(|scalar| scalar.as_string().map(|s| s.to_string()))
+                })
+            })
+        })
     }
 
     pub async fn clean_task_afters(&self, task_name: &str) -> Result<()> {

--- a/tests/task/test-private-task.sh
+++ b/tests/task/test-private-task.sh
@@ -343,6 +343,77 @@ else
     exit 1
 fi
 
+# Check Task Fan-out
+
+response=$(query_sql_with_auth "root:" "CREATE OR REPLACE TABLE fanout_sink (child string)")
+check_response_error "$response"
+
+response=$(query_sql_with_auth "root:" "CREATE TASK fanout_root AS SELECT 1")
+check_response_error "$response"
+
+response=$(query_sql_with_auth "root:" "CREATE TASK fanout_child_a AFTER 'fanout_root' AS INSERT INTO fanout_sink VALUES ('a')")
+check_response_error "$response"
+
+response=$(query_sql_with_auth "root:" "CREATE TASK fanout_child_b AFTER 'fanout_root' AS INSERT INTO fanout_sink VALUES ('b')")
+check_response_error "$response"
+
+response=$(query_sql_with_auth "root:" "CREATE TASK fanout_child_c AFTER 'fanout_root' AS INSERT INTO fanout_sink VALUES ('c')")
+check_response_error "$response"
+
+response=$(query_sql_with_auth "root:" "ALTER TASK fanout_child_a RESUME")
+check_response_error "$response"
+
+response=$(query_sql_with_auth "root:" "ALTER TASK fanout_child_b RESUME")
+check_response_error "$response"
+
+response=$(query_sql_with_auth "root:" "ALTER TASK fanout_child_c RESUME")
+check_response_error "$response"
+
+actual_after_count=0
+for _ in {1..20}; do
+    response=$(query_sql_with_auth "root:" "SELECT count(*) FROM system_task.task_after WHERE task_name = 'fanout_root' AND next_task IN ('fanout_child_a', 'fanout_child_b', 'fanout_child_c')")
+    check_response_error "$response"
+    actual_after_count=$(echo "$response" | jq -r '.data[0][0]')
+    if [ "$actual_after_count" = "3" ]; then
+        break
+    fi
+    sleep 1
+done
+
+if [ "$actual_after_count" = "3" ]; then
+    echo "✅ Private task fan-out AFTER bindings are ready"
+else
+    echo "❌ Expected private task fan-out AFTER bindings to be ready"
+    echo "Expected: 3"
+    echo "Actual  : $actual_after_count"
+    exit 1
+fi
+
+response=$(query_sql_with_auth "root:" "EXECUTE TASK fanout_root")
+check_response_error "$response"
+
+actual='[]'
+for _ in {1..20}; do
+    response=$(query_sql_with_auth "root:" "SELECT child FROM fanout_sink ORDER BY child")
+    check_response_error "$response"
+    actual=$(echo "$response" | jq -c '.data')
+    if [ "$actual" = '[["a"],["b"],["c"]]' ]; then
+        break
+    fi
+    sleep 1
+done
+
+expected='[["a"],["b"],["c"]]'
+
+if [ "$actual" = "$expected" ]; then
+    echo "✅ Private task fan-out triggers all successors"
+else
+    echo "❌ Expected private task fan-out to trigger all successors"
+    echo "Expected: $expected"
+    echo "Actual  : $actual"
+    exit 1
+fi
+
 response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"CREATE TASK my_task_1 SCHEDULE = 5 SECOND AS insert into t1 values(0)\"}")
 check_response_error "$response"
 create_task_1_query_id=$(echo $response | jq -r '.id')


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Fixes: #20112
- Expand all rows returned by private task DAG successor lookup instead of only the first row.
- Add regression coverage for a root task that fans out to three AFTER children.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20120)
<!-- Reviewable:end -->
