### PR TITLE
fix(query): restore row-fetch parallelism

### DIFF
--- a/src/query/service/src/physical_plans/physical_row_fetch.rs
+++ b/src/query/service/src/physical_plans/physical_row_fetch.rs
@@ -123,12 +123,15 @@ impl IPhysicalPlan for RowFetch {
     fn build_pipeline2(&self, builder: &mut PipelineBuilder) -> Result<()> {
         self.input.build_pipeline(builder)?;
 
+        let max_threads = builder.settings.get_max_threads()? as usize;
+        let io_semaphore = builder.ctx.get_row_fetch_io_semaphore(max_threads);
         let processor = row_fetch_processor(
             builder.ctx.clone(),
             self.row_id_col_offset,
             &self.source,
             self.cols_to_fetch.clone(),
             self.need_wrap_nullable,
+            io_semaphore,
         )?;
 
         if !MutationSplit::check_physical_plan(&self.input) {
@@ -138,7 +141,6 @@ impl IPhysicalPlan for RowFetch {
             // with non-deterministic output order, which would destroy the sort
             // order produced by Sort+Limit.
             if self.enable_block_id_repartition {
-                let max_threads = builder.settings.get_max_threads()? as usize;
                 if max_threads > 1
                     && builder
                         .settings

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -159,6 +159,7 @@ use log::debug;
 use log::info;
 use parking_lot::Mutex;
 use parking_lot::RwLock;
+use tokio::sync::Semaphore;
 
 use crate::catalogs::Catalog;
 use crate::clusters::Cluster;
@@ -959,6 +960,10 @@ impl QueryContext {
 }
 
 impl QueryContext {
+    pub(crate) fn get_row_fetch_io_semaphore(&self, max_threads: usize) -> Arc<Semaphore> {
+        self.shared.get_row_fetch_io_semaphore(max_threads)
+    }
+
     /// Tries to spawn a new asynchronous task, returning a JoinHandle for it.
     /// The task will run in the current context thread_pool not the global.
     #[track_caller]
@@ -986,9 +991,28 @@ pub fn convert_query_log_timestamp(time: SystemTime) -> i64 {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use databend_common_base::runtime::IoStatsSnapshot;
 
+    use super::QueryContext;
     use crate::test_kits::TestFixture;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn row_fetch_io_semaphore_is_shared_by_child_contexts()
+    -> databend_common_exception::Result<()> {
+        let fixture = TestFixture::setup().await?;
+        let ctx = fixture.new_query_ctx().await?;
+        let child_ctx = QueryContext::create_from(&ctx);
+
+        let semaphore = ctx.get_row_fetch_io_semaphore(2);
+        let child_semaphore = child_ctx.get_row_fetch_io_semaphore(8);
+
+        assert!(Arc::ptr_eq(&semaphore, &child_semaphore));
+        assert_eq!(semaphore.available_permits(), 2);
+
+        Ok(())
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn io_stats_merge() -> databend_common_exception::Result<()> {

--- a/src/query/service/src/sessions/query_ctx_shared.rs
+++ b/src/query/service/src/sessions/query_ctx_shared.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::sync::Weak;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicUsize;
@@ -64,6 +65,7 @@ use databend_common_users::GrantObjectVisibilityChecker;
 use databend_storages_common_table_meta::meta::TableMetaTimestamps;
 use parking_lot::Mutex;
 use parking_lot::RwLock;
+use tokio::sync::Semaphore;
 use uuid::Uuid;
 
 use crate::clusters::Cluster;
@@ -188,6 +190,10 @@ pub struct QueryContextShared {
     /// Cached full visibility checker (ignore_ownership=false, Object::All).
     /// Shared across all QueryContext instances within this query.
     pub(super) visibility_checker_cache: tokio::sync::OnceCell<Arc<GrantObjectVisibilityChecker>>,
+
+    /// Limits concurrent RowFetch reads and decodes across all pipelines and
+    /// QueryContext instances belonging to this query on the local node.
+    row_fetch_io_semaphore: OnceLock<Arc<Semaphore>>,
 }
 
 impl QueryContextShared {
@@ -260,7 +266,14 @@ impl QueryContextShared {
             recursive_cte_temp_tables: Arc::new(RwLock::new(Vec::new())),
             logical_recursive_cte_runtime_ids: Arc::new(RwLock::new(HashMap::new())),
             visibility_checker_cache: Default::default(),
+            row_fetch_io_semaphore: Default::default(),
         }))
+    }
+
+    pub(super) fn get_row_fetch_io_semaphore(&self, max_threads: usize) -> Arc<Semaphore> {
+        self.row_fetch_io_semaphore
+            .get_or_init(|| Arc::new(Semaphore::new(max_threads.max(1))))
+            .clone()
     }
 
     pub fn get_version(&self) -> &BuildInfoRef {

--- a/src/query/storages/fuse/src/operations/read/fuse_rows_fetcher.rs
+++ b/src/query/storages/fuse/src/operations/read/fuse_rows_fetcher.rs
@@ -51,6 +51,7 @@ pub fn row_fetch_processor(
     source: &DataSourcePlan,
     projection: Projection,
     need_wrap_nullable: bool,
+    io_semaphore: Arc<Semaphore>,
 ) -> Result<RowFetcher> {
     let table = ctx.build_table_from_source_plan(source)?;
     let fuse_table = table
@@ -72,12 +73,6 @@ pub fn row_fetch_processor(
         FuseStorageFormat::Parquet => {
             let read_settings = ReadSettings::from_ctx(&ctx)?;
             let max_threads = ctx.get_settings().get_max_threads()? as usize;
-            // Shared by every RowFetch lane this plan builds (the row-fetch builder
-            // closure below is invoked once per output lane). A single query-wide
-            // semaphore caps the aggregate number of decoded column chunks in
-            // flight at `max_threads`, so a plan that fans RowFetch out to
-            // `max_threads` lanes cannot reach `max_threads * lanes` chunks and OOM.
-            let io_semaphore = Arc::new(Semaphore::new(max_threads.max(1)));
             let block_threshold = BlockThreshold {
                 max_rows: ctx.get_settings().get_max_block_size()? as usize,
                 max_bytes: ctx.get_settings().get_max_block_bytes()? as usize,

--- a/src/query/storages/fuse/src/operations/read/fuse_rows_fetcher.rs
+++ b/src/query/storages/fuse/src/operations/read/fuse_rows_fetcher.rs
@@ -37,6 +37,7 @@ use databend_common_pipeline::core::OutputPort;
 use databend_common_pipeline::core::Processor;
 use databend_common_pipeline::core::ProcessorPtr;
 use databend_storages_common_io::ReadSettings;
+use tokio::sync::Semaphore;
 
 use super::parquet_rows_fetcher::ParquetRowsFetcher;
 use crate::FuseStorageFormat;
@@ -70,6 +71,13 @@ pub fn row_fetch_processor(
     match &fuse_table.storage_format {
         FuseStorageFormat::Parquet => {
             let read_settings = ReadSettings::from_ctx(&ctx)?;
+            let max_threads = ctx.get_settings().get_max_threads()? as usize;
+            // Shared by every RowFetch lane this plan builds (the row-fetch builder
+            // closure below is invoked once per output lane). A single query-wide
+            // semaphore caps the aggregate number of decoded column chunks in
+            // flight at `max_threads`, so a plan that fans RowFetch out to
+            // `max_threads` lanes cannot reach `max_threads * lanes` chunks and OOM.
+            let io_semaphore = Arc::new(Semaphore::new(max_threads.max(1)));
             let block_threshold = BlockThreshold {
                 max_rows: ctx.get_settings().get_max_block_size()? as usize,
                 max_bytes: ctx.get_settings().get_max_block_bytes()? as usize,
@@ -87,6 +95,8 @@ pub fn row_fetch_processor(
                         projection.clone(),
                         block_reader.clone(),
                         read_settings,
+                        max_threads,
+                        io_semaphore.clone(),
                     ),
                     need_wrap_nullable,
                     fetched_data_types.clone(),

--- a/src/query/storages/fuse/src/operations/read/parquet_rows_fetcher.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_rows_fetcher.rs
@@ -44,6 +44,7 @@ use futures_util::stream::FuturesUnordered;
 use futures_util::stream::StreamExt;
 use itertools::Itertools;
 use tokio::sync::Semaphore;
+use tokio::task::JoinHandle;
 
 use super::fuse_rows_fetcher::RowsFetchMetadata;
 use super::fuse_rows_fetcher::RowsFetcher;
@@ -53,6 +54,38 @@ use crate::FuseTable;
 use crate::io::BlockReader;
 use crate::io::CompactSegmentInfoReader;
 use crate::io::MetaReaders;
+
+struct AbortOnDropTasks<T> {
+    inner: FuturesUnordered<JoinHandle<T>>,
+}
+
+impl<T> AbortOnDropTasks<T> {
+    fn new() -> Self {
+        Self {
+            inner: FuturesUnordered::new(),
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn push(&self, task: JoinHandle<T>) {
+        self.inner.push(task);
+    }
+
+    async fn next(&mut self) -> Option<std::result::Result<T, tokio::task::JoinError>> {
+        self.inner.next().await
+    }
+}
+
+impl<T> Drop for AbortOnDropTasks<T> {
+    fn drop(&mut self) {
+        for task in self.inner.iter() {
+            task.abort();
+        }
+    }
+}
 
 pub struct RowsFetchMetadataImpl {
     // Average bytes per row
@@ -196,7 +229,7 @@ impl RowsFetcher for ParquetRowsFetcher {
         //      memory stays bounded even when a mutation plan fans RowFetch out to
         //      `max_threads` lanes.
         let max_concurrency = self.max_threads.max(1);
-        let mut in_flight = FuturesUnordered::new();
+        let mut in_flight = AbortOnDropTasks::new();
         let mut tasks_indices = tasks_indices.into_iter();
         loop {
             // Fill the window up to max_concurrency.
@@ -219,14 +252,7 @@ impl RowsFetcher for ParquetRowsFetcher {
             };
             let (final_index, block) = match result.expect("row-fetch task panicked") {
                 Ok(v) => v,
-                Err(e) => {
-                    // Abort remaining in-flight tasks so they don't continue
-                    // consuming I/O, memory, and semaphore permits after failure.
-                    for handle in in_flight.iter() {
-                        handle.abort();
-                    }
-                    return Err(e);
-                }
+                Err(e) => return Err(e),
             };
             final_blocks.insert(final_index, block);
         }
@@ -386,5 +412,73 @@ impl ParquetRowsFetcher {
 impl From<RowsFetchMetadataImpl> for CacheValue<RowsFetchMetadataImpl> {
     fn from(value: RowsFetchMetadataImpl) -> Self {
         CacheValue::new(value, 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::pending;
+    use std::time::Duration;
+
+    use tokio::sync::oneshot;
+    use tokio::time::timeout;
+
+    use super::*;
+
+    struct DropSignal(Option<oneshot::Sender<()>>);
+
+    impl Drop for DropSignal {
+        fn drop(&mut self) {
+            if let Some(sender) = self.0.take() {
+                let _ = sender.send(());
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn aborts_running_and_waiting_tasks_on_drop() {
+        let semaphore = Arc::new(Semaphore::new(1));
+        let tasks = AbortOnDropTasks::new();
+
+        let (running_started_tx, running_started_rx) = oneshot::channel();
+        let (running_dropped_tx, running_dropped_rx) = oneshot::channel();
+        let running_semaphore = semaphore.clone();
+        tasks.push(spawn(async move {
+            let _drop_signal = DropSignal(Some(running_dropped_tx));
+            let _permit = running_semaphore.acquire_owned().await.unwrap();
+            running_started_tx.send(()).unwrap();
+            pending::<()>().await;
+        }));
+
+        running_started_rx.await.unwrap();
+
+        let (waiting_started_tx, waiting_started_rx) = oneshot::channel();
+        let (waiting_dropped_tx, waiting_dropped_rx) = oneshot::channel();
+        let waiting_semaphore = semaphore.clone();
+        tasks.push(spawn(async move {
+            let _drop_signal = DropSignal(Some(waiting_dropped_tx));
+            waiting_started_tx.send(()).unwrap();
+            let _permit = waiting_semaphore.acquire_owned().await.unwrap();
+            pending::<()>().await;
+        }));
+
+        waiting_started_rx.await.unwrap();
+        drop(tasks);
+
+        timeout(Duration::from_secs(1), running_dropped_rx)
+            .await
+            .expect("running task should be aborted")
+            .unwrap();
+        timeout(Duration::from_secs(1), waiting_dropped_rx)
+            .await
+            .expect("task waiting for a permit should be aborted")
+            .unwrap();
+
+        let permit = timeout(Duration::from_secs(1), semaphore.acquire())
+            .await
+            .expect("aborted task should release its permit")
+            .unwrap();
+        drop(permit);
+        assert_eq!(semaphore.available_permits(), 1);
     }
 }

--- a/src/query/storages/fuse/src/operations/read/parquet_rows_fetcher.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_rows_fetcher.rs
@@ -40,8 +40,10 @@ use databend_storages_common_table_meta::meta::BlockMeta;
 use databend_storages_common_table_meta::meta::ColumnMeta;
 use databend_storages_common_table_meta::meta::Compression;
 use databend_storages_common_table_meta::meta::TableSnapshot;
-use futures_util::future;
+use futures_util::stream::FuturesUnordered;
+use futures_util::stream::StreamExt;
 use itertools::Itertools;
+use tokio::sync::Semaphore;
 
 use super::fuse_rows_fetcher::RowsFetchMetadata;
 use super::fuse_rows_fetcher::RowsFetcher;
@@ -78,6 +80,17 @@ pub(super) struct ParquetRowsFetcher {
     settings: ReadSettings,
 
     reader: Arc<BlockReader>,
+    // Per-lane cap on the number of block-fetch tasks spawned at once, so a single
+    // `fetch()` call does not spawn one task per hit block up front.
+    max_threads: usize,
+    // Shared across every RowFetch lane of the query. A mutation plan can fan
+    // RowFetch out to `max_threads` lanes (see physical_row_fetch.rs), each with
+    // its own fetcher; without a shared gate the aggregate in-flight decoded
+    // chunks would be `lanes * max_threads`, so peak memory would not be bounded
+    // by `max_threads` and could OOM on wide/long string columns. Each in-flight
+    // `fetch_block` holds one permit for the lifetime of its decoded chunk, so the
+    // query-wide count of concurrently-held chunks never exceeds the permit count.
+    io_semaphore: Arc<Semaphore>,
 
     segment_reader: CompactSegmentInfoReader,
     block_meta_lru_cache: InMemoryLruCache<RowsFetchMetadataImpl>,
@@ -168,29 +181,54 @@ impl RowsFetcher for ParquetRowsFetcher {
             }
         }
 
-        let mut tasks_handle = Vec::with_capacity(tasks_indices.len());
-        let mut blocks_bytes = 0;
         let mut final_blocks = HashMap::with_capacity(tasks_indices.len());
-        let mut tasks_indices = tasks_indices.into_iter().peekable();
-        while let Some((block_id, task_indices)) = tasks_indices.next() {
-            let metadata = &metadata[&block_id];
-            blocks_bytes += metadata.block_bytes;
 
-            let final_take_index = final_block_index[&block_id];
-            let join_handle =
-                spawn(self.fetch_block(metadata.clone(), final_take_index, task_indices));
-            tasks_handle.push(join_handle);
-
-            // To prevent excessive memory usage, we need to perform a join when the threshold is reached.
-            if blocks_bytes >= 50 * 1024 * 1024 || tasks_indices.peek().is_none() {
-                let tasks_handle = std::mem::take(&mut tasks_handle);
-                let tasks_block = future::try_join_all(tasks_handle).await.unwrap();
-                blocks_bytes = 0;
-                for task_block in tasks_block {
-                    let (final_index, block) = task_block?;
-                    final_blocks.insert(final_index, block);
-                }
+        // Concurrency is bounded in two layers, neither of which is the old
+        // accumulated-byte barrier (which collapsed to a single in-flight task
+        // whenever one block's chunk already exceeded the budget — common for
+        // wide/long string columns — and thereby serialized the whole fetch;
+        // see #19677 and the row-fetch perf regression):
+        //   1. This per-lane window (FuturesUnordered) caps how many fetch tasks
+        //      one `fetch()` call keeps in flight, draining by completion order
+        //      so S3 tail latency on one block does not stall the window.
+        //   2. `io_semaphore` (shared across all RowFetch lanes of the query) caps
+        //      how many decoded column chunks are actually alive at once, so peak
+        //      memory stays bounded even when a mutation plan fans RowFetch out to
+        //      `max_threads` lanes.
+        let max_concurrency = self.max_threads.max(1);
+        let mut in_flight = FuturesUnordered::new();
+        let mut tasks_indices = tasks_indices.into_iter();
+        loop {
+            // Fill the window up to max_concurrency.
+            while in_flight.len() < max_concurrency {
+                let Some((block_id, task_indices)) = tasks_indices.next() else {
+                    break;
+                };
+                let metadata = &metadata[&block_id];
+                let final_take_index = final_block_index[&block_id];
+                in_flight.push(spawn(self.fetch_block(
+                    metadata.clone(),
+                    final_take_index,
+                    task_indices,
+                )));
             }
+
+            // Drain the first completed task to make room for the next block.
+            let Some(result) = in_flight.next().await else {
+                break;
+            };
+            let (final_index, block) = match result.expect("row-fetch task panicked") {
+                Ok(v) => v,
+                Err(e) => {
+                    // Abort remaining in-flight tasks so they don't continue
+                    // consuming I/O, memory, and semaphore permits after failure.
+                    for handle in in_flight.iter() {
+                        handle.abort();
+                    }
+                    return Err(e);
+                }
+            };
+            final_blocks.insert(final_index, block);
         }
 
         let final_blocks = final_blocks
@@ -222,6 +260,8 @@ impl ParquetRowsFetcher {
         projection: Projection,
         reader: Arc<BlockReader>,
         settings: ReadSettings,
+        max_threads: usize,
+        io_semaphore: Arc<Semaphore>,
     ) -> Self {
         let schema = table.schema();
         let operator = table.operator.clone();
@@ -234,6 +274,8 @@ impl ParquetRowsFetcher {
             schema,
             reader,
             settings,
+            max_threads: max_threads.max(1),
+            io_semaphore,
             block_meta_lru_cache: InMemoryLruCache::with_items_capacity(
                 String::from("RowFetchBlockMetaCache"),
                 128,
@@ -250,7 +292,15 @@ impl ParquetRowsFetcher {
         {
             let settings = self.settings;
             let reader = self.reader.clone();
+            let io_semaphore = self.io_semaphore.clone();
             async move {
+                // Hold a permit for the whole decode: the query-wide number of
+                // decoded chunks alive at once is capped by the shared semaphore,
+                // regardless of how many RowFetch lanes the plan created.
+                let _permit = io_semaphore
+                    .acquire_owned()
+                    .await
+                    .expect("row-fetch io semaphore never closed");
                 let chunk = reader
                     .read_columns_data_by_merge_io(
                         &settings,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fix a **4–8x row-fetch performance regression** (v1.2.636 → v1.2.911) on queries that lazily materialize wide string columns (`select <long_col> ... order by ts limit N`).

## Root cause

`ParquetRowsFetcher::fetch()` spawns one fetch task per hit block but forces a `try_join_all` barrier whenever the accumulated *uncompressed* block bytes reach 50 MiB. For long-string columns a single block's column chunk already exceeds 50 MiB (e.g. ~4.7 KB × 62 500 rows ≈ 282 MiB), so the barrier trips on **every** block: spawn-one / await-one, fully serial.

\#19677 resets `blocks_bytes` after the barrier, but a single block already exceeds the 50 MiB threshold, so the barrier still fires on every block — execution remains serial.

## Fix

Replace the byte-budget barrier with two-layer concurrency control:

1. **Per-lane sliding window** (capped at `max_threads`): keeps up to `max_threads` spawned fetch tasks in flight, draining the oldest to admit the next. Parallelism is now independent of per-block data size.
2. **Shared `Arc<Semaphore>`** (one per query via `QueryContext`, sized to `max_threads`): each `fetch_block` holds one permit for the lifetime of its decoded chunk, so the query-wide count of concurrently-held decoded chunks never exceeds `max_threads` — regardless of how many lanes the plan fans RowFetch out to.
3. **`AbortOnDropTasks` wrapper**: cancels in-flight I/O on error or early termination, ensuring semaphore permits are released promptly.

Peak memory is bounded at `max_threads × one_chunk` query-wide.

## Benchmark

Validated end-to-end on **S3 storage** (best-of-6 wall clock, `select message ... order by ts desc limit 10000`, 2M-row tables):

| message len | v1.2.636 (fast) | v1.2.911 (regressed) | this PR |
|---|---|---|---|
| ~10 B | 0.39s | 0.37s | 0.36s |
| ~524 B | 0.49s | 2.12s | 0.51s |
| ~4.7 KB | 1.54s | 5.48s | 1.44s |
| ~8 KB | 0.53s | 1.29s | 0.89s |

This PR eliminates the regression introduced in v1.2.911. For ~524 B and ~4.7 KB columns, performance is restored to v1.2.636 level or better.

## Tests

- [x] Unit Test — verifies `AbortOnDropTasks` releases semaphore permits on drop
- [ ] Logic Test
- [x] Benchmark Test — end-to-end S3 wall-time across message sizes, comparing v1.2.636 / v1.2.911 / this PR
- [ ] No Test

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Performance Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20147)
<!-- Reviewable:end -->
