### PR TITLE
feat(metabench): add bulk-load and random-read benchmarks

### DIFF
--- a/scripts/databend_test_helper/src/.gitignore
+++ b/scripts/databend_test_helper/src/.gitignore
@@ -1,1 +1,1 @@
-/databend_test_helper.egg-info
+/databend_test_helper.egg-info/

--- a/scripts/databend_test_helper/src/databend_test_helper/__init__.py
+++ b/scripts/databend_test_helper/src/databend_test_helper/__init__.py
@@ -4,9 +4,13 @@ A Python library for starting and stopping Databend processes during testing.
 Provides utilities for managing databend-meta and databend-query instances.
 """
 
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
-__version__ = version("databend-test-helper")
+try:
+    __version__ = version("databend-test-helper")
+except PackageNotFoundError:
+    # Imported straight from the source tree without `pip install`.
+    __version__ = "0.0.0+uninstalled"
 
 from .meta import DatabendMeta
 from .query import DatabendQuery

--- a/scripts/databend_test_helper/src/databend_test_helper/meta.py
+++ b/scripts/databend_test_helper/src/databend_test_helper/meta.py
@@ -1,5 +1,6 @@
 """Databend Meta service management utilities."""
 
+import os
 from typing import Optional
 
 from .progress import ProgressReporter
@@ -39,6 +40,27 @@ class DatabendMeta:
         config = self._parse_config()
         grpc_address = config.get("grpc_api_address", "0.0.0.0:9191")
         return int(grpc_address.split(":")[-1])
+
+    def pid_file(self) -> str:
+        """Path of the pid file: a sibling of the node's raft dir.
+
+        It must not live inside raft_dir: databend-meta treats that directory
+        as its own and removes foreign files on startup.
+        """
+        raft_dir = self.get_raft_config()["raft_dir"]
+        return raft_dir.rstrip("/") + ".pid"
+
+    def pid(self) -> Optional[int]:
+        """Pid of the running process, from this instance or the pid file.
+
+        Returns None when the service is not running. The pid file makes the
+        process reachable across Python invocations, e.g. a `stop` command run
+        after the `start` process has exited.
+        """
+        if ProcessManager.is_process_running(self.process):
+            return self.process.pid
+        pid = ProcessManager.read_pid_file(self.pid_file())
+        return pid if ProcessManager.is_pid_running(pid) else None
 
     def _print_start_info(self) -> None:
         """Print startup information."""
@@ -92,7 +114,7 @@ class DatabendMeta:
 
     def start(self, wait_for_ready: bool = True, dry_run: bool = False) -> None:
         """Start databend-meta process."""
-        if ProcessManager.is_process_running(self.process):
+        if self.is_running():
             raise RuntimeError("Meta service is already running")
 
         self._print_start_info()
@@ -113,7 +135,9 @@ class DatabendMeta:
 
         config = self._parse_config()
         log_dir = config["log"]["file"]["dir"]
-        self.process = ProcessManager.start_process(cmd, "meta", log_dir)
+        self.process = ProcessManager.start_process(
+            cmd, "meta", log_dir, pid_file=self.pid_file()
+        )
 
         if wait_for_ready:
             port = self._get_grpc_port()
@@ -121,13 +145,19 @@ class DatabendMeta:
             ProgressReporter.print_ready_info("databend-meta", port)
 
     def stop(self) -> None:
-        """Stop databend-meta process."""
-        ProcessManager.stop_process(self.process, "meta")
-        self.process = None
+        """Stop databend-meta, whether started by this instance or an earlier one."""
+        if self.process is not None:
+            ProcessManager.stop_process(self.process, "meta")
+            self.process = None
+            return
+
+        pid = self.pid()
+        if pid is not None:
+            ProcessManager.stop_pid(pid, "meta")
 
     def is_running(self) -> bool:
-        """Check if meta service is running."""
-        return ProcessManager.is_process_running(self.process)
+        """Check if meta service is running (this instance or via pid file)."""
+        return self.pid() is not None
 
     def get_raft_config(self) -> dict:
         """Get raft configuration from parsed config."""

--- a/scripts/databend_test_helper/src/databend_test_helper/meta.py
+++ b/scripts/databend_test_helper/src/databend_test_helper/meta.py
@@ -56,11 +56,16 @@ class DatabendMeta:
         Returns None when the service is not running. The pid file makes the
         process reachable across Python invocations, e.g. a `stop` command run
         after the `start` process has exited.
+
+        A pid read from the file is trusted only when it still belongs to a
+        databend-meta process, so a stale file whose pid the OS has recycled
+        for an unrelated process is not mistaken for a live meta.
         """
         if ProcessManager.is_process_running(self.process):
             return self.process.pid
         pid = ProcessManager.read_pid_file(self.pid_file())
