### PR TITLE
feat(meta): add metactl.now_ms() monotonic clock for Lua scripts

### DIFF
--- a/src/meta/control/LUA_API.md
+++ b/src/meta/control/LUA_API.md
@@ -55,6 +55,21 @@ metactl.sleep(0.5)  -- Sleep for 500ms
 metactl.sleep(2.0)  -- Sleep for 2 seconds
 ```
 
+### metactl.now_ms()
+
+Returns a monotonic clock reading in milliseconds, for timing and benchmarks.
+
+**Returns:**
+- A number of milliseconds (fractional). The value never decreases between calls; only the difference between two readings is meaningful (the origin is when the Lua environment was created).
+
+**Example:**
+```lua
+local t0 = metactl.now_ms()
+client:upsert("my_key", "my_value")
+local elapsed_ms = metactl.now_ms() - t0
+print(string.format("upsert took %.3f ms", elapsed_ms))
+```
+
 ### metactl.to_string(value)
 
 Converts any Lua value to a human-readable string representation.

--- a/src/meta/control/src/lua_support.rs
+++ b/src/meta/control/src/lua_support.rs
@@ -461,6 +461,18 @@ pub fn setup_lua_environment(lua: &Lua) -> anyhow::Result<()> {
         .set("sleep", sleep_fn)
         .map_err(|e| anyhow::anyhow!("Failed to register sleep function: {}", e))?;
 
+    // Register a monotonic millisecond clock for timing and benchmarks. The
+    // epoch is this environment's setup time; only differences between calls are
+    // meaningful. `Instant` guarantees the value never goes backwards.
+    let start = std::time::Instant::now();
+    let now_ms_fn = lua
+        .create_function(move |_lua, ()| Ok(start.elapsed().as_secs_f64() * 1000.0))
+        .map_err(|e| anyhow::anyhow!("Failed to create now_ms function: {}", e))?;
+
+    metactl_table
+        .set("now_ms", now_ms_fn)
+        .map_err(|e| anyhow::anyhow!("Failed to register now_ms function: {}", e))?;
+
     // Register the Zipf load generator. The module returns the `ZipfGenerator`
     // table, exposed as `metactl.ZipfGenerator` so any script can call
     // `metactl.ZipfGenerator:new(num_keys, alpha)` directly.
@@ -789,5 +801,25 @@ mod tests {
             .eval::<i64>()
             .unwrap();
         assert_eq!(24, index);
+    }
+
+    #[test]
+    fn test_now_ms_is_monotonic() {
+        let lua = Lua::new();
+        setup_lua_environment(&lua).unwrap();
+        let (a, b) = lua
+            .load(
+                r#"
+                local a = metactl.now_ms()
+                local sum = 0
+                for i = 1, 1000000 do sum = sum + i end
+                local b = metactl.now_ms()
+                return a, b
+                "#,
+            )
+            .eval::<(f64, f64)>()
+            .unwrap();
+        assert!(a >= 0.0, "now_ms must be non-negative, got {a}");
+        assert!(b >= a, "now_ms must not go backwards: {a} then {b}");
     }
 }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat(meta): add metactl.now_ms() monotonic clock for Lua scripts
# Summary

Adds a `metactl.now_ms()` function to the Lua control environment so
scripts can time operations for benchmarks, backed by a monotonic
`Instant` captured when the environment is set up.

# Details

- `lua_support.rs` registers `now_ms`, returning elapsed milliseconds
  (fractional) since environment setup; only differences between calls
  are meaningful, and the value never decreases.
- Adds `test_now_ms_is_monotonic`, asserting two readings taken around
  a CPU-bound loop are non-negative and non-decreasing.
- `LUA_API.md` documents the new function with its return semantics
  and a benchmarking example.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20136)
<!-- Reviewable:end -->
