### PR TITLE
chore: bump databend-meta and databend-meta-client to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3775,7 +3775,7 @@ dependencies = [
  "databend-enterprise-query",
  "databend-meta",
  "databend-meta-cli-config",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "databend-meta-runtime",
  "databend-query",
  "form_urlencoded",
@@ -3961,7 +3961,7 @@ dependencies = [
  "databend-common-statistics",
  "databend-common-storage",
  "databend-common-users",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "databend-meta-runtime",
  "databend-storages-common-session",
  "databend-storages-common-table-meta",
@@ -4075,7 +4075,7 @@ dependencies = [
  "databend-common-meta-app",
  "databend-common-storage",
  "databend-common-tracing",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "log",
  "serde",
  "serde_ignored",
@@ -4420,7 +4420,7 @@ dependencies = [
  "databend-common-meta-store",
  "databend-common-proto-conv",
  "databend-common-version",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "databend-meta-plugin-cache",
  "databend-meta-runtime",
  "enumflags2",
@@ -4449,7 +4449,7 @@ dependencies = [
  "databend-common-meta-app",
  "databend-common-meta-store",
  "databend-common-proto-conv",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "databend-meta-runtime",
  "display-more 0.2.6",
  "fastrace",
@@ -4485,7 +4485,7 @@ dependencies = [
  "databend-common-expression",
  "databend-common-io",
  "databend-common-meta-app-storage",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "derive_more 1.0.0",
  "display-more 0.2.6",
  "encoding_rs",
@@ -4531,7 +4531,7 @@ dependencies = [
  "databend-common-tracing",
  "databend-meta",
  "databend-meta-admin",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "databend-meta-runtime",
  "display-more 0.2.6",
  "futures",
@@ -4573,7 +4573,7 @@ dependencies = [
  "databend-common-meta-api",
  "databend-common-meta-app",
  "databend-common-proto-conv",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "fastrace",
  "log",
  "maplit",
@@ -4589,7 +4589,7 @@ dependencies = [
  "databend-common-meta-schema-api-test-suite",
  "databend-common-meta-store",
  "databend-common-version",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "databend-meta-runtime",
  "databend-meta-test-harness",
  "fastrace",
@@ -4605,7 +4605,7 @@ dependencies = [
  "databend-base",
  "databend-common-tracing",
  "databend-meta",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "databend-meta-plugin-semaphore",
  "databend-meta-runtime",
  "fastrace",
@@ -4699,7 +4699,7 @@ dependencies = [
  "databend-common-io",
  "databend-common-meta-app",
  "databend-common-protos",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "enumflags2",
  "fastrace",
  "log",
@@ -4806,7 +4806,7 @@ dependencies = [
  "databend-common-users",
  "databend-enterprise-data-mask-feature",
  "databend-enterprise-row-access-policy-feature",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "databend-meta-runtime",
  "databend-storages-common-cache",
  "databend-storages-common-session",
@@ -4931,7 +4931,7 @@ dependencies = [
  "databend-common-pipeline",
  "databend-common-storage",
  "databend-common-storages-parquet",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "databend-storages-common-blocks",
  "databend-storages-common-table-meta",
  "log",
@@ -5028,7 +5028,7 @@ dependencies = [
  "databend-common-users",
  "databend-enterprise-fail-safe",
  "databend-enterprise-vacuum-handler",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "databend-storages-common-blocks",
  "databend-storages-common-cache",
  "databend-storages-common-index",
@@ -5088,7 +5088,7 @@ dependencies = [
  "databend-common-storage",
  "databend-common-storages-parquet",
  "databend-common-users",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "databend-storages-common-pruner",
  "databend-storages-common-table-meta",
  "fastrace",
@@ -5126,7 +5126,7 @@ dependencies = [
  "databend-common-storages-orc",
  "databend-common-storages-parquet",
  "databend-common-users",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "databend-storages-common-cache",
  "databend-storages-common-stage",
  "databend-storages-common-table-meta",
@@ -5333,7 +5333,7 @@ dependencies = [
  "databend-common-storages-fuse",
  "databend-common-storages-stream",
  "databend-common-users",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "databend-storages-common-cache",
  "databend-storages-common-table-meta",
  "futures",
@@ -5426,7 +5426,7 @@ dependencies = [
  "databend-common-meta-store",
  "databend-common-metrics",
  "databend-common-version",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "databend-meta-plugin-cache",
  "databend-meta-runtime",
  "divan",
@@ -5487,7 +5487,7 @@ dependencies = [
  "databend-common-exception",
  "databend-common-meta-app",
  "databend-common-meta-store",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
 ]
 
 [[package]]
@@ -5558,7 +5558,7 @@ dependencies = [
  "databend-enterprise-stream-handler",
  "databend-enterprise-table-ref-handler",
  "databend-enterprise-vacuum-handler",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "databend-meta-runtime",
  "databend-query",
  "databend-storages-common-cache",
@@ -5586,7 +5586,7 @@ dependencies = [
  "databend-common-config",
  "databend-common-exception",
  "databend-common-management",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
 ]
 
 [[package]]
@@ -5598,7 +5598,7 @@ dependencies = [
  "databend-common-exception",
  "databend-common-meta-app",
  "databend-common-meta-store",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
 ]
 
 [[package]]
@@ -5735,8 +5735,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta"
-version = "260628.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.0.0#58697dc08ee0ef3c8be12aa92bd8cd8076301a74"
+version = "260628.1.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.1.0#d8737a753b42a842d946e981d0a1998f4ba83a8e"
 dependencies = [
  "anyerror",
  "anyhow",
@@ -5746,13 +5746,13 @@ dependencies = [
  "base2histogram",
  "chrono",
  "databend-base",
- "databend-meta-client 260628.0.0",
- "databend-meta-kvapi 260628.0.0",
+ "databend-meta-client 260628.1.0",
+ "databend-meta-kvapi 260628.1.0",
  "databend-meta-raft-store",
- "databend-meta-runtime-api 260628.0.0",
+ "databend-meta-runtime-api 260628.1.0",
  "databend-meta-sled-store",
- "databend-meta-types 260628.0.0",
- "databend-meta-version 260628.0.0",
+ "databend-meta-types 260628.1.0",
+ "databend-meta-version 260628.1.0",
  "deepsize",
  "derive_more 2.1.1",
  "display-more 0.2.6",
@@ -5813,8 +5813,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-base"
-version = "260628.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.0.0#58697dc08ee0ef3c8be12aa92bd8cd8076301a74"
+version = "260628.1.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.1.0#d8737a753b42a842d946e981d0a1998f4ba83a8e"
 dependencies = [
  "anyerror",
  "deepsize",
@@ -5848,7 +5848,7 @@ dependencies = [
  "databend-meta",
  "databend-meta-admin",
  "databend-meta-cli-config",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "databend-meta-plugin-semaphore",
  "databend-meta-runtime",
  "databend-meta-ver",
@@ -5885,19 +5885,19 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client"
-version = "260205.12.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.12.0#fadc7e18af9f88a81d3876362cb46299ffe95b0b"
+version = "260205.13.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.0#551fc5303d6b10c75160e591e94b0ec53a3d3beb"
 dependencies = [
  "anyerror",
  "arrow-flight 56.2.0",
  "async-backtrace",
  "chrono",
  "databend-base",
- "databend-meta-kvapi 260205.12.0",
- "databend-meta-kvapi-test-suite 260205.12.0",
- "databend-meta-runtime-api 260205.12.0",
- "databend-meta-types 260205.12.0",
- "databend-meta-version 260205.12.0",
+ "databend-meta-kvapi 260205.13.0",
+ "databend-meta-kvapi-test-suite 260205.13.0",
+ "databend-meta-runtime-api 260205.13.0",
+ "databend-meta-types 260205.13.0",
+ "databend-meta-version 260205.13.0",
  "derive_more 2.1.1",
  "display-more 0.2.6",
  "fastrace",
@@ -5917,8 +5917,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client"
-version = "260628.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.0.0#58697dc08ee0ef3c8be12aa92bd8cd8076301a74"
+version = "260628.1.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.1.0#d8737a753b42a842d946e981d0a1998f4ba83a8e"
 dependencies = [
  "anyerror",
  "arrow-flight 56.2.0",
@@ -5927,10 +5927,10 @@ dependencies = [
  "chrono",
  "databend-base",
  "databend-meta-client-types",
- "databend-meta-kvapi 260628.0.0",
- "databend-meta-kvapi-test-suite 260628.0.0",
- "databend-meta-runtime-api 260628.0.0",
- "databend-meta-version 260628.0.0",
+ "databend-meta-kvapi 260628.1.0",
+ "databend-meta-kvapi-test-suite 260628.1.0",
+ "databend-meta-runtime-api 260628.1.0",
+ "databend-meta-version 260628.1.0",
  "derive_more 2.1.1",
  "display-more 0.2.6",
  "fastrace",
@@ -5951,8 +5951,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client-types"
-version = "260628.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.0.0#58697dc08ee0ef3c8be12aa92bd8cd8076301a74"
+version = "260628.1.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.1.0#d8737a753b42a842d946e981d0a1998f4ba83a8e"
 dependencies = [
  "anyerror",
  "databend-meta-proto",
@@ -5975,18 +5975,18 @@ dependencies = [
  "databend-common-meta-api",
  "databend-common-meta-app",
  "databend-common-meta-store",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "databend-meta-test-harness",
  "tokio",
 ]
 
 [[package]]
 name = "databend-meta-kvapi"
-version = "260205.12.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.12.0#fadc7e18af9f88a81d3876362cb46299ffe95b0b"
+version = "260205.13.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.0#551fc5303d6b10c75160e591e94b0ec53a3d3beb"
 dependencies = [
  "async-trait",
- "databend-meta-types 260205.12.0",
+ "databend-meta-types 260205.13.0",
  "display-more 0.2.6",
  "futures-util",
  "log",
@@ -5996,8 +5996,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi"
-version = "260628.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.0.0#58697dc08ee0ef3c8be12aa92bd8cd8076301a74"
+version = "260628.1.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.1.0#d8737a753b42a842d946e981d0a1998f4ba83a8e"
 dependencies = [
  "async-trait",
  "databend-meta-client-types",
@@ -6010,12 +6010,12 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi-test-suite"
-version = "260205.12.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.12.0#fadc7e18af9f88a81d3876362cb46299ffe95b0b"
+version = "260205.13.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.0#551fc5303d6b10c75160e591e94b0ec53a3d3beb"
 dependencies = [
  "anyhow",
- "databend-meta-kvapi 260205.12.0",
- "databend-meta-types 260205.12.0",
+ "databend-meta-kvapi 260205.13.0",
+ "databend-meta-types 260205.13.0",
  "display-more 0.2.6",
  "fastrace",
  "futures-util",
@@ -6026,12 +6026,12 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi-test-suite"
-version = "260628.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.0.0#58697dc08ee0ef3c8be12aa92bd8cd8076301a74"
+version = "260628.1.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.1.0#d8737a753b42a842d946e981d0a1998f4ba83a8e"
 dependencies = [
  "anyhow",
  "databend-meta-client-types",
- "databend-meta-kvapi 260628.0.0",
+ "databend-meta-kvapi 260628.1.0",
  "display-more 0.2.6",
  "fastrace",
  "futures-util",
@@ -6046,7 +6046,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "databend-meta-runtime",
  "databend-meta-test-harness",
  "fastrace",
@@ -6064,7 +6064,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "codeq 0.5.2",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "databend-meta-runtime",
  "databend-meta-test-harness",
  "display-more 0.2.6",
@@ -6082,8 +6082,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-proto"
-version = "260628.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.0.0#58697dc08ee0ef3c8be12aa92bd8cd8076301a74"
+version = "260628.1.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.1.0#d8737a753b42a842d946e981d0a1998f4ba83a8e"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -6105,18 +6105,18 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-raft-store"
-version = "260628.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.0.0#58697dc08ee0ef3c8be12aa92bd8cd8076301a74"
+version = "260628.1.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.1.0#d8737a753b42a842d946e981d0a1998f4ba83a8e"
 dependencies = [
  "anyerror",
  "anyhow",
  "async-trait",
  "bincode 2.0.1",
  "databend-base",
- "databend-meta-kvapi 260628.0.0",
- "databend-meta-runtime-api 260628.0.0",
+ "databend-meta-kvapi 260628.1.0",
+ "databend-meta-runtime-api 260628.1.0",
  "databend-meta-sled-store",
- "databend-meta-types 260628.0.0",
+ "databend-meta-types 260628.1.0",
  "deepsize",
  "derive_more 2.1.1",
  "display-more 0.2.6",
@@ -6153,7 +6153,7 @@ dependencies = [
  "databend-common-metrics",
  "databend-common-tracing",
  "databend-meta",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "fastrace",
  "hyper-util",
  "tokio",
@@ -6162,8 +6162,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-runtime-api"
-version = "260205.12.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.12.0#fadc7e18af9f88a81d3876362cb46299ffe95b0b"
+version = "260205.13.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.0#551fc5303d6b10c75160e591e94b0ec53a3d3beb"
 dependencies = [
  "env_logger 0.11.8",
  "hickory-resolver 0.25.2",
@@ -6175,8 +6175,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-runtime-api"
-version = "260628.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.0.0#58697dc08ee0ef3c8be12aa92bd8cd8076301a74"
+version = "260628.1.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.1.0#d8737a753b42a842d946e981d0a1998f4ba83a8e"
 dependencies = [
  "env_logger 0.11.8",
  "hickory-resolver 0.26.1",
@@ -6188,12 +6188,12 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-sled-store"
-version = "260628.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.0.0#58697dc08ee0ef3c8be12aa92bd8cd8076301a74"
+version = "260628.1.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.1.0#d8737a753b42a842d946e981d0a1998f4ba83a8e"
 dependencies = [
  "anyerror",
  "byteorder",
- "databend-meta-types 260628.0.0",
+ "databend-meta-types 260628.1.0",
  "fastrace",
  "log",
  "serde",
@@ -6206,14 +6206,14 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-test-harness"
-version = "260628.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.0.0#58697dc08ee0ef3c8be12aa92bd8cd8076301a74"
+version = "260628.1.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.1.0#d8737a753b42a842d946e981d0a1998f4ba83a8e"
 dependencies = [
  "anyhow",
  "databend-base",
  "databend-meta",
- "databend-meta-runtime-api 260628.0.0",
- "databend-meta-types 260628.0.0",
+ "databend-meta-runtime-api 260628.1.0",
+ "databend-meta-types 260628.1.0",
  "fastrace",
  "log",
  "tempfile",
@@ -6223,8 +6223,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-types"
-version = "260205.12.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.12.0#fadc7e18af9f88a81d3876362cb46299ffe95b0b"
+version = "260205.13.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.0#551fc5303d6b10c75160e591e94b0ec53a3d3beb"
 dependencies = [
  "anyerror",
  "deepsize",
@@ -6251,8 +6251,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-types"
-version = "260628.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.0.0#58697dc08ee0ef3c8be12aa92bd8cd8076301a74"
+version = "260628.1.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.1.0#d8737a753b42a842d946e981d0a1998f4ba83a8e"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -6286,16 +6286,16 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-version"
-version = "260205.12.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.12.0#fadc7e18af9f88a81d3876362cb46299ffe95b0b"
+version = "260205.13.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.0#551fc5303d6b10c75160e591e94b0ec53a3d3beb"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "databend-meta-version"
-version = "260628.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.0.0#58697dc08ee0ef3c8be12aa92bd8cd8076301a74"
+version = "260628.1.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260628.1.0#d8737a753b42a842d946e981d0a1998f4ba83a8e"
 dependencies = [
  "semver",
 ]
@@ -6388,7 +6388,7 @@ dependencies = [
  "databend-enterprise-stream-handler",
  "databend-enterprise-table-ref-handler",
  "databend-enterprise-vacuum-handler",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "databend-meta-plugin-semaphore",
  "databend-meta-runtime",
  "databend-query-script-udf-support",
@@ -6711,7 +6711,7 @@ dependencies = [
  "databend-common-exception",
  "databend-common-meta-app",
  "databend-common-storage",
- "databend-meta-client 260205.12.0",
+ "databend-meta-client 260205.13.0",
  "databend-storages-common-blocks",
  "databend-storages-common-table-meta",
  "log",
@@ -12876,9 +12876,9 @@ dependencies = [
 
 [[package]]
 name = "openraft"
-version = "0.10.0-alpha.27"
+version = "0.10.0-alpha.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "543cde97b501169472efb6d5724c9c44531dfd7c5acf6ea1399ea39e4fecb727"
+checksum = "0456aaaa818f1bd12179999d4ebbefc8f0a14091a9c6481cfda4f3ef93e76ac4"
 dependencies = [
  "anyerror",
  "backoff-series",
@@ -12906,9 +12906,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-macros"
-version = "0.10.0-alpha.27"
+version = "0.10.0-alpha.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d43c6ef109db505b8ef57de389b34d54927181f3a07819f09c9f0a6cf0ff72c"
+checksum = "1db90aa6d2074d963f8ca2360b146f2423fe914e336c8e66aeb6c266ef295cf9"
 dependencies = [
  "chrono",
  "proc-macro2",
@@ -12919,9 +12919,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt"
-version = "0.10.0-alpha.27"
+version = "0.10.0-alpha.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd3e555284a21902ba525163451fb86c24329e8617143387b0dbddfd7e362de9"
+checksum = "5d9d3c0616bcb3be41c1ac5743cf60a3cbc73f62ab2458527b40079ce3d077c9"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -12932,9 +12932,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt-tokio"
-version = "0.10.0-alpha.27"
+version = "0.10.0-alpha.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2514284b14f28321f8a5614bf82ebae5e2bf8a444d6d879a460a684f71b5c2f7"
+checksum = "f6a3c58d8a68bd8f6398fde62afde01aa876ad412a10f86c8aa341d833490796"
 dependencies = [
  "futures-util",
  "openraft-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,11 +163,11 @@ databend-storages-common-stage = { path = "src/query/storages/common/stage" }
 databend-storages-common-table-meta = { path = "src/query/storages/common/table_meta" }
 
 # External meta service
-databend-meta = "260628.0.0"
-databend-meta-test-harness = "260628.0.0"
+databend-meta = "260628.1.0"
+databend-meta-test-harness = "260628.1.0"
 
 # External meta client
-databend-meta-client = "260205.12.0"
+databend-meta-client = "260205.13.0"
 structkey = "0.1.1"
 
 # Crates.io dependencies
@@ -626,9 +626,9 @@ backtrace = { git = "https://github.com/rust-lang/backtrace-rs.git", rev = "7226
 color-eyre = { git = "https://github.com/eyre-rs/eyre.git", rev = "e5d92c3" }
 csv-core = { git = "https://github.com/youngsofun/rust-csv.git", rev = "44a0b3c" }
 databend-base = { git = "https://github.com/databendlabs/databend-base", tag = "v0.4.0" }
-databend-meta = { git = "https://github.com/databendlabs/databend-meta.git", tag = "v260628.0.0" }
-databend-meta-client = { git = "https://github.com/databendlabs/databend-meta.git", tag = "v260205.12.0" }
-databend-meta-test-harness = { git = "https://github.com/databendlabs/databend-meta.git", tag = "v260628.0.0" }
+databend-meta = { git = "https://github.com/databendlabs/databend-meta.git", tag = "v260628.1.0" }
+databend-meta-client = { git = "https://github.com/databendlabs/databend-meta.git", tag = "v260205.13.0" }
+databend-meta-test-harness = { git = "https://github.com/databendlabs/databend-meta.git", tag = "v260628.1.0" }
 deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "9954bff" }
 jsonb = { git = "https://github.com/databendlabs/jsonb.git", rev = "a16344417d1fec6df4a62d8e77679211e909f86e" }
 lance-arrow = { git = "https://github.com/datafuse-extras/lance", rev = "85f9401d3246d52a287bca21457dbae0466858ee" }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### chore: bump databend-meta and databend-meta-client to latest
# Summary

Advance the meta crates the query-service pins by git tag to their latest
published releases. The server crate moves forward on the 260628 line while the
client stays on the 260205 line, matching the split release series these two
dependencies deliberately track. Both releases exist to package the OpenRaft
alpha.28 upgrade, which carries two consensus-layer bug fixes relevant to
databend-meta as a raft consumer.

# Details

- databend-meta and databend-meta-test-harness: 260628.0.0 -> 260628.1.0
- databend-meta-client: 260205.12.0 -> 260205.13.0

Both bumps package the OpenRaft =0.10.0-alpha.27 -> =0.10.0-alpha.28 upgrade,
which fixes:

- `recv_msg` no longer hangs forever when a state machine drops an
  `ApplyResponder` without calling `send()`; the wait is now bounded and
  returns `Fatal::Stopped` (openraft #1816).
- stale replication acks are rejected after a follower log reversion. In
  pipeline (`LogsSince`) mode, acks queued before a reset could otherwise
  advance the matched index over reverted logs (a false quorum) or replay an
  already-consumed command.

databend has no direct openraft dependency, so the transitive alpha.27 ->
alpha.28 resolution in the lock file is contained to the meta crates.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20127)
<!-- Reviewable:end -->