-        return pid if ProcessManager.is_pid_running(pid) else None
+        binary = os.path.basename(self.binary_path)
+        return pid if ProcessManager.is_pid_command(pid, binary) else None
 
     def _print_start_info(self) -> None:
         """Print startup information."""
@@ -149,11 +154,12 @@ class DatabendMeta:
         if self.process is not None:
             ProcessManager.stop_process(self.process, "meta")
             self.process = None
-            return
+        else:
+            pid = self.pid()
+            if pid is not None:
+                ProcessManager.stop_pid(pid, "meta")
 
-        pid = self.pid()
-        if pid is not None:
-            ProcessManager.stop_pid(pid, "meta")
+        ProcessManager.remove_pid_file(self.pid_file())
 
     def is_running(self) -> bool:
         """Check if meta service is running (this instance or via pid file)."""

--- a/scripts/databend_test_helper/src/databend_test_helper/utils.py
+++ b/scripts/databend_test_helper/src/databend_test_helper/utils.py
@@ -1,6 +1,7 @@
 """Common utilities for Databend services."""
 
 import os
+import signal
 import subprocess
 import socket
 import time
@@ -108,9 +109,16 @@ class ProcessManager:
 
     @staticmethod
     def start_process(
-        cmd: list, service_name: str, log_dir: Optional[str] = None
+        cmd: list,
+        service_name: str,
+        log_dir: Optional[str] = None,
+        pid_file: Optional[str] = None,
     ) -> subprocess.Popen:
-        """Start a subprocess with common configuration."""
+        """Start a subprocess with common configuration.
+
+        If `pid_file` is given, the child pid is written there so that a later
+        invocation (a different Python process) can stop or inspect it.
+        """
         from .progress import ProgressReporter
 
         ProgressReporter.print_message(f"🔧 Executing: {' '.join(cmd)}")
@@ -126,7 +134,60 @@ class ProcessManager:
 
         proc = subprocess.Popen(cmd, stdout=stdout_file, stderr=stderr_file, text=True)
         proc._log_files = (stdout_file, stderr_file)  # Store for cleanup
+
+        if pid_file is not None:
+            pid_dir = os.path.dirname(pid_file)
+            if pid_dir:
+                os.makedirs(pid_dir, exist_ok=True)
+            with open(pid_file, "w") as f:
+                f.write(str(proc.pid))
+
         return proc
+
+    @staticmethod
+    def read_pid_file(pid_file: str) -> Optional[int]:
+        """Read a pid from a pid file; None if missing or malformed."""
+        try:
+            with open(pid_file) as f:
+                return int(f.read().strip())
+        except (FileNotFoundError, ValueError):
+            return None
+
+    @staticmethod
+    def is_pid_running(pid: Optional[int]) -> bool:
+        """Check if a pid refers to a live process."""
+        if pid is None:
+            return False
+        try:
+            os.kill(pid, 0)
+            return True
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+
+    @staticmethod
+    def stop_pid(pid: int, service_name: str, timeout: int = 10) -> None:
+        """Stop a process by pid: SIGTERM, then SIGKILL after `timeout` seconds."""
+        from .progress import ProgressReporter
+
+        ProgressReporter.print_stop_info(f"databend-{service_name}")
+
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if not ProcessManager.is_pid_running(pid):
+                return
+            time.sleep(0.3)
+
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
 
     @staticmethod
     def stop_process(process: subprocess.Popen, service_name: str) -> None:

--- a/scripts/databend_test_helper/src/databend_test_helper/utils.py
+++ b/scripts/databend_test_helper/src/databend_test_helper/utils.py
@@ -6,6 +6,7 @@ import subprocess
 import socket
 import time
 import toml
+import psutil
 from typing import Optional, Dict, Any
 
 
@@ -154,6 +155,14 @@ class ProcessManager:
             return None
 
     @staticmethod
