### PR TITLE
feat: metactl: run ordered Lua sources

### DIFF
--- a/src/meta/binaries/metactl/main.rs
+++ b/src/meta/binaries/metactl/main.rs
@@ -33,6 +33,7 @@ use databend_common_meta_control::args::ImportArgs;
 use databend_common_meta_control::args::KeysLayoutArgs;
 use databend_common_meta_control::args::ListFeatures;
 use databend_common_meta_control::args::LuaArgs;
+use databend_common_meta_control::args::LuaScript;
 use databend_common_meta_control::args::MemberListArgs;
 use databend_common_meta_control::args::MetricsArgs;
 use databend_common_meta_control::args::SetFeature;
@@ -269,22 +270,23 @@ impl App {
         // Setup Lua environment with gRPC client support
         lua_support::setup_lua_environment(&lua)?;
 
-        let script = match &args.file {
-            Some(path) => std::fs::read_to_string(path)?,
-            None => {
-                let mut buffer = String::new();
-                io::stdin().read_to_string(&mut buffer)?;
-                buffer
-            }
-        };
-
         #[allow(clippy::disallowed_types)]
         let local = tokio::task::LocalSet::new();
-        let res = local.run_until(lua.load(&script).exec_async()).await;
 
-        if let Err(e) = res {
-            return Err(anyhow::anyhow!("Lua execution error: {}", e));
+        if args.scripts.is_empty() {
+            let mut script = String::new();
+            io::stdin().read_to_string(&mut script)?;
+            return execute_lua_script(&lua, &local, &script).await;
         }
+
+        for source in &args.scripts {
+            let script = match source {
+                LuaScript::File(path) => std::fs::read_to_string(path)?,
+                LuaScript::Inline(script) => script.clone(),
+            };
+            execute_lua_script(&lua, &local, &script).await?;
+        }
+
         Ok(())
     }
 
@@ -325,6 +327,18 @@ return metrics, nil
     ) -> Result<Arc<ClientHandle<DatabendRuntime>>, CreationError> {
         lua_support::new_grpc_client(addresses)
     }
+}
+
+#[allow(clippy::disallowed_types)]
+async fn execute_lua_script(
+    lua: &Lua,
+    local: &tokio::task::LocalSet,
+    script: &str,
+) -> anyhow::Result<()> {
+    local
+        .run_until(lua.load(script).exec_async())
+        .await
+        .map_err(|e| anyhow::anyhow!("Lua execution error: {}", e))
 }
 
 #[derive(Debug, Clone, Deserialize, Subcommand)]
@@ -545,6 +559,12 @@ enum CtlCommand {
     ///
     /// Example (from file):
     ///   metactl lua --file script.lua
+    ///
+    /// Example (inline):
+    ///   metactl lua --script 'print("hello")'
+    ///
+    /// Sources run in command-line order:
+    ///   metactl lua --file define.lua --script 'callit()' --file cleanup.lua
     ///
     /// Example (from stdin):
     ///   echo 'print("hello")' | metactl lua

--- a/src/meta/control/src/args.rs
+++ b/src/meta/control/src/args.rs
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use clap::ArgMatches;
 use clap::Args;
+use clap::Command;
+use clap::Error;
+use clap::FromArgMatches;
 use databend_common_tracing::CONFIG_DEFAULT_LOG_LEVEL;
 use databend_meta::raft_store::config::RaftConfig;
 use serde::Deserialize;
@@ -283,11 +287,78 @@ pub struct TriggerSnapshotArgs {
     pub admin_api_address: String,
 }
 
-#[derive(Debug, Clone, Deserialize, Args)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub enum LuaScript {
+    File(String),
+    Inline(String),
+}
+
+#[derive(Debug, Clone, Deserialize)]
 pub struct LuaArgs {
-    /// Path to the Lua script file. If not provided, script is read from stdin
-    #[clap(long)]
-    pub file: Option<String>,
+    #[serde(default)]
+    pub scripts: Vec<LuaScript>,
+}
+
+impl FromArgMatches for LuaArgs {
+    fn from_arg_matches(matches: &ArgMatches) -> Result<Self, Error> {
+        Ok(Self {
+            scripts: ordered_lua_scripts(matches),
+        })
+    }
+
+    fn update_from_arg_matches(&mut self, matches: &ArgMatches) -> Result<(), Error> {
+        *self = Self::from_arg_matches(matches)?;
+        Ok(())
+    }
+}
+
+impl Args for LuaArgs {
+    fn augment_args(command: Command) -> Command {
+        add_lua_args(command)
+    }
+
+    fn augment_args_for_update(command: Command) -> Command {
+        add_lua_args(command)
+    }
+}
+
+fn add_lua_args(command: Command) -> Command {
+    command
+        .arg(
+            clap::Arg::new("file")
+                .long("file")
+                .value_name("FILE")
+                .help("Path to a Lua script file. May be specified multiple times.")
+                .action(clap::ArgAction::Append),
+        )
+        .arg(
+            clap::Arg::new("script")
+                .long("script")
+                .value_name("SCRIPT")
+                .help("Lua code to execute. May be specified multiple times.")
+                .action(clap::ArgAction::Append),
+        )
+}
+
+fn ordered_lua_scripts(matches: &ArgMatches) -> Vec<LuaScript> {
+    let mut scripts = matches
+        .indices_of("file")
+        .into_iter()
+        .flatten()
+        .zip(matches.get_many::<String>("file").into_iter().flatten())
+        .map(|(index, path)| (index, LuaScript::File(path.clone())))
+        .chain(
+            matches
+                .indices_of("script")
+                .into_iter()
+                .flatten()
+                .zip(matches.get_many::<String>("script").into_iter().flatten())
+                .map(|(index, script)| (index, LuaScript::Inline(script.clone()))),
+        )
+        .collect::<Vec<_>>();
+
+    scripts.sort_unstable_by_key(|(index, _)| *index);
+    scripts.into_iter().map(|(_, script)| script).collect()
 }
 
 #[derive(Debug, Clone, Deserialize, Args)]
