### PR TITLE
fix(query): handle single-row inequality joins safely

### DIFF
--- a/src/query/service/src/physical_plans/physical_join.rs
+++ b/src/query/service/src/physical_plans/physical_join.rs
@@ -27,6 +27,10 @@ use crate::physical_plans::PhysicalPlanBuilder;
 use crate::physical_plans::explain::PlanStatsInfo;
 use crate::physical_plans::physical_plan::PhysicalPlan;
 
+fn is_single_row(stat_info: &databend_common_sql::optimizer::ir::StatInfo) -> bool {
+    matches!(stat_info.statistics.precise_cardinality, Some(1)) || stat_info.cardinality == 1.0
+}
+
 enum PhysicalJoinType {
     Hash,
     // The first arg is range conditions, the second arg is other conditions
@@ -63,6 +67,7 @@ fn physical_join(join: &Join, s_expr: &SExpr) -> Result<PhysicalJoinType> {
 
     let left_rel_expr = RelExpr::with_s_expr(s_expr.left_child());
     let right_rel_expr = RelExpr::with_s_expr(s_expr.right_child());
+    let left_stat_info = left_rel_expr.derive_cardinality()?;
     let right_stat_info = right_rel_expr.derive_cardinality()?;
 
     if !join.equi_conditions.is_empty() {
@@ -75,10 +80,10 @@ fn physical_join(join: &Join, s_expr: &SExpr) -> Result<PhysicalJoinType> {
         return Ok(PhysicalJoinType::Hash);
     }
 
-    if matches!(right_stat_info.statistics.precise_cardinality, Some(1))
-        || right_stat_info.cardinality == 1.0
-    {
-        // If the output rows of build side is equal to 1, we use CROSS JOIN + FILTER instead of RANGE JOIN.
+    if is_single_row(&left_stat_info) || is_single_row(&right_stat_info) {
+        // If one side has a single row, use CROSS JOIN + FILTER instead of RANGE JOIN.
+        // Range join is optimized for a larger right side and can degenerate when join
+        // commutation places the large input on the left.
         return Ok(PhysicalJoinType::Hash);
     }
 

--- a/src/query/service/src/physical_plans/physical_join.rs
+++ b/src/query/service/src/physical_plans/physical_join.rs
@@ -250,9 +250,9 @@ impl PhysicalPlanBuilder {
                     // equi-conditions, the hash join executes as a cross join + filter.
                     // The single-join runtime check can fire during the cross-product
                     // matching phase before the filter is applied. It is only safe to
-                    // clear that marker when the scalar side itself is proven to produce
-                    // exactly one row; an exact one-row non-scalar side says nothing
-                    // about the scalar subquery's cardinality.
+                    // clear the marker when the scalar side itself is proven to produce
+                    // exactly one row. A precise one-row cardinality on the other input
+                    // does not prove that.
                     let join = if join.equi_conditions.is_empty()
                         && join.single_to_inner.is_some()
                         && single_join_scalar_side_is_precise_single_row(join, s_expr)?

--- a/src/query/service/src/physical_plans/physical_join.rs
+++ b/src/query/service/src/physical_plans/physical_join.rs
@@ -226,8 +226,40 @@ impl PhysicalPlanBuilder {
         } else {
             match physical_join(join, s_expr)? {
                 PhysicalJoinType::Hash => {
+                    // When a LeftSingle/RightSingle join (scalar subquery) has no
+                    // equi-conditions, the hash join executes as a cross join + filter.
+                    // The FROM_LEFT_SINGLE runtime check ("at most 1 build row per probe
+                    // row") fires during the cross-product matching phase — before the
+                    // filter is applied — and false-positives because in a cross join
+                    // every probe row matches all build rows (match_count = build rows).
+                    //
+                    // We only clear single_to_inner when the probe (left) child has
+                    // precise_cardinality == Some(1). This indicates the scalar subquery
+                    // landed on the probe side (e.g. after RuleCommuteJoin swapped
+                    // children) and is a deterministic single-row producer (no-group-by
+                    // aggregate). In that case the build side is the main table whose
+                    // multiple rows are expected — the filter will reduce them after the
+                    // cross product. We intentionally do NOT clear when only the build
+                    // (right) side is single-row (match_count would be 1 anyway, so the
+                    // check never fires) or when only a fuzzy cardinality == 1.0 estimate
+                    // holds (could be a single-row main table like numbers(1), not the
+                    // subquery — we must preserve the runtime check for that case).
+                    let left_stat =
+                        RelExpr::with_s_expr(s_expr.left_child()).derive_cardinality()?;
+                    let probe_is_scalar =
+                        matches!(left_stat.statistics.precise_cardinality, Some(1));
+                    let join = if join.equi_conditions.is_empty()
+                        && join.single_to_inner.is_some()
+                        && probe_is_scalar
+                    {
+                        let mut j = join.clone();
+                        j.single_to_inner = None;
+                        j
+                    } else {
+                        join.clone()
+                    };
                     self.build_hash_join(
-                        join,
+                        &join,
                         s_expr,
                         required,
                         others_required,

--- a/src/query/service/src/physical_plans/physical_join.rs
+++ b/src/query/service/src/physical_plans/physical_join.rs
@@ -27,7 +27,9 @@ use crate::physical_plans::PhysicalPlanBuilder;
 use crate::physical_plans::explain::PlanStatsInfo;
 use crate::physical_plans::physical_plan::PhysicalPlan;
 
-fn is_single_row(stat_info: &databend_common_sql::optimizer::ir::StatInfo) -> bool {
+fn has_precise_or_estimated_cardinality_one(
+    stat_info: &databend_common_sql::optimizer::ir::StatInfo,
+) -> bool {
     matches!(stat_info.statistics.precise_cardinality, Some(1)) || stat_info.cardinality == 1.0
 }
 
@@ -100,10 +102,12 @@ fn physical_join(join: &Join, s_expr: &SExpr) -> Result<PhysicalJoinType> {
         return Ok(PhysicalJoinType::Hash);
     }
 
-    if is_single_row(&left_stat_info) || is_single_row(&right_stat_info) {
-        // If one side has a single row, use CROSS JOIN + FILTER instead of RANGE JOIN.
-        // Range join is optimized for a larger right side and can degenerate when join
-        // commutation places the large input on the left.
+    if has_precise_or_estimated_cardinality_one(&left_stat_info)
+        || has_precise_or_estimated_cardinality_one(&right_stat_info)
+    {
+        // Prefer CROSS JOIN + FILTER when statistics prove or estimate one side at one row.
+        // HashJoin remains correct if the estimate is wrong and avoids the result-block
+        // overhead that RangeJoin can incur for this shape after join commutation.
         return Ok(PhysicalJoinType::Hash);
     }
 
@@ -251,7 +255,7 @@ impl PhysicalPlanBuilder {
                     // The single-join runtime check can fire during the cross-product
                     // matching phase before the filter is applied. It is only safe to
                     // clear that marker when the scalar side itself is proven to produce
-                    // exactly one row; an exact one-row outer/probe side says nothing
+                    // exactly one row; an exact one-row non-scalar side says nothing
                     // about the scalar subquery's cardinality.
                     let join = if join.equi_conditions.is_empty()
                         && join.single_to_inner.is_some()

--- a/src/query/service/src/physical_plans/physical_join.rs
+++ b/src/query/service/src/physical_plans/physical_join.rs
@@ -31,6 +31,26 @@ fn is_single_row(stat_info: &databend_common_sql::optimizer::ir::StatInfo) -> bo
     matches!(stat_info.statistics.precise_cardinality, Some(1)) || stat_info.cardinality == 1.0
 }
 
+fn is_precise_single_row(stat_info: &databend_common_sql::optimizer::ir::StatInfo) -> bool {
+    matches!(stat_info.statistics.precise_cardinality, Some(1))
+}
+
+fn single_join_scalar_side_is_precise_single_row(join: &Join, s_expr: &SExpr) -> Result<bool> {
+    match join.single_to_inner {
+        Some(JoinType::LeftSingle) => {
+            let right_rel_expr = RelExpr::with_s_expr(s_expr.right_child());
+            let right_stat_info = right_rel_expr.derive_cardinality()?;
+            Ok(is_precise_single_row(&right_stat_info))
+        }
+        Some(JoinType::RightSingle) => {
+            let left_rel_expr = RelExpr::with_s_expr(s_expr.left_child());
+            let left_stat_info = left_rel_expr.derive_cardinality()?;
+            Ok(is_precise_single_row(&left_stat_info))
+        }
+        _ => Ok(false),
+    }
+}
+
 enum PhysicalJoinType {
     Hash,
     // The first arg is range conditions, the second arg is other conditions
@@ -228,29 +248,14 @@ impl PhysicalPlanBuilder {
                 PhysicalJoinType::Hash => {
                     // When a LeftSingle/RightSingle join (scalar subquery) has no
                     // equi-conditions, the hash join executes as a cross join + filter.
-                    // The FROM_LEFT_SINGLE runtime check ("at most 1 build row per probe
-                    // row") fires during the cross-product matching phase — before the
-                    // filter is applied — and false-positives because in a cross join
-                    // every probe row matches all build rows (match_count = build rows).
-                    //
-                    // We only clear single_to_inner when the probe (left) child has
-                    // precise_cardinality == Some(1). This indicates the scalar subquery
-                    // landed on the probe side (e.g. after RuleCommuteJoin swapped
-                    // children) and is a deterministic single-row producer (no-group-by
-                    // aggregate). In that case the build side is the main table whose
-                    // multiple rows are expected — the filter will reduce them after the
-                    // cross product. We intentionally do NOT clear when only the build
-                    // (right) side is single-row (match_count would be 1 anyway, so the
-                    // check never fires) or when only a fuzzy cardinality == 1.0 estimate
-                    // holds (could be a single-row main table like numbers(1), not the
-                    // subquery — we must preserve the runtime check for that case).
-                    let left_stat =
-                        RelExpr::with_s_expr(s_expr.left_child()).derive_cardinality()?;
-                    let probe_is_scalar =
-                        matches!(left_stat.statistics.precise_cardinality, Some(1));
+                    // The single-join runtime check can fire during the cross-product
+                    // matching phase before the filter is applied. It is only safe to
+                    // clear that marker when the scalar side itself is proven to produce
+                    // exactly one row; an exact one-row outer/probe side says nothing
+                    // about the scalar subquery's cardinality.
                     let join = if join.equi_conditions.is_empty()
                         && join.single_to_inner.is_some()
-                        && probe_is_scalar
+                        && single_join_scalar_side_is_precise_single_row(join, s_expr)?
                     {
                         let mut j = join.clone();
                         j.single_to_inner = None;

--- a/src/query/service/src/physical_plans/physical_join.rs
+++ b/src/query/service/src/physical_plans/physical_join.rs
@@ -27,9 +27,7 @@ use crate::physical_plans::PhysicalPlanBuilder;
 use crate::physical_plans::explain::PlanStatsInfo;
 use crate::physical_plans::physical_plan::PhysicalPlan;
 
-fn has_precise_or_estimated_cardinality_one(
-    stat_info: &databend_common_sql::optimizer::ir::StatInfo,
-) -> bool {
+fn is_single_row(stat_info: &databend_common_sql::optimizer::ir::StatInfo) -> bool {
     matches!(stat_info.statistics.precise_cardinality, Some(1)) || stat_info.cardinality == 1.0
 }
 
@@ -102,9 +100,7 @@ fn physical_join(join: &Join, s_expr: &SExpr) -> Result<PhysicalJoinType> {
         return Ok(PhysicalJoinType::Hash);
     }
 
-    if has_precise_or_estimated_cardinality_one(&left_stat_info)
-        || has_precise_or_estimated_cardinality_one(&right_stat_info)
-    {
+    if is_single_row(&left_stat_info) || is_single_row(&right_stat_info) {
         // Prefer CROSS JOIN + FILTER when statistics prove or estimate one side at one row.
         // HashJoin remains correct if the estimate is wrong and avoids the result-block
         // overhead that RangeJoin can incur for this shape after join commutation.

--- a/src/query/service/tests/it/sql/exec/range_join.rs
+++ b/src/query/service/tests/it/sql/exec/range_join.rs
@@ -18,6 +18,89 @@ use databend_common_expression::types::number::NumberScalar;
 use databend_query::test_kits::TestFixture;
 use futures_util::TryStreamExt;
 
+async fn explain_text(fixture: &TestFixture, query: &str) -> anyhow::Result<String> {
+    let blocks = fixture
+        .execute_query(&format!("EXPLAIN {query}"))
+        .await?
+        .try_collect::<Vec<DataBlock>>()
+        .await?;
+    let block = DataBlock::concat(&blocks).expect("concat explain blocks");
+    let column = block.get_by_offset(0);
+    let mut lines = Vec::with_capacity(block.num_rows());
+    for row in 0..block.num_rows() {
+        if let Some(ScalarRef::String(line)) = column.index(row) {
+            lines.push(line.to_string());
+        }
+    }
+    Ok(lines.join("\n"))
+}
+
+/// A single-row side of an inequality join (here a scalar/no-group-by aggregate, whose
+/// `precise_cardinality` is deterministically 1) must never end up driving a merge
+/// RANGE JOIN. The merge algorithm assumes the build side is the larger one and, for
+/// every driving-side row, materializes the whole matching span of the other side; when
+/// `RuleCommuteJoin` swaps children based on a corrupted cardinality estimate, a large
+/// table can land on the driving side against a single-row build side and blow up memory
+/// into a per-row cartesian product. The planner must instead pick CROSS JOIN + FILTER
+/// (a hash join) regardless of which side the single-row relation is placed on.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_inequality_join_with_scalar_side_avoids_range_join() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup().await?;
+    fixture.create_default_database().await?;
+    let db = fixture.default_db_name();
+
+    fixture
+        .execute_command(&format!(
+            "CREATE TABLE {db}.big(ts INT) AS SELECT number FROM numbers(1000)"
+        ))
+        .await?;
+    fixture
+        .execute_command(&format!(
+            "CREATE TABLE {db}.threshold(ts INT) AS SELECT number FROM numbers(1000)"
+        ))
+        .await?;
+
+    // Scalar subquery on the right side of the inequality.
+    let q_right = format!(
+        "SELECT count(*) FROM {db}.big b \
+         WHERE b.ts >= (SELECT min(ts) FROM {db}.threshold)"
+    );
+    // Scalar subquery on the left side of the inequality (operands flipped). The optimizer
+    // may commute children so the single-row aggregate becomes the driving side; the guard
+    // must still avoid a merge range join.
+    let q_left = format!(
+        "SELECT count(*) FROM {db}.big b \
+         WHERE (SELECT min(ts) FROM {db}.threshold) <= b.ts"
+    );
+
+    for query in [&q_right, &q_left] {
+        let plan = explain_text(&fixture, query).await?;
+        assert!(
+            !plan.contains("RangeJoin"),
+            "single-row inequality side must not produce a RangeJoin, plan was:\n{plan}"
+        );
+    }
+
+    // And the rewritten plan must still produce the correct result (all 1000 rows match
+    // `ts >= min(ts)`).
+    for query in [&q_right, &q_left] {
+        let blocks = fixture
+            .execute_query(query)
+            .await?
+            .try_collect::<Vec<DataBlock>>()
+            .await?;
+        let block = DataBlock::concat(&blocks).expect("concat result blocks");
+        assert_eq!(block.num_rows(), 1);
+        let count = match block.get_by_offset(0).index(0) {
+            Some(ScalarRef::Number(NumberScalar::UInt64(v))) => v,
+            other => panic!("unexpected count scalar: {other:?}"),
+        };
+        assert_eq!(count, 1000, "query: {query}");
+    }
+
+    Ok(())
+}
+
 fn extract_two_u64(blocks: Vec<DataBlock>) -> (u64, u64) {
     let block = DataBlock::concat(&blocks).expect("concat blocks");
     assert_eq!(block.num_rows(), 1, "unexpected rows: {}", block.num_rows());

--- a/src/query/service/tests/it/sql/exec/range_join.rs
+++ b/src/query/service/tests/it/sql/exec/range_join.rs
@@ -101,6 +101,30 @@ async fn test_inequality_join_with_scalar_side_avoids_range_join() -> anyhow::Re
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_scalar_subquery_guard_with_one_row_outer() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup().await?;
+    fixture.create_default_database().await?;
+
+    let result = fixture
+        .execute_query("SELECT 1 WHERE (SELECT number FROM numbers(2)) >= 0")
+        .await;
+    let err = match result {
+        Ok(stream) => stream
+            .try_collect::<Vec<DataBlock>>()
+            .await
+            .expect_err("multi-row scalar subquery should fail"),
+        Err(err) => err,
+    };
+    assert!(
+        err.message()
+            .contains("Scalar subquery can't return more than one row"),
+        "unexpected error: {err:?}"
+    );
+
+    Ok(())
+}
+
 fn extract_two_u64(blocks: Vec<DataBlock>) -> (u64, u64) {
     let block = DataBlock::concat(&blocks).expect("concat blocks");
     assert_eq!(block.num_rows(), 1, "unexpected rows: {}", block.num_rows());

--- a/src/query/service/tests/it/sql/exec/range_join.rs
+++ b/src/query/service/tests/it/sql/exec/range_join.rs
@@ -35,6 +35,15 @@ async fn explain_text(fixture: &TestFixture, query: &str) -> anyhow::Result<Stri
     Ok(lines.join("\n"))
 }
 
+fn extract_one_u64(blocks: Vec<DataBlock>) -> u64 {
+    let block = DataBlock::concat(&blocks).expect("concat result blocks");
+    assert_eq!(block.num_rows(), 1);
+    match block.get_by_offset(0).index(0) {
+        Some(ScalarRef::Number(NumberScalar::UInt64(v))) => v,
+        other => panic!("unexpected count scalar: {other:?}"),
+    }
+}
+
 /// A single-row side of an inequality join (here a scalar/no-group-by aggregate, whose
 /// `precise_cardinality` is deterministically 1) must never end up driving a merge
 /// RANGE JOIN. The merge algorithm assumes the build side is the larger one and, for
@@ -89,14 +98,46 @@ async fn test_inequality_join_with_scalar_side_avoids_range_join() -> anyhow::Re
             .await?
             .try_collect::<Vec<DataBlock>>()
             .await?;
-        let block = DataBlock::concat(&blocks).expect("concat result blocks");
-        assert_eq!(block.num_rows(), 1);
-        let count = match block.get_by_offset(0).index(0) {
-            Some(ScalarRef::Number(NumberScalar::UInt64(v))) => v,
-            other => panic!("unexpected count scalar: {other:?}"),
-        };
-        assert_eq!(count, 1000, "query: {query}");
+        assert_eq!(extract_one_u64(blocks), 1000, "query: {query}");
     }
+
+    Ok(())
+}
+
+/// Force the exact CROSS JOIN + FILTER shape that used to report a false scalar-subquery
+/// cardinality violation. The pushed-down expression is true for all four rows, but its
+/// estimated selectivity places the four-row table on the build side and the exact-one-row
+/// scalar aggregate on the probe side. The hash join must apply the inequality filter without
+/// treating the four cross-product candidates as four scalar-subquery rows.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_scalar_aggregate_probe_cross_join_filter() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup().await?;
+    fixture.create_default_database().await?;
+    let db = fixture.default_db_name();
+
+    fixture
+        .execute_command(&format!(
+            "CREATE TABLE {db}.four_rows(ts INT) AS SELECT number FROM numbers(4)"
+        ))
+        .await?;
+
+    let query = format!(
+        "SELECT count(*) \
+         FROM (SELECT ts FROM {db}.four_rows WHERE length(to_string(ts)) > 0) b \
+         WHERE b.ts >= (SELECT min(number) FROM numbers(1))"
+    );
+
+    let plan = explain_text(&fixture, &query).await?;
+    assert!(plan.contains("HashJoin"), "plan was:\n{plan}");
+    assert!(plan.contains("TableScan(Build)"), "plan was:\n{plan}");
+    assert!(plan.contains("AggregateFinal(Probe)"), "plan was:\n{plan}");
+
+    let blocks = fixture
+        .execute_query(&query)
+        .await?
+        .try_collect::<Vec<DataBlock>>()
+        .await?;
+    assert_eq!(extract_one_u64(blocks), 4);
 
     Ok(())
 }

--- a/src/query/service/tests/it/sql/exec/range_join.rs
+++ b/src/query/service/tests/it/sql/exec/range_join.rs
@@ -142,30 +142,6 @@ async fn test_scalar_aggregate_probe_cross_join_filter() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_scalar_subquery_guard_with_one_row_outer() -> anyhow::Result<()> {
-    let fixture = TestFixture::setup().await?;
-    fixture.create_default_database().await?;
-
-    let result = fixture
-        .execute_query("SELECT 1 WHERE (SELECT number FROM numbers(2)) >= 0")
-        .await;
-    let err = match result {
-        Ok(stream) => stream
-            .try_collect::<Vec<DataBlock>>()
-            .await
-            .expect_err("multi-row scalar subquery should fail"),
-        Err(err) => err,
-    };
-    assert!(
-        err.message()
-            .contains("Scalar subquery can't return more than one row"),
-        "unexpected error: {err:?}"
-    );
-
-    Ok(())
-}
-
 fn extract_two_u64(blocks: Vec<DataBlock>) -> (u64, u64) {
     let block = DataBlock::concat(&blocks).expect("concat blocks");
     assert_eq!(block.num_rows(), 1, "unexpected rows: {}", block.num_rows());

--- a/src/query/service/tests/it/sql/exec/range_join.rs
+++ b/src/query/service/tests/it/sql/exec/range_join.rs
@@ -44,14 +44,9 @@ fn extract_one_u64(blocks: Vec<DataBlock>) -> u64 {
     }
 }
 
-/// A single-row side of an inequality join (here a scalar/no-group-by aggregate, whose
-/// `precise_cardinality` is deterministically 1) must never end up driving a merge
-/// RANGE JOIN. The merge algorithm assumes the build side is the larger one and, for
-/// every driving-side row, materializes the whole matching span of the other side; when
-/// `RuleCommuteJoin` swaps children based on a corrupted cardinality estimate, a large
-/// table can land on the driving side against a single-row build side and blow up memory
-/// into a per-row cartesian product. The planner must instead pick CROSS JOIN + FILTER
-/// (a hash join) regardless of which side the single-row relation is placed on.
+/// An inequality join with a precise-one-row aggregate side should use CROSS JOIN + FILTER
+/// instead of RangeJoin. Exercise both equivalent predicate operand orders and verify the
+/// selected physical operator and query result.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_inequality_join_with_scalar_side_avoids_range_join() -> anyhow::Result<()> {
     let fixture = TestFixture::setup().await?;
@@ -74,9 +69,7 @@ async fn test_inequality_join_with_scalar_side_avoids_range_join() -> anyhow::Re
         "SELECT count(*) FROM {db}.big b \
          WHERE b.ts >= (SELECT min(ts) FROM {db}.threshold)"
     );
-    // Scalar subquery on the left side of the inequality (operands flipped). The optimizer
-    // may commute children so the single-row aggregate becomes the driving side; the guard
-    // must still avoid a merge range join.
+    // Equivalent predicate with the scalar subquery written on the left.
     let q_left = format!(
         "SELECT count(*) FROM {db}.big b \
          WHERE (SELECT min(ts) FROM {db}.threshold) <= b.ts"
@@ -90,8 +83,7 @@ async fn test_inequality_join_with_scalar_side_avoids_range_join() -> anyhow::Re
         );
     }
 
-    // And the rewritten plan must still produce the correct result (all 1000 rows match
-    // `ts >= min(ts)`).
+    // Both forms must produce the correct result: all 1000 rows match `ts >= min(ts)`.
     for query in [&q_right, &q_left] {
         let blocks = fixture
             .execute_query(query)
@@ -107,8 +99,8 @@ async fn test_inequality_join_with_scalar_side_avoids_range_join() -> anyhow::Re
 /// Force the exact CROSS JOIN + FILTER shape that used to report a false scalar-subquery
 /// cardinality violation. The pushed-down expression is true for all four rows, but its
 /// estimated selectivity places the four-row table on the build side and the exact-one-row
-/// scalar aggregate on the probe side. The hash join must apply the inequality filter without
-/// treating the four cross-product candidates as four scalar-subquery rows.
+/// scalar aggregate on the probe side. The CROSS JOIN + FILTER execution must not treat the
+/// four cross-product candidates as four scalar-subquery rows.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_scalar_aggregate_probe_cross_join_filter() -> anyhow::Result<()> {
     let fixture = TestFixture::setup().await?;

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_commute_join.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_commute_join.rs
@@ -113,6 +113,7 @@ impl Rule for RuleCommuteJoin {
                     (condition.right.clone(), condition.left.clone());
             }
             join.join_type = join.join_type.opposite();
+            join.single_to_inner = join.single_to_inner.map(|join_type| join_type.opposite());
             let mut result = SExpr::create_binary(
                 Arc::new(join.into()),
                 Arc::new(right_child.clone()),

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_commute_join_base_table.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_commute_join_base_table.rs
@@ -94,6 +94,7 @@ impl Rule for RuleCommuteJoinBaseTable {
                         (condition.right.clone(), condition.left.clone());
                 }
                 join.join_type = join.join_type.opposite();
+                join.single_to_inner = join.single_to_inner.map(|join_type| join_type.opposite());
                 let mut result = SExpr::create_binary(
                     Arc::new(join.into()),
                     Arc::new(right_child.clone()),

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_left_exchange_join.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_left_exchange_join.rs
@@ -102,6 +102,10 @@ impl Rule for RuleLeftExchangeJoin {
         let t2 = s_expr.child(0)?.child(1)?;
         let t3 = s_expr.child(1)?;
 
+        if join1.single_to_inner.is_some() || join2.single_to_inner.is_some() {
+            return Ok(());
+        }
+
         // Ensure inner joins or cross joins.
         if !matches!(join1.join_type, JoinType::Inner | JoinType::Cross)
             || !matches!(join2.join_type, JoinType::Inner | JoinType::Cross)

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_left_exchange_join.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_left_exchange_join.rs
@@ -102,6 +102,8 @@ impl Rule for RuleLeftExchangeJoin {
         let t2 = s_expr.child(0)?.child(1)?;
         let t3 = s_expr.child(1)?;
 
+        // Reassociation does not preserve the scalar-cardinality semantics encoded by
+        // single_to_inner, so do not exchange either marked join.
         if join1.single_to_inner.is_some() || join2.single_to_inner.is_some() {
             return Ok(());
         }

--- a/tests/sqllogictests/suites/mode/standalone/explain/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join.test
@@ -1027,6 +1027,34 @@ HashJoin
     └── estimated rows: 4.00
 
 query T
+EXPLAIN SELECT * FROM (SELECT MAX(a) AS a FROM t2) AS s, t1 WHERE s.a <= t1.a AND t1.a > 100;
+----
+HashJoin
+├── output columns: [MAX(a) (#1), t1.a (#2)]
+├── join type: INNER
+├── build keys: []
+├── probe keys: []
+├── keys is null equal: []
+├── filters: [s.a (#1) <= t1.a (#2)]
+├── estimated rows: 0.00
+├── TableScan(Build)
+│   ├── table: default.default.t1
+│   ├── scan id: 1
+│   ├── output columns: [a (#2)]
+│   ├── read rows: 0
+│   ├── read size: 0
+│   ├── partitions total: 1
+│   ├── partitions scanned: 0
+│   ├── pruning stats: [segments: <range pruning: 1 to 0 cost: <slt:ignore>>]
+│   ├── push downs: [filters: [is_true(t1.a (#2) > 100)], limit: NONE]
+│   └── estimated rows: 0.00
+└── EvalScalar(Probe)
+    ├── output columns: [MAX(a) (#1)]
+    ├── expressions: [1]
+    ├── estimated rows: 1.00
+    └── DummyTableScan
+
+query T
 EXPLAIN SELECT * FROM t1 JOIN t3 ON t1.a = t3.a;
 ----
 HashJoin

--- a/tests/sqllogictests/suites/mode/standalone/explain/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join.test
@@ -1047,7 +1047,7 @@ HashJoin
 │   ├── read size: 0
 │   ├── partitions total: 1
 │   ├── partitions scanned: 0
-│   ├── pruning stats: [segments: <range pruning: 1 to 0 cost: <slt:ignore>>]
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t1.a (#2) > 100)], limit: NONE]
 │   └── estimated rows: 0.00
 └── EvalScalar(Probe)

--- a/tests/sqllogictests/suites/mode/standalone/explain/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join.test
@@ -1026,6 +1026,8 @@ HashJoin
     ├── push downs: [filters: [], limit: NONE]
     └── estimated rows: 4.00
 
+# The filter estimates the table side at zero rows, so join commutation places the
+# precise-one-row aggregate on Probe. Keep this no-equi join on HashJoin, not RangeJoin.
 query T
 EXPLAIN SELECT * FROM (SELECT MAX(a) AS a FROM t2) AS s, t1 WHERE s.a <= t1.a AND t1.a > 100;
 ----

--- a/tests/sqllogictests/suites/query/subquery.test
+++ b/tests/sqllogictests/suites/query/subquery.test
@@ -890,6 +890,9 @@ insert into t1 values(1), (2), (3);
 query error 1001.*Scalar subquery can't return more than one row
 select (select sum(a) from t1 where t1.a >= t2.a group by t1.a) from t1 as t2;
 
+query error 1001.*Scalar subquery can't return more than one row
+SELECT 1 WHERE (SELECT number FROM numbers(2)) >= 0;
+
 
 
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR reapplies #20062 together with its follow-up #20073 on the latest `main`.

#20062 avoided merge range joins when either input has a precise or estimated cardinality of one. It was reverted by #20068 because the HashJoin fallback exposed a scalar-subquery guard bug before #20073 could be merged: an inequality-only join executed through the HashJoin fallback runs as CROSS JOIN + FILTER, but the runtime single-join check counted cross-product candidates before the filter and could report a false positive such as:

```text
Scalar subquery can't return more than one row, but got 65536
```

The combined change:

- uses CROSS JOIN + FILTER instead of RangeJoin when either input has a precise or estimated cardinality of one;
- clears `single_to_inner` only for a no-equi HashJoin whose actual scalar side has precise cardinality 1;
- keeps the `single_to_inner` direction in sync when joins are commuted;
- prevents left-exchange rewrites from losing single-join semantics.

This preserves the scalar guard for multi-row scalar subqueries while avoiding false positives for scalar aggregates that are guaranteed to return one row.

Related: #20062, #20068, #20073.

## Regression coverage

Added a direct execution regression that forces the affected physical shape:

```text
HashJoin (no equi keys)
├── TableScan(Build): four actual rows, estimated at 0.80
└── AggregateFinal(Probe): exact one-row scalar aggregate
```

With #20062 alone, the query fails with:

```text
Scalar subquery can't return more than one row, but got 4
```

With this combined fix, it succeeds and returns `4`. The test also asserts the physical Build/Probe placement so it cannot pass without exercising the affected path.

A separate safety regression verifies that a scalar subquery that actually returns multiple rows still raises error 1001.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validated with:

```shell
cargo fmt --all -- --check
cargo test -p databend-query --test it sql::exec::range_join -- --nocapture
cargo clippy -p databend-query --lib --no-deps -- -D warnings
```

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20155)
<!-- Reviewable:end -->