+    def remove_pid_file(pid_file: str) -> None:
+        """Remove a pid file, tolerating a missing file."""
+        try:
+            os.remove(pid_file)
+        except FileNotFoundError:
+            pass
+
+    @staticmethod
     def is_pid_running(pid: Optional[int]) -> bool:
         """Check if a pid refers to a live process."""
         if pid is None:
@@ -165,6 +174,21 @@ class ProcessManager:
             return False
         except PermissionError:
             return True
+
+    @staticmethod
+    def is_pid_command(pid: Optional[int], command: str) -> bool:
+        """Check if `pid` is a live process whose executable is named `command`.
+
+        Guards against pid reuse: once a process exits, the OS may recycle its
+        pid for an unrelated process. Matching the executable name keeps a
+        stale pid file from being mistaken for the original service.
+        """
+        if pid is None:
+            return False
+        try:
+            return psutil.Process(pid).name() == command
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            return False
 
     @staticmethod
     def stop_pid(pid: int, service_name: str, timeout: int = 10) -> None:

--- a/src/meta/binaries/metabench/main.rs
+++ b/src/meta/binaries/metabench/main.rs
@@ -727,11 +727,11 @@ async fn benchmark_batch_create_tables(
         };
 
         txn.if_then.extend([
-            /* name -> id */
+            // name -> id
             txn_put_pb(&name_key, &TableId::new(table_id)),
-            /* id -> meta */
+            // id -> meta
             txn_put_pb(&TableId::new(table_id), &table_meta),
-            /* name history */
+            // name history
             txn_put_pb(
                 &TableIdHistoryIdent {
                     database_id: db_id,
@@ -739,7 +739,7 @@ async fn benchmark_batch_create_tables(
                 },
                 &id_list,
             ),
-            /* id -> name */
+            // id -> name
             txn_put_pb(&TableIdToName { table_id }, &name_key),
         ]);
     }
