### PR TITLE
fix(query): support table index privilege checks

### DIFF
--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -503,6 +503,154 @@ impl PrivilegeAccess {
         Ok(())
     }
 
+    async fn validate_table_index_access(
+        &self,
+        catalog_name: &str,
+        db_name: &str,
+        table_name: &str,
+    ) -> Result<()> {
+        self.access_system_history(
+            Some(catalog_name),
+            Some(db_name),
+            None,
+            UserPrivilegeType::Alter,
+        )?;
+
+        self.validate_table_index_alter_or_super_access(catalog_name, db_name, table_name)
+            .await
+    }
+
+    async fn validate_drop_table_index_access(
+        &self,
+        catalog_name: &str,
+        db_name: &str,
+        table_name: &str,
+    ) -> Result<()> {
+        self.access_system_history(
+            Some(catalog_name),
+            Some(db_name),
+            None,
+            UserPrivilegeType::Drop,
+        )?;
+
+        match self
+            .validate_table_index_alter_or_super_access(catalog_name, db_name, table_name)
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(err) if err.code() == ErrorCode::PERMISSION_DENIED => {
+                match self
+                    .validate_access(&GrantObject::Global, UserPrivilegeType::Drop, false, false)
+                    .await
+                {
+                    Ok(()) => Ok(()),
+                    Err(drop_err) if drop_err.code() == ErrorCode::PERMISSION_DENIED => Err(err),
+                    Err(drop_err) => Err(drop_err),
+                }
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn validate_table_index_alter_or_super_access(
+        &self,
+        catalog_name: &str,
+        db_name: &str,
+        table_name: &str,
+    ) -> Result<()> {
+        match self
+            .validate_real_table_alter_access(catalog_name, db_name, table_name)
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(err) if err.code() == ErrorCode::PERMISSION_DENIED => {
+                match self
+                    .validate_access(&GrantObject::Global, UserPrivilegeType::Super, false, false)
+                    .await
+                {
+                    Ok(()) => Ok(()),
+                    Err(super_err) if super_err.code() == ErrorCode::PERMISSION_DENIED => Err(err),
+                    Err(super_err) => Err(super_err),
+                }
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn validate_real_table_alter_access(
+        &self,
+        catalog_name: &str,
+        db_name: &str,
+        table_name: &str,
+    ) -> Result<()> {
+        if self.ctx.is_temp_table(catalog_name, db_name, table_name) {
+            return Ok(());
+        }
+
+        let tenant = self.ctx.get_tenant();
+        let catalog = self.ctx.get_catalog(catalog_name).await?;
+
+        match self
+            .validate_access(
+                &GrantObject::Table(
+                    catalog_name.to_string(),
+                    db_name.to_string(),
+                    table_name.to_string(),
+                ),
+                UserPrivilegeType::Alter,
+                false,
+                false,
+            )
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(err) if err.code() == ErrorCode::PERMISSION_DENIED => {
+                match self
+                    .convert_to_id(&tenant, &catalog, db_name, Some(table_name), false)
+                    .await
+                {
+                    Ok(ObjectId::Table(db_id, table_id)) => {
+                        match self
+                            .validate_access(
+                                &GrantObject::TableById(catalog_name.to_string(), db_id, table_id),
+                                UserPrivilegeType::Alter,
+                                false,
+                                false,
+                            )
+                            .await
+                        {
+                            Ok(()) => Ok(()),
+                            Err(err) if err.code() == ErrorCode::PERMISSION_DENIED => {
+                                let current_user = self.ctx.get_current_user()?;
+                                let session = self.ctx.get_current_session();
+                                let roles_name = session
+                                    .get_all_effective_roles()
+                                    .await?
+                                    .iter()
+                                    .map(|r| r.name.clone())
+                                    .collect::<Vec<_>>()
+                                    .join(",");
+                                Err(ErrorCode::PermissionDenied(format!(
+                                    "Permission denied: privilege [{:?}] is required on '{}'.'{}'.'{}' for user {} with roles [{}]",
+                                    UserPrivilegeType::Alter,
+                                    catalog_name,
+                                    db_name,
+                                    table_name,
+                                    &current_user.identity().display(),
+                                    roles_name,
+                                )))
+                            }
+                            Err(err) => Err(err),
+                        }
+                    }
+                    Ok(ObjectId::Database(_)) => unreachable!("table name is provided"),
+                    Err(err) => Err(err.add_message("error on validating table index access")),
+                }
+            }
+            Err(err) => Err(err),
+        }
+    }
+
     async fn validate_warehouse_ownership(
         &self,
         warehouse: String,
@@ -1403,11 +1551,13 @@ impl AccessChecker for PrivilegeAccess {
             Plan::DropDatabase(plan) => {
                 self.validate_db_access(&plan.catalog, &plan.database, UserPrivilegeType::Drop, plan.if_exists).await?;
             }
-            Plan::UndropDatabase(_)
-            | Plan::DropIndex(_)
-            | Plan::DropTableIndex(_) => {
+            Plan::UndropDatabase(_) | Plan::DropIndex(_) => {
                 // undroptable/db need convert name to id. But because of drop, can not find the id. Upgrade Object to Database.
                 self.validate_access(&GrantObject::Global, UserPrivilegeType::Drop, false, false)
+                    .await?;
+            }
+            Plan::DropTableIndex(plan) => {
+                self.validate_drop_table_index_access(&plan.catalog, &plan.database, &plan.table)
                     .await?;
             }
             Plan::CreateStage(_) => {
@@ -1893,10 +2043,13 @@ impl AccessChecker for PrivilegeAccess {
             | Plan::RevertTable(_)
             | Plan::AlterUDF(_)
             | Plan::RefreshIndex(_)
-            | Plan::RefreshTableIndex(_)
             | Plan::AlterRole(_)
             | Plan::AlterUser(_) => {
                 self.validate_access(&GrantObject::Global, UserPrivilegeType::Alter, false, false)
+                    .await?;
+            }
+            Plan::RefreshTableIndex(plan) => {
+                self.validate_table_index_access(&plan.catalog, &plan.database, &plan.table)
                     .await?;
             }
             Plan::CopyIntoTable(plan) => {
@@ -1998,7 +2151,6 @@ impl AccessChecker for PrivilegeAccess {
             | Plan::DropPasswordPolicy(_)
             | Plan::DescPasswordPolicy(_)
             | Plan::CreateIndex(_)
-            | Plan::CreateTableIndex(_)
             | Plan::CreateNotification(_)
             | Plan::DropNotification(_)
             | Plan::DescNotification(_)
@@ -2016,6 +2168,10 @@ impl AccessChecker for PrivilegeAccess {
             | Plan::DropWorker(_)
             | Plan::ShowWorkers => {
                 self.validate_access(&GrantObject::Global, UserPrivilegeType::Super, false, false)
+                    .await?;
+            }
+            Plan::CreateTableIndex(plan) => {
+                self.validate_table_index_access(&plan.catalog, &plan.database, &plan.table)
                     .await?;
             }
             Plan::CreateDatamaskPolicy(_) => {

--- a/src/query/sql/src/planner/binder/ddl/index.rs
+++ b/src/query/sql/src/planner/binder/ddl/index.rs
@@ -547,6 +547,8 @@ impl Binder {
             index_type: *index_type,
             create_option: create_option.clone().into(),
             catalog,
+            database,
+            table: table.name().to_string(),
             index_name,
             column_ids,
             table_id,
@@ -923,6 +925,8 @@ impl Binder {
             index_type: *index_type,
             if_exists: *if_exists,
             catalog,
+            database,
+            table: table.name().to_string(),
             index_name,
             table_id,
         };

--- a/src/query/sql/src/planner/plans/ddl/index.rs
+++ b/src/query/sql/src/planner/plans/ddl/index.rs
@@ -65,6 +65,8 @@ pub struct CreateTableIndexPlan {
     pub index_type: TableIndexType,
     pub create_option: CreateOption,
     pub catalog: String,
+    pub database: String,
+    pub table: String,
     pub index_name: String,
     pub column_ids: Vec<ColumnId>,
     pub table_id: MetaId,
@@ -78,6 +80,8 @@ pub struct DropTableIndexPlan {
     pub index_type: TableIndexType,
     pub if_exists: bool,
     pub catalog: String,
+    pub database: String,
+    pub table: String,
     pub index_name: String,
     pub table_id: MetaId,
 }

--- a/tests/suites/0_stateless/18_rbac/18_0019_table_index_privilege.result
+++ b/tests/suites/0_stateless/18_rbac/18_0019_table_index_privilege.result
@@ -1,0 +1,17 @@
+=== denied table index ===
+1
+=== table function name collision ===
+1
+=== alter ngram index ===
+alter ok
+=== table owner inverted index ===
+0
+table owner ok
+=== db owner vector index ===
+db owner ok
+=== super table index ===
+super ok
+=== global drop table index ===
+global drop ok
+=== system_history hard deny for super ===
+1

--- a/tests/suites/0_stateless/18_rbac/18_0019_table_index_privilege.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0019_table_index_privilege.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../../../shell_env.sh
+
+export TEST_USER_PASSWORD="password"
+export ALTER_USER_CONNECT="bendsql_connect_user idx_alter password -A"
+export TABLE_OWNER_CONNECT="bendsql_connect_user idx_table_owner password -A"
+export DB_OWNER_CONNECT="bendsql_connect_user idx_db_owner password -A"
+export SUPER_USER_CONNECT="bendsql_connect_user idx_super password -A"
+export DROP_USER_CONNECT="bendsql_connect_user idx_drop password -A"
+export DENIED_USER_CONNECT="bendsql_connect_user idx_denied password -A"
+
+run_user_alter() {
+	cat <<SQL | $ALTER_USER_CONNECT
+$1
+SQL
+}
+
+run_table_owner() {
+	cat <<SQL | $TABLE_OWNER_CONNECT
+$1
+SQL
+}
+
+run_db_owner() {
+	cat <<SQL | $DB_OWNER_CONNECT
+$1
+SQL
+}
+
+run_user_super() {
+	cat <<SQL | $SUPER_USER_CONNECT
+$1
+SQL
+}
+
+run_user_drop() {
+	cat <<SQL | $DROP_USER_CONNECT
+$1
+SQL
+}
+
+run_root_sql "
+drop user if exists idx_alter;
+drop user if exists idx_table_owner;
+drop user if exists idx_db_owner;
+drop user if exists idx_super;
+drop user if exists idx_drop;
+drop user if exists idx_denied;
+drop role if exists idx_table_owner_role;
+drop role if exists idx_db_owner_role;
+drop database if exists idx_priv;
+
+create user idx_alter identified by '$TEST_USER_PASSWORD';
+create user idx_table_owner identified by '$TEST_USER_PASSWORD';
+create user idx_db_owner identified by '$TEST_USER_PASSWORD';
+create user idx_super identified by '$TEST_USER_PASSWORD';
+create user idx_drop identified by '$TEST_USER_PASSWORD';
+create user idx_denied identified by '$TEST_USER_PASSWORD';
+create role idx_table_owner_role;
+create role idx_db_owner_role;
+
+create database idx_priv;
+create table idx_priv.t_alter(id int, content string);
+create table idx_priv.t_table_owner(id int, content string);
+create table idx_priv.t_db_owner_vec(id int, embedding vector(4));
+create table idx_priv.t_super(id int, content string);
+create table idx_priv.t_global_drop(id int, content string);
+create table idx_priv.t_denied(id int, content string);
+create table idx_priv.numbers(id int, content string);
+create ngram index idx_ngram_global_drop on idx_priv.t_global_drop(content) gram_size = 2 bloom_size = 1048576;
+
+grant alter on idx_priv.t_alter to idx_alter;
+grant ownership on idx_priv.t_table_owner to role idx_table_owner_role;
+grant role idx_table_owner_role to idx_table_owner;
+alter user idx_table_owner with default_role = 'idx_table_owner_role';
+grant super on *.* to idx_super;
+grant drop on *.* to idx_drop;
+grant ownership on idx_priv.* to role idx_db_owner_role;
+grant role idx_db_owner_role to idx_db_owner;
+alter user idx_db_owner with default_role = 'idx_db_owner_role';
+"
+
+echo "=== denied table index ==="
+echo "CREATE NGRAM INDEX idx_denied ON idx_priv.t_denied(content) gram_size = 2 bloom_size = 1048576" |
+	$DENIED_USER_CONNECT 2>&1 |
+	grep 'privilege \[Alter\]' |
+	wc -l
+
+echo "=== table function name collision ==="
+echo "CREATE NGRAM INDEX idx_numbers ON idx_priv.numbers(content) gram_size = 2 bloom_size = 1048576" |
+	$DENIED_USER_CONNECT 2>&1 |
+	grep 'privilege \[Alter\]' |
+	wc -l
+
+echo "=== alter ngram index ==="
+run_user_alter "
+CREATE NGRAM INDEX idx_ngram_alter ON idx_priv.t_alter(content) gram_size = 2 bloom_size = 1048576;
+DROP NGRAM INDEX idx_ngram_alter ON idx_priv.t_alter;
+"
+echo "alter ok"
+
+echo "=== table owner inverted index ==="
+run_table_owner "
+CREATE INVERTED INDEX idx_inv_table_owner ON idx_priv.t_table_owner(content);
+REFRESH INVERTED INDEX idx_inv_table_owner ON idx_priv.t_table_owner;
+DROP INVERTED INDEX idx_inv_table_owner ON idx_priv.t_table_owner;
+"
+echo "table owner ok"
+
+echo "=== db owner vector index ==="
+run_db_owner "
+CREATE VECTOR INDEX idx_vec_db_owner ON idx_priv.t_db_owner_vec(embedding) m=10 ef_construct=40 distance='cosine';
+DROP VECTOR INDEX idx_vec_db_owner ON idx_priv.t_db_owner_vec;
+"
+echo "db owner ok"
+
+echo "=== super table index ==="
+run_user_super "
+CREATE NGRAM INDEX idx_ngram_super ON idx_priv.t_super(content) gram_size = 2 bloom_size = 1048576;
+DROP NGRAM INDEX idx_ngram_super ON idx_priv.t_super;
+"
+echo "super ok"
+
+echo "=== global drop table index ==="
+run_user_drop "
+DROP NGRAM INDEX idx_ngram_global_drop ON idx_priv.t_global_drop;
+"
+echo "global drop ok"
+
+echo "=== system_history hard deny for super ==="
+echo "REFRESH NGRAM INDEX idx_priv_sys ON system_history.idx_priv_sys" |
+	$SUPER_USER_CONNECT 2>&1 |
+	grep 'sensitive system resource' |
+	wc -l
+
+run_root_sql "
+drop user if exists idx_alter;
+drop user if exists idx_table_owner;
+drop user if exists idx_db_owner;
+drop user if exists idx_super;
+drop user if exists idx_drop;
+drop user if exists idx_denied;
+drop role if exists idx_table_owner_role;
+drop role if exists idx_db_owner_role;
+drop database if exists idx_priv;
+"


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Allow table index create, refresh, and drop operations with target table ALTER access or ownership, while preserving GLOBAL SUPER as a compatibility fallback.

Document the scoped table-index privilege model and add RBAC coverage for denied, ALTER, database owner, and SUPER cases.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20124)
<!-- Reviewable:end -->
