### PR TITLE
fix(query): drop heap-backed min-max aggregate states

### DIFF
--- a/src/query/functions/src/aggregates/aggregate_min_max_any.rs
+++ b/src/query/functions/src/aggregates/aggregate_min_max_any.rs
@@ -369,10 +369,30 @@ where
 
 fn need_manual_drop_state(data_type: &DataType) -> bool {
     match data_type {
-        DataType::String | DataType::Variant => true,
-        DataType::Nullable(t) | DataType::Array(t) | DataType::Map(t) => need_manual_drop_state(t),
-        DataType::Tuple(ts) => ts.iter().any(need_manual_drop_state),
-        _ => false,
+        DataType::Binary
+        | DataType::String
+        | DataType::Array(_)
+        | DataType::Map(_)
+        | DataType::Bitmap
+        | DataType::Tuple(_)
+        | DataType::Variant
+        | DataType::Geometry
+        | DataType::Geography
+        | DataType::Vector(_) => true,
+        DataType::Nullable(data_type) => need_manual_drop_state(data_type),
+        DataType::Null
+        | DataType::EmptyArray
+        | DataType::EmptyMap
+        | DataType::Boolean
+        | DataType::Number(_)
+        | DataType::Decimal(_)
+        | DataType::Timestamp
+        | DataType::TimestampTz
+        | DataType::Date
+        | DataType::Interval
+        | DataType::Opaque(_)
+        | DataType::Generic(_)
+        | DataType::StageLocation => false,
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

close: https://github.com/databendlabs/databend/issues/20145

- Fix a memory leak in `min`, `max`, and `any` aggregate states for heap-backed scalar types
- Treat `Array`, `Map`, and `Tuple` containers themselves as requiring destruction instead of inspecting only their nested types
- Cover other heap-backed scalar types such as `Binary`, `Bitmap`, `Geometry`, `Geography`, and `Vector`

Aggregate states are allocated in raw bump-arena memory, so their destructors only run when `need_manual_drop_state()` returns true. The previous recursive classification returned false for types such as `Array(Int32)`, leaving the state-owned `Column` buffers referenced after query completion.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Memory release is not observable through sqllogictest output; the existing `max/min(Array)` sqllogictest exercises the affected execution path.

Validation performed:

- `cargo fmt --check -- src/query/functions/src/aggregates/aggregate_min_max_any.rs`
- `git diff --check`
- `cargo clippy -p databend-common-functions --lib -- -D warnings`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20146)
<!-- Reviewable:end -->