@@ -808,7 +808,10 @@ async fn benchmark_get_table_rand(
         .await;
 
     if let Err(e) = &res {
-        println!("ERROR: get_table_rand({}/{}) failed: {:?}", db_name, table_name, e);
+        println!(
+            "ERROR: get_table_rand({}/{}) failed: {:?}",
+            db_name, table_name, e
+        );
     } else if i % 100_000 == 0 {
         println!("{:>10}-th get_table_rand ok: {}/{}", i, db_name, table_name);
     }

--- a/src/meta/binaries/metabench/main.rs
+++ b/src/meta/binaries/metabench/main.rs
@@ -41,6 +41,7 @@ use databend_common_meta_app::schema::DropTableByIdReq;
 use databend_common_meta_app::schema::GetTableReq;
 use databend_common_meta_app::schema::TableCopiedFileInfo;
 use databend_common_meta_app::schema::TableCopiedFileNameIdent;
+use databend_common_meta_app::schema::TableMeta;
 use databend_common_meta_app::schema::TableNameIdent;
 use databend_common_meta_app::schema::UpsertTableOptionReq;
 use databend_common_meta_app::schema::database_name_ident::DatabaseNameIdent;
@@ -216,6 +217,8 @@ struct Config {
     /// The RPC to benchmark:
     /// "upsert_kv": send kv-api upsert_kv,
     /// "table": create db, table and upsert_table_option;
+    /// "create_tables": accumulate distinct tables, a new db every `db_size` tables;
+    /// "create_tables:{"db_size":1000,"meta_size":600}": after ":" is a json config string;
     /// "get_table": single get_table() rpc;
     /// "table_copy_file": upsert table with copy file.
     /// "table_copy_file:{"file_cnt":100}": upsert table with 100 copy files. After ":" is a json config string
@@ -227,6 +230,11 @@ struct Config {
     /// "list:{"prefix":"custom_prefix","limit":50,"interval_ms":100}": combine all options;
     #[clap(long, default_value = "upsert_kv")]
     pub rpc: String,
+
+    /// Stop issuing new operations after this many seconds; 0 means no time limit.
+    /// Each client still runs at most `--number` operations.
+    #[clap(long, default_value = "0")]
+    pub run_secs: u64,
 }
 
 #[tokio::main]
@@ -265,6 +273,11 @@ async fn main() {
     println!("effective client_pool_size: {}", client_pool_size);
 
     let start = Instant::now();
+    let deadline = if config.run_secs > 0 {
+        Some(start + Duration::from_secs(config.run_secs))
+    } else {
+        None
+    };
     let mut client_num = 0;
     let mut handles = Vec::new();
     let stats = Arc::new(BenchStats::new());
@@ -284,6 +297,11 @@ async fn main() {
         let handle = DatabendRuntime::spawn(
             async move {
                 for i in 0..number {
+                    if let Some(deadline) = deadline {
+                        if Instant::now() >= deadline {
+                            break;
+                        }
+                    }
                     let op_start = Instant::now();
                     let success =
                         run_benchmark_once(&client, &cmd, &rpc, prefix, client_num, i, &param)
@@ -361,6 +379,8 @@ async fn run_benchmark_once(
         benchmark_upsert(client, prefix, client_num, i).await
     } else if cmd == "table" {
         benchmark_table(client, prefix, client_num, i).await
+    } else if cmd == "create_tables" {
+        benchmark_create_tables(client, prefix, client_num, i, param).await
     } else if cmd == "get_table" {
         benchmark_get_table(client, prefix, client_num, i).await
     } else if cmd == "table_copy_file" {
@@ -483,6 +503,83 @@ async fn benchmark_table(client: &MetaStore, prefix: u64, client_num: u64, i: u6
 
     print_res(i, "create_table again", &res);
     success && res.is_ok()
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+struct CreateTablesConfig {
+    /// Number of tables per database: client `c` puts table `t-{i}` into db `db-{prefix}-{c}-{i/db_size}`.
+    db_size: u64,
+    /// Bytes of padding in `TableMeta.options`, to control the serialized TableMeta size.
+    meta_size: usize,
+}
+
+impl Default for CreateTablesConfig {
+    fn default() -> Self {
+        Self {
+            db_size: 1000,
+            meta_size: 600,
+        }
+    }
+}
+
+/// Create distinct tables that accumulate, unlike `table` which churns a single table.
+///
+/// Each client works in its own databases so that concurrent creates do not
+/// conflict on the same db_meta record.
+async fn benchmark_create_tables(
+    client: &MetaStore,
+    prefix: u64,
+    client_num: u64,
+    i: u64,
+    param: &str,
+) -> bool {
+    let param: CreateTablesConfig = if param.is_empty() {
+        Default::default()
+    } else {
+        serde_json::from_str(param).unwrap()
+    };
+
+    let tenant = Tenant::new_literal(&format!("bench-{}", prefix));
+    let db_name = format!("db-{}-{}-{}", prefix, client_num, i / param.db_size);
+
+    if i % param.db_size == 0 {
+        let res = client
+            .create_database(CreateDatabaseReq {
+                override_existing: false,
+                catalog_name: None,
+                name_ident: DatabaseNameIdent::new(&tenant, &db_name),
+                meta: Default::default(),
+            })
+            .await;
+        print_res(i, "create_db", &res);
+    }
+
+    let mut table_meta = TableMeta {
+        engine: "FUSE".to_string(),
+        ..Default::default()
+    };
+    table_meta
+        .options
+        .insert("bench_pad".to_string(), "x".repeat(param.meta_size));
+
+    let res = client
+        .create_table(CreateTableReq {
+            create_option: CreateOption::CreateIfNotExists,
+            catalog_name: None,
+            name_ident: TableNameIdent {
+                tenant,
+                db_name,
+                table_name: format!("t-{}", i),
+            },
+            table_meta,
+            as_dropped: false,
+            table_properties: None,
+            table_partition: None,
+        })
+        .await;
+
+    print_res(i, "create_tables", &res);
+    res.is_ok()
 }
 
 async fn benchmark_get_table(client: &MetaStore, prefix: u64, client_num: u64, i: u64) -> bool {

--- a/src/meta/binaries/metabench/main.rs
+++ b/src/meta/binaries/metabench/main.rs
@@ -33,14 +33,23 @@ use chrono::Utc;
 use clap::Parser;
 use databend_common_meta_api::DatabaseApi;
 use databend_common_meta_api::TableApi;
+use databend_common_meta_api::fetch_id;
+use databend_common_meta_api::txn_put_pb;
 use databend_common_meta_api::txn_put_pb_with_ttl;
+use databend_common_meta_app::id_generator::IdGenerator;
 use databend_common_meta_app::schema::CreateDatabaseReq;
 use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::schema::CreateTableReq;
+use databend_common_meta_app::schema::DBIdTableName;
 use databend_common_meta_app::schema::DropTableByIdReq;
+use databend_common_meta_app::schema::GetDatabaseReq;
 use databend_common_meta_app::schema::GetTableReq;
 use databend_common_meta_app::schema::TableCopiedFileInfo;
 use databend_common_meta_app::schema::TableCopiedFileNameIdent;
+use databend_common_meta_app::schema::TableId;
+use databend_common_meta_app::schema::TableIdHistoryIdent;
+use databend_common_meta_app::schema::TableIdList;
+use databend_common_meta_app::schema::TableIdToName;
 use databend_common_meta_app::schema::TableMeta;
 use databend_common_meta_app::schema::TableNameIdent;
 use databend_common_meta_app::schema::UpsertTableOptionReq;
@@ -219,6 +228,8 @@ struct Config {
     /// "table": create db, table and upsert_table_option;
     /// "create_tables": accumulate distinct tables, a new db every `db_size` tables;
     /// "create_tables:{"db_size":1000,"meta_size":600}": after ":" is a json config string;
+    /// "batch_create_tables": bulk-load, one txn writes the records of `batch` tables;
+    /// "batch_create_tables:{"batch":1000,"db_size":1000,"meta_size":600}";
     /// "get_table": single get_table() rpc;
     /// "table_copy_file": upsert table with copy file.
     /// "table_copy_file:{"file_cnt":100}": upsert table with 100 copy files. After ":" is a json config string
@@ -351,9 +362,11 @@ async fn main() {
     println!("benchmark latency histogram: {}", snapshot.histogram_line());
 }
 
+/// `grpc_api_address` is a comma-separated endpoint list; give the client every
+/// node so it can follow leader changes instead of forwarding via one node.
 fn create_remote_meta_store(grpc_api_address: &str) -> MetaStore {
     let client_handle = MetaGrpcClient::try_create_with_features(
-        vec![grpc_api_address.to_string()],
+        grpc_api_address.split(',').map(str::to_string).collect(),
         "root",
         "xxx",
         None,
@@ -381,8 +394,12 @@ async fn run_benchmark_once(
         benchmark_table(client, prefix, client_num, i).await
     } else if cmd == "create_tables" {
         benchmark_create_tables(client, prefix, client_num, i, param).await
+    } else if cmd == "batch_create_tables" {
+        benchmark_batch_create_tables(client, prefix, client_num, i, param).await
     } else if cmd == "get_table" {
         benchmark_get_table(client, prefix, client_num, i).await
+    } else if cmd == "get_table_rand" {
+        benchmark_get_table_rand(client, client_num, i, param).await
     } else if cmd == "table_copy_file" {
         benchmark_table_copy_file(client, prefix, client_num, i, param).await
     } else if cmd == "semaphore" {
@@ -582,6 +599,157 @@ async fn benchmark_create_tables(
     res.is_ok()
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+struct BatchCreateTablesConfig {
+    /// Number of tables written in one transaction.
+    batch: u64,
+    /// Number of tables per database.
+    db_size: u64,
+    /// Bytes of padding in `TableMeta.options`, to control the serialized TableMeta size.
+    meta_size: usize,
+}
+
+impl Default for BatchCreateTablesConfig {
+    fn default() -> Self {
+        Self {
+            batch: 1000,
+            db_size: 1000,
+            meta_size: 600,
+        }
+    }
+}
+
+/// Resolve a database id, creating the database if it does not exist yet.
+async fn ensure_db(client: &MetaStore, tenant: &Tenant, db_name: &str) -> Option<u64> {
+    let res = client
+        .create_database(CreateDatabaseReq {
+            override_existing: false,
+            catalog_name: None,
+            name_ident: DatabaseNameIdent::new(tenant, db_name),
+            meta: Default::default(),
+        })
+        .await;
+
+    match res {
+        Ok(reply) => Some(*reply.db_id),
+        // Likely DatabaseAlreadyExists, e.g. filled by a previous batch.
+        Err(_) => {
+            let res = client
+                .get_database(GetDatabaseReq::new(tenant.clone(), db_name))
+                .await;
+            match res {
+                Ok(info) => Some(*info.database_id),
+                Err(e) => {
+                    println!("ERROR: get_database({}) failed: {:?}", db_name, e);
+                    None
+                }
+            }
+        }
+    }
+}
+
+/// Bulk-load tables: one transaction writes the records of `batch` tables,
+/// instead of one id-allocation plus one conditional transaction per table.
+/// Use it to fill a cluster to a target data volume fast; use `create_tables`
+/// to measure the real per-table DDL path.
+///
+/// Table ids are `fetch_id() * 1_000_000 + offset`: one generator bump per
+/// batch keeps ids unique across clients, runs and restarts on the same
+/// cluster. Do not mix with `create_table`-based load on a cluster that has
+/// to stay consistent: normal ids could collide with this id space once the
+/// generator itself exceeds 1_000_000.
+///
+/// Per-table records match `create_table` exactly (name->id, id->meta, name
+/// history, id->name); the db_meta seq bump of the normal path is skipped.
+async fn benchmark_batch_create_tables(
+    client: &MetaStore,
+    prefix: u64,
+    client_num: u64,
+    i: u64,
+    param: &str,
+) -> bool {
+    let param: BatchCreateTablesConfig = if param.is_empty() {
+        Default::default()
+    } else {
+        serde_json::from_str(param).unwrap()
+    };
+    assert!(
+        param.batch <= 1_000_000,
+        "batch must be <= 1_000_000, the id space of one generator bump"
+    );
+
+    let tenant = Tenant::new_literal(&format!("bench-{}", prefix));
+
+    let gen_id = match fetch_id(client, IdGenerator::table_id()).await {
+        Ok(id) => id,
+        Err(e) => {
+            println!("ERROR: fetch_id failed: {:?}", e);
+            return false;
+        }
+    };
+
+    let mut txn = TxnRequest::default();
+    let mut current_db: Option<(u64, u64)> = None; // (db_index, db_id)
+
+    for k in 0..param.batch {
+        let table_index = i * param.batch + k;
+        let db_index = table_index / param.db_size;
+
+        let db_id = match current_db {
+            Some((index, id)) if index == db_index => id,
+            _ => {
+                let db_name = format!("db-{}-{}-{}", prefix, client_num, db_index);
+                let Some(id) = ensure_db(client, &tenant, &db_name).await else {
+                    return false;
+                };
+                current_db = Some((db_index, id));
+                id
+            }
+        };
+
+        let table_id = gen_id * 1_000_000 + k;
+        let table_name = format!("t-{}", table_index);
+
+        let mut table_meta = TableMeta {
+            engine: "FUSE".to_string(),
+            ..Default::default()
+        };
+        table_meta
+            .options
+            .insert("bench_pad".to_string(), "x".repeat(param.meta_size));
+
+        let mut id_list = TableIdList::new();
+        id_list.append(table_id);
+
+        let name_key = DBIdTableName {
+            db_id,
+            table_name: table_name.clone(),
+        };
+
+        txn.if_then.extend([
+            /* name -> id */
+            txn_put_pb(&name_key, &TableId::new(table_id)),
+            /* id -> meta */
+            txn_put_pb(&TableId::new(table_id), &table_meta),
+            /* name history */
+            txn_put_pb(
+                &TableIdHistoryIdent {
+                    database_id: db_id,
+                    table_name,
+                },
+                &id_list,
+            ),
+            /* id -> name */
+            txn_put_pb(&TableIdToName { table_id }, &name_key),
+        ]);
+    }
+
+    let res = client.transaction(txn).await;
+
+    print_res(i, "batch_create_tables", &res);
+    res.is_ok()
+}
+
 async fn benchmark_get_table(client: &MetaStore, prefix: u64, client_num: u64, i: u64) -> bool {
     let tenant = || Tenant::new_literal(&format!("tenant-{}-{}", prefix, client_num));
     let db_name = || format!("db-{}-{}", prefix, client_num);
@@ -592,6 +760,58 @@ async fn benchmark_get_table(client: &MetaStore, prefix: u64, client_num: u64, i
         .await;
 
     print_res(i, "get_table", &res);
+    res.is_ok()
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+struct GetTableRandConfig {
+    /// `--prefix` of the `batch_create_tables` fill round to read from.
+    fill_prefix: u64,
+    /// `--client` of the fill round.
+    fill_clients: u64,
+    /// Tables each fill client created (`--number` x `batch`).
+    tables_per_client: u64,
+    /// `db_size` of the fill round.
+    db_size: u64,
+}
+
+/// Read one uniformly pseudo-random table created by a previous
+/// `batch_create_tables` round: tenant/db -> db_id -> table, the same
+/// lookup path a real by-name access takes.
+async fn benchmark_get_table_rand(
+    client: &MetaStore,
+    client_num: u64,
+    i: u64,
+    param: &str,
+) -> bool {
+    let param: GetTableRandConfig = serde_json::from_str(param).unwrap();
+
+    // splitmix64 on (client_num, i): deterministic uniform spread.
+    let mut x = (client_num << 32) ^ i;
+    let mut next = || {
+        x = x.wrapping_add(0x9E3779B97F4A7C15);
+        let mut z = x;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+        z ^ (z >> 31)
+    };
+    // client_num in the fill run is 1-based.
+    let c = next() % param.fill_clients + 1;
+    let n = next() % param.tables_per_client;
+
+    let tenant = Tenant::new_literal(&format!("bench-{}", param.fill_prefix));
+    let db_name = format!("db-{}-{}-{}", param.fill_prefix, c, n / param.db_size);
+    let table_name = format!("t-{}", n);
+
+    let res = client
+        .get_table(GetTableReq::new(&tenant, &db_name, &table_name))
+        .await;
+
+    if let Err(e) = &res {
+        println!("ERROR: get_table_rand({}/{}) failed: {:?}", db_name, table_name, e);
+    } else if i % 100_000 == 0 {
+        println!("{:>10}-th get_table_rand ok: {}/{}", i, db_name, table_name);
+    }
     res.is_ok()
 }
 


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat(metabench): add bulk-load and random-read benchmarks
# Summary

Add the two benchmarks needed to drive and measure a large table
population: a bulk loader that fills a cluster fast and a random reader
that samples what it wrote. Also point the benchmark client at every
cluster node so it follows leader changes.

# Details

- batch_create_tables writes the records of `batch` tables in one
  transaction, skipping the per-table id allocation and conditional
  create of the real DDL path, to fill a cluster to a target volume
  quickly. Table ids are `fetch_id() * 1_000_000 + offset`, so one
  generator bump per batch keeps ids unique across clients, runs, and
  restarts; the per-table records match create_table exactly (name->id,
  id->meta, name history, id->name). Use create_tables instead when
  measuring the real per-table DDL cost.
- get_table_rand reads a uniformly pseudo-random table from a prior
  batch_create_tables round through the tenant/db/table name path, to
  measure read latency against a populated cluster. A splitmix64 hash
  of (client, op index) gives a deterministic uniform spread.
- create_remote_meta_store now splits grpc_api_address on commas and
  hands the client every endpoint, so it follows leader changes instead
  of forwarding through a single node.


##### chore(test-helper): ignore egg-info as a directory
# Summary

Add a trailing slash to the databend_test_helper.egg-info ignore
pattern so it matches the generated directory specifically rather than
a path of that name.


##### feat(metabench): add run_secs limit and create_tables benchmark
# Summary

Extend metabench for large-scale meta workloads with a wall-clock run
limit and a benchmark that accumulates distinct tables instead of
repeatedly rewriting a single one.

# Details

- --run-secs stops issuing new operations once the given number of
  seconds elapses; 0 preserves the previous behavior of bounding each
  client only by --number.
- New create_tables rpc creates distinct, accumulating tables, opening
  a fresh database every db_size tables and padding TableMeta.options
  with meta_size bytes to control the serialized record size. Each
  client uses its own databases so concurrent creates do not conflict
  on one db_meta record. Both knobs take a JSON suffix, e.g.
  create_tables:{"db_size":1000,"meta_size":600}.


##### feat(test-helper): track meta process via pid file
# Summary

Make the databend-meta helper manageable across separate Python
invocations by recording the child pid in a file, so a `stop` can find
and terminate a process that an earlier `start` launched and left
running.

# Details

- start_process writes the child pid to an optional pid_file; new
  read_pid_file, is_pid_running, and stop_pid helpers inspect or stop a
  process by pid, escalating from SIGTERM to SIGKILL after a timeout.
- DatabendMeta keeps its pid file as a sibling of the raft dir rather
  than inside it, since databend-meta deletes foreign files under its
  raft dir on startup; pid, start, stop, and is_running all route
  through the pid file.
- Fall back to a 0.0.0+uninstalled version when the package is imported
  from the source tree without an install, so import never raises
  PackageNotFoundError.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Other

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20137)
<!-- Reviewable:end -->
