### PR TITLE
feat: meta: add Lua transaction support

### DIFF
--- a/scripts/databend_test_helper/src/.gitignore
+++ b/scripts/databend_test_helper/src/.gitignore
@@ -1,0 +1,1 @@
+/databend_test_helper.egg-info

--- a/src/meta/binaries/metactl/main.rs
+++ b/src/meta/binaries/metactl/main.rs
@@ -551,7 +551,7 @@ enum CtlCommand {
     ///
     /// Sample Lua script:
     ///   local client = metactl.new_grpc_client("127.0.0.1:9191")
-    ///   local result, err = client:get_kv("mykey")
+    ///   local result, err = client:get("mykey")
     ///   if err then print("error:", err) else print(result) end
     Lua(LuaArgs),
 

--- a/src/meta/control/LUA_API.md
+++ b/src/meta/control/LUA_API.md
@@ -47,7 +47,7 @@ task:join()
 Asynchronously sleeps for the specified duration.
 
 **Parameters:**
-- `seconds` (number): Duration to sleep in seconds (supports fractional values)
+- `seconds` (number): Finite, non-negative duration in seconds (supports fractional values)
 
 **Example:**
 ```lua
@@ -67,16 +67,16 @@ Converts any Lua value to a human-readable string representation.
 
 **Features:**
 - Handles nested tables recursively
-- Detects and converts byte vectors to strings
+- Detects and converts byte vectors to escaped strings
 - Sorts table keys for consistent output
 - Handles NULL values from meta service
-- Escapes quotes in strings
+- Escapes quotes, backslashes, control bytes, and non-ASCII bytes in strings
 - Single-line output format
 
 **Example:**
 ```lua
-print(metactl.to_string({key="value", data={1,2,3}}))
--- Output: {"data"={1,2,3},"key"="value"}
+print(metactl.to_string({key="value", data={count=3}}))
+-- Output: {"data"={"count"=3},"key"="value"}
 
 print(metactl.to_string(metactl.NULL))
 -- Output: NULL
@@ -128,7 +128,7 @@ Inserts or updates a key-value pair in the meta service.
 
 **Parameters:**
 - `key` (string): The key to upsert
-- `value` (string): The value to store
+- `value` (string): The binary-safe Lua string to store
 
 **Returns:**
 - `result`: Operation result containing sequence number and other metadata
@@ -143,6 +143,84 @@ if err then
 else
     print("Upsert result:", metactl.to_string(result))
 end
+```
+
+### client:transaction(transaction)
+
+Executes a transaction atomically.
+
+**Parameters:**
+- `transaction` (table): Conditions and operations in the format described below
+
+**Returns:**
+- `result`: Transaction reply with `success`, `execution_path`, and `responses` fields
+- `error`: Validation or gRPC error message, nil otherwise
+
+A false condition is not an error. In that case, the client executes the `else` operations and returns a reply with `success = false`.
+
+**Example:**
+```lua
+local client = metactl.new_grpc_client("127.0.0.1:9191")
+local transaction = {
+    conditions = {
+        {key = "my_key", op = "eq_seq", value = 0}
+    },
+    ["then"] = {
+        {op = "put", key = "my_key", value = "my_value", ttl = 60},
+        {op = "get", key = "my_key"}
+    },
+    ["else"] = {
+        {op = "get", key = "my_key"}
+    }
+}
+
+local result, err = client:transaction(transaction)
+if err then
+    print("Transaction failed:", err)
+else
+    print("Transaction result:", metactl.to_string(result))
+end
+```
+
+## Transaction Tables
+
+A transaction table accepts these optional fields:
+
+- `conditions`: A dense array of conditions. All conditions must match to run the `then` operations.
+- `["then"]`: A dense array of operations to run when all conditions match.
+- `["else"]`: A dense array of operations to run when a condition does not match.
+
+Each condition has `key`, `op`, and `value` fields. Supported condition operations are:
+
+- `eq_seq`: The key's sequence must equal the non-negative integer `value`. Sequence 0 means the key must not exist.
+- `ge_seq`: The key's sequence must be greater than or equal to the non-negative integer `value`.
+- `eq_value`: The key's bytes must equal the binary-safe Lua string `value`.
+
+Each operation has `op` and `key` fields. Supported operations are:
+
+- `put`: Stores the binary-safe Lua string `value`. The optional numeric `ttl` sets the lifetime in seconds.
+- `get`: Returns the current value.
+- `delete`: Deletes the key.
+
+The `metactl` namespace provides helpers that create the same tables:
+
+- `metactl.eq_seq(key, seq)`
+- `metactl.ge_seq(key, seq)`
+- `metactl.eq_value(key, value)`
+- `metactl.put_op(key, value, ttl)`
+- `metactl.get_op(key)`
+- `metactl.delete_op(key)`
+- `metactl.new_txn(conditions, then_ops, else_ops)`
+
+```lua
+local transaction = metactl.new_txn(
+    {metactl.eq_seq("my_key", 0)},
+    {
+        metactl.put_op("my_key", "my_value", 60),
+        metactl.get_op("my_key")
+    },
+    {metactl.get_op("my_key")}
+)
 ```
 
 ## Task Handling
@@ -248,7 +326,7 @@ The meta service returns structured data that can be processed using `metactl.to
 
 ## Best Practices
 
-1. **Always check for errors**: Both `get` and `upsert` operations can fail
+1. **Always check for errors**: `get`, `upsert`, and `transaction` operations can fail
 2. **Handle NULL values**: Use `metactl.NULL` comparison for missing keys
 3. **Use concurrent operations**: Leverage `metactl.spawn()` for parallel processing
 4. **Format output**: Use `metactl.to_string()` for readable data display
@@ -258,5 +336,6 @@ The meta service returns structured data that can be processed using `metactl.to
 
 See the test files in `tests/metactl/subcommands/` for comprehensive usage examples:
 - `cmd_lua_grpc.py` - Basic gRPC operations
+- `cmd_lua_transaction.py` - Atomic conditional transactions
 - `cmd_lua_spawn_grpc.py` - Concurrent gRPC operations
 - `cmd_lua_spawn_concurrent.py` - Task spawning patterns

--- a/src/meta/control/lua_util.lua
+++ b/src/meta/control/lua_util.lua
@@ -25,6 +25,27 @@ local function normalize_value(value)
     return value
 end
 
+local string_escapes = {
+    [8] = "\\b",
+    [9] = "\\t",
+    [10] = "\\n",
+    [12] = "\\f",
+    [13] = "\\r",
+    [34] = '\\"',
+    [92] = "\\\\"
+}
+
+local function quote_string(value)
+    local result = {}
+    for i = 1, #value do
+        local byte = string.byte(value, i)
+        result[i] = string_escapes[byte]
+            or (byte >= 32 and byte <= 126 and string.char(byte))
+            or string.format("\\x%02X", byte)
+    end
+    return '"' .. table.concat(result) .. '"'
+end
+
 -- Function to check if a table represents a bytes vector and convert it to string
 local function bytes_vector_to_string(value)
     -- Check if table represents a bytes vector (integer indices starting from 1, u8 values)
@@ -53,7 +74,7 @@ local function bytes_vector_to_string(value)
         if actual_length == expected_length then
             -- Check size limit to prevent memory exhaustion (max 1MB)
             if max_index > 1048576 then
-                return '"<bytes vector too large: ' .. max_index .. ' bytes>"'
+                return quote_string("<bytes vector too large: " .. max_index .. " bytes>")
             end
 
             -- Convert bytes vector to string
@@ -61,7 +82,7 @@ local function bytes_vector_to_string(value)
             for i = 1, max_index do
                 chars[i] = string.char(value[i])
             end
-            return '"' .. table.concat(chars) .. '"'
+            return quote_string(table.concat(chars))
         end
     end
 
@@ -87,8 +108,7 @@ local function to_string(value)
     end
 
     if type(value) == "string" then
-        -- Escape quotes in the string
-        return '"' .. string.gsub(value, '"', '\\"') .. '"'
+        return quote_string(value)
     end
 
     if type(value) == "table" then
@@ -141,7 +161,7 @@ local function to_string(value)
 
                 local key_str
                 if type(k) == "string" then
-                    key_str = '"' .. string.gsub(k, '"', '\\"') .. '"'
+                    key_str = quote_string(k)
                 else
                     key_str = "[" .. tostring(k) .. "]"
                 end
@@ -158,5 +178,56 @@ local function to_string(value)
     return "<" .. type(value) .. ">"
 end
 
--- Register to_string function in metactl namespace
+local function eq_seq(key, seq)
+    return {key = key, op = "eq_seq", value = seq}
+end
+
+local function ge_seq(key, seq)
+    return {key = key, op = "ge_seq", value = seq}
+end
+
+local function eq_value(key, value)
+    return {key = key, op = "eq_value", value = value}
+end
+
+local function put_op(key, value, ttl)
+    local op = {op = "put", key = key, value = value}
+    if ttl ~= nil then
+        op.ttl = ttl
+    end
+    return op
+end
+
+local function get_op(key)
+    return {op = "get", key = key}
+end
+
+local function delete_op(key)
+    return {op = "delete", key = key}
+end
+
+local function new_txn(conditions, then_ops, else_ops)
+    if conditions == nil then
+        conditions = {}
+    end
+    if then_ops == nil then
+        then_ops = {}
+    end
+    if else_ops == nil then
+        else_ops = {}
+    end
+    return {
+        conditions = conditions,
+        ["then"] = then_ops,
+        ["else"] = else_ops
+    }
+end
+
 metactl.to_string = to_string
+metactl.eq_seq = eq_seq
+metactl.ge_seq = ge_seq
+metactl.eq_value = eq_value
+metactl.put_op = put_op
+metactl.get_op = get_op
+metactl.delete_op = delete_op
+metactl.new_txn = new_txn

--- a/src/meta/control/src/lua_support.rs
+++ b/src/meta/control/src/lua_support.rs
@@ -22,10 +22,16 @@ use databend_meta_client::ClientHandle;
 use databend_meta_client::DEFAULT_GRPC_MESSAGE_SIZE;
 use databend_meta_client::MetaGrpcClient;
 use databend_meta_client::errors::CreationError;
+use databend_meta_client::types::ConditionResult;
+use databend_meta_client::types::TxnCondition;
+use databend_meta_client::types::TxnOp;
+use databend_meta_client::types::TxnRequest;
 use databend_meta_client::types::UpsertKV;
 use databend_meta_runtime::DatabendRuntime;
+use mlua::Error;
 use mlua::Lua;
 use mlua::LuaSerdeExt;
+use mlua::Table;
 use mlua::UserData;
 use mlua::UserDataMethods;
 use mlua::Value;
@@ -35,6 +41,206 @@ use tokio::time;
 use crate::admin::MetaAdminClient;
 
 const LUA_UTIL: &str = include_str!("../lua_util.lua");
+
+fn invalid_input(path: &str, message: impl std::fmt::Display) -> Error {
+    Error::RuntimeError(format!("{path}: {message}"))
+}
+
+fn transaction_error(error: Error) -> String {
+    match error {
+        Error::RuntimeError(message) => format!("Invalid transaction: {message}"),
+        error => format!("Invalid transaction: {error}"),
+    }
+}
+
+fn validate_fields(table: &Table, path: &str, allowed: &[&str]) -> mlua::Result<()> {
+    for pair in table.clone().pairs::<Value, Value>() {
+        let (key, _) = pair?;
+        let Value::String(key) = key else {
+            return Err(invalid_input(path, "field names must be strings"));
+        };
+        let key = key
+            .to_str()
+            .map_err(|_| invalid_input(path, "field names must be UTF-8"))?;
+        if !allowed.contains(&key.as_ref()) {
+            return Err(invalid_input(path, format!("unknown field `{key}`")));
+        }
+    }
+    Ok(())
+}
+
+fn required_string(table: &Table, path: &str, field: &str) -> mlua::Result<mlua::String> {
+    let value = table.raw_get::<Value>(field)?;
+    match value {
+        Value::String(value) => Ok(value),
+        Value::Nil => Err(invalid_input(path, format!("missing field `{field}`"))),
+        value => Err(invalid_input(
+            path,
+            format!(
+                "field `{field}` must be a string, got {}",
+                value.type_name()
+            ),
+        )),
+    }
+}
+
+fn required_utf8(table: &Table, path: &str, field: &str) -> mlua::Result<String> {
+    let value = required_string(table, path, field)?;
+    value
+        .to_str()
+        .map(|value| value.to_owned())
+        .map_err(|_| invalid_input(path, format!("field `{field}` must be UTF-8")))
+}
+
+fn required_u64(table: &Table, path: &str, field: &str) -> mlua::Result<u64> {
+    let value = table.raw_get::<Value>(field)?;
+    match value {
+        Value::Integer(value) if value >= 0 => Ok(value as u64),
+        Value::Nil => Err(invalid_input(path, format!("missing field `{field}`"))),
+        value => Err(invalid_input(
+            path,
+            format!(
+                "field `{field}` must be a non-negative integer, got {}",
+                value.type_name()
+            ),
+        )),
+    }
+}
+
+fn duration_from_seconds(seconds: f64, path: &str) -> mlua::Result<Duration> {
+    let duration = Duration::try_from_secs_f64(seconds).map_err(|_| {
+        invalid_input(
+            path,
+            "duration must be finite, non-negative, and representable",
+        )
+    })?;
+    if duration.as_millis() > u64::MAX as u128 {
+        return Err(invalid_input(
+            path,
+            "duration exceeds the meta service limit",
+        ));
+    }
+    Ok(duration)
+}
+
+fn optional_ttl(table: &Table, path: &str) -> mlua::Result<Option<Duration>> {
+    let value = table.raw_get::<Value>("ttl")?;
+    let seconds = match value {
+        Value::Nil => return Ok(None),
+        Value::Integer(value) => value as f64,
+        Value::Number(value) => value,
+        value => {
+            return Err(invalid_input(
+                path,
+                format!("field `ttl` must be a number, got {}", value.type_name()),
+            ));
+        }
+    };
+    duration_from_seconds(seconds, &format!("{path}.ttl")).map(Some)
+}
+
+fn dense_table_array(table: Table, path: &str) -> mlua::Result<Vec<Table>> {
+    let len = table.raw_len();
+    let mut count = 0;
+    for pair in table.clone().pairs::<Value, Value>() {
+        let (key, _) = pair?;
+        count += 1;
+        if !matches!(key, Value::Integer(index) if index >= 1 && index as usize <= len) {
+            return Err(invalid_input(path, "must be a dense array"));
+        }
+    }
+    if count != len {
+        return Err(invalid_input(path, "must be a dense array"));
+    }
+    (1..=len)
+        .map(|index| {
+            table
+                .raw_get::<Table>(index)
+                .map_err(|_| invalid_input(path, format!("item {index} must be a table")))
+        })
+        .collect()
+}
+
+fn optional_array(parent: &Table, field: &str, path: &str) -> mlua::Result<Vec<Table>> {
+    match parent.raw_get::<Value>(field)? {
+        Value::Nil => Ok(Vec::new()),
+        Value::Table(table) => dense_table_array(table, path),
+        value => Err(invalid_input(
+            path,
+            format!("must be an array, got {}", value.type_name()),
+        )),
+    }
+}
+
+fn parse_condition(table: &Table, path: &str) -> mlua::Result<TxnCondition> {
+    validate_fields(table, path, &["key", "op", "value"])?;
+    let key = required_utf8(table, path, "key")?;
+    let op = required_utf8(table, path, "op")?;
+    match op.as_str() {
+        "eq_seq" => Ok(TxnCondition::eq_seq(
+            key,
+            required_u64(table, path, "value")?,
+        )),
+        "ge_seq" => Ok(TxnCondition::match_seq(
+            key,
+            ConditionResult::Ge,
+            required_u64(table, path, "value")?,
+        )),
+        "eq_value" => Ok(TxnCondition::eq_value(
+            key,
+            required_string(table, path, "value")?.as_bytes().to_vec(),
+        )),
+        _ => Err(invalid_input(path, format!("unknown condition `{op}`"))),
+    }
+}
+
+fn parse_operation(table: &Table, path: &str) -> mlua::Result<TxnOp> {
+    let op = required_utf8(table, path, "op")?;
+    let key = required_utf8(table, path, "key")?;
+    match op.as_str() {
+        "put" => {
+            validate_fields(table, path, &["op", "key", "value", "ttl"])?;
+            let value = required_string(table, path, "value")?.as_bytes().to_vec();
+            Ok(TxnOp::put_with_ttl(key, value, optional_ttl(table, path)?))
+        }
+        "get" => {
+            validate_fields(table, path, &["op", "key"])?;
+            Ok(TxnOp::get(key))
+        }
+        "delete" => {
+            validate_fields(table, path, &["op", "key"])?;
+            Ok(TxnOp::delete(key))
+        }
+        _ => Err(invalid_input(path, format!("unknown operation `{op}`"))),
+    }
+}
+
+fn parse_conditions(table: &Table) -> mlua::Result<Vec<TxnCondition>> {
+    optional_array(table, "conditions", "transaction.conditions")?
+        .iter()
+        .enumerate()
+        .map(|(index, condition)| {
+            parse_condition(condition, &format!("transaction.conditions[{}]", index + 1))
+        })
+        .collect()
+}
+
+fn parse_operations(table: &Table, field: &str) -> mlua::Result<Vec<TxnOp>> {
+    let path = format!("transaction[\"{field}\"]");
+    optional_array(table, field, &path)?
+        .iter()
+        .enumerate()
+        .map(|(index, operation)| parse_operation(operation, &format!("{path}[{}]", index + 1)))
+        .collect()
+}
+
+fn parse_transaction(table: Table) -> mlua::Result<TxnRequest> {
+    validate_fields(&table, "transaction", &["conditions", "then", "else"])?;
+    let conditions = parse_conditions(&table)?;
+    let then_ops = parse_operations(&table, "then")?;
+    let else_ops = parse_operations(&table, "else")?;
+    Ok(TxnRequest::new(conditions, then_ops).with_else(else_ops))
+}
 
 /// Call an async API method, convert the result to a Lua value, and return
 /// the `(Option<Value>, Option<String>)` tuple expected by Lua methods.
@@ -79,11 +285,21 @@ impl UserData for LuaGrpcClient {
 
         methods.add_async_method(
             "upsert",
-            |lua, this, (key, value): (String, String)| async move {
-                let upsert = UpsertKV::update(key, value.as_bytes());
+            |lua, this, (key, value): (String, mlua::String)| async move {
+                let upsert = UpsertKV::update(key, value.as_bytes().as_ref());
                 lua_call(&lua, "gRPC error", || this.client.upsert_kv(upsert)).await
             },
         );
+
+        methods.add_async_method("transaction", |lua, this, table: Table| async move {
+            let txn = match parse_transaction(table) {
+                Ok(txn) => txn,
+                Err(error) => {
+                    return Ok((None::<Value>, Some(transaction_error(error))));
+                }
+            };
+            lua_call(&lua, "gRPC error", || this.client.transaction(txn)).await
+        });
     }
 }
 
@@ -234,7 +450,7 @@ pub fn setup_lua_environment(lua: &Lua) -> anyhow::Result<()> {
     // Register async sleep function
     let sleep_fn = lua
         .create_async_function(|_lua, seconds: f64| async move {
-            let duration = Duration::from_secs_f64(seconds);
+            let duration = duration_from_seconds(seconds, "sleep")?;
             time::sleep(duration).await;
             Ok(())
         })
@@ -338,5 +554,211 @@ pub async fn run_lua_script_with_result(
             }
         }
         Err(e) => Err(anyhow::anyhow!("Lua execution error: {}", e)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(lua: &Lua, script: &str) -> TxnRequest {
+        let table = lua.load(script).eval::<Table>().unwrap();
+        parse_transaction(table).unwrap()
+    }
+
+    fn parse_error(lua: &Lua, script: &str) -> String {
+        let table = lua.load(script).eval::<Table>().unwrap();
+        parse_transaction(table).unwrap_err().to_string()
+    }
+
+    #[test]
+    fn test_parse_transaction() {
+        let lua = Lua::new();
+        let actual = parse(
+            &lua,
+            r#"
+            return {
+                conditions = {
+                    {key = "missing", op = "eq_seq", value = 0},
+                    {key = "existing", op = "ge_seq", value = 2},
+                    {key = "blob", op = "eq_value", value = "\000\255"},
+                },
+                ["then"] = {
+                    {op = "put", key = "blob", value = "\000\255", ttl = 1.25},
+                    {op = "get", key = "blob"},
+                    {op = "delete", key = "obsolete"},
+                },
+                ["else"] = {
+                    {op = "put", key = "fallback", value = ""},
+                },
+            }
+            "#,
+        );
+
+        let expected = TxnRequest::new(
+            vec![
+                TxnCondition::eq_seq("missing", 0),
+                TxnCondition::match_seq("existing", ConditionResult::Ge, 2),
+                TxnCondition::eq_value("blob", vec![0, 255]),
+            ],
+            vec![
+                TxnOp::put_with_ttl("blob", vec![0, 255], Some(Duration::from_millis(1_250))),
+                TxnOp::get("blob"),
+                TxnOp::delete("obsolete"),
+            ],
+        )
+        .with_else(vec![TxnOp::put("fallback", Vec::new())]);
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_transaction_helpers() {
+        let lua = Lua::new();
+        setup_lua_environment(&lua).unwrap();
+        let actual = parse(
+            &lua,
+            r#"
+            return metactl.new_txn(
+                {
+                    metactl.eq_seq("new", 0),
+                    metactl.ge_seq("old", 1),
+                    metactl.eq_value("flag", "on"),
+                },
+                {
+                    metactl.put_op("new", "value", 0.5),
+                    metactl.get_op("new"),
+                },
+                {metactl.delete_op("old")}
+            )
+            "#,
+        );
+
+        let expected = TxnRequest::new(
+            vec![
+                TxnCondition::eq_seq("new", 0),
+                TxnCondition::match_seq("old", ConditionResult::Ge, 1),
+                TxnCondition::eq_value("flag", b"on".to_vec()),
+            ],
+            vec![
+                TxnOp::put_with_ttl("new", b"value".to_vec(), Some(Duration::from_millis(500))),
+                TxnOp::get("new"),
+            ],
+        )
+        .with_else(vec![TxnOp::delete("old")]);
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_parse_empty_transaction() {
+        let lua = Lua::new();
+        assert_eq!(TxnRequest::default(), parse(&lua, "return {}"));
+    }
+
+    #[test]
+    fn test_reject_invalid_transactions() {
+        let lua = Lua::new();
+        let cases = [
+            (
+                "return {unknown = {}}",
+                "transaction: unknown field `unknown`",
+            ),
+            (
+                "return {conditions = 1}",
+                "transaction.conditions: must be an array, got integer",
+            ),
+            (
+                "return {conditions = {[1] = {}, [3] = {}}}",
+                "transaction.conditions: must be a dense array",
+            ),
+            (
+                "return {conditions = {{op = 'eq_seq', value = 0}}}",
+                "transaction.conditions[1]: missing field `key`",
+            ),
+            (
+                "return {conditions = {{key = 'k', op = 'eq_seq', value = -1}}}",
+                "field `value` must be a non-negative integer",
+            ),
+            (
+                "return {conditions = {{key = 'k', op = 'eq_seq', value = 1.0}}}",
+                "field `value` must be a non-negative integer",
+            ),
+            (
+                "return {conditions = {{key = 'k', op = 'bad', value = 0}}}",
+                "unknown condition `bad`",
+            ),
+            (
+                "return {[\"then\"] = {'get'}}",
+                "transaction[\"then\"]: item 1 must be a table",
+            ),
+            (
+                "return {[\"then\"] = {{op = 'put', key = 'k'}}}",
+                "transaction[\"then\"][1]: missing field `value`",
+            ),
+            (
+                "return {[\"then\"] = {{op = 'bad', key = 'k'}}}",
+                "unknown operation `bad`",
+            ),
+            (
+                "return {[\"then\"] = {{op = 'get', key = 'k', ttl = 1}}}",
+                "unknown field `ttl`",
+            ),
+            (
+                "return {[\"then\"] = {{op = 'put', key = 'k', value = 1}}}",
+                "field `value` must be a string, got integer",
+            ),
+            (
+                "return {[\"then\"] = {{op = 'put', key = 'k', value = 'v', ttl = -1}}}",
+                "duration must be finite, non-negative, and representable",
+            ),
+            (
+                "return {[\"then\"] = {{op = 'put', key = 'k', value = 'v', ttl = 0/0}}}",
+                "duration must be finite, non-negative, and representable",
+            ),
+            (
+                "return {[\"then\"] = {{op = 'put', key = 'k', value = 'v', ttl = 1e17}}}",
+                "duration exceeds the meta service limit",
+            ),
+        ];
+
+        for (script, expected) in cases {
+            let error = parse_error(&lua, script);
+            assert!(
+                error.contains(expected),
+                "expected {expected:?} in {error:?} for {script:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_duration_validation() {
+        assert_eq!(
+            Duration::from_millis(125),
+            duration_from_seconds(0.125, "duration").unwrap()
+        );
+        for seconds in [-1.0, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert!(duration_from_seconds(seconds, "duration").is_err());
+        }
+    }
+
+    #[test]
+    fn test_to_string_escapes_strings_and_bytes() {
+        let lua = Lua::new();
+        setup_lua_environment(&lua).unwrap();
+        let string = lua
+            .load(r#"return metactl.to_string("a\n\"\\\000\127\128\255")"#)
+            .eval::<String>()
+            .unwrap();
+        let bytes = lua
+            .load("return metactl.to_string({97, 10, 34, 92, 0, 127, 128, 255})")
+            .eval::<String>()
+            .unwrap();
+        let key = lua
+            .load(r#"return metactl.to_string({["a\n"] = 1})"#)
+            .eval::<String>()
+            .unwrap();
+
+        assert_eq!(r#""a\n\"\\\x00\x7F\x80\xFF""#, string);
+        assert_eq!(r#""a\n\"\\\x00\x7F\x80\xFF""#, bytes);
+        assert_eq!(r#"{"a\n"=1}"#, key);
     }
 }

--- a/tests/metactl/subcommands/cmd_lua_transaction.py
+++ b/tests/metactl/subcommands/cmd_lua_transaction.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+
+import shutil
+import subprocess
+
+from metactl_utils import metactl_bin
+from utils import kill_databend_meta, print_title, start_meta_node
+
+
+GRPC_ADDR = "127.0.0.1:9191"
+
+EXPECTED_OUTPUT = """table transaction: ok
+helper else: ok
+conditions: ok
+atomic: ok
+unconditional: ok
+binary: ok
+ttl: ok
+invalid: ok"""
+
+LUA_SCRIPT = r"""
+local client = metactl.new_grpc_client("__GRPC_ADDR__")
+
+local function assert_equal(actual, expected, label)
+    if actual ~= expected then
+        error(label .. ": expected " .. metactl.to_string(expected) ..
+            ", got " .. metactl.to_string(actual))
+    end
+end
+
+local function assert_fields(value, expected, label)
+    local fields = {}
+    for field in pairs(value) do
+        table.insert(fields, field)
+    end
+    table.sort(fields)
+    assert_equal(table.concat(fields, ","), expected, label)
+end
+
+local function bytes_to_string(value)
+    if value == nil or value == metactl.NULL then
+        return nil
+    end
+    return string.char(table.unpack(value))
+end
+
+local function assert_seqv(value, seq, data, label)
+    assert_fields(value, "data,meta,seq", label .. " fields")
+    assert_equal(value.seq, seq, label .. " seq")
+    assert_equal(bytes_to_string(value.data), data, label .. " data")
+    assert_equal(type(value.meta), "table", label .. " meta")
+    assert_equal(type(value.meta.proposed_at_ms), "number", label .. " proposed_at_ms")
+end
+
+local function assert_reply(reply, success, path, response_count, label)
+    assert_fields(reply, "execution_path,responses,success", label .. " fields")
+    assert_equal(reply.success, success, label .. " success")
+    assert_equal(reply.execution_path, path, label .. " path")
+    assert_equal(#reply.responses, response_count, label .. " response count")
+end
+
+local function response(reply, index, kind, fields, label)
+    local wrapper = reply.responses[index]
+    assert_fields(wrapper, "response", label .. " wrapper")
+    assert_fields(wrapper.response, kind, label .. " variant")
+    local value = wrapper.response[kind]
+    assert_fields(value, fields, label .. " fields")
+    return value
+end
+
+local function transact(txn, label)
+    local reply, err = client:transaction(txn)
+    assert_equal(err, nil, label .. " error")
+    if reply == nil then
+        error(label .. ": missing reply")
+    end
+    return reply
+end
+
+local function get(key, label)
+    local value, err = client:get(key)
+    assert_equal(err, nil, label .. " error")
+    return value
+end
+
+local function upsert(key, value, label)
+    local reply, err = client:upsert(key, value)
+    assert_equal(err, nil, label .. " error")
+    if reply == nil then
+        error(label .. ": missing reply")
+    end
+    return reply
+end
+
+local seed = upsert("lua-txn/delete", "old", "seed")
+local seed_seq = seed.result.seq
+assert_seqv(seed.result, seed_seq, "old", "seed result")
+
+local table_txn = {
+    conditions = {{key = "lua-txn/created", op = "eq_seq", value = 0}},
+    ["then"] = {
+        {op = "put", key = "lua-txn/created", value = "alpha"},
+        {op = "get", key = "lua-txn/created"},
+        {op = "delete", key = "lua-txn/delete"}
+    },
+    ["else"] = {{op = "put", key = "lua-txn/unexpected", value = "bad"}}
+}
+local table_reply = transact(table_txn, "table transaction")
+assert_reply(table_reply, true, "then", 3, "table transaction")
+
+local put = response(
+    table_reply, 1, "Put", "current,key,prev_value", "table put")
+assert_equal(put.key, "lua-txn/created", "table put key")
+assert_equal(put.prev_value, metactl.NULL, "table put previous")
+local created_seq = put.current.seq
+assert_equal(created_seq, seed_seq + 1, "table put sequence")
+assert_seqv(put.current, created_seq, "alpha", "table put current")
+
+local read = response(table_reply, 2, "Get", "key,value", "table get")
+assert_equal(read.key, "lua-txn/created", "table get key")
+assert_seqv(read.value, created_seq, "alpha", "table get value")
+
+local deleted = response(
+    table_reply, 3, "Delete", "key,prev_value,success", "table delete")
+assert_equal(deleted.key, "lua-txn/delete", "table delete key")
+assert_equal(deleted.success, true, "table delete success")
+assert_seqv(deleted.prev_value, seed_seq, "old", "table delete previous")
+assert_seqv(get("lua-txn/created", "created state"), created_seq, "alpha", "created state")
+assert_equal(get("lua-txn/delete", "deleted state"), metactl.NULL, "deleted state")
+assert_equal(get("lua-txn/unexpected", "unexpected state"), metactl.NULL, "unexpected state")
+print("table transaction: ok")
+
+local else_txn = metactl.new_txn(
+    {metactl.eq_seq("lua-txn/created", 0)},
+    {metactl.put_op("lua-txn/unexpected", "bad")},
+    {
+        metactl.get_op("lua-txn/created"),
+        metactl.put_op("lua-txn/else", "selected")
+    })
+local else_reply = transact(else_txn, "helper else")
+assert_reply(else_reply, false, "else", 2, "helper else")
+local else_get = response(else_reply, 1, "Get", "key,value", "else get")
+assert_equal(else_get.key, "lua-txn/created", "else get key")
+assert_seqv(else_get.value, created_seq, "alpha", "else get value")
+local else_put = response(
+    else_reply, 2, "Put", "current,key,prev_value", "else put")
+assert_equal(else_put.key, "lua-txn/else", "else put key")
+assert_equal(else_put.prev_value, metactl.NULL, "else put previous")
+local else_seq = else_put.current.seq
+assert_seqv(else_put.current, else_seq, "selected", "else put current")
+assert_equal(get("lua-txn/unexpected", "else unexpected"), metactl.NULL, "else unexpected")
+
+local no_else_reply = transact(
+    metactl.new_txn(
+        {metactl.eq_seq("lua-txn/created", 0)},
+        {metactl.put_op("lua-txn/unexpected", "bad")}),
+    "omitted else")
+assert_reply(no_else_reply, false, "else", 0, "omitted else")
+assert_equal(get("lua-txn/unexpected", "omitted else state"), metactl.NULL, "omitted else state")
+print("helper else: ok")
+
+local and_txn = metactl.new_txn(
+    {
+        metactl.eq_seq("lua-txn/created", created_seq),
+        metactl.ge_seq("lua-txn/created", created_seq),
+        metactl.eq_value("lua-txn/created", "alpha")
+    },
+    {
+        metactl.put_op("lua-txn/and", "matched"),
+        metactl.get_op("lua-txn/and")
+    },
+    {metactl.put_op("lua-txn/and-failed", "bad")})
+local and_reply = transact(and_txn, "AND conditions")
+assert_reply(and_reply, true, "then", 2, "AND conditions")
+local and_put = response(and_reply, 1, "Put", "current,key,prev_value", "AND put")
+local and_seq = and_put.current.seq
+assert_equal(and_seq, else_seq + 1, "AND put sequence")
+assert_seqv(and_put.current, and_seq, "matched", "AND put current")
+local and_get = response(and_reply, 2, "Get", "key,value", "AND get")
+assert_seqv(and_get.value, and_seq, "matched", "AND get value")
+assert_equal(get("lua-txn/and-failed", "AND else state"), metactl.NULL, "AND else state")
+
+local failed_and = metactl.new_txn(
+    {
+        metactl.eq_seq("lua-txn/created", created_seq),
+        metactl.eq_value("lua-txn/created", "wrong")
+    },
+    {metactl.put_op("lua-txn/and-unexpected", "bad")},
+    {metactl.put_op("lua-txn/and-failed", "selected")})
+local failed_reply = transact(failed_and, "failed AND")
+assert_reply(failed_reply, false, "else", 1, "failed AND")
+assert_equal(get("lua-txn/and-unexpected", "failed AND then"), metactl.NULL, "failed AND then")
+local failed_value = get("lua-txn/and-failed", "failed AND else")
+assert_seqv(failed_value, failed_value.seq, "selected", "failed AND else")
+print("conditions: ok")
+
+local contenders_ready = 0
+
+local function contend(value)
+    local worker = metactl.new_grpc_client("__GRPC_ADDR__")
+    contenders_ready = contenders_ready + 1
+    while contenders_ready < 2 do
+        metactl.sleep(0.001)
+    end
+    local reply, err = worker:transaction(metactl.new_txn(
+        {metactl.eq_seq("lua-txn/race", 0)},
+        {
+            metactl.put_op("lua-txn/race", value),
+            metactl.put_op("lua-txn/race-side/" .. value, value)
+        },
+        {metactl.get_op("lua-txn/race")}))
+    assert_equal(err, nil, value .. " contender error")
+    return reply
+end
+
+local left_task = metactl.spawn(function() return contend("left") end)
+local right_task = metactl.spawn(function() return contend("right") end)
+local left_reply = left_task:join()
+local right_reply = right_task:join()
+local winner_count = (left_reply.success and 1 or 0) + (right_reply.success and 1 or 0)
+assert_equal(winner_count, 1, "race winner count")
+
+local winner = left_reply.success and "left" or "right"
+local loser = left_reply.success and "right" or "left"
+local winner_reply = left_reply.success and left_reply or right_reply
+local loser_reply = left_reply.success and right_reply or left_reply
+assert_reply(winner_reply, true, "then", 2, "race winner")
+assert_reply(loser_reply, false, "else", 1, "race loser")
+local race_put = response(winner_reply, 1, "Put", "current,key,prev_value", "race put")
+assert_equal(race_put.prev_value, metactl.NULL, "race put previous")
+local race_seq = race_put.current.seq
+assert_seqv(race_put.current, race_seq, winner, "race put current")
+local race_side_put = response(
+    winner_reply, 2, "Put", "current,key,prev_value", "race side put")
+local race_side_seq = race_side_put.current.seq
+assert_equal(race_side_put.key, "lua-txn/race-side/" .. winner, "race side put key")
+assert_equal(race_side_put.prev_value, metactl.NULL, "race side put previous")
+assert_seqv(race_side_put.current, race_side_seq, winner, "race side put current")
+local race_get = response(loser_reply, 1, "Get", "key,value", "race loser get")
+assert_seqv(race_get.value, race_seq, winner, "race loser value")
+assert_seqv(get("lua-txn/race", "race state"), race_seq, winner, "race state")
+local winner_side = get("lua-txn/race-side/" .. winner, "race winner side")
+assert_seqv(winner_side, race_side_seq, winner, "race winner side")
+assert_equal(get("lua-txn/race-side/" .. loser, "race loser side"), metactl.NULL,
+    "race loser side")
+print("atomic: ok")
+
+local unconditional = metactl.new_txn(nil, {
+    metactl.put_op("lua-txn/unconditional", "written"),
+    metactl.get_op("lua-txn/unconditional")
+})
+local unconditional_reply = transact(unconditional, "unconditional")
+assert_reply(unconditional_reply, true, "then", 2, "unconditional")
+local unconditional_put = response(
+    unconditional_reply, 1, "Put", "current,key,prev_value", "unconditional put")
+local unconditional_seq = unconditional_put.current.seq
+assert_seqv(
+    unconditional_put.current, unconditional_seq, "written", "unconditional put current")
+local unconditional_get = response(
+    unconditional_reply, 2, "Get", "key,value", "unconditional get")
+assert_seqv(
+    unconditional_get.value, unconditional_seq, "written", "unconditional get value")
+local empty_reply = transact({}, "empty transaction")
+assert_reply(empty_reply, true, "then", 0, "empty transaction")
+print("unconditional: ok")
+
+local binary = string.char(0, 1, 127, 128, 255)
+local binary_upsert = upsert("lua-txn/upsert-binary", binary, "binary upsert")
+local binary_upsert_seq = binary_upsert.result.seq
+assert_seqv(
+    binary_upsert.result, binary_upsert_seq, binary, "binary upsert result")
+assert_seqv(
+    get("lua-txn/upsert-binary", "binary upsert state"),
+    binary_upsert_seq,
+    binary,
+    "binary upsert state")
+local binary_reply = transact(
+    metactl.new_txn(nil, {
+        metactl.put_op("lua-txn/binary", binary),
+        metactl.get_op("lua-txn/binary")
+    }),
+    "binary")
+assert_reply(binary_reply, true, "then", 2, "binary")
+local binary_put = response(
+    binary_reply, 1, "Put", "current,key,prev_value", "binary put")
+local binary_seq = binary_put.current.seq
+assert_seqv(binary_put.current, binary_seq, binary, "binary put current")
+local binary_get = response(binary_reply, 2, "Get", "key,value", "binary get")
+assert_seqv(binary_get.value, binary_seq, binary, "binary get value")
+assert_seqv(get("lua-txn/binary", "binary state"), binary_seq, binary, "binary state")
+print("binary: ok")
+
+local ttl_reply = transact(
+    metactl.new_txn(nil, {metactl.put_op("lua-txn/ttl", "temporary", 2)}),
+    "TTL")
+assert_reply(ttl_reply, true, "then", 1, "TTL")
+local ttl_put = response(ttl_reply, 1, "Put", "current,key,prev_value", "TTL put")
+local ttl_seq = ttl_put.current.seq
+assert_seqv(ttl_put.current, ttl_seq, "temporary", "TTL current")
+assert_seqv(get("lua-txn/ttl", "TTL immediate"), ttl_seq, "temporary", "TTL immediate")
+metactl.sleep(2.5)
+assert_equal(get("lua-txn/ttl", "TTL expired"), metactl.NULL, "TTL expired")
+print("ttl: ok")
+
+local function expect_invalid(txn, expected, label)
+    local result, err = client:transaction(txn)
+    assert_equal(result, nil, label .. " result")
+    assert_equal(err, "Invalid transaction: " .. expected, label .. " error")
+end
+
+expect_invalid(
+    {unknown = {}},
+    "transaction: unknown field `unknown`",
+    "unknown transaction field")
+expect_invalid(
+    {conditions = "invalid"},
+    "transaction.conditions: must be an array, got string",
+    "conditions type")
+expect_invalid(
+    {conditions = {{key = "key", op = "unknown", value = 0}}},
+    "transaction.conditions[1]: unknown condition `unknown`",
+    "unknown condition")
+expect_invalid(
+    {["then"] = {{op = "unknown", key = "lua-txn/invalid"}}},
+    "transaction[\"then\"][1]: unknown operation `unknown`",
+    "unknown operation")
+expect_invalid(
+    {["then"] = {{op = "put", key = "lua-txn/invalid"}}},
+    "transaction[\"then\"][1]: missing field `value`",
+    "missing put value")
+expect_invalid(
+    {["then"] = {[1] = metactl.put_op("lua-txn/invalid", "bad"),
+        [3] = metactl.get_op("lua-txn/invalid")}},
+    "transaction[\"then\"]: must be a dense array",
+    "sparse operations")
+expect_invalid(
+    {["then"] = {{op = "get", key = "lua-txn/invalid", ttl = 1}}},
+    "transaction[\"then\"][1]: unknown field `ttl`",
+    "get TTL")
+expect_invalid(
+    metactl.new_txn(nil, {metactl.put_op("lua-txn/invalid", "bad", "soon")}),
+    "transaction[\"then\"][1]: field `ttl` must be a number, got string",
+    "TTL type")
+
+for label, ttl in pairs({negative = -1, infinite = math.huge, nan = 0 / 0}) do
+    expect_invalid(
+        metactl.new_txn(nil, {metactl.put_op("lua-txn/invalid", "bad", ttl)}),
+        "transaction[\"then\"][1].ttl: duration must be finite, non-negative, and representable",
+        label .. " TTL")
+end
+assert_equal(get("lua-txn/invalid", "invalid state"), metactl.NULL, "invalid state")
+print("invalid: ok")
+"""
+
+
+def setup_test_environment():
+    kill_databend_meta()
+    shutil.rmtree(".databend", ignore_errors=True)
+    start_meta_node(1, False)
+
+
+def test_lua_transactions():
+    print_title("Test Lua transactions")
+    setup_test_environment()
+    result = subprocess.run(
+        [metactl_bin, "lua"],
+        input=LUA_SCRIPT.replace("__GRPC_ADDR__", GRPC_ADDR),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    assert result.stdout.strip() == EXPECTED_OUTPUT, result.stdout
+    kill_databend_meta()
+    shutil.rmtree(".databend", ignore_errors=True)
+
+
+def main():
+    test_lua_transactions()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat: meta: add Lua transaction support
# Summary

Expose atomic meta-service transactions to Lua with validated table inputs,
binary-safe values, and regression coverage.

# Details

Lua scripts can now execute conditional put, get, and delete operations with
optional TTLs through the existing gRPC client. Invalid transaction tables
return Lua-style errors before reaching the service.

The integration suite covers transaction branches, conditions, ordering,
binary values, TTL expiry, invalid input, and concurrent compare-and-set
behavior.

Ignore generated test-helper egg-info metadata.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] New Feature (non-breaking change which adds functionality)

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20131)
<!-- Reviewable:end -->
