### PR TITLE
fix(query): preserve segment order during compaction

### DIFF
--- a/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/segments_compact_mutator.rs
@@ -265,6 +265,30 @@ async fn check_count(result_stream: SendableDataBlockStream) -> Result<u64> {
     }
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_compact_segment_changes_preserve_position() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup().await?;
+    let ctx = fixture.new_query_ctx().await?;
+    let threshold = BlockThresholds {
+        block_per_segment: 3,
+        ..Default::default()
+    };
+    let mut case_fixture = CompactSegmentTestFixture::try_new(&ctx, threshold)?;
+
+    let (state, _) = case_fixture
+        .run(&[10, 10, 1, 2, 10, 10], None, None)
+        .await?;
+
+    assert_eq!(state.new_segment_paths.len(), 1);
+    let new_segment = (state.new_segment_paths[0].clone(), SegmentInfo::VERSION);
+    assert_eq!(state.replaced_segments.get(&2), Some(&new_segment));
+    assert_eq!(state.removed_segment_indexes, vec![3]);
+    assert_eq!(state.segments_locations[2], new_segment);
+    assert_eq!(state.segments_locations.len(), 5);
+
+    Ok(())
+}
+
 pub async fn compact_segment(ctx: Arc<QueryContext>, table: &Arc<dyn Table>) -> Result<()> {
     let fuse_table = FuseTable::try_from_table(table.as_ref())?;
     let mutator = build_mutator(fuse_table, ctx.clone(), None).await?.unwrap();
@@ -727,8 +751,14 @@ impl CompactSegmentTestFixture {
         }
         self.input_blocks = blocks;
         let limit = limit.unwrap_or(usize::MAX);
+        let num_locations = locations.len();
+        let reverse_locations = locations
+            .into_iter()
+            .enumerate()
+            .map(|(idx, location)| (num_locations - idx - 1, location))
+            .collect();
         let state = seg_acc
-            .compact(locations, limit, |status| {
+            .compact(reverse_locations, limit, |status| {
                 self.ctx.set_status_info(&status);
             })
             .await?;
@@ -1082,8 +1112,14 @@ async fn test_compact_segment_with_cluster() -> anyhow::Result<()> {
             &location_gen,
             TestFixture::default_table_meta_timestamps(),
         );
+        let num_locations = locations.len();
+        let reverse_locations = locations
+            .into_iter()
+            .enumerate()
+            .map(|(idx, location)| (num_locations - idx - 1, location))
+            .collect();
         let state = seg_acc
-            .compact(locations, limit, |status| {
+            .compact(reverse_locations, limit, |status| {
                 ctx.set_status_info(&status);
             })
             .await?;

--- a/src/query/storages/fuse/src/operations/compact.rs
+++ b/src/query/storages/fuse/src/operations/compact.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use databend_common_catalog::plan::Partitions;
@@ -26,9 +25,7 @@ use databend_common_io::constants::DEFAULT_BLOCK_PER_SEGMENT;
 use databend_common_pipeline::core::Pipeline;
 use databend_common_pipeline::sources::OneBlockSource;
 use databend_common_sql::executor::physical_plans::MutationKind;
-use databend_storages_common_table_meta::meta::SegmentInfo;
 use databend_storages_common_table_meta::meta::TableSnapshot;
-use databend_storages_common_table_meta::meta::Versioned;
 
 use crate::FUSE_OPT_KEY_BLOCK_PER_SEGMENT;
 use crate::FuseTable;
@@ -105,26 +102,10 @@ impl FuseTable {
         base_snapshot: Arc<TableSnapshot>,
         table_meta_timestamps: databend_storages_common_table_meta::meta::TableMetaTimestamps,
     ) -> Result<()> {
-        let base_segments = &base_snapshot.segments;
-        let final_segments_set: HashSet<&_> = compaction.segments_locations.iter().collect();
-
-        let removed_segment_indexes: Vec<usize> = base_segments
-            .iter()
-            .enumerate()
-            .filter(|(_, loc)| !final_segments_set.contains(loc))
-            .map(|(idx, _)| idx)
-            .collect();
-
-        let appended_segments: Vec<_> = compaction
-            .new_segment_paths
-            .iter()
-            .map(|p| (p.clone(), SegmentInfo::VERSION))
-            .collect();
-
         let snapshot_changes = SnapshotChanges {
-            appended_segments,
-            replaced_segments: HashMap::new(),
-            removed_segment_indexes,
+            appended_segments: vec![],
+            replaced_segments: compaction.replaced_segments,
+            removed_segment_indexes: compaction.removed_segment_indexes,
             merged_statistics: compaction.removed_statistics.clone(),
             removed_statistics: compaction.removed_statistics,
         };

--- a/src/query/storages/fuse/src/operations/mutation/mutator/segment_compact_mutator.rs
+++ b/src/query/storages/fuse/src/operations/mutation/mutator/segment_compact_mutator.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -43,6 +44,10 @@ pub struct SegmentCompactionState {
     pub segments_locations: Vec<Location>,
     // paths of all the newly created segments (which are compacted), need this to rollback the compaction
     pub new_segment_paths: Vec<String>,
+    // base segment indexes to be replaced by compacted segments.
+    pub replaced_segments: HashMap<usize, Location>,
+    // base segment indexes removed by segment compaction.
+    pub removed_segment_indexes: Vec<usize>,
     // number of fragmented segments compacted
     pub num_fragments_compacted: usize,
     // statistics of segments that were consumed by compaction
@@ -95,7 +100,14 @@ impl SegmentCompactMutator {
     pub async fn target_select(&mut self) -> Result<bool> {
         let select_begin = Instant::now();
 
-        let mut base_segment_locations = self.compact_params.base_snapshot.segments.clone();
+        let mut base_segment_locations = self
+            .compact_params
+            .base_snapshot
+            .segments
+            .iter()
+            .cloned()
+            .enumerate()
+            .collect::<Vec<_>>();
         if base_segment_locations.len() <= 1 {
             // no need to compact
             return Ok(false);
@@ -157,7 +169,7 @@ pub struct SegmentCompactor<'a> {
     threshold: u64,
     default_cluster_key_id: Option<u32>,
     // fragmented segment collected so far, it will be reset to empty if compaction occurs
-    fragmented_segments: Vec<(SegmentInfo, Location)>,
+    fragmented_segments: Vec<(usize, SegmentInfo, Location)>,
     // state which keep the number of blocks of all the fragmented segment collected so far,
     // it will be reset to 0 if compaction occurs
     accumulated_num_blocks: u64,
@@ -197,7 +209,7 @@ impl<'a> SegmentCompactor<'a> {
     #[async_backtrace::framed]
     pub async fn compact<T>(
         mut self,
-        reverse_locations: Vec<Location>,
+        reverse_locations: Vec<(usize, Location)>,
         limit: usize,
         status_callback: T,
     ) -> Result<SegmentCompactionState>
@@ -212,26 +224,32 @@ impl<'a> SegmentCompactor<'a> {
         let mut checked_end_at = 0;
         let mut is_end = false;
         for chunk in reverse_locations.chunks(chunk_size) {
+            let chunk_locations = chunk
+                .iter()
+                .map(|(_, location)| location.clone())
+                .collect::<Vec<_>>();
             let mut segment_infos = segments_io
-                .read_segments::<SegmentInfo>(chunk, false)
+                .read_segments::<SegmentInfo>(&chunk_locations, false)
                 .await?
                 .into_iter()
                 .zip(chunk.iter())
-                .map(|(sg, chunk)| sg.map(|v| (v, chunk)))
+                .map(|(sg, (segment_idx, location))| {
+                    sg.map(|segment| (*segment_idx, segment, location))
+                })
                 .collect::<Result<Vec<_>>>()?;
 
             if let Some(default_cluster_key) = self.default_cluster_key_id {
                 // sort ascending.
                 segment_infos.sort_by(|a, b| {
                     sort_by_cluster_stats(
-                        a.0.summary.cluster_stats.as_ref(),
-                        b.0.summary.cluster_stats.as_ref(),
+                        a.1.summary.cluster_stats.as_ref(),
+                        b.1.summary.cluster_stats.as_ref(),
                         default_cluster_key,
                     )
                 });
             }
 
-            for (segment, location) in segment_infos.into_iter() {
+            for (segment_idx, segment, location) in segment_infos.into_iter() {
                 if is_end {
                     self.compacted_state
                         .segments_locations
@@ -239,7 +257,7 @@ impl<'a> SegmentCompactor<'a> {
                     continue;
                 }
 
-                self.add(segment, location.clone()).await?;
+                self.add(segment_idx, segment, location.clone()).await?;
                 let compacted = self.num_fragments_compacted();
                 if compacted >= limit {
                     if !self.fragmented_segments.is_empty() {
@@ -275,9 +293,11 @@ impl<'a> SegmentCompactor<'a> {
         if fragments_compacted {
             // if some compaction occurred, the reminders
             // which are outside of the limit should also be collected
-            compaction
-                .segments_locations
-                .extend(reverse_locations[checked_end_at..].iter().cloned());
+            compaction.segments_locations.extend(
+                reverse_locations[checked_end_at..]
+                    .iter()
+                    .map(|(_, location)| location.clone()),
+            );
         }
         // reverse the segments back
         compaction.segments_locations.reverse();
@@ -287,10 +307,18 @@ impl<'a> SegmentCompactor<'a> {
 
     // accumulate one segment
     #[async_backtrace::framed]
-    pub async fn add(&mut self, segment_info: SegmentInfo, location: Location) -> Result<()> {
+    pub async fn add(
+        &mut self,
+        segment_idx: usize,
+        segment_info: SegmentInfo,
+        location: Location,
+    ) -> Result<()> {
         let num_blocks_current_segment = segment_info.blocks.len() as u64;
 
         if num_blocks_current_segment == 0 {
+            self.compacted_state
+                .removed_segment_indexes
+                .push(segment_idx);
             return Ok(());
         }
 
@@ -299,10 +327,12 @@ impl<'a> SegmentCompactor<'a> {
         if s < self.threshold {
             // not enough blocks yet, just keep this segment for later compaction
             self.accumulated_num_blocks = s;
-            self.fragmented_segments.push((segment_info, location));
+            self.fragmented_segments
+                .push((segment_idx, segment_info, location));
         } else if s >= self.threshold && s < 2 * self.threshold {
             // compact the fragmented segments
-            self.fragmented_segments.push((segment_info, location));
+            self.fragmented_segments
+                .push((segment_idx, segment_info, location));
             self.compact_fragments().await?;
         } else {
             // JackTan25: I think this won't happen, right? so need to remove this branch??
@@ -332,7 +362,7 @@ impl<'a> SegmentCompactor<'a> {
             // if only one segment there, keep it as it is
             self.compacted_state
                 .segments_locations
-                .push(fragments[0].1.clone());
+                .push(fragments[0].2.clone());
             return Ok(());
         }
 
@@ -344,7 +374,9 @@ impl<'a> SegmentCompactor<'a> {
         let mut hlls_has_none = false;
 
         self.compacted_state.num_fragments_compacted += fragments.len();
-        for (segment, _location) in fragments {
+        let mut fragment_indexes = Vec::with_capacity(fragments.len());
+        for (segment_idx, segment, _location) in fragments {
+            fragment_indexes.push(segment_idx);
             merge_statistics_mut(
                 &mut new_statistics,
                 &segment.summary,
@@ -403,9 +435,24 @@ impl<'a> SegmentCompactor<'a> {
         self.compacted_state
             .new_segment_paths
             .push(location.clone());
+        let new_segment_location = (location, SegmentInfo::VERSION);
+        // CommitSink applies SnapshotChanges as local replacements/removals on the latest
+        // snapshot. This preserves natural order for ordinary contiguous segment compaction.
+        // With cluster-key sorting, fragments may come from non-contiguous base positions; in
+        // that case we still replace the earliest consumed base segment and remove the rest,
+        // accepting the order defined by SnapshotChanges instead of forcing the sorted target.
+        let replace_idx = *fragment_indexes.iter().min().unwrap();
+        self.compacted_state
+            .replaced_segments
+            .insert(replace_idx, new_segment_location.clone());
+        self.compacted_state.removed_segment_indexes.extend(
+            fragment_indexes
+                .into_iter()
+                .filter(|idx| *idx != replace_idx),
+        );
         self.compacted_state
             .segments_locations
-            .push((location, SegmentInfo::VERSION));
+            .push(new_segment_location);
         Ok(())
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Fix the segment-order regression introduced when segment compaction moved to `CommitSink` in #20114
- Let segment compaction record base segment indexes while selecting fragments
- Commit compacted groups as sparse in-place replacements plus removals instead of appending new compacted segments
- Remove zero-block segments through the same `SnapshotChanges` path when a compaction is committed
- Document the cluster-key sorting tradeoff: non-contiguous sorted fragments use `SnapshotChanges` local replace/remove ordering
- Add regression coverage for preserving the compacted segment position

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20128)
<!-- Reviewable:end -->