### PR TITLE
feat(query): cache parameterized logical plans

### DIFF
--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -3348,6 +3348,14 @@ pub struct CacheConfig {
     )]
     pub table_data_cache_population_queue_size: u32,
 
+    /// Maximum memory used by parameterized and exact logical plan cache entries.
+    #[clap(
+        long = "cache-planner-cache-max-bytes",
+        value_name = "VALUE",
+        default_value = "536870912"
+    )]
+    pub planner_cache_max_bytes: u64,
+
     /// Bytes of data cache in-memory
     #[clap(
         long = "cache-data-cache-in-memory-bytes",
@@ -3437,6 +3445,7 @@ impl Default for CacheConfig {
             disk_cache_virtual_column_meta_size: 0,
             data_cache_storage: CacheStorageTypeConfig::None,
             table_data_cache_population_queue_size: 0,
+            planner_cache_max_bytes: 512 * 1024 * 1024,
             data_cache_in_memory_bytes: 0,
             disk_cache_config: DiskCacheConfig::default(),
             data_cache_key_reload_policy: DiskCacheKeyReloadPolicy::Reset,

--- a/src/query/functions/src/lib.rs
+++ b/src/query/functions/src/lib.rs
@@ -28,6 +28,8 @@ mod cast_rules;
 pub mod scalars;
 pub mod srfs;
 
+pub const PLAN_PARAMETER_FUNCTION: &str = "__plan_parameter";
+
 pub fn is_builtin_function(name: &str) -> bool {
     let name = Ascii::new(name);
     BUILTIN_FUNCTIONS.contains(name.into_inner())

--- a/src/query/functions/src/scalars/other.rs
+++ b/src/query/functions/src/scalars/other.rs
@@ -67,6 +67,8 @@ use rand::Rng;
 use rand::SeedableRng;
 use uuid::Uuid;
 
+use crate::PLAN_PARAMETER_FUNCTION;
+
 pub fn register(registry: &mut FunctionRegistry) {
     registry.register_aliases("inet_aton", &["ipv4_string_to_num"]);
     registry.register_aliases("try_inet_aton", &["try_ipv4_string_to_num"]);
@@ -89,6 +91,19 @@ pub fn register(registry: &mut FunctionRegistry) {
     registry.properties.insert(
         "gen_random_uuid".to_string(),
         FunctionProperty::default().non_deterministic(),
+    );
+
+    // This function is only used while binding a parameterized plan-cache template. Marking it
+    // non-deterministic prevents constant folding from erasing the parameter slot. The planner
+    // replaces every call before optimization and execution.
+    registry.properties.insert(
+        PLAN_PARAMETER_FUNCTION.to_string(),
+        FunctionProperty::default().non_deterministic(),
+    );
+    registry.register_2_arg_core::<NumberType<u64>, GenericType<0>, GenericType<0>, _, _>(
+        PLAN_PARAMETER_FUNCTION,
+        |_, _, domain| FunctionDomain::Domain(domain.clone()),
+        |_, value, _| value.to_owned(),
     );
 
     registry

--- a/src/query/service/src/catalogs/default/database_catalog.rs
+++ b/src/query/service/src/catalogs/default/database_catalog.rs
@@ -120,6 +120,8 @@ use databend_common_meta_app::schema::dictionary_id_ident::DictionaryIdIdent;
 use databend_common_meta_app::schema::dictionary_name_ident::DictionaryNameIdent;
 use databend_common_meta_app::schema::least_visible_time_ident::LeastVisibleTimeIdent;
 use databend_common_meta_app::tenant::Tenant;
+use databend_common_sql::clear_planner_cache;
+use databend_common_sql::invalidate_planner_cache_for_tables;
 use databend_common_users::GrantObjectVisibilityChecker;
 use databend_meta_client::types::Change;
 use databend_meta_client::types::MetaId;
@@ -135,6 +137,13 @@ use crate::sessions::TableContext;
 use crate::storages::Table;
 use crate::table_functions::TableFunctionFactory;
 use crate::table_functions::UDTFTable;
+
+fn clear_planner_cache_on_success<T>(result: Result<T>) -> Result<T> {
+    if result.is_ok() {
+        clear_planner_cache();
+    }
+    result
+}
 
 /// Combine two catalogs together
 /// - read/search like operations are always performed at
@@ -251,7 +260,8 @@ impl Catalog for DatabaseCatalog {
             )));
         }
         // create db in BOTTOM layer only
-        self.mutable_catalog.create_database(req).await
+        let result = self.mutable_catalog.create_database(req).await;
+        clear_planner_cache_on_success(result)
     }
 
     #[async_backtrace::framed]
@@ -266,7 +276,8 @@ impl Catalog for DatabaseCatalog {
         {
             return self.immutable_catalog.drop_database(req).await;
         }
-        self.mutable_catalog.drop_database(req).await
+        let result = self.mutable_catalog.drop_database(req).await;
+        clear_planner_cache_on_success(result)
     }
 
     #[async_backtrace::framed]
@@ -285,7 +296,8 @@ impl Catalog for DatabaseCatalog {
             return self.immutable_catalog.rename_database(req).await;
         }
 
-        self.mutable_catalog.rename_database(req).await
+        let result = self.mutable_catalog.rename_database(req).await;
+        clear_planner_cache_on_success(result)
     }
 
     fn get_table_by_info(&self, table_info: &TableInfo) -> Result<Arc<dyn Table>> {
@@ -442,12 +454,14 @@ impl Catalog for DatabaseCatalog {
 
     #[async_backtrace::framed]
     async fn create_table_tag(&self, req: CreateTableTagReq) -> Result<()> {
-        self.mutable_catalog.create_table_tag(req).await
+        let result = self.mutable_catalog.create_table_tag(req).await;
+        clear_planner_cache_on_success(result)
     }
 
     #[async_backtrace::framed]
     async fn drop_table_tag(&self, req: DropTableTagReq) -> Result<()> {
-        self.mutable_catalog.drop_table_tag(req).await
+        let result = self.mutable_catalog.drop_table_tag(req).await;
+        clear_planner_cache_on_success(result)
     }
 
     #[async_backtrace::framed]
@@ -566,13 +580,14 @@ impl Catalog for DatabaseCatalog {
         {
             return self.immutable_catalog.create_table(req).await;
         }
-        self.mutable_catalog.create_table(req).await
+        let result = self.mutable_catalog.create_table(req).await;
+        clear_planner_cache_on_success(result)
     }
 
     #[async_backtrace::framed]
     async fn drop_table_by_id(&self, req: DropTableByIdReq) -> Result<DropTableReply> {
-        let res = self.mutable_catalog.drop_table_by_id(req).await?;
-        Ok(res)
+        let result = self.mutable_catalog.drop_table_by_id(req).await;
+        clear_planner_cache_on_success(result)
     }
 
     #[async_backtrace::framed]
@@ -586,7 +601,8 @@ impl Catalog for DatabaseCatalog {
         {
             return self.immutable_catalog.undrop_table(req).await;
         }
-        self.mutable_catalog.undrop_table(req).await
+        let result = self.mutable_catalog.undrop_table(req).await;
+        clear_planner_cache_on_success(result)
     }
 
     #[async_backtrace::framed]
@@ -600,7 +616,8 @@ impl Catalog for DatabaseCatalog {
         {
             return self.immutable_catalog.undrop_table_by_id(req).await;
         }
-        self.mutable_catalog.undrop_table_by_id(req).await
+        let result = self.mutable_catalog.undrop_table_by_id(req).await;
+        clear_planner_cache_on_success(result)
     }
 
     #[async_backtrace::framed]
@@ -614,13 +631,15 @@ impl Catalog for DatabaseCatalog {
         {
             return self.immutable_catalog.undrop_database(req).await;
         }
-        self.mutable_catalog.undrop_database(req).await
+        let result = self.mutable_catalog.undrop_database(req).await;
+        clear_planner_cache_on_success(result)
     }
 
     async fn commit_table_meta(&self, req: CommitTableMetaReq) -> Result<CommitTableMetaReply> {
         info!("commit_table_meta from req:{:?}", req);
 
-        self.mutable_catalog.commit_table_meta(req).await
+        let result = self.mutable_catalog.commit_table_meta(req).await;
+        clear_planner_cache_on_success(result)
     }
 
     #[async_backtrace::framed]
@@ -641,7 +660,8 @@ impl Catalog for DatabaseCatalog {
             ));
         }
 
-        self.mutable_catalog.rename_table(req).await
+        let result = self.mutable_catalog.rename_table(req).await;
+        clear_planner_cache_on_success(result)
     }
 
     #[async_backtrace::framed]
@@ -658,17 +678,20 @@ impl Catalog for DatabaseCatalog {
             ));
         }
 
-        self.mutable_catalog.swap_table(req).await
+        let result = self.mutable_catalog.swap_table(req).await;
+        clear_planner_cache_on_success(result)
     }
 
     #[async_backtrace::framed]
     async fn create_table_index(&self, req: CreateTableIndexReq) -> Result<()> {
-        self.mutable_catalog.create_table_index(req).await
+        let result = self.mutable_catalog.create_table_index(req).await;
+        clear_planner_cache_on_success(result)
     }
 
     #[async_backtrace::framed]
     async fn drop_table_index(&self, req: DropTableIndexReq) -> Result<()> {
-        self.mutable_catalog.drop_table_index(req).await
+        let result = self.mutable_catalog.drop_table_index(req).await;
+        clear_planner_cache_on_success(result)
     }
 
     #[async_backtrace::framed]
@@ -701,7 +724,12 @@ impl Catalog for DatabaseCatalog {
         table_info: &TableInfo,
         req: TruncateTableReq,
     ) -> Result<TruncateTableReply> {
-        self.mutable_catalog.truncate_table(table_info, req).await
+        let table_id = table_info.ident.table_id;
+        let result = self.mutable_catalog.truncate_table(table_info, req).await;
+        if result.is_ok() {
+            invalidate_planner_cache_for_tables(&[table_id]);
+        }
+        result
     }
 
     #[async_backtrace::framed]
@@ -711,9 +739,11 @@ impl Catalog for DatabaseCatalog {
         db_name: &str,
         req: UpsertTableOptionReq,
     ) -> Result<UpsertTableOptionReply> {
-        self.mutable_catalog
+        let result = self
+            .mutable_catalog
             .upsert_table_option(tenant, db_name, req)
-            .await
+            .await;
+        clear_planner_cache_on_success(result)
     }
 
     #[async_backtrace::framed]
@@ -721,9 +751,20 @@ impl Catalog for DatabaseCatalog {
         &self,
         reqs: UpdateMultiTableMetaReq,
     ) -> Result<UpdateMultiTableMetaResult> {
-        self.mutable_catalog
+        let table_ids = reqs
+            .update_table_metas
+            .iter()
+            .map(|(req, _)| req.table_id)
+            .chain(reqs.update_temp_tables.iter().map(|req| req.table_id))
+            .collect::<Vec<_>>();
+        let result = self
+            .mutable_catalog
             .retryable_update_multi_table_meta(reqs)
-            .await
+            .await;
+        if matches!(&result, Ok(Ok(_))) {
+            invalidate_planner_cache_for_tables(&table_ids);
+        }
+        result
     }
 
     #[async_backtrace::framed]
@@ -731,7 +772,8 @@ impl Catalog for DatabaseCatalog {
         &self,
         req: SetTableColumnMaskPolicyReq,
     ) -> Result<SetTableColumnMaskPolicyReply> {
-        self.mutable_catalog.set_table_column_mask_policy(req).await
+        let result = self.mutable_catalog.set_table_column_mask_policy(req).await;
+        clear_planner_cache_on_success(result)
     }
 
     #[async_backtrace::framed]
