### PR TITLE
fix(query): improve private task run tracking

### DIFF
--- a/src/meta/app/src/principal/task.rs
+++ b/src/meta/app/src/principal/task.rs
@@ -38,6 +38,7 @@ pub enum State {
     Succeeded = 2,
     Failed = 3,
     Cancelled = 4,
+    Skipped = 5,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/query/management/src/task/task_mgr.rs
+++ b/src/query/management/src/task/task_mgr.rs
@@ -76,9 +76,38 @@ impl TaskMgr {
 
     #[async_backtrace::framed]
     #[fastrace::trace]
-    pub async fn update_task(&self, task: Task) -> Result<Result<(), TaskError>, TaskApiError> {
-        self.create_task_inner(task, &CreateOption::CreateOrReplace, true, None)
-            .await
+    pub async fn update_task(&self, task: Task) -> Result<Result<bool, TaskError>, TaskApiError> {
+        let key = TaskIdent::new(&self.tenant, &task.task_name);
+        loop {
+            let Some(seq_task) = self.kv_api.get_pb(&key).await? else {
+                return Ok(Err(TaskError::NotFound {
+                    tenant: self.tenant.tenant_name().to_string(),
+                    name: task.task_name,
+                    context: "while updating task schedule".to_string(),
+                }));
+            };
+
+            let seq = seq_task.seq;
+            let mut current_task = seq_task.data;
+            if current_task.task_id != task.task_id
+                || current_task.status != Status::Started
+                || current_task.schedule_options != task.schedule_options
+                || current_task.warehouse_options != task.warehouse_options
+            {
+                return Ok(Ok(false));
+            }
+
+            current_task.next_scheduled_at = task.next_scheduled_at;
+            if current_task.updated_at < task.updated_at {
+                current_task.updated_at = task.updated_at;
+            }
+
+            let req = UpsertPB::update(key.clone(), current_task).with(MatchSeq::Exact(seq));
+            let res = self.kv_api.upsert_pb(&req).await?;
+            if res.is_changed() {
+                return Ok(Ok(true));
+            }
+        }
     }
 
     #[async_backtrace::framed]

--- a/src/query/management/tests/it/task.rs
+++ b/src/query/management/tests/it/task.rs
@@ -15,6 +15,7 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use chrono::Duration;
 use chrono::Utc;
 use databend_common_ast::ast::AlterTaskOptions;
 use databend_common_ast::ast::ScheduleOptions as AstScheduleOptions;
@@ -192,6 +193,52 @@ async fn test_alter_task_set_schedule_preserves_warehouse() -> anyhow::Result<()
             schedule_type: ScheduleType::IntervalType,
             milliseconds_interval: None,
         })
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_scheduler_update_does_not_overwrite_alter() -> anyhow::Result<()> {
+    let (_kv, task_mgr) = new_task_api().await?;
+    let mut task = test_task("task_1", "select 1");
+    task.status = Status::Started;
+    task.schedule_options = Some(ScheduleOptions {
+        interval: Some(60),
+        cron: None,
+        time_zone: None,
+        schedule_type: ScheduleType::IntervalType,
+        milliseconds_interval: None,
+    });
+    task_mgr.create_task(task, &CreateOption::Create).await??;
+
+    let mut stale_task = task_mgr.describe_task("task_1").await??.unwrap();
+    task_mgr
+        .alter_task(
+            "task_1",
+            &AlterTaskOptions::ModifyAs(TaskSql::SingleStatement("select 2".to_string())),
+        )
+        .await??;
+
+    let next_scheduled_at = Utc::now() + Duration::minutes(1);
+    stale_task.next_scheduled_at = Some(next_scheduled_at);
+    stale_task.updated_at = Utc::now();
+    assert!(task_mgr.update_task(stale_task.clone()).await??);
+
+    let current_task = task_mgr.describe_task("task_1").await??.unwrap();
+    assert_eq!(
+        current_task.task_sql,
+        MetaTaskSql::Sql("select 2".to_string())
+    );
+    assert_eq!(current_task.next_scheduled_at, Some(next_scheduled_at));
+
+    task_mgr
+        .alter_task("task_1", &AlterTaskOptions::Suspend)
+        .await??;
+    assert!(!task_mgr.update_task(stale_task).await??);
+    assert_eq!(
+        task_mgr.describe_task("task_1").await??.unwrap().status,
+        Status::Suspended
     );
 
     Ok(())

--- a/src/query/service/src/table_functions/private_task_history.rs
+++ b/src/query/service/src/table_functions/private_task_history.rs
@@ -252,7 +252,7 @@ impl PrivateTaskHistoryArgs {
         }
         if self.error_only.unwrap_or(false) {
             filters.push(
-                "(COALESCE(error_code, 0) != 0 OR error_message IS NOT NULL OR state = 'FAILED')"
+                "(state != 'SKIPPED' AND (COALESCE(error_code, 0) != 0 OR error_message IS NOT NULL OR state = 'FAILED'))"
                     .to_string(),
             );
         }

--- a/src/query/service/src/task/service.rs
+++ b/src/query/service/src/task/service.rs
@@ -287,7 +287,9 @@ impl TaskService {
                                             let committed_at = Utc::now();
                                             task.next_scheduled_at = Some(committed_at + duration);
                                             task.updated_at = committed_at;
-                                            task_mgr.update_task(task.clone()).await??;
+                                            if !task_mgr.update_task(task.clone()).await?? {
+                                                return Ok(());
+                                            }
                                             loop {
                                                 tokio::select! {
                                                     _ = sleep(duration) => {
@@ -297,7 +299,9 @@ impl TaskService {
                                                         let committed_at = Utc::now();
                                                         task.next_scheduled_at = Some(committed_at + duration);
                                                         task.updated_at = committed_at;
-                                                        task_mgr.update_task(task.clone()).await??;
+                                                        if !task_mgr.update_task(task.clone()).await?? {
+                                                            break;
+                                                        }
                                                         if task_service.has_executing_task_run(&task.task_name).await? {
                                                             task_service.record_overlapping_skip(&task).await?;
                                                             continue;
@@ -344,18 +348,23 @@ impl TaskService {
 
                                                 task.next_scheduled_at = Some(next_time.with_timezone(&Utc));
                                                 task.updated_at = now;
-                                                task_mgr.update_task(task.clone()).await??;
+                                                if !task_mgr.update_task(task.clone()).await?? {
+                                                    break;
+                                                }
                                                 tokio::select! {
                                                     _ = sleep(duration) => {
                                                         let Some(_guard) = fn_lock(&task_service, &task_key, duration.as_millis() as u64).await? else {
                                                             continue;
                                                         };
                                                         let committed_at = Utc::now();
-                                                        task.next_scheduled_at = upcoming
+                                                        let next_scheduled_at = upcoming
                                                             .peek()
                                                             .map(|next| next.with_timezone(&Utc));
+                                                        task.next_scheduled_at = next_scheduled_at;
                                                         task.updated_at = committed_at;
-                                                        task_mgr.update_task(task.clone()).await??;
+                                                        if !task_mgr.update_task(task.clone()).await?? {
+                                                            break;
+                                                        }
                                                         if task_service.has_executing_task_run(&task.task_name).await? {
                                                             task_service.record_overlapping_skip(&task).await?;
                                                             continue;

--- a/src/query/service/src/task/service.rs
+++ b/src/query/service/src/task/service.rs
@@ -94,6 +94,10 @@ use crate::task::session::get_task_user;
 
 pub type TaskMessageStream = BoxStream<'static, Result<(String, TaskMessage)>>;
 
+const OVERLAPPING_EXECUTION: &str = "OVERLAPPING_EXECUTION";
+const WHEN_CONDITION_EVALUATION_ERROR: &str = "WHEN_CONDITION_EVALUATION_ERROR";
+const WHEN_CONDITION_FALSE: &str = "WHEN_CONDITION_FALSE";
+
 /// Currently, query uses the watch in meta to imitate channel to obtain tasks. When task messages are sent to channels, they are stored in meta using TaskMessage::key.
 /// TaskMessage::key is divided into only 4 types of keys that will overwrite each other to avoid repeated storage and repeated processing.
 /// Whenever a new key is inserted for overwriting, each query will receive the corresponding key change and process it, thus realizing the channel
@@ -280,7 +284,9 @@ impl TaskService {
                                 runtime
                                     .spawn(async move {
                                         let mut fn_work = async move || {
-                                            task.next_scheduled_at = Some(Utc::now() + duration);
+                                            let committed_at = Utc::now();
+                                            task.next_scheduled_at = Some(committed_at + duration);
+                                            task.updated_at = committed_at;
                                             task_mgr.update_task(task.clone()).await??;
                                             loop {
                                                 tokio::select! {
@@ -288,10 +294,15 @@ impl TaskService {
                                                         let Some(_guard) = fn_lock(&task_service, &task_key, duration.as_millis() as u64).await? else {
                                                             continue;
                                                         };
+                                                        let committed_at = Utc::now();
+                                                        task.next_scheduled_at = Some(committed_at + duration);
+                                                        task.updated_at = committed_at;
+                                                        task_mgr.update_task(task.clone()).await??;
                                                         if task_service.has_executing_task_run(&task.task_name).await? {
+                                                            task_service.record_overlapping_skip(&task).await?;
                                                             continue;
                                                         }
-                                                        if !Self::check_when(&task, &owner, &task_service).await? {
+                                                        if !Self::check_when_and_record(&task, &owner, &task_service).await? {
                                                             continue;
                                                         }
                                                         task_mgr.send(TaskMessage::ExecuteTask(task.clone())).await.map_err(meta_service_error)?;
@@ -323,25 +334,33 @@ impl TaskService {
                                 runtime
                                     .spawn(async move {
                                         let mut fn_work = async move || {
-                                            let upcoming = schedule.upcoming(tz);
+                                            let mut upcoming = schedule.upcoming(tz).peekable();
 
-                                            for next_time in upcoming {
+                                            while let Some(next_time) = upcoming.next() {
                                                 let now = Utc::now();
                                                 let duration = (next_time.with_timezone(&Utc) - now)
                                                     .to_std()
                                                     .unwrap_or(Duration::ZERO);
 
-                                                task.next_scheduled_at = Some(Utc::now() + duration);
+                                                task.next_scheduled_at = Some(next_time.with_timezone(&Utc));
+                                                task.updated_at = now;
                                                 task_mgr.update_task(task.clone()).await??;
                                                 tokio::select! {
                                                     _ = sleep(duration) => {
                                                         let Some(_guard) = fn_lock(&task_service, &task_key, duration.as_millis() as u64).await? else {
                                                             continue;
                                                         };
+                                                        let committed_at = Utc::now();
+                                                        task.next_scheduled_at = upcoming
+                                                            .peek()
+                                                            .map(|next| next.with_timezone(&Utc));
+                                                        task.updated_at = committed_at;
+                                                        task_mgr.update_task(task.clone()).await??;
                                                         if task_service.has_executing_task_run(&task.task_name).await? {
+                                                            task_service.record_overlapping_skip(&task).await?;
                                                             continue;
                                                         }
-                                                        if !Self::check_when(&task, &owner, &task_service).await? {
+                                                        if !Self::check_when_and_record(&task, &owner, &task_service).await? {
                                                             continue;
                                                         }
                                                         task_mgr.send(TaskMessage::ExecuteTask(task.clone())).await.map_err(meta_service_error)?;
@@ -387,6 +406,7 @@ impl TaskService {
                     };
 
                     if task_service.has_executing_task_run(&task_name).await? {
+                        task_service.record_overlapping_skip(&task).await?;
                         continue;
                     }
                     let mut task_run = Self::new_task_run(&task);
@@ -420,19 +440,22 @@ impl TaskService {
                                                 .ok_or_else(|| ErrorCode::UnknownTask(next_task))?;
                                             let next_owner =
                                                 Self::get_task_owner(&next_task, &tenant).await?;
-                                            if Self::check_when(
+                                            if task_service
+                                                .has_executing_task_run(&next_task.task_name)
+                                                .await?
+                                            {
+                                                task_service
+                                                    .record_overlapping_skip(&next_task)
+                                                    .await?;
+                                                continue;
+                                            }
+                                            if Self::check_when_and_record(
                                                 &next_task,
                                                 &next_owner,
                                                 &task_service,
                                             )
                                             .await?
                                             {
-                                                if task_service
-                                                    .has_executing_task_run(&next_task.task_name)
-                                                    .await?
-                                                {
-                                                    continue;
-                                                }
                                                 task_mgr
                                                     .send(TaskMessage::ExecuteTask(next_task))
                                                     .await
@@ -605,6 +628,58 @@ impl TaskService {
         }
     }
 
+    fn new_terminal_task_run(
+        task: &Task,
+        state: State,
+        error_code: i64,
+        error_message: String,
+    ) -> TaskRun {
+        let now = Utc::now();
+        TaskRun {
+            task: task.clone(),
+            run_id: Self::make_run_id(),
+            attempt_number: 0,
+            state,
+            scheduled_at: now,
+            completed_at: Some(now),
+            error_code,
+            error_message: Some(error_message),
+            root_task_id: EMPTY_TASK_ID,
+        }
+    }
+
+    async fn record_overlapping_skip(&self, task: &Task) -> Result<()> {
+        let reason = format!("{OVERLAPPING_EXECUTION}: previous task run is still executing");
+        let task_run = Self::new_terminal_task_run(task, State::Skipped, 0, reason);
+        self.update_or_create_task_run(&task_run).await?;
+        Ok(())
+    }
+
+    async fn check_when_and_record(
+        task: &Task,
+        user: &UserInfo,
+        task_service: &Arc<TaskService>,
+    ) -> Result<bool> {
+        match Self::check_when(task, user, task_service).await {
+            Ok(true) => Ok(true),
+            Ok(false) => {
+                let condition = task.when_condition.as_deref().unwrap_or_default();
+                let reason =
+                    format!("{WHEN_CONDITION_FALSE}: condition '{condition}' evaluated to false");
+                let task_run = Self::new_terminal_task_run(task, State::Skipped, 0, reason);
+                task_service.update_or_create_task_run(&task_run).await?;
+                Ok(false)
+            }
+            Err(err) => {
+                let reason = format!("{WHEN_CONDITION_EVALUATION_ERROR}: {}", err.message());
+                let task_run =
+                    Self::new_terminal_task_run(task, State::Failed, err.code() as i64, reason);
+                task_service.update_or_create_task_run(&task_run).await?;
+                Ok(false)
+            }
+        }
+    }
+
     async fn check_when(
         task: &Task,
         user: &UserInfo,
@@ -714,6 +789,7 @@ impl TaskService {
             State::Succeeded => "SUCCEEDED".to_string(),
             State::Failed => "FAILED".to_string(),
             State::Cancelled => "CANCELLED".to_string(),
+            State::Skipped => "SKIPPED".to_string(),
         };
         let scheduled_at = task_run.scheduled_at.timestamp();
         let completed_at = task_run
@@ -930,6 +1006,7 @@ WHERE ta.task_name = {task_name}
             State::Succeeded => "SUCCEEDED",
             State::Failed => "FAILED",
             State::Cancelled => "CANCELLED",
+            State::Skipped => "SKIPPED",
         });
         let error_message = Self::sql_optional_string(task_run.error_message.as_deref());
         let completed_at = task_run

--- a/src/query/service/src/task/service.rs
+++ b/src/query/service/src/task/service.rs
@@ -858,6 +858,7 @@ impl TaskService {
             completed_at,
             ROW_NUMBER() OVER (PARTITION BY task_name ORDER BY completed_at DESC) AS rn
         FROM system_task.task_run
+        WHERE NOT (state = 'SKIPPED' AND COALESCE(error_message, '') LIKE 'OVERLAPPING_EXECUTION:%')
     ) ranked
     WHERE rn = 1
 ),

--- a/src/query/service/src/task/service.rs
+++ b/src/query/service/src/task/service.rs
@@ -223,7 +223,18 @@ impl TaskService {
 
             // Delete cleanup updates shared metadata, so it must run even if the
             // task's assigned warehouse currently has no live query node.
-            if !matches!(&task_message, TaskMessage::DeleteTask(_, _, _)) {
+            let is_delete = matches!(&task_message, TaskMessage::DeleteTask(_, _, _));
+            if is_delete
+                && self
+                    .create_context(None)
+                    .await?
+                    .get_cluster()
+                    .get_warehouse_id()
+                    .is_err()
+            {
+                continue;
+            }
+            if !is_delete {
                 if let Some(WarehouseOptions {
                     warehouse: Some(warehouse),
                     ..

--- a/src/query/task_support/src/system_tables/private_task_history.rs
+++ b/src/query/task_support/src/system_tables/private_task_history.rs
@@ -31,44 +31,40 @@ pub struct PrivateTaskHistoryTable;
 
 impl PrivateTaskHistoryTable {
     pub fn create(table_id: u64) -> Arc<dyn Table> {
+        // Keep the private-task system table compatible with the cloud task-history
+        // contract. The underlying task_run table is an implementation detail and
+        // may grow independently without changing this public schema.
         let query = "SELECT
-        task_id,
-        task_name,
-        query_text,
-        when_condition,
-        after,
+        COALESCE(task_name, '') AS name,
+        COALESCE(task_id, 0) AS id,
+        COALESCE(owner, '') AS owner,
         comment,
-        owner,
-        owner_user,
-        warehouse_name,
-        using_warehouse_size,
-        schedule_type,
-        interval,
-        interval_milliseconds,
-        cron,
-        time_zone,
-        run_id,
-        attempt_number,
-        state,
-        error_code,
-        error_message,
-        root_task_id,
-        scheduled_at,
-        completed_at,
-        next_scheduled_at,
-        error_integration,
-        status,
-        created_at,
-        updated_at,
-        session_params,
-        last_suspended_at,
-        suspend_task_after_num_failures
+        CASE
+            WHEN schedule_type = 0 AND interval_milliseconds IS NOT NULL THEN CONCAT('INTERVAL ', COALESCE(CAST(interval AS STRING), '0'), ' SECOND ', CAST(interval_milliseconds AS STRING), ' MILLISECOND')
+            WHEN schedule_type = 0 THEN CONCAT('INTERVAL ', COALESCE(CAST(interval AS STRING), '0'), ' SECOND')
+            WHEN schedule_type = 1 AND time_zone IS NOT NULL THEN CONCAT('CRON ', cron, ' TIMEZONE ', time_zone)
+            WHEN schedule_type = 1 THEN CONCAT('CRON ', cron)
+            ELSE NULL
+        END AS schedule,
+        warehouse_name AS warehouse,
+        COALESCE(state, '') AS state,
+        COALESCE(query_text, '') AS definition,
+        COALESCE(when_condition, '') AS condition_text,
+        CAST(COALESCE(run_id, 0) AS STRING) AS run_id,
+        '' AS query_id,
+        COALESCE(error_code, 0) AS exception_code,
+        error_message AS exception_text,
+        COALESCE(attempt_number, 0) AS attempt_number,
+        completed_at AS completed_time,
+        COALESCE(scheduled_at, TO_TIMESTAMP(0)) AS scheduled_time,
+        CAST(COALESCE(root_task_id, 0) AS STRING) AS root_task_id,
+        session_params AS session_parameters
         FROM system_task.task_run ORDER BY run_id DESC;";
 
         let mut options = BTreeMap::new();
         options.insert(QUERY.to_string(), query.to_string());
         let table_info = TableInfo {
-            desc: "'information_schema'.'task_history'".to_string(),
+            desc: "'system'.'task_history'".to_string(),
             name: "task_history".to_string(),
             ident: TableIdent::new(table_id, 0),
             meta: TableMeta {

--- a/tests/task/test-private-task.sh
+++ b/tests/task/test-private-task.sh
@@ -376,6 +376,17 @@ else
     exit 1
 fi
 
+response=$(query_sql_with_auth "root:" "SELECT count(*) FROM TASK_HISTORY(TASK_NAME => 'when_false_task', ERROR_ONLY => TRUE)")
+check_response_error "$response"
+actual=$(echo "$response" | jq -r '.data[0][0]')
+if [ "$actual" = "0" ]; then
+    echo "✅ Skipped task runs are excluded from error-only history"
+else
+    echo "❌ Expected error-only history to exclude skipped task runs"
+    echo "Actual: $actual"
+    exit 1
+fi
+
 response=$(query_sql_with_auth "root:" "SELECT count_if(c1 = 99) FROM t1")
 check_response_error "$response"
 actual=$(echo "$response" | jq -r '.data[0][0]')

--- a/tests/task/test-private-task.sh
+++ b/tests/task/test-private-task.sh
@@ -706,6 +706,32 @@ else
     exit 1
 fi
 
+response=$(query_sql_with_auth "root:" "UPDATE system_task.task_run SET state = 'SKIPPED', error_code = 0, error_message = 'OVERLAPPING_EXECUTION: test', completed_at = to_timestamp(4102444800) WHERE task_name = 'fanout_root'")
+check_response_error "$response"
+
+response=$(query_sql_with_auth "root:" "EXECUTE TASK fanout_root")
+check_response_error "$response"
+
+actual=0
+for _ in {1..20}; do
+    response=$(query_sql_with_auth "root:" "SELECT count(*) FROM fanout_sink")
+    check_response_error "$response"
+    actual=$(echo "$response" | jq -r '.data[0][0]')
+    if [ "$actual" = "6" ]; then
+        break
+    fi
+    sleep 1
+done
+
+if [ "$actual" = "6" ]; then
+    echo "✅ Overlap skips do not mask successful parent runs"
+else
+    echo "❌ Expected successful parent run to release all successors after an overlap skip"
+    echo "Expected: 6"
+    echo "Actual  : $actual"
+    exit 1
+fi
+
 response=$(curl -s -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d "{\"sql\": \"CREATE TASK my_task_1 SCHEDULE = 5 SECOND AS insert into t1 values(0)\"}")
 check_response_error "$response"
 create_task_1_query_id=$(echo $response | jq -r '.id')

--- a/tests/task/test-private-task.sh
+++ b/tests/task/test-private-task.sh
@@ -236,7 +236,47 @@ check_response_error "$response"
 response=$(query_sql_with_auth "root:" "ALTER TASK overlap_schedule_task RESUME")
 check_response_error "$response"
 
-sleep 9
+sleep 1
+
+response=$(query_sql_with_auth "root:" "SELECT next_schedule_time, last_committed_on FROM system.tasks WHERE name = 'overlap_schedule_task'")
+check_response_error "$response"
+initial_next_schedule_time=$(echo "$response" | jq -r '.data[0][0]')
+initial_last_committed_on=$(echo "$response" | jq -r '.data[0][1]')
+
+sleep 3
+
+response=$(query_sql_with_auth "root:" "SELECT if(next_schedule_time > to_timestamp('${initial_next_schedule_time}'), 1, 0), if(last_committed_on > to_timestamp('${initial_last_committed_on}'), 1, 0) FROM system.tasks WHERE name = 'overlap_schedule_task'")
+check_response_error "$response"
+actual=$(echo "$response" | jq -c '.data')
+expected='[["1","1"]]'
+if [ "$actual" = "$expected" ]; then
+    echo "✅ Interval scheduling advances next_schedule_time and last_committed_on"
+else
+    echo "❌ Expected interval scheduling metadata to advance"
+    echo "Expected: $expected"
+    echo "Actual  : $actual"
+    exit 1
+fi
+
+response=$(query_sql_with_auth "root:" "SHOW TASKS")
+check_response_error "$response"
+show_next_schedule_time=$(echo "$response" | jq -r '.data[] | select(.[1] == "overlap_schedule_task") | .[13]')
+show_last_committed_on=$(echo "$response" | jq -r '.data[] | select(.[1] == "overlap_schedule_task") | .[14]')
+if [ -n "$show_next_schedule_time" ] &&
+    [ "$show_next_schedule_time" != "$initial_next_schedule_time" ] &&
+    [ -n "$show_last_committed_on" ] &&
+    [ "$show_last_committed_on" != "$initial_last_committed_on" ]; then
+    echo "✅ SHOW TASKS exposes advancing scheduling metadata"
+else
+    echo "❌ Expected SHOW TASKS scheduling metadata to advance"
+    echo "Initial next schedule: $initial_next_schedule_time"
+    echo "SHOW next schedule   : $show_next_schedule_time"
+    echo "Initial commit       : $initial_last_committed_on"
+    echo "SHOW commit          : $show_last_committed_on"
+    exit 1
+fi
+
+sleep 5
 
 response=$(query_sql_with_auth "root:" "ALTER TASK overlap_schedule_task SUSPEND")
 check_response_error "$response"
@@ -264,6 +304,121 @@ else
     echo "Actual  : $actual"
     exit 1
 fi
+
+response=$(query_sql_with_auth "root:" "SELECT count_if(state = 'SCHEDULED'), count(*) - count(DISTINCT run_id) FROM system_task.task_run WHERE task_name = 'overlap_schedule_task'")
+check_response_error "$response"
+actual=$(echo "$response" | jq -c '.data')
+expected='[["0","0"]]'
+if [ "$actual" = "$expected" ]; then
+    echo "✅ Each trigger creates one history row with a unique run_id"
+else
+    echo "❌ Expected no duplicate scheduled/history rows"
+    echo "Expected: $expected"
+    echo "Actual  : $actual"
+    exit 1
+fi
+
+response=$(query_sql_with_auth "root:" "SELECT count_if(state = 'SKIPPED' AND error_message LIKE 'OVERLAPPING_EXECUTION:%') FROM system_task.task_run WHERE task_name = 'overlap_schedule_task'")
+check_response_error "$response"
+actual=$(echo "$response" | jq -r '.data[0][0]')
+if [ "$actual" -ge 1 ]; then
+    echo "✅ Overlapping schedule windows are recorded as SKIPPED"
+else
+    echo "❌ Expected overlapping schedule windows to record a skip reason"
+    echo "Actual  : $actual"
+    exit 1
+fi
+
+response=$(query_sql_with_auth "root:" "SELECT * FROM system.task_history WHERE name = 'overlap_schedule_task' LIMIT 1")
+check_response_error "$response"
+check_task_history_schema "$response"
+
+response=$(query_sql_with_auth "root:" "CREATE TASK when_false_task SCHEDULE = 500 MILLISECOND WHEN 1 = 0 AS INSERT INTO t1 VALUES (99)")
+check_response_error "$response"
+
+response=$(query_sql_with_auth "root:" "ALTER TASK when_false_task RESUME")
+check_response_error "$response"
+
+sleep 2
+
+response=$(query_sql_with_auth "root:" "ALTER TASK when_false_task SUSPEND")
+check_response_error "$response"
+
+sleep 1
+
+response=$(query_sql_with_auth "root:" "SELECT count_if(state = 'SKIPPED' AND error_message LIKE 'WHEN_CONDITION_FALSE:%'), count_if(state IN ('EXECUTING', 'SUCCEEDED', 'FAILED')) FROM system_task.task_run WHERE task_name = 'when_false_task'")
+check_response_error "$response"
+skipped_count=$(echo "$response" | jq -r '.data[0][0]')
+executed_count=$(echo "$response" | jq -r '.data[0][1]')
+if [ "$skipped_count" -ge 2 ] && [ "$executed_count" = "0" ]; then
+    echo "✅ False WHEN conditions are recorded without executing the task"
+else
+    echo "❌ Expected false WHEN conditions to produce only SKIPPED history"
+    echo "Skipped : $skipped_count"
+    echo "Executed: $executed_count"
+    exit 1
+fi
+
+response=$(query_sql_with_auth "root:" "SELECT state, exception_code, exception_text FROM system.task_history WHERE name = 'when_false_task' ORDER BY scheduled_time DESC LIMIT 1")
+check_response_error "$response"
+history_state=$(echo "$response" | jq -r '.data[0][0]')
+history_code=$(echo "$response" | jq -r '.data[0][1]')
+history_reason=$(echo "$response" | jq -r '.data[0][2]')
+if [ "$history_state" = "SKIPPED" ] &&
+    [ "$history_code" = "0" ] &&
+    [[ "$history_reason" == WHEN_CONDITION_FALSE:* ]]; then
+    echo "✅ system.task_history explains why the task was skipped"
+else
+    echo "❌ Expected public task history to expose the skip reason"
+    echo "State : $history_state"
+    echo "Code  : $history_code"
+    echo "Reason: $history_reason"
+    exit 1
+fi
+
+response=$(query_sql_with_auth "root:" "SELECT count_if(c1 = 99) FROM t1")
+check_response_error "$response"
+actual=$(echo "$response" | jq -r '.data[0][0]')
+if [ "$actual" = "0" ]; then
+    echo "✅ False WHEN condition did not execute task SQL"
+else
+    echo "❌ Task SQL executed despite a false WHEN condition"
+    echo "Actual  : $actual"
+    exit 1
+fi
+
+response=$(query_sql_with_auth "root:" "CREATE TASK when_error_task SCHEDULE = 500 MILLISECOND WHEN EXISTS (SELECT 1 FROM missing_when_source) AS SELECT 1")
+check_response_error "$response"
+
+response=$(query_sql_with_auth "root:" "ALTER TASK when_error_task RESUME")
+check_response_error "$response"
+
+sleep 2
+
+response=$(query_sql_with_auth "root:" "SELECT count_if(state = 'FAILED' AND error_code != 0 AND error_message LIKE 'WHEN_CONDITION_EVALUATION_ERROR:%') FROM system_task.task_run WHERE task_name = 'when_error_task'")
+check_response_error "$response"
+actual=$(echo "$response" | jq -r '.data[0][0]')
+if [ "$actual" -ge 2 ]; then
+    echo "✅ WHEN evaluation errors are recorded and later schedules continue"
+else
+    echo "❌ Expected repeated WHEN evaluation failures in task history"
+    echo "Actual  : $actual"
+    exit 1
+fi
+
+response=$(query_sql_with_auth "root:" "SELECT state FROM system.tasks WHERE name = 'when_error_task'")
+check_response_error "$response"
+actual=$(echo "$response" | jq -r '.data[0][0]')
+if [ "$actual" = "Started" ]; then
+    echo "✅ WHEN evaluation errors do not silently stop the scheduler"
+else
+    echo "❌ Expected task scheduler to remain started after WHEN errors"
+    echo "Actual  : $actual"
+    exit 1
+fi
+
+response=$(query_sql_with_auth "root:" "ALTER TASK when_error_task SUSPEND")
+check_response_error "$response"
 
 response=$(query_sql_with_auth "root:" "CREATE TABLE t_failed_task_recovery (c1 int)")
 check_response_error "$response"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR fixes four private-task issues:

1. Keep system.task_history compatible with the 18-column Cloud schema.
2. Advance next schedule time and last committed time for interval and cron tasks.
3. Record false WHEN conditions and overlapping windows as SKIPPED with reasons.
4. Record WHEN evaluation errors as FAILED without stopping later schedules.

It also adds regression coverage for scheduling metadata, history uniqueness, non-overlap, and skip/failure visibility.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20150)
<!-- Reviewable:end -->
