### PR TITLE
ci: accept TestNG skipped exit code

### DIFF
--- a/tests/nox/noxfile.py
+++ b/tests/nox/noxfile.py
@@ -36,6 +36,7 @@ JDBC_RELEASE_DOWNLOAD_ROOT = (
 )
 JDBC_SOURCE_BUILD_ENV = {"TEST_HANDLERS": "http"}
 JDBC_EXCLUDED_GROUPS = "FLAKY,cluster,MULTI_HOST"
+TESTNG_EXIT_CODE_SKIPPED = 2
 JDBC_MAIN_TEST_ARGS = [
     "-B",
     "-ntp",
@@ -350,6 +351,8 @@ def run_jdbc_release_test(session, jdbc_target):
         str(testng_suite),
         external=True,
         env=jdbc_target["env"],
+        # TestNG returns 2 when tests are only skipped. Keep failures non-zero.
+        success_codes=[0, TESTNG_EXIT_CODE_SKIPPED],
     )
 
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix： test_compact_client_cluster fail after databend-jdbc release 0.4.8. **which blocks CI**.

- Accept TestNG's skipped-test exit code for release JDBC nox tests.
- Align the `driver_version='latest'` path with the Maven-based `driver_version='main'` path, where skipped tests do not fail the nox session when there are no failures.
- Keep actual TestNG failures non-zero by accepting only exit codes `0` and `2`.


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:

- `python3 -m py_compile tests/nox/noxfile.py`
- `nox -f tests/nox/noxfile.py -s "java_client(driver_version='latest')"`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20148)
<!-- Reviewable:end -->