@@ -739,19 +781,22 @@ impl Catalog for DatabaseCatalog {
         &self,
         req: SetTableRowAccessPolicyReq,
     ) -> Result<SetTableRowAccessPolicyReply> {
-        self.mutable_catalog.set_table_row_access_policy(req).await
+        let result = self.mutable_catalog.set_table_row_access_policy(req).await;
+        clear_planner_cache_on_success(result)
     }
 
     // Table index
 
     #[async_backtrace::framed]
     async fn create_index(&self, req: CreateIndexReq) -> Result<CreateIndexReply> {
-        self.mutable_catalog.create_index(req).await
+        let result = self.mutable_catalog.create_index(req).await;
+        clear_planner_cache_on_success(result)
     }
 
     #[async_backtrace::framed]
     async fn drop_index(&self, req: DropIndexReq) -> Result<()> {
-        self.mutable_catalog.drop_index(req).await
+        let result = self.mutable_catalog.drop_index(req).await;
+        clear_planner_cache_on_success(result)
     }
 
     #[async_backtrace::framed]
@@ -807,7 +852,8 @@ impl Catalog for DatabaseCatalog {
 
     #[async_backtrace::framed]
     async fn update_index(&self, req: UpdateIndexReq) -> Result<UpdateIndexReply> {
-        self.mutable_catalog.update_index(req).await
+        let result = self.mutable_catalog.update_index(req).await;
+        clear_planner_cache_on_success(result)
     }
 
     #[async_backtrace::framed]
@@ -886,7 +932,8 @@ impl Catalog for DatabaseCatalog {
     }
 
     async fn create_sequence(&self, req: CreateSequenceReq) -> Result<CreateSequenceReply> {
-        self.mutable_catalog.create_sequence(req).await
+        let result = self.mutable_catalog.create_sequence(req).await;
+        clear_planner_cache_on_success(result)
     }
     async fn get_sequence(
         &self,
@@ -929,7 +976,8 @@ impl Catalog for DatabaseCatalog {
     }
 
     async fn drop_sequence(&self, req: DropSequenceReq) -> Result<DropSequenceReply> {
-        self.mutable_catalog.drop_sequence(req).await
+        let result = self.mutable_catalog.drop_sequence(req).await;
+        clear_planner_cache_on_success(result)
     }
 
     fn set_session_state(&self, state: SessionState) -> Arc<dyn Catalog> {
@@ -967,7 +1015,8 @@ impl Catalog for DatabaseCatalog {
     /// Dictionary
     #[async_backtrace::framed]
     async fn create_dictionary(&self, req: CreateDictionaryReq) -> Result<CreateDictionaryReply> {
-        self.mutable_catalog.create_dictionary(req).await
+        let result = self.mutable_catalog.create_dictionary(req).await;
+        clear_planner_cache_on_success(result)
     }
 
     #[async_backtrace::framed]
@@ -984,9 +1033,11 @@ impl Catalog for DatabaseCatalog {
         id_ident: DictionaryIdIdent,
         dictionary_meta: DictionaryMeta,
     ) -> Result<Change<DictionaryMeta>> {
-        self.mutable_catalog
+        let result = self
+            .mutable_catalog
             .update_dictionary_by_id(id_ident, dictionary_meta)
-            .await
+            .await;
+        clear_planner_cache_on_success(result)
     }
 
     #[async_backtrace::framed]
@@ -994,7 +1045,8 @@ impl Catalog for DatabaseCatalog {
         &self,
         dict_ident: DictionaryNameIdent,
     ) -> Result<Option<SeqV<DictionaryMeta>>> {
-        self.mutable_catalog.drop_dictionary(dict_ident).await
+        let result = self.mutable_catalog.drop_dictionary(dict_ident).await;
+        clear_planner_cache_on_success(result)
     }
 
     #[async_backtrace::framed]
@@ -1026,7 +1078,8 @@ impl Catalog for DatabaseCatalog {
     }
 
     async fn rename_dictionary(&self, req: RenameDictionaryReq) -> Result<()> {
-        self.mutable_catalog.rename_dictionary(req).await
+        let result = self.mutable_catalog.rename_dictionary(req).await;
+        clear_planner_cache_on_success(result)
     }
 
     async fn get_autoincrement_next_value(

--- a/src/query/service/src/global_services.rs
+++ b/src/query/service/src/global_services.rs
@@ -34,6 +34,7 @@ use databend_common_management::WorkloadMgr;
 use databend_common_meta_api::kv_pb_api::compress;
 use databend_common_meta_app::schema::CatalogType;
 use databend_common_meta_store::MetaStoreProvider;
+use databend_common_sql::set_planner_cache_max_bytes;
 use databend_common_storage::DataOperator;
 use databend_common_storage::ShareTableConfig;
 use databend_common_storages_hive::HiveCreator;
@@ -183,6 +184,7 @@ impl GlobalServices {
             config.query.tenant_id.tenant_name().to_string(),
             ee_mode,
         )?;
+        set_planner_cache_max_bytes(config.cache.planner_cache_max_bytes);
         TempDirManager::init(&config.spill, config.query.tenant_id.tenant_name())?;
 
         if let Some(addr) = config

--- a/src/query/sql/src/planner/mod.rs
+++ b/src/query/sql/src/planner/mod.rs
@@ -24,6 +24,7 @@ mod execution;
 mod expression;
 pub mod optimizer;
 mod planner_cache;
+mod planner_cache_parameter;
 pub mod plans;
 
 pub use binder::BindContext;
@@ -43,6 +44,9 @@ pub use optimizer::optimize;
 pub use planner::PlanExtras;
 pub use planner::Planner;
 pub use planner::get_query_kind;
+pub use planner_cache::clear_planner_cache;
+pub use planner_cache::invalidate_planner_cache_for_tables;
+pub use planner_cache::set_planner_cache_max_bytes;
 pub use plans::DELETE_NAME;
 pub use plans::INSERT_NAME;
 pub use plans::InsertInputSource;

--- a/src/query/sql/src/planner/planner.rs
+++ b/src/query/sql/src/planner/planner.rs
@@ -250,44 +250,133 @@ impl Planner {
         // Step 3: Bind AST with catalog, and generate a pure logical SExpr
         let name_resolution_ctx = NameResolutionContext::try_from(settings.as_ref())?;
 
-        let plan_cache_context =
-            self.build_plan_cache_context(name_resolution_ctx.clone(), stmt)?;
+        let enable_distributed_optimization = !force_disable_distributed_optimization
+            && !self.ctx.get_cluster().is_empty()
+            && !settings.get_enforce_local()?;
+        let mut plan_cache_context = self.build_plan_cache_context(
+            name_resolution_ctx.clone(),
+            stmt,
+            enable_distributed_optimization,
+        )?;
+        let formatted_ast = settings
+            .get_enable_query_result_cache()?
+            .then(|| stmt.to_string());
 
+        let mut bound_plan = None;
+        let mut fresh_metadata = None;
+        let mut parameterized_cache_failed = false;
         if let Some(cache_ctx) = &plan_cache_context {
-            if let Some(plan) = self.get_cache(cache_ctx) {
-                info!(
-                    "Logical plan retrieved from cache, elapsed: {:?}",
-                    start.elapsed()
-                );
+            if let Some(plan_item) = self.get_optimized_cache(cache_ctx) {
                 // update for clickhouse handler
                 self.ctx.attach_query_str(query_kind, stmt.to_mask_sql());
-                return Ok(plan.plan);
+                info!(
+                    "Optimized logical plan retrieved from cache, elapsed: {:?}",
+                    start.elapsed()
+                );
+                return Ok(plan_item.plan);
             }
         }
 
-        let metadata = Arc::new(RwLock::new(Metadata::default()));
-        let binder = Binder::new(
-            self.ctx.clone(),
-            CatalogManager::instance(),
-            name_resolution_ctx,
-            metadata.clone(),
-        )
-        .with_subquery_executor(self.query_executor.clone());
+        if let Some(cache_ctx) = &mut plan_cache_context {
+            self.prepare_parameterized_cache_context(cache_ctx, stmt)?;
+            if cache_ctx.is_parameterized() {
+                if let Some(plan_item) = self.get_parameterized_cache(cache_ctx) {
+                    // update for clickhouse handler
+                    self.ctx.attach_query_str(query_kind, stmt.to_mask_sql());
+                    match self.instantiate_cached_plan(
+                        cache_ctx,
+                        &plan_item.plan,
+                        formatted_ast.clone(),
+                    ) {
+                        Ok(plan) => {
+                            bound_plan = Some(plan);
+                            info!(
+                                "Parameterized bound plan retrieved from cache, elapsed: {:?}",
+                                start.elapsed()
+                            );
+                        }
+                        Err(error) => {
+                            warn!("Ignoring invalid parameterized planner-cache entry: {error}");
+                            self.evict_parameterized_cache(cache_ctx);
+                            parameterized_cache_failed = true;
+                        }
+                    }
+                }
+            }
+        }
 
-        // must attach before bind, because ParquetRSTable::create used it.
-        self.ctx.attach_query_str(query_kind, stmt.to_mask_sql());
-        let plan = binder.bind(stmt).await?;
-        // attach again to avoid the query kind is overwritten by the subquery
-        self.ctx.attach_query_str(query_kind, stmt.to_mask_sql());
+        let plan = match bound_plan {
+            Some(plan) => plan,
+            None => {
+                let metadata = Arc::new(RwLock::new(Metadata::default()));
+                fresh_metadata = Some(metadata.clone());
+                let binder = Binder::new(
+                    self.ctx.clone(),
+                    CatalogManager::instance(),
+                    name_resolution_ctx.clone(),
+                    metadata,
+                )
+                .with_subquery_executor(self.query_executor.clone());
+
+                // must attach before bind, because ParquetRSTable::create used it.
+                self.ctx.attach_query_str(query_kind, stmt.to_mask_sql());
+                let bind_parameterized_template = !parameterized_cache_failed
+                    && plan_cache_context
+                        .as_ref()
+                        .is_some_and(|cache_ctx| cache_ctx.is_parameterized());
+                let bind_stmt = plan_cache_context
+                    .as_ref()
+                    .filter(|_| bind_parameterized_template)
+                    .map_or(stmt, |cache_ctx| cache_ctx.bind_statement(stmt));
+                let plan = binder.bind(bind_stmt).await?;
+                // attach again to avoid the query kind is overwritten by the subquery
+                self.ctx.attach_query_str(query_kind, stmt.to_mask_sql());
+
+                if !bind_parameterized_template {
+                    plan
+                } else {
+                    let cache_ctx = plan_cache_context
+                        .as_ref()
+                        .expect("parameterized template requires a cache context");
+                    match self.instantiate_cached_plan(cache_ctx, &plan, formatted_ast.clone()) {
+                        Ok(instantiated) => {
+                            self.set_parameterized_cache(cache_ctx, plan);
+                            instantiated
+                        }
+                        Err(error) => {
+                            warn!(
+                                "Falling back from unsupported parameterized plan template: {error}"
+                            );
+                            let metadata = Arc::new(RwLock::new(Metadata::default()));
+                            fresh_metadata = Some(metadata.clone());
+                            let binder = Binder::new(
+                                self.ctx.clone(),
+                                CatalogManager::instance(),
+                                name_resolution_ctx,
+                                metadata,
+                            )
+                            .with_subquery_executor(self.query_executor.clone());
+                            self.ctx.attach_query_str(query_kind, stmt.to_mask_sql());
+                            let plan = binder.bind(stmt).await?;
+                            self.ctx.attach_query_str(query_kind, stmt.to_mask_sql());
+                            plan
+                        }
+                    }
+                }
+            }
+        };
+
+        let metadata = match &plan {
+            Plan::Query { metadata, .. } => metadata.clone(),
+            _ => fresh_metadata.ok_or_else(|| {
+                ErrorCode::Internal("freshly bound plan is missing planner metadata".to_string())
+            })?,
+        };
 
         // Step 4: Optimize the SExpr with optimizers, and generate optimized physical SExpr
         let opt_ctx = OptimizerContext::new(self.ctx.clone(), metadata.clone())
             .with_settings(&settings)?
-            .set_enable_distributed_optimization(
-                !force_disable_distributed_optimization
-                    && !self.ctx.get_cluster().is_empty()
-                    && !settings.get_enforce_local()?,
-            )
+            .set_enable_distributed_optimization(enable_distributed_optimization)
             .set_sample_executor(self.query_executor.clone())
             .clone();
 
@@ -309,9 +398,10 @@ impl Planner {
 
         let optimized_plan = optimize(opt_ctx, plan).await?;
 
-        if let Some(cache_ctx) = plan_cache_context {
-            self.set_cache(cache_ctx, optimized_plan.clone());
-        }
+        let optimized_plan = match plan_cache_context {
+            Some(cache_ctx) => self.set_cache(cache_ctx, optimized_plan),
+            None => optimized_plan,
+        };
 
         info!(
             "Logical plan construction completed, elapsed: {:?}",

--- a/src/query/sql/src/planner/planner_cache.rs
+++ b/src/query/sql/src/planner/planner_cache.rs
@@ -14,8 +14,11 @@
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::LazyLock;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 
 use databend_common_ast::ast::FunctionCall;
 use databend_common_ast::ast::Identifier;
@@ -32,6 +35,7 @@ use databend_common_functions::is_cacheable_function;
 use databend_common_meta_app::schema::SecurityPolicyColumnMap;
 use databend_common_meta_app::schema::TableMeta;
 use databend_common_settings::ChangeValue;
+use databend_meta_client::types::MetaId;
 use databend_storages_common_cache::CacheAccessor;
 use databend_storages_common_cache::CacheValue;
 use databend_storages_common_cache::InMemoryLruCache;
@@ -39,6 +43,7 @@ use databend_storages_common_table_meta::table::OPT_KEY_SNAPSHOT_LOCATION;
 use derive_visitor::Drive;
 use derive_visitor::Visitor;
 use itertools::Itertools;
+use parking_lot::RwLock;
 use sha2::Digest;
 use sha2::Sha256;
 
@@ -46,21 +51,214 @@ use crate::NameResolutionContext;
 use crate::Planner;
 use crate::TableEntry;
 use crate::normalize_identifier;
+use crate::planner::planner_cache_parameter::ParameterizedStatement;
+use crate::planner::planner_cache_parameter::instantiate_plan;
 use crate::plans::Plan;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PlanCacheEntryKind {
+    BoundTemplate { parameter_count: usize },
+    Optimized,
+}
 
 #[derive(Clone)]
 pub struct PlanCacheItem {
     pub(crate) plan: Plan,
     pub(crate) setting_changes: Vec<(String, ChangeValue)>,
     pub(crate) variables: HashMap<String, Scalar>,
+    kind: PlanCacheEntryKind,
+    ddl_generation: u64,
+    table_generations: Vec<(MetaId, u64)>,
 }
 
-static PLAN_CACHE: LazyLock<InMemoryLruCache<PlanCacheItem>> =
-    LazyLock::new(|| InMemoryLruCache::with_items_capacity("planner_cache".to_string(), 512));
+pub const DEFAULT_PLANNER_CACHE_MAX_BYTES: usize = 512 * 1024 * 1024;
+
+static PLAN_CACHE: LazyLock<InMemoryLruCache<PlanCacheItem>> = LazyLock::new(|| {
+    InMemoryLruCache::with_bytes_capacity(
+        "planner_cache".to_string(),
+        DEFAULT_PLANNER_CACHE_MAX_BYTES,
+    )
+});
+static PLAN_CACHE_DDL_GENERATION: AtomicU64 = AtomicU64::new(0);
+static PLAN_CACHE_MUTATION_EPOCH: AtomicU64 = AtomicU64::new(0);
+static PLAN_CACHE_TABLE_GENERATIONS: LazyLock<RwLock<HashMap<MetaId, u64>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+static PLAN_CACHE_TABLE_KEYS: LazyLock<RwLock<HashMap<MetaId, HashSet<String>>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+static PLAN_CACHE_INSERT_COUNT: AtomicU64 = AtomicU64::new(0);
+
+pub fn invalidate_planner_cache_for_tables(table_ids: &[MetaId]) {
+    if table_ids.is_empty() {
+        return;
+    }
+    PLAN_CACHE_MUTATION_EPOCH.fetch_add(1, Ordering::AcqRel);
+
+    let table_ids = table_ids.iter().copied().collect::<HashSet<_>>();
+    {
+        let mut generations = PLAN_CACHE_TABLE_GENERATIONS.write();
+        for table_id in &table_ids {
+            let generation = generations.entry(*table_id).or_default();
+            *generation = generation.wrapping_add(1);
+        }
+    }
+
+    let keys = {
+        let mut index = PLAN_CACHE_TABLE_KEYS.write();
+        let keys = table_ids
+            .iter()
+            .filter_map(|table_id| index.remove(table_id))
+            .flatten()
+            .collect::<HashSet<_>>();
+        for indexed_keys in index.values_mut() {
+            indexed_keys.retain(|key| !keys.contains(key));
+        }
+        index.retain(|_, indexed_keys| !indexed_keys.is_empty());
+        keys
+    };
+
+    let cache = LazyLock::force(&PLAN_CACHE);
+    for key in keys {
+        cache.evict(&key);
+    }
+}
+
+pub fn clear_planner_cache() {
+    PLAN_CACHE_MUTATION_EPOCH.fetch_add(1, Ordering::AcqRel);
+    PLAN_CACHE_DDL_GENERATION.fetch_add(1, Ordering::AcqRel);
+    LazyLock::force(&PLAN_CACHE).clear();
+    PLAN_CACHE_TABLE_KEYS.write().clear();
+    PLAN_CACHE_TABLE_GENERATIONS.write().clear();
+}
+
+pub fn set_planner_cache_max_bytes(max_bytes: u64) {
+    let max_bytes = usize::try_from(max_bytes).unwrap_or(usize::MAX);
+    LazyLock::force(&PLAN_CACHE).set_bytes_capacity(max_bytes);
+}
 
 impl From<PlanCacheItem> for CacheValue<PlanCacheItem> {
     fn from(val: PlanCacheItem) -> Self {
-        CacheValue::new(val, 1024)
+        let plan_bytes = format!("{:?}", val.plan).len();
+        let settings_bytes = val
+            .setting_changes
+            .iter()
+            .map(|(name, value)| name.len() + format!("{value:?}").len())
+            .sum::<usize>();
+        let variables_bytes = val
+            .variables
+            .iter()
+            .map(|(name, value)| name.len() + format!("{value:?}").len())
+            .sum::<usize>();
+        let estimated_bytes = std::mem::size_of::<PlanCacheItem>()
+            .saturating_add(plan_bytes)
+            .saturating_add(settings_bytes)
+            .saturating_add(variables_bytes);
+        CacheValue::new(val, estimated_bytes)
+    }
+}
+
+impl PlanCacheItem {
+    fn create(
+        plan: Plan,
+        setting_changes: Vec<(String, ChangeValue)>,
+        variables: HashMap<String, Scalar>,
+        kind: PlanCacheEntryKind,
+    ) -> Option<Self> {
+        let table_ids = plan_table_ids(&plan)?;
+        let table_generations = current_table_generations(&table_ids);
+        Some(Self {
+            plan,
+            setting_changes,
+            variables,
+            kind,
+            ddl_generation: PLAN_CACHE_DDL_GENERATION.load(Ordering::Acquire),
+            table_generations,
+        })
+    }
+
+    fn is_current(&self) -> bool {
+        generations_are_current(self.ddl_generation, &self.table_generations)
+    }
+}
+
+fn plan_table_ids(plan: &Plan) -> Option<Vec<MetaId>> {
+    let Plan::Query { metadata, .. } = plan else {
+        return None;
+    };
+    let metadata = metadata.read();
+    let mut table_ids = metadata
+        .tables()
+        .iter()
+        .map(|table| table.table().get_table_info().ident.table_id)
+        .collect::<Vec<_>>();
+    table_ids.sort_unstable();
+    table_ids.dedup();
+    (!table_ids.is_empty()).then_some(table_ids)
+}
+
+fn current_table_generations(table_ids: &[MetaId]) -> Vec<(MetaId, u64)> {
+    let generations = PLAN_CACHE_TABLE_GENERATIONS.read();
+    table_ids
+        .iter()
+        .map(|table_id| (*table_id, generations.get(table_id).copied().unwrap_or(0)))
+        .collect()
+}
+
+fn generations_are_current(ddl_generation: u64, table_generations: &[(MetaId, u64)]) -> bool {
+    if PLAN_CACHE_DDL_GENERATION.load(Ordering::Acquire) != ddl_generation {
+        return false;
+    }
+    let current = PLAN_CACHE_TABLE_GENERATIONS.read();
+    table_generations
+        .iter()
+        .all(|(table_id, generation)| current.get(table_id).copied().unwrap_or(0) == *generation)
+}
+
+fn unregister_cache_key(cache_key: &str) {
+    let mut index = PLAN_CACHE_TABLE_KEYS.write();
+    for keys in index.values_mut() {
+        keys.remove(cache_key);
+    }
+    index.retain(|_, keys| !keys.is_empty());
+}
+
+fn insert_cache_item(cache_key: String, item: PlanCacheItem, expected_mutation_epoch: u64) {
+    if !item.is_current()
+        || PLAN_CACHE_MUTATION_EPOCH.load(Ordering::Acquire) != expected_mutation_epoch
+    {
+        return;
+    }
+
+    let ddl_generation = item.ddl_generation;
+    let table_generations = item.table_generations.clone();
+    unregister_cache_key(&cache_key);
+    LazyLock::force(&PLAN_CACHE).insert(cache_key.clone(), item);
+    {
+        let mut index = PLAN_CACHE_TABLE_KEYS.write();
+        for (table_id, _) in &table_generations {
+            index
+                .entry(*table_id)
+                .or_default()
+                .insert(cache_key.clone());
+        }
+    }
+
+    // The underlying LRU does not report keys evicted by its byte limit. Periodically prune the
+    // reverse index so workloads over immutable tables cannot accumulate stale dependency keys.
+    if PLAN_CACHE_INSERT_COUNT.fetch_add(1, Ordering::Relaxed) % 256 == 255 {
+        let cache = LazyLock::force(&PLAN_CACHE);
+        let mut index = PLAN_CACHE_TABLE_KEYS.write();
+        for keys in index.values_mut() {
+            keys.retain(|key| cache.contains_key(key));
+        }
+        index.retain(|_, keys| !keys.is_empty());
+    }
+
+    // Close the race with a mutation that committed between the first check and registration.
+    if !generations_are_current(ddl_generation, &table_generations)
+        || PLAN_CACHE_MUTATION_EPOCH.load(Ordering::Acquire) != expected_mutation_epoch
+    {
+        LazyLock::force(&PLAN_CACHE).evict(&cache_key);
+        unregister_cache_key(&cache_key);
     }
 }
 
@@ -74,12 +272,14 @@ impl Planner {
         &self,
         name_resolution_ctx: NameResolutionContext,
         stmt: &Statement,
+        enable_distributed_optimization: bool,
     ) -> Result<Option<PlanCacheContext>> {
         if !matches!(stmt, Statement::Query(_))
             || !self.ctx.get_settings().get_enable_planner_cache()?
         {
             return Ok(None);
         }
+        let mutation_epoch = PLAN_CACHE_MUTATION_EPOCH.load(Ordering::Acquire);
 
         let mut visitor = TableRefVisitor {
             ctx: self.ctx.clone(),
@@ -94,27 +294,68 @@ impl Planner {
             return Ok(None);
         }
 
-        let cache_key = self.planner_cache_key_for_stmt(stmt, visitor.has_security_policy)?;
+        let optimized_namespace = if enable_distributed_optimization {
+            "optimized-distributed"
+        } else {
+            "optimized-local"
+        };
+        let optimized_cache_key = self.planner_cache_key_for_sql(
+            optimized_namespace,
+            &stmt.to_string(),
+            visitor.has_security_policy,
+        )?;
         Ok(Some(PlanCacheContext {
-            cache_key,
+            optimized_cache_key,
+            template_cache_key: None,
             table_snapshots: visitor.table_snapshots,
+            parameterized_stmt: None,
+            has_security_policy: visitor.has_security_policy,
+            mutation_epoch,
         }))
     }
 
-    fn planner_cache_key_for_stmt(
+    pub(crate) fn prepare_parameterized_cache_context(
         &self,
+        cache_ctx: &mut PlanCacheContext,
         stmt: &Statement,
+    ) -> Result<()> {
+        let parameterized_stmt = ParameterizedStatement::create(stmt)?;
+        cache_ctx.template_cache_key = parameterized_stmt
+            .is_parameterized()
+            .then(|| {
+                self.planner_cache_key_for_sql(
+                    "bound-template",
+                    parameterized_stmt.cache_key_sql(),
+                    cache_ctx.has_security_policy,
+                )
+            })
+            .transpose()?;
+        cache_ctx.parameterized_stmt = Some(parameterized_stmt);
+        Ok(())
+    }
+
+    fn planner_cache_key_for_sql(
+        &self,
+        namespace: &str,
+        sql: &str,
         has_security_policy: bool,
     ) -> Result<String> {
-        if has_security_policy {
-            return Ok(Self::planner_cache_key(&format!(
-                "{}\0{}",
-                self.security_policy_cache_key_prefix()?,
-                stmt
-            )));
-        }
-
-        Ok(Self::planner_cache_key(&stmt.to_string()))
+        let tenant = self.ctx.get_tenant();
+        let context = format!(
+            "{}\0{}\0{}",
+            tenant.tenant_name(),
+            self.ctx.get_current_catalog(),
+            self.ctx.get_current_database(),
+        );
+        let key_source = if has_security_policy {
+            format!(
+                "{context}\0{}\0{namespace}\0{sql}",
+                self.security_policy_cache_key_prefix()?
+            )
+        } else {
+            format!("{context}\0{namespace}\0{sql}")
+        };
+        Ok(Self::planner_cache_key(&key_source))
     }
 
     fn security_policy_cache_key_prefix(&self) -> Result<String> {
@@ -151,15 +392,27 @@ impl Planner {
         }
     }
 
-    pub(crate) fn get_cache(&self, cache_ctx: &PlanCacheContext) -> Option<PlanCacheItem> {
+    fn get_cache_item(
+        &self,
+        cache_ctx: &PlanCacheContext,
+        cache_key: &str,
+        expected_kind: PlanCacheEntryKind,
+    ) -> Option<PlanCacheItem> {
         debug_assert!(!cache_ctx.table_snapshots.is_empty());
 
         let cache = LazyLock::force(&PLAN_CACHE);
-        let plan_item = cache.get(&cache_ctx.cache_key)?;
+        let plan_item = cache.get(cache_key)?;
+        if !plan_item.is_current() {
+            cache.evict(cache_key);
+            unregister_cache_key(cache_key);
+            return None;
+        }
 
-        let settings = self.ctx.get_settings();
-        if settings.changes().len() != plan_item.setting_changes.len()
-            || self.setting_changes() != plan_item.setting_changes
+        if plan_item.kind != expected_kind {
+            return None;
+        }
+
+        if self.setting_changes() != plan_item.setting_changes
             || self.ctx.get_all_variables() != plan_item.variables
         {
             return None;
@@ -170,19 +423,94 @@ impl Planner {
         };
 
         let metadata = metadata.read();
-        cache_ctx
-            .matches_metadata_tables(metadata.tables())
-            .then(|| plan_item.as_ref().clone())
+        if !cache_ctx.matches_metadata_tables(metadata.tables()) {
+            drop(metadata);
+            cache.evict(cache_key);
+            unregister_cache_key(cache_key);
+            return None;
+        }
+
+        Some(plan_item.as_ref().clone())
     }
 
-    pub(crate) fn set_cache(&self, cache_ctx: PlanCacheContext, plan: Plan) {
-        let plan_item = PlanCacheItem {
-            plan,
-            setting_changes: self.setting_changes(),
-            variables: self.ctx.get_all_variables(),
+    pub(crate) fn get_optimized_cache(
+        &self,
+        cache_ctx: &PlanCacheContext,
+    ) -> Option<PlanCacheItem> {
+        self.get_cache_item(
+            cache_ctx,
+            &cache_ctx.optimized_cache_key,
+            PlanCacheEntryKind::Optimized,
+        )
+    }
+
+    pub(crate) fn get_parameterized_cache(
+        &self,
+        cache_ctx: &PlanCacheContext,
+    ) -> Option<PlanCacheItem> {
+        let cache_key = cache_ctx.template_cache_key.as_deref()?;
+        let kind = PlanCacheEntryKind::BoundTemplate {
+            parameter_count: cache_ctx.parameter_count(),
         };
-        let cache = LazyLock::force(&PLAN_CACHE);
-        cache.insert(cache_ctx.cache_key, plan_item);
+        self.get_cache_item(cache_ctx, cache_key, kind)
+    }
+
+    pub(crate) fn evict_parameterized_cache(&self, cache_ctx: &PlanCacheContext) {
+        if let Some(cache_key) = &cache_ctx.template_cache_key {
+            LazyLock::force(&PLAN_CACHE).evict(cache_key);
+            unregister_cache_key(cache_key);
+        }
+    }
+
+    pub(crate) fn instantiate_cached_plan(
+        &self,
+        cache_ctx: &PlanCacheContext,
+        template: &Plan,
+        formatted_ast: Option<String>,
+    ) -> Result<Plan> {
+        let parameterized_stmt = cache_ctx.parameterized_stmt.as_ref().ok_or_else(|| {
+            databend_common_exception::ErrorCode::Internal(
+                "planner cache tried to instantiate a non-parameterized entry".to_string(),
+            )
+        })?;
+        instantiate_plan(template, &parameterized_stmt.values, formatted_ast)
+    }
+
+    pub(crate) fn set_parameterized_cache(&self, cache_ctx: &PlanCacheContext, plan: Plan) {
+        debug_assert!(cache_ctx.is_parameterized());
+        let Some(cache_key) = cache_ctx.template_cache_key.clone() else {
+            return;
+        };
+        let Some(plan_item) = PlanCacheItem::create(
+            plan,
+            self.setting_changes(),
+            self.ctx.get_all_variables(),
+            PlanCacheEntryKind::BoundTemplate {
+                parameter_count: cache_ctx.parameter_count(),
+            },
+        ) else {
+            return;
+        };
+        insert_cache_item(cache_key, plan_item, cache_ctx.mutation_epoch);
+    }
+
+    pub(crate) fn set_cache(&self, cache_ctx: PlanCacheContext, plan: Plan) -> Plan {
+        let setting_changes = self.setting_changes();
+        let variables = self.ctx.get_all_variables();
+        let Some(plan_item) = PlanCacheItem::create(
+            plan.clone(),
+            setting_changes,
+            variables,
+            PlanCacheEntryKind::Optimized,
+        ) else {
+            return plan;
+        };
+        insert_cache_item(
+            cache_ctx.optimized_cache_key,
+            plan_item,
+            cache_ctx.mutation_epoch,
+        );
+        plan
     }
 
     fn setting_changes(&self) -> Vec<(String, ChangeValue)> {
@@ -206,12 +534,36 @@ struct TableRefVisitor {
     has_security_policy: bool,
 }
 
+#[derive(Clone)]
 pub(crate) struct PlanCacheContext {
-    cache_key: String,
+    optimized_cache_key: String,
+    template_cache_key: Option<String>,
     table_snapshots: Vec<TableSnapshot>,
+    has_security_policy: bool,
+    parameterized_stmt: Option<ParameterizedStatement>,
+    mutation_epoch: u64,
 }
 
 impl PlanCacheContext {
+    pub(crate) fn is_parameterized(&self) -> bool {
+        self.parameterized_stmt
+            .as_ref()
+            .is_some_and(ParameterizedStatement::is_parameterized)
+    }
+
+    pub(crate) fn bind_statement<'a>(&'a self, original: &'a Statement) -> &'a Statement {
+        self.parameterized_stmt
+            .as_ref()
+            .filter(|stmt| stmt.is_parameterized())
+            .map_or(original, |stmt| &stmt.template)
+    }
+
+    fn parameter_count(&self) -> usize {
+        self.parameterized_stmt
+            .as_ref()
+            .map_or(0, |p| p.values.len())
+    }
+
     fn matches_metadata_tables(&self, tables: &[TableEntry]) -> bool {
         self.table_snapshots.iter().all(|snapshot| {
             tables
@@ -223,22 +575,38 @@ impl PlanCacheContext {
 
 #[derive(Clone)]
 struct TableSnapshot {
+    catalog_name: String,
+    database_name: String,
+    table_name: String,
+    table_id: MetaId,
+    table_seq: u64,
     schema: TableSchemaRef,
     snapshot_location: String,
     security_policy: SecurityPolicySnapshot,
 }
 
 impl TableSnapshot {
-    fn from_resolved_table(table: &dyn Table) -> Option<Self> {
+    fn from_resolved_table(
+        table: &dyn Table,
+        catalog_name: String,
+        database_name: String,
+        table_name: String,
+    ) -> Option<Self> {
         if table.is_temp() || table.is_stage_table() || table.is_stream() {
             return None;
         }
 
+        let table_info = table.get_table_info();
         let snapshot_location = table.options().get(OPT_KEY_SNAPSHOT_LOCATION)?.clone();
         Some(Self {
+            catalog_name,
+            database_name,
+            table_name,
+            table_id: table_info.ident.table_id,
+            table_seq: table_info.ident.seq,
             schema: table.schema(),
             snapshot_location,
-            security_policy: SecurityPolicySnapshot::from(&table.get_table_info().meta),
+            security_policy: SecurityPolicySnapshot::from(&table_info.meta),
         })
     }
 
@@ -247,17 +615,24 @@ impl TableSnapshot {
     }
 
     fn matches_table_entry(&self, table_entry: &TableEntry) -> bool {
+        if table_entry.catalog() != self.catalog_name
+            || table_entry.database() != self.database_name
+            || table_entry.name() != self.table_name
+        {
+            return false;
+        }
         let table = table_entry.table();
-        self.matches_table(table.as_ref())
-    }
-
-    fn matches_table(&self, table: &dyn Table) -> bool {
-        if table.is_temp() || table.schema().ne(&self.schema) {
+        let table_info = table.get_table_info();
+        if table.is_temp()
+            || table_info.ident.table_id != self.table_id
+            || table_info.ident.seq != self.table_seq
+            || table.schema().ne(&self.schema)
+        {
             return false;
         }
 
         table.options().get(OPT_KEY_SNAPSHOT_LOCATION) == Some(&self.snapshot_location)
-            && SecurityPolicySnapshot::from(&table.get_table_info().meta) == self.security_policy
+            && SecurityPolicySnapshot::from(&table_info.meta) == self.security_policy
     }
 }
 
@@ -300,6 +675,14 @@ impl TableRefVisitor {
         if self.cache_miss {
             return;
         }
+        if matches!(
+            table_ref,
+            TableReference::TableFunction { .. } | TableReference::Location { .. }
+        ) {
+            self.cache_miss = true;
+            return;
+        }
+
         if let TableReference::Table {
             table,
             temporal,
@@ -345,7 +728,12 @@ impl TableRefVisitor {
                     )
                     .await
                 {
-                    if let Some(snapshot) = TableSnapshot::from_resolved_table(table.as_ref()) {
+                    if let Some(snapshot) = TableSnapshot::from_resolved_table(
+                        table.as_ref(),
+                        catalog_name,
+                        database_name,
+                        table_name,
+                    ) {
                         self.has_security_policy |= snapshot.has_security_policy();
                         self.table_snapshots.push(snapshot);
                         return;
@@ -354,5 +742,116 @@ impl TableRefVisitor {
                 self.cache_miss = true;
             });
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicU64;
+
+    use parking_lot::Mutex;
+
+    use super::*;
+
+    static PLANNER_CACHE_TEST_LOCK: Mutex<()> = Mutex::new(());
+    static NEXT_TEST_TABLE_ID: AtomicU64 = AtomicU64::new(u64::MAX / 2);
+
+    fn synthetic_item(table_id: MetaId) -> PlanCacheItem {
+        let generation = PLAN_CACHE_TABLE_GENERATIONS
+            .read()
+            .get(&table_id)
+            .copied()
+            .unwrap_or(0);
+        PlanCacheItem {
+            plan: Plan::ExplainAst {
+                formatted_string: String::new(),
+            },
+            setting_changes: vec![],
+            variables: HashMap::new(),
+            kind: PlanCacheEntryKind::BoundTemplate { parameter_count: 1 },
+            ddl_generation: PLAN_CACHE_DDL_GENERATION.load(Ordering::Acquire),
+            table_generations: vec![(table_id, generation)],
+        }
+    }
+
+    #[test]
+    fn test_default_cache_capacity_is_512_mib() {
+        assert_eq!(
+            LazyLock::force(&PLAN_CACHE).bytes_capacity(),
+            DEFAULT_PLANNER_CACHE_MAX_BYTES as u64
+        );
+    }
+
+    #[test]
+    fn test_dml_evicts_only_dependent_table_plans() {
+        let _guard = PLANNER_CACHE_TEST_LOCK.lock();
+        let first_table = NEXT_TEST_TABLE_ID.fetch_add(2, Ordering::Relaxed);
+        let second_table = first_table + 1;
+        let first_key = format!("planner-cache-test-{first_table}");
+        let second_key = format!("planner-cache-test-{second_table}");
+        let mutation_epoch = PLAN_CACHE_MUTATION_EPOCH.load(Ordering::Acquire);
+
+        insert_cache_item(
+            first_key.clone(),
+            synthetic_item(first_table),
+            mutation_epoch,
+        );
+        insert_cache_item(
+            second_key.clone(),
+            synthetic_item(second_table),
+            mutation_epoch,
+        );
+        let cache = LazyLock::force(&PLAN_CACHE);
+        assert!(cache.contains_key(&first_key));
+        assert!(cache.contains_key(&second_key));
+
+        invalidate_planner_cache_for_tables(&[first_table]);
+        assert!(!cache.contains_key(&first_key));
+        assert!(cache.contains_key(&second_key));
+
+        invalidate_planner_cache_for_tables(&[second_table]);
+        assert!(!cache.contains_key(&second_key));
+    }
+
+    #[test]
+    fn test_ddl_clears_all_cached_plans() {
+        let _guard = PLANNER_CACHE_TEST_LOCK.lock();
+        let first_table = NEXT_TEST_TABLE_ID.fetch_add(2, Ordering::Relaxed);
+        let second_table = first_table + 1;
+        let first_key = format!("planner-cache-test-{first_table}");
+        let second_key = format!("planner-cache-test-{second_table}");
+        let mutation_epoch = PLAN_CACHE_MUTATION_EPOCH.load(Ordering::Acquire);
+
+        insert_cache_item(
+            first_key.clone(),
+            synthetic_item(first_table),
+            mutation_epoch,
+        );
+        insert_cache_item(
+            second_key.clone(),
+            synthetic_item(second_table),
+            mutation_epoch,
+        );
+        let cache = LazyLock::force(&PLAN_CACHE);
+        assert!(cache.contains_key(&first_key));
+        assert!(cache.contains_key(&second_key));
+
+        clear_planner_cache();
+        assert!(!cache.contains_key(&first_key));
+        assert!(!cache.contains_key(&second_key));
+    }
+
+    #[test]
+    fn test_mutation_rejects_plan_built_before_commit() {
+        let _guard = PLANNER_CACHE_TEST_LOCK.lock();
+        let table_id = NEXT_TEST_TABLE_ID.fetch_add(1, Ordering::Relaxed);
+        let cache_key = format!("planner-cache-test-{table_id}");
+        let mutation_epoch = PLAN_CACHE_MUTATION_EPOCH.load(Ordering::Acquire);
+        let stale_item = synthetic_item(table_id);
+
+        invalidate_planner_cache_for_tables(&[table_id]);
+        insert_cache_item(cache_key.clone(), stale_item, mutation_epoch);
+
+        assert!(!LazyLock::force(&PLAN_CACHE).contains_key(&cache_key));
     }
 }

--- a/src/query/sql/src/planner/planner_cache_parameter.rs
+++ b/src/query/sql/src/planner/planner_cache_parameter.rs
@@ -1,0 +1,526 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use databend_common_ast::ast::BinaryOperator;
+use databend_common_ast::ast::Expr;
+use databend_common_ast::ast::FunctionCall as AstFunctionCall;
+use databend_common_ast::ast::Identifier;
+use databend_common_ast::ast::Literal;
+use databend_common_ast::ast::Statement;
+use databend_common_ast::ast::UnaryOperator;
+use databend_common_ast::visit::VisitControl;
+use databend_common_ast::visit::VisitorMut as AstVisitorMut;
+use databend_common_ast::visit::WalkMut;
+use databend_common_exception::ErrorCode;
+use databend_common_exception::Result;
+use databend_common_expression::Scalar;
+use databend_common_expression::types::NumberScalar;
+use databend_common_expression::types::decimal::DecimalScalar;
+use databend_common_expression::types::decimal::DecimalSize;
+use databend_common_expression::types::i256;
+use databend_common_functions::PLAN_PARAMETER_FUNCTION;
+use parking_lot::RwLock;
+
+use crate::optimizer::ir::SExpr;
+use crate::plans::ConstantExpr;
+use crate::plans::FunctionCall;
+use crate::plans::Operator;
+use crate::plans::Plan;
+use crate::plans::ScalarExpr;
+use crate::plans::SubqueryExpr;
+use crate::plans::VisitorMut;
+
+#[derive(Clone, Debug)]
+pub(crate) struct ParameterizedStatement {
+    pub(crate) template: Statement,
+    pub(crate) values: Vec<Scalar>,
+    normalized_sql: String,
+}
+
+impl ParameterizedStatement {
+    pub(crate) fn create(stmt: &Statement) -> Result<Self> {
+        let mut template = stmt.clone();
+        let mut marker_visitor = ExistingMarkerVisitor::default();
+        template.walk_mut(&mut marker_visitor)?;
+        // SQL text must not supply markers that template instantiation will consume.
+        if marker_visitor.found {
+            return Ok(Self {
+                template: stmt.clone(),
+                values: Vec::new(),
+                normalized_sql: stmt.to_string(),
+            });
+        }
+
+        let mut visitor = ParameterizeVisitor::default();
+        template.walk_mut(&mut visitor)?;
+
+        let mut normalized = template.clone();
+        normalized.walk_mut(&mut NormalizeParameters)?;
+        Ok(Self {
+            template,
+            values: visitor.values,
+            normalized_sql: normalized.to_string(),
+        })
+    }
+
+    pub(crate) fn is_parameterized(&self) -> bool {
+        !self.values.is_empty()
+    }
+
+    pub(crate) fn cache_key_sql(&self) -> &str {
+        &self.normalized_sql
+    }
+}
+
+fn is_plan_parameter(expr: &Expr) -> bool {
+    matches!(
+        expr,
+        Expr::FunctionCall { func, .. }
+            if func.name.name.eq_ignore_ascii_case(PLAN_PARAMETER_FUNCTION)
+    )
+}
+
+#[derive(Default)]
+struct ExistingMarkerVisitor {
+    found: bool,
+}
+
+impl AstVisitorMut for ExistingMarkerVisitor {
+    type Error = ErrorCode;
+
+    fn visit_expr(&mut self, expr: &mut Expr) -> Result<VisitControl> {
+        if is_plan_parameter(expr) {
+            self.found = true;
+            return Ok(VisitControl::SkipChildren);
+        }
+
+        Ok(VisitControl::Continue)
+    }
+}
+
+#[derive(Default)]
+struct ParameterizeVisitor {
+    values: Vec<Scalar>,
+}
+
+impl ParameterizeVisitor {
+    fn parameterize_value_expr(&mut self, expr: &mut Expr) {
+        match expr {
+            Expr::Literal { .. } => self.parameterize_literal(expr),
+            Expr::UnaryOp {
+                op: UnaryOperator::Plus | UnaryOperator::Minus,
+                expr,
+                ..
+            } => self.parameterize_value_expr(expr),
+            _ => {}
+        }
+    }
+
+    fn parameterize_literal(&mut self, expr: &mut Expr) {
+        let Expr::Literal { span, value } = expr else {
+            return;
+        };
+        if matches!(value, Literal::Null) {
+            return;
+        }
+
+        let span = *span;
+        let value = value.clone();
+        let index = self.values.len();
+        self.values.push(literal_to_scalar(&value));
+
+        *expr = Expr::FunctionCall {
+            span,
+            func: AstFunctionCall {
+                name: Identifier::from_name(span, PLAN_PARAMETER_FUNCTION),
+                args: vec![
+                    Expr::Literal {
+                        span,
+                        value: Literal::UInt64(index as u64),
+                    },
+                    Expr::Literal { span, value },
+                ],
+                ..Default::default()
+            },
+        };
+    }
+}
+
+impl AstVisitorMut for ParameterizeVisitor {
+    type Error = ErrorCode;
+
+    fn visit_expr(&mut self, expr: &mut Expr) -> Result<VisitControl> {
+        if is_plan_parameter(expr) {
+            return Ok(VisitControl::SkipChildren);
+        }
+
+        match expr {
+            Expr::IsDistinctFrom { left, right, .. } => {
+                self.parameterize_value_expr(left);
+                self.parameterize_value_expr(right);
+            }
+            Expr::InList { list, .. } => {
+                for item in list {
+                    self.parameterize_value_expr(item);
+                }
+            }
+            Expr::Between { low, high, .. } => {
+                self.parameterize_value_expr(low);
+                self.parameterize_value_expr(high);
+            }
+            Expr::BinaryOp {
+                op, left, right, ..
+            } if is_parameterized_binary_operator(op) => {
+                self.parameterize_value_expr(left);
+                self.parameterize_value_expr(right);
+            }
+            Expr::LikeAnyWithEscape { right, .. } | Expr::LikeWithEscape { right, .. } => {
+                self.parameterize_value_expr(right);
+            }
+            _ => {}
+        }
+
+        Ok(VisitControl::Continue)
+    }
+}
+
+struct NormalizeParameters;
+
+impl AstVisitorMut for NormalizeParameters {
+    type Error = ErrorCode;
+
+    fn visit_expr(&mut self, expr: &mut Expr) -> Result<VisitControl> {
+        let Expr::FunctionCall { func, .. } = expr else {
+            return Ok(VisitControl::Continue);
+        };
+        if !func.name.name.eq_ignore_ascii_case(PLAN_PARAMETER_FUNCTION) {
+            return Ok(VisitControl::Continue);
+        }
+
+        let Some(Expr::Literal { value, .. }) = func.args.get_mut(1) else {
+            return Err(ErrorCode::Internal(
+                "invalid planner-cache parameter marker".to_string(),
+            ));
+        };
+        *value = canonical_literal(value);
+        Ok(VisitControl::SkipChildren)
+    }
+}
+
+fn is_parameterized_binary_operator(op: &BinaryOperator) -> bool {
+    matches!(
+        op,
+        BinaryOperator::Gt
+            | BinaryOperator::Lt
+            | BinaryOperator::Gte
+            | BinaryOperator::Lte
+            | BinaryOperator::Eq
+            | BinaryOperator::NotEq
+            | BinaryOperator::Like(_)
+            | BinaryOperator::NotLike(_)
+            | BinaryOperator::LikeAny(_)
+            | BinaryOperator::ILike(_)
+            | BinaryOperator::NotILike(_)
+            | BinaryOperator::ILikeAny(_)
+            | BinaryOperator::Regexp
+            | BinaryOperator::PgRegexpMatch
+            | BinaryOperator::RLike
+            | BinaryOperator::NotRegexp
+            | BinaryOperator::NotRLike
+            | BinaryOperator::SoundsLike
+    )
+}
+
+fn canonical_literal(value: &Literal) -> Literal {
+    match value {
+        Literal::UInt64(_) => Literal::UInt64(0),
+        Literal::Decimal256 {
+            precision, scale, ..
+        } => Literal::Decimal256 {
+            value: 0.into(),
+            precision: *precision,
+            scale: *scale,
+        },
+        Literal::Float64(_) => Literal::Float64(0.0),
+        Literal::String(_) => Literal::String(String::new()),
+        Literal::Binary(_) => Literal::Binary(Vec::new()),
+        Literal::Boolean(_) => Literal::Boolean(false),
+        Literal::Null => Literal::Null,
+    }
+}
+
+fn literal_to_scalar(value: &Literal) -> Scalar {
+    match value {
+        Literal::UInt64(value) => Scalar::Number(NumberScalar::UInt64(*value)),
+        Literal::Decimal256 {
+            value,
+            precision,
+            scale,
+        } => Scalar::Decimal(DecimalScalar::Decimal256(
+            i256(*value),
+            DecimalSize::new_unchecked(*precision, *scale),
+        )),
+        Literal::Float64(value) => Scalar::Number(NumberScalar::Float64((*value).into())),
+        Literal::String(value) => Scalar::String(value.clone()),
+        Literal::Binary(value) => Scalar::Binary(value.clone()),
+        Literal::Boolean(value) => Scalar::Boolean(*value),
+        Literal::Null => Scalar::Null,
+    }
+}
+
+pub(crate) fn instantiate_plan(
+    template: &Plan,
+    values: &[Scalar],
+    formatted_ast: Option<String>,
+) -> Result<Plan> {
+    let Plan::Query {
+        s_expr,
+        metadata,
+        bind_context,
+        rewrite_kind,
+        formatted_ast: cached_formatted_ast,
+        ignore_result,
+        ..
+    } = template
+    else {
+        return Err(ErrorCode::Internal(
+            "parameterized planner cache contains a non-query plan".to_string(),
+        ));
+    };
+
+    let mut instantiator = ParameterInstantiator::new(values);
+    let s_expr = instantiate_s_expr(s_expr, &mut instantiator)?;
+
+    let mut metadata = metadata.read().clone();
+    let mut agg_indices = metadata.agg_indices().clone();
+    for indices in agg_indices.values_mut() {
+        for (_, _, expr) in indices {
+            *expr = instantiate_s_expr(expr, &mut instantiator)?;
+        }
+    }
+    metadata.replace_agg_indices(agg_indices);
+    instantiator.finish()?;
+
+    Ok(Plan::Query {
+        s_expr: Box::new(s_expr),
+        metadata: Arc::new(RwLock::new(metadata)),
+        bind_context: bind_context.clone(),
+        rewrite_kind: rewrite_kind.clone(),
+        formatted_ast: cached_formatted_ast
+            .as_ref()
+            .map(|_| formatted_ast.expect("formatted AST is present when result cache is enabled")),
+        ignore_result: *ignore_result,
+    })
+}
+
+fn instantiate_s_expr(
+    template: &SExpr,
+    instantiator: &mut ParameterInstantiator<'_>,
+) -> Result<SExpr> {
+    let mut plan = template.plan().clone();
+    let mut result = Ok(());
+    plan.visit_scalar_expr_mut(&mut |expr| {
+        if result.is_ok() {
+            result = instantiator.visit(expr);
+        }
+    });
+    result?;
+
+    let children = template
+        .children()
+        .map(|child| instantiate_s_expr(child, instantiator).map(Arc::new))
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(SExpr::create(plan, children, None, None, None))
+}
+
+struct ParameterInstantiator<'a> {
+    values: &'a [Scalar],
+    seen: Vec<bool>,
+}
+
+impl<'a> ParameterInstantiator<'a> {
+    fn new(values: &'a [Scalar]) -> Self {
+        Self {
+            values,
+            seen: vec![false; values.len()],
+        }
+    }
+
+    fn finish(self) -> Result<()> {
+        if self.seen.iter().all(|seen| *seen) {
+            Ok(())
+        } else {
+            Err(ErrorCode::Internal(
+                "parameterized planner cache template did not consume all parameters".to_string(),
+            ))
+        }
+    }
+
+    fn marker_index(function: &FunctionCall) -> Result<usize> {
+        let Some(ScalarExpr::ConstantExpr(ConstantExpr {
+            value: Scalar::Number(index),
+            ..
+        })) = function.arguments.first()
+        else {
+            return Err(ErrorCode::Internal(
+                "invalid parameter index in planner cache template".to_string(),
+            ));
+        };
+
+        let index = match index {
+            NumberScalar::UInt8(value) => *value as usize,
+            NumberScalar::UInt16(value) => *value as usize,
+            NumberScalar::UInt32(value) => *value as usize,
+            NumberScalar::UInt64(value) => *value as usize,
+            _ => {
+                return Err(ErrorCode::Internal(
+                    "non-unsigned parameter index in planner cache template".to_string(),
+                ));
+            }
+        };
+        Ok(index)
+    }
+}
+
+impl<'a, 'b> VisitorMut<'a> for ParameterInstantiator<'b> {
+    fn visit(&mut self, expr: &'a mut ScalarExpr) -> Result<()> {
+        if let ScalarExpr::FunctionCall(function) = expr
+            && function
+                .func_name
+                .eq_ignore_ascii_case(PLAN_PARAMETER_FUNCTION)
+        {
+            let index = Self::marker_index(function)?;
+            let Some(value) = self.values.get(index) else {
+                return Err(ErrorCode::Internal(format!(
+                    "parameter index {index} is out of bounds for planner cache template"
+                )));
+            };
+            self.seen[index] = true;
+            *expr = ScalarExpr::ConstantExpr(ConstantExpr {
+                span: function.span,
+                value: value.clone(),
+            });
+            return Ok(());
+        }
+        crate::plans::walk_expr_mut(self, expr)
+    }
+
+    fn visit_subquery_expr(&mut self, subquery: &'a mut SubqueryExpr) -> Result<()> {
+        if let Some(child_expr) = subquery.child_expr.as_mut() {
+            self.visit(child_expr)?;
+        }
+        subquery.subquery = Box::new(instantiate_s_expr(&subquery.subquery, self)?);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_ast::parser::Dialect;
+    use databend_common_ast::parser::parse_sql;
+    use databend_common_ast::parser::tokenize_sql;
+
+    use super::*;
+
+    fn parse(sql: &str) -> Statement {
+        let tokens = tokenize_sql(sql).unwrap();
+        parse_sql(&tokens, Dialect::Experimental).unwrap().0
+    }
+
+    #[test]
+    fn test_normalizes_predicate_literals_but_not_limit() {
+        let left = ParameterizedStatement::create(&parse(
+            "SELECT * FROM t WHERE a = 1 AND b = 'first' LIMIT 10",
+        ))
+        .unwrap();
+        let right = ParameterizedStatement::create(&parse(
+            "SELECT * FROM t WHERE a = 2 AND b = 'second' LIMIT 10",
+        ))
+        .unwrap();
+
+        assert_eq!(left.cache_key_sql(), right.cache_key_sql());
+        assert_eq!(left.values.len(), 2);
+        assert_eq!(right.values.len(), 2);
+        assert!(left.template.to_string().contains("LIMIT 10"));
+    }
+
+    #[test]
+    fn test_parameter_type_and_limit_remain_in_cache_key() {
+        let number =
+            ParameterizedStatement::create(&parse("SELECT * FROM t WHERE a = 1 LIMIT 1")).unwrap();
+        let string =
+            ParameterizedStatement::create(&parse("SELECT * FROM t WHERE a = '1' LIMIT 1"))
+                .unwrap();
+        let other_limit =
+            ParameterizedStatement::create(&parse("SELECT * FROM t WHERE a = 2 LIMIT 2")).unwrap();
+
+        assert_ne!(number.cache_key_sql(), string.cache_key_sql());
+        assert_ne!(number.cache_key_sql(), other_limit.cache_key_sql());
+    }
+
+    #[test]
+    fn test_normalizes_in_and_between_literals() {
+        let left = ParameterizedStatement::create(&parse(
+            "SELECT * FROM t WHERE a IN (1, 2) AND b BETWEEN 'a' AND 'z'",
+        ))
+        .unwrap();
+        let right = ParameterizedStatement::create(&parse(
+            "SELECT * FROM t WHERE a IN (3, 4) AND b BETWEEN 'b' AND 'y'",
+        ))
+        .unwrap();
+
+        assert_eq!(left.cache_key_sql(), right.cache_key_sql());
+        assert_eq!(left.values.len(), 4);
+    }
+
+    #[test]
+    fn test_normalizes_signed_like_and_distinct_literals() {
+        let left = ParameterizedStatement::create(&parse(
+            "SELECT * FROM t WHERE a = -1 AND b LIKE 'left%' AND c IS DISTINCT FROM 10",
+        ))
+        .unwrap();
+        let right = ParameterizedStatement::create(&parse(
+            "SELECT * FROM t WHERE a = -2 AND b LIKE 'right%' AND c IS DISTINCT FROM 20",
+        ))
+        .unwrap();
+
+        assert_eq!(left.cache_key_sql(), right.cache_key_sql());
+        assert_eq!(left.values.len(), 3);
+    }
+
+    #[test]
+    fn test_existing_parameter_marker_disables_parameterization() {
+        let statement = parse("SELECT __plan_parameter(0, 'user value') FROM t WHERE a = 1");
+        let parameterized = ParameterizedStatement::create(&statement).unwrap();
+
+        assert!(!parameterized.is_parameterized());
+        assert!(parameterized.values.is_empty());
+        assert_eq!(parameterized.template.to_string(), statement.to_string());
+    }
+
+    #[test]
+    fn test_decimal_scale_remains_in_cache_key() {
+        let left = ParameterizedStatement::create(&parse("SELECT * FROM t WHERE a = 1.1")).unwrap();
+        let same_scale =
+            ParameterizedStatement::create(&parse("SELECT * FROM t WHERE a = 2.2")).unwrap();
+        let other_scale =
+            ParameterizedStatement::create(&parse("SELECT * FROM t WHERE a = 2.22")).unwrap();
+
+        assert_eq!(left.cache_key_sql(), same_scale.cache_key_sql());
+        assert_ne!(left.cache_key_sql(), other_scale.cache_key_sql());
+    }
+}

--- a/src/query/sql/src/planner/plans/aggregate.rs
+++ b/src/query/sql/src/planner/plans/aggregate.rs
@@ -249,6 +249,15 @@ impl Operator for Aggregate {
         Box::new(iter)
     }
 
+    fn visit_scalar_expr_mut(&mut self, visitor: &mut dyn FnMut(&mut ScalarExpr)) {
+        for item in &mut self.group_items {
+            visitor(&mut item.scalar);
+        }
+        for item in &mut self.aggregate_functions {
+            visitor(&mut item.scalar);
+        }
+    }
+
     fn derive_physical_prop(&self, rel_expr: &RelExpr) -> Result<PhysicalProperty> {
         let input_physical_prop = rel_expr.derive_physical_prop_child(0)?;
 

--- a/src/query/sql/src/planner/plans/async_function.rs
+++ b/src/query/sql/src/planner/plans/async_function.rs
@@ -53,6 +53,12 @@ impl Operator for AsyncFunction {
         Box::new(self.items.iter().map(|expr| &expr.scalar))
     }
 
+    fn visit_scalar_expr_mut(&mut self, visitor: &mut dyn FnMut(&mut ScalarExpr)) {
+        for item in &mut self.items {
+            visitor(&mut item.scalar);
+        }
+    }
+
     fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<Arc<RelationalProperty>> {
         let input_prop = rel_expr.derive_relational_prop_child(0)?;
 

--- a/src/query/sql/src/planner/plans/eval_scalar.rs
+++ b/src/query/sql/src/planner/plans/eval_scalar.rs
@@ -87,6 +87,12 @@ impl Operator for EvalScalar {
         Box::new(self.items.iter().map(|expr| &expr.scalar))
     }
 
+    fn visit_scalar_expr_mut(&mut self, visitor: &mut dyn FnMut(&mut ScalarExpr)) {
+        for item in &mut self.items {
+            visitor(&mut item.scalar);
+        }
+    }
+
     fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<Arc<RelationalProperty>> {
         let input_prop = rel_expr.derive_relational_prop_child(0)?;
 

--- a/src/query/sql/src/planner/plans/exchange.rs
+++ b/src/query/sql/src/planner/plans/exchange.rs
@@ -48,6 +48,14 @@ impl Operator for Exchange {
         }
     }
 
+    fn visit_scalar_expr_mut(&mut self, visitor: &mut dyn FnMut(&mut ScalarExpr)) {
+        if let Exchange::NodeToNodeHash(hash_keys) | Exchange::GlobalHash(hash_keys) = self {
+            for key in hash_keys {
+                visitor(key);
+            }
+        }
+    }
+
     fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<Arc<RelationalProperty>> {
         rel_expr.derive_relational_prop_child(0)
     }

--- a/src/query/sql/src/planner/plans/filter.rs
+++ b/src/query/sql/src/planner/plans/filter.rs
@@ -52,6 +52,12 @@ impl Operator for Filter {
         Box::new(self.predicates.iter())
     }
 
+    fn visit_scalar_expr_mut(&mut self, visitor: &mut dyn FnMut(&mut ScalarExpr)) {
+        for predicate in &mut self.predicates {
+            visitor(predicate);
+        }
+    }
+
     fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<Arc<RelationalProperty>> {
         let input_prop = rel_expr.derive_relational_prop_child(0)?;
         let output_columns = input_prop.output_columns.clone();

--- a/src/query/sql/src/planner/plans/join.rs
+++ b/src/query/sql/src/planner/plans/join.rs
@@ -661,6 +661,16 @@ impl Operator for Join {
         Box::new(iter)
     }
 
+    fn visit_scalar_expr_mut(&mut self, visitor: &mut dyn FnMut(&mut ScalarExpr)) {
+        for condition in &mut self.equi_conditions {
+            visitor(&mut condition.left);
+            visitor(&mut condition.right);
+        }
+        for condition in &mut self.non_equi_conditions {
+            visitor(condition);
+        }
+    }
+
     fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<Arc<RelationalProperty>> {
         let left_prop = rel_expr.derive_relational_prop_child(0)?;
         let right_prop = rel_expr.derive_relational_prop_child(1)?;

--- a/src/query/sql/src/planner/plans/mutation_source.rs
+++ b/src/query/sql/src/planner/plans/mutation_source.rs
@@ -83,6 +83,15 @@ impl Operator for MutationSource {
         )
     }
 
+    fn visit_scalar_expr_mut(&mut self, visitor: &mut dyn FnMut(&mut ScalarExpr)) {
+        for predicate in &mut self.secure_predicates {
+            visitor(predicate);
+        }
+        for predicate in &mut self.user_predicates {
+            visitor(predicate);
+        }
+    }
+
     fn derive_relational_prop(&self, _rel_expr: &RelExpr) -> Result<Arc<RelationalProperty>> {
         Ok(Arc::new(RelationalProperty {
             output_columns: self.columns.clone(),

--- a/src/query/sql/src/planner/plans/operator.rs
+++ b/src/query/sql/src/planner/plans/operator.rs
@@ -69,6 +69,8 @@ pub trait Operator {
         Box::new(std::iter::empty())
     }
 
+    fn visit_scalar_expr_mut(&mut self, _visitor: &mut dyn FnMut(&mut ScalarExpr)) {}
+
     /// Derive relational property
     fn derive_relational_prop(&self, _rel_expr: &RelExpr) -> Result<Arc<RelationalProperty>> {
         Ok(Arc::new(RelationalProperty::default()))
@@ -211,6 +213,10 @@ impl Operator for RelOperator {
 
     fn scalar_expr_iter(&self) -> Box<dyn Iterator<Item = &ScalarExpr> + '_> {
         match_rel_op!(self, scalar_expr_iter)
+    }
+
+    fn visit_scalar_expr_mut(&mut self, visitor: &mut dyn FnMut(&mut ScalarExpr)) {
+        match_rel_op!(self, visit_scalar_expr_mut(visitor))
     }
 
     fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<Arc<RelationalProperty>> {

--- a/src/query/sql/src/planner/plans/project_set.rs
+++ b/src/query/sql/src/planner/plans/project_set.rs
@@ -52,6 +52,12 @@ impl Operator for ProjectSet {
         Box::new(self.srfs.iter().map(|expr| &expr.scalar))
     }
 
+    fn visit_scalar_expr_mut(&mut self, visitor: &mut dyn FnMut(&mut ScalarExpr)) {
+        for item in &mut self.srfs {
+            visitor(&mut item.scalar);
+        }
+    }
+
     fn derive_relational_prop(
         &self,
         rel_expr: &RelExpr,

--- a/src/query/sql/src/planner/plans/scan.rs
+++ b/src/query/sql/src/planner/plans/scan.rs
@@ -327,6 +327,32 @@ impl Operator for Scan {
         )
     }
 
+    fn visit_scalar_expr_mut(&mut self, visitor: &mut dyn FnMut(&mut ScalarExpr)) {
+        if let Some(predicates) = &mut self.push_down_predicates {
+            for predicate in predicates {
+                visitor(predicate);
+            }
+        }
+        if let Some(predicates) = &mut self.secure_predicates {
+            for predicate in predicates {
+                visitor(predicate);
+            }
+        }
+        if let Some(prewhere) = &mut self.prewhere {
+            for predicate in &mut prewhere.predicates {
+                visitor(predicate);
+            }
+        }
+        if let Some(agg_index) = &mut self.agg_index {
+            for predicate in &mut agg_index.predicates {
+                visitor(predicate);
+            }
+            for selection in &mut agg_index.selection {
+                visitor(&mut selection.scalar);
+            }
+        }
+    }
+
     fn arity(&self) -> usize {
         0
     }

--- a/src/query/sql/src/planner/plans/udf.rs
+++ b/src/query/sql/src/planner/plans/udf.rs
@@ -54,6 +54,12 @@ impl Operator for Udf {
         Box::new(self.items.iter().map(|expr| &expr.scalar))
     }
 
+    fn visit_scalar_expr_mut(&mut self, visitor: &mut dyn FnMut(&mut ScalarExpr)) {
+        for item in &mut self.items {
+            visitor(&mut item.scalar);
+        }
+    }
+
     fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<Arc<RelationalProperty>> {
         let input_prop = rel_expr.derive_relational_prop_child(0)?;
 

--- a/src/query/sql/src/planner/plans/window.rs
+++ b/src/query/sql/src/planner/plans/window.rs
@@ -181,6 +181,15 @@ impl Operator for WindowGroup {
         Box::new(scalar_items.chain(windows))
     }
 
+    fn visit_scalar_expr_mut(&mut self, visitor: &mut dyn FnMut(&mut ScalarExpr)) {
+        for item in &mut self.scalar_items {
+            visitor(&mut item.scalar);
+        }
+        for window in &mut self.windows {
+            window.visit_scalar_expr_mut(visitor);
+        }
+    }
+
     fn compute_required_prop_child(
         &self,
         _ctx: Arc<dyn TableContext>,
@@ -263,6 +272,34 @@ impl Operator for Window {
                 Box::new(iter.chain(std::iter::once(nth_value_function.arg.as_ref())))
             }
             _ => Box::new(iter),
+        }
+    }
+
+    fn visit_scalar_expr_mut(&mut self, visitor: &mut dyn FnMut(&mut ScalarExpr)) {
+        for item in &mut self.order_by {
+            visitor(&mut item.order_by_item.scalar);
+        }
+        for item in &mut self.partition_by {
+            visitor(&mut item.scalar);
+        }
+        for item in &mut self.arguments {
+            visitor(&mut item.scalar);
+        }
+
+        match &mut self.function {
+            WindowFuncType::Aggregate(aggregate) => {
+                for expr in aggregate.exprs_mut() {
+                    visitor(expr);
+                }
+            }
+            WindowFuncType::LagLead(function) => {
+                visitor(&mut function.arg);
+                if let Some(default) = &mut function.default {
+                    visitor(default);
+                }
+            }
+            WindowFuncType::NthValue(function) => visitor(&mut function.arg),
+            _ => {}
         }
     }
 

--- a/src/query/sql/src/planner/semantic/type_check/scalar_function.rs
+++ b/src/query/sql/src/planner/semantic/type_check/scalar_function.rs
@@ -37,6 +37,7 @@ use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_functions::GENERAL_LAMBDA_FUNCTIONS;
 use databend_common_functions::GENERAL_SEARCH_FUNCTIONS;
 use databend_common_functions::GENERAL_WINDOW_FUNCTIONS;
+use databend_common_functions::PLAN_PARAMETER_FUNCTION;
 use simsearch::SimSearch;
 use smallvec::SmallVec;
 use unicase::Ascii;
@@ -616,7 +617,9 @@ where A: TypeCheckAdapter
             _ => args,
         };
 
-        if !expr.is_deterministic(&BUILTIN_FUNCTIONS) {
+        if !func_name.eq_ignore_ascii_case(PLAN_PARAMETER_FUNCTION)
+            && !expr.is_deterministic(&BUILTIN_FUNCTIONS)
+        {
             self.adapter.set_result_cache_uncacheable();
         }
 

--- a/tests/sqllogictests/suites/base/20+_others/20_0020_planner_cache.test
+++ b/tests/sqllogictests/suites/base/20+_others/20_0020_planner_cache.test
@@ -8,7 +8,20 @@ statement ok
 USE db20_20;
 
 statement ok
+SET GLOBAL enable_planner_cache = 0;
+
+query TT
+SELECT value, level FROM system.settings WHERE name = 'enable_planner_cache';
+----
+0 GLOBAL
+
+statement ok
 SET enable_planner_cache = 1;
+
+query TT
+SELECT value, level FROM system.settings WHERE name = 'enable_planner_cache';
+----
+1 SESSION
 
 statement ok
 SET variable a = 'a';
@@ -76,6 +89,263 @@ SELECT * FROM t1 ORDER BY a;
 1 s
 2 s
 3 s
+
+statement ok
+SET enable_planner_cache = 1;
+
+statement ok
+SET lazy_read_threshold = 0;
+
+statement ok
+SET enable_distributed_pruning = 0;
+
+statement ok
+SET enable_query_result_cache = 0;
+
+statement ok
+CREATE TABLE t2 (a INT NOT NULL);
+
+statement ok
+INSERT INTO t2 VALUES (1);
+
+query I
+SELECT * FROM t2 ORDER BY a;
+----
+1
+
+query I
+SELECT * FROM t2 ORDER BY a;
+----
+1
+
+statement ok
+INSERT INTO t2 VALUES (2);
+
+query I
+SELECT * FROM t2 ORDER BY a;
+----
+1
+2
+
+statement ok
+ALTER TABLE t2 ADD COLUMN b STRING DEFAULT 's';
+
+query IT
+SELECT * FROM t2 ORDER BY a;
+----
+1 s
+2 s
+
+statement ok
+SET lazy_read_threshold = 1000;
+
+statement ok
+CREATE TABLE t3 (a INT NOT NULL, payload STRING NOT NULL);
+
+statement ok
+INSERT INTO t3 VALUES (1, 'one');
+
+query IT
+SELECT * FROM t3 ORDER BY a LIMIT 1;
+----
+1 one
+
+query IT
+SELECT * FROM t3 ORDER BY a LIMIT 1;
+----
+1 one
+
+statement ok
+INSERT INTO t3 VALUES (0, 'zero');
+
+query IT
+SELECT * FROM t3 ORDER BY a LIMIT 1;
+----
+0 zero
+
+statement ok
+SET enable_query_result_cache = 1;
+
+statement ok
+SET query_result_cache_min_execute_secs = 0;
+
+statement ok
+CREATE TABLE t4 (a INT NOT NULL, payload STRING NOT NULL);
+
+statement ok
+INSERT INTO t4 VALUES (1, 'one'), (2, 'two');
+
+query IT
+SELECT a, payload FROM t4 WHERE a = 1 ORDER BY a;
+----
+1 one
+
+query IT
+SELECT a, payload FROM t4 WHERE a = 2 ORDER BY a;
+----
+2 two
+
+query IT
+SELECT a, payload FROM t4 WHERE a = 1 ORDER BY a;
+----
+1 one
+
+statement ok
+INSERT INTO t4 VALUES (3, 'three');
+
+query IT
+SELECT a, payload FROM t4 WHERE a = 3 ORDER BY a;
+----
+3 three
+
+statement ok
+ALTER TABLE t4 ADD COLUMN extra STRING DEFAULT 'new';
+
+query ITT
+SELECT a, payload, extra FROM t4 WHERE a = 2 ORDER BY a;
+----
+2 two new
+
+statement ok
+SET enable_query_result_cache = 0;
+
+statement ok
+CREATE TABLE t5 (a INT NOT NULL, b STRING NOT NULL, d DECIMAL(10, 2) NOT NULL);
+
+statement ok
+INSERT INTO t5 VALUES
+    (-2, 'alpha', 1.10),
+    (-1, 'beta', 2.20),
+    (1, 'bravo', 3.30),
+    (2, 'charlie', 4.40),
+    (3, 'delta', 5.50);
+
+query I
+SELECT a FROM t5 WHERE a = -1 ORDER BY a;
+----
+-1
+
+query I
+SELECT a FROM t5 WHERE a = -2 ORDER BY a;
+----
+-2
+
+query I
+SELECT a FROM t5 WHERE a IN (1, 2) ORDER BY a;
+----
+1
+2
+
+query I
+SELECT a FROM t5 WHERE a IN (2, 3) ORDER BY a;
+----
+2
+3
+
+query I
+SELECT a FROM t5 WHERE a BETWEEN -1 AND 1 ORDER BY a;
+----
+-1
+1
+
+query I
+SELECT a FROM t5 WHERE a BETWEEN 1 AND 3 ORDER BY a;
+----
+1
+2
+3
+
+query I
+SELECT a FROM t5 WHERE b LIKE 'b%' ORDER BY a;
+----
+-1
+1
+
+query I
+SELECT a FROM t5 WHERE b LIKE 'd%' ORDER BY a;
+----
+3
+
+query I
+SELECT a FROM t5 WHERE a IS DISTINCT FROM -1 ORDER BY a;
+----
+-2
+1
+2
+3
+
+query I
+SELECT a FROM t5 WHERE a IS DISTINCT FROM 2 ORDER BY a;
+----
+-2
+-1
+1
+3
+
+query I
+SELECT a FROM t5 WHERE d = 1.10 ORDER BY a;
+----
+-2
+
+query I
+SELECT a FROM t5 WHERE d = 2.20 ORDER BY a;
+----
+-1
+
+query I
+SELECT a
+FROM t5
+WHERE a IN (SELECT a FROM t5 WHERE d = 1.10)
+ORDER BY a;
+----
+-2
+
+query I
+SELECT a
+FROM t5
+WHERE a IN (SELECT a FROM t5 WHERE d = 2.20)
+ORDER BY a;
+----
+-1
+
+query I
+SELECT l.a
+FROM t5 AS l
+JOIN t5 AS r ON l.a = r.a
+WHERE r.d = 1.10
+ORDER BY l.a;
+----
+-2
+
+query I
+SELECT l.a
+FROM t5 AS l
+JOIN t5 AS r ON l.a = r.a
+WHERE r.d = 2.20
+ORDER BY l.a;
+----
+-1
+
+query TI
+SELECT __plan_parameter(0, 'first'), a FROM t5 WHERE a = -1 ORDER BY a;
+----
+first -1
+
+query TI
+SELECT __plan_parameter(0, 'second'), a FROM t5 WHERE a = -2 ORDER BY a;
+----
+second -2
+
+statement ok
+SET enable_planner_cache = 0;
+
+query ITT
+SELECT a, payload, extra FROM t4 WHERE a = 1 ORDER BY a;
+----
+1 one new
+
+statement ok
+UNSET GLOBAL enable_planner_cache;
 
 statement ok
 DROP DATABASE db20_20;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR extracts the planner-cache work from #20144. It does not include ordered top-k, PresortedMerge, page statistics, or their settings.

It adds a bounded two-level logical planner cache:

1. The exact-SQL cache stores an optimized concrete logical plan.
2. The parameterized cache shares a bound logical template across predicate literals. On a template hit, the current typed literals are injected and the optimizer runs again.

Only logical planning is cached. Physical planning, block pruning, and execution are performed for every query, so different predicate values still produce value-specific physical plans and scan ranges. The query-result-cache key continues to use the current query's original formatted AST.

Parameterized predicates cover comparisons, IN, BETWEEN, LIKE/regexp, and IS DISTINCT FROM. LIMIT and OFFSET remain part of the template shape and are not parameterized. Unsupported plans fall back to the normal AST bind path. User-written calls using the internal parameter-marker name disable parameterization defensively.

Cache isolation and validation include tenant, catalog, database, optimizer-relevant settings, variables, security context, table IDs/sequences/schemas/snapshots, and security policies. A table-snapshot mismatch evicts the local stale entry before reuse, including when the metadata change was made by another query node. Table functions, external locations, async functions, and other unsafe dependencies are not cached.

Successful DML invalidates entries for affected table IDs. Successful catalog DDL advances the DDL generation and clears the cache, including table/database/index/policy/tag/sequence/dictionary paths. Mutation generations close concurrent insert/invalidate races.

The enable_planner_cache setting supports both session SET and persistent SET GLOBAL scopes. The cache uses a byte-bounded LRU configured by cache.planner_cache_max_bytes, with a 512 MiB default. The previous standalone physical-plan-cache experiment and enable_standalone_fast_planner_cache setting are intentionally not included.

## No-lazy benchmark

Authoritative binaries:

- Baseline: 22a762701e
- Final: 58ca1fd268

Environment: one standalone query node on web3-i4i, on-disk data cache enabled, lazy_read_threshold=0, query-result cache disabled, planner cache enabled, distributed pruning disabled, max_threads=16, 5 concurrent clients, and fixed seed 2026071305.

The test used two interleaved baseline/final rounds. For each process, Q1/Q2/Flex were all warmed first (400 iterations per worker), then each query ran 3,000 measured requests. This preserves mixed-query exact-cache pressure instead of making one query's exact plans artificially hot immediately before measurement.

| Query | Mean latency | p95 latency | QPS |
|---|---:|---:|---:|
| Q1 | 1.99% lower | 9.01% lower | 2.01% higher |
| Q2 | 2.08% lower | 9.52% lower | 2.12% higher |
| Flex | 2.53% lower | 8.50% lower | 2.60% higher |

All 36,000 measured requests succeeded. Each baseline round recorded 15,030 accesses / 1,103 misses / 13,927 hits. Each final round recorded 15,630 accesses / 603 misses / 15,027 hits; the additional template lookup path produced 597 hits and only 3 misses across the 600 distinct exact-SQL misses.

A query-local hot-cache control warmed and measured each query consecutively. All mean/p95/QPS changes stayed within 0.6%, showing no material regression when every exact plan already fits and is hot.

## Tests

- [x] Unit Test
- [x] Logic Test
- [x] Benchmark Test
- [ ] No Test - _Explain why_

Validation performed on web3-i4i:

- cargo fmt --all and format check
- git diff --check
- Targeted clippy for databend-common-functions, databend-common-sql, and databend-query --lib with -D warnings
- databend-query --lib cargo check
- Planner-cache unit tests: 10/10 passed
- 20_0020_planner_cache.test: MySQL handler 75/75 passed
- 20_0020_planner_cache.test: HTTP handler 75/75 passed
- Cache disabled vs enabled, deterministic Q1/Q2/Flex results: 600/600 matched, including row order
- Runtime metric sequence verified cross-literal template hits, exact-plan hits, table DML eviction, CREATE/DROP SEQUENCE clearing, session/global disable behavior, and user-marker bypass
- Final phase-separated A/B: 36,000/36,000 requests passed with zero errors

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20152)
<!-- Reviewable:end -->