@@ -328,4 +399,49 @@ pub struct DumpRaftLogWalArgs {
     /// Show raw protobuf bytes for values in UpsertKV and Transaction operations
     #[clap(short = 'R', long, default_value_t = false)]
     pub raw: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+    use clap::Subcommand;
+
+    use super::LuaArgs;
+    use super::LuaScript;
+
+    #[derive(Parser)]
+    struct TestApp {
+        #[command(subcommand)]
+        command: TestCommand,
+    }
+
+    #[derive(Subcommand)]
+    enum TestCommand {
+        Lua(LuaArgs),
+    }
+
+    #[test]
+    fn test_lua_scripts_preserve_command_line_order() {
+        let app = TestApp::try_parse_from([
+            "metactl",
+            "lua",
+            "--script",
+            "first()",
+            "--file",
+            "first.lua",
+            "--script",
+            "second()",
+            "--file",
+            "second.lua",
+        ])
+        .unwrap();
+
+        let TestCommand::Lua(args) = app.command;
+        assert_eq!(args.scripts, vec![
+            LuaScript::Inline("first()".to_string()),
+            LuaScript::File("first.lua".to_string()),
+            LuaScript::Inline("second()".to_string()),
+            LuaScript::File("second.lua".to_string()),
+        ]);
+    }
 }

--- a/tests/metactl/subcommands/cmd_lua.py
+++ b/tests/metactl/subcommands/cmd_lua.py
@@ -2,7 +2,8 @@
 
 import subprocess
 import tempfile
-import os
+from pathlib import Path
+
 from metactl_utils import metactl_bin
 from utils import print_title
 
@@ -54,10 +55,46 @@ def test_lua_stdin():
     print("✓ Lua stdin execution test passed")
 
 
+def test_lua_sources_in_order():
+    """Test interleaved Lua files and inline scripts."""
+    print_title("Test Lua source execution order")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        first = Path(temp_dir, "first.lua")
+        second = Path(temp_dir, "second.lua")
+        first.write_text('order = "file-1"\n')
+        second.write_text('print(order .. ", file-2")\n')
+
+        result = subprocess.run(
+            [
+                metactl_bin,
+                "lua",
+                "--file",
+                str(first),
+                "--script",
+                'order = order .. ", inline-1"',
+                "--file",
+                str(second),
+                "--script",
+                'print(order .. ", inline-2")',
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    assert result.stdout.strip().splitlines() == [
+        "file-1, inline-1, file-2",
+        "file-1, inline-1, inline-2",
+    ]
+    print("✓ Lua source execution order test passed")
+
+
 def main():
     """Main function to run all lua tests."""
     test_lua_file()
     test_lua_stdin()
+    test_lua_sources_in_order()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat: metactl: run ordered Lua sources
# Summary

Metactl can now combine repeatable Lua files with inline `--script` code, executing every source in command-line order while retaining one Lua interpreter state.

# Details

- Add repeatable `--file` and `--script` inputs, preserving their interleaving so scripts can define state for later sources.
- Keep stdin input when no source is supplied and add parser and CLI regression coverage for ordered execution.

Example:

    metactl lua --file define.lua --script 'callit()' --file cleanup.lua

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] New Feature (non-breaking change which adds functionality)

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20149)
<!-- Reviewable:end -->
