### PR TITLE
fix(query): make synchronous spill processors interruptible

### DIFF
--- a/src/common/base/src/runtime/runtime_tracker.rs
+++ b/src/common/base/src/runtime/runtime_tracker.rs
@@ -46,6 +46,7 @@ use std::cell::RefCell;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
@@ -147,6 +148,7 @@ pub struct TrackingPayload {
     pub time_series_profile: Option<Arc<QueryTimeSeriesProfile>>,
     pub local_time_series_profile: Option<Arc<TimeSeriesProfiles>>,
     pub workload_group_resource: Option<Arc<WorkloadGroupResource>>,
+    pub processor_interrupt: Option<Arc<AtomicBool>>,
     pub perf_enabled: bool,
     pub process_rows: AtomicUsize,
 }
@@ -324,6 +326,7 @@ impl Clone for TrackingPayload {
             time_series_profile: self.time_series_profile.clone(),
             local_time_series_profile: self.local_time_series_profile.clone(),
             workload_group_resource: self.workload_group_resource.clone(),
+            processor_interrupt: self.processor_interrupt.clone(),
             perf_enabled: self.perf_enabled,
             process_rows: AtomicUsize::new(
                 self.process_rows.load(std::sync::atomic::Ordering::SeqCst),
@@ -410,6 +413,7 @@ impl ThreadTracker {
                 time_series_profile: None,
                 local_time_series_profile: None,
                 workload_group_resource: None,
+                processor_interrupt: None,
                 perf_enabled: false,
                 process_rows: AtomicUsize::new(0),
             }),
@@ -482,6 +486,19 @@ impl ThreadTracker {
 
     pub fn new_tracking_payload() -> TrackingPayload {
         TRACKER.with(|x| x.borrow().payload.as_ref().clone())
+    }
+
+    pub fn is_interrupted() -> bool {
+        TRACKER
+            .try_with(|tracker| {
+                tracker
+                    .borrow()
+                    .payload
+                    .processor_interrupt
+                    .as_ref()
+                    .is_some_and(|interrupt| interrupt.load(Ordering::Acquire))
+            })
+            .unwrap_or(false)
     }
 
     /// Replace the `out_of_limit_desc` with the current thread's.

--- a/src/query/pipeline/src/core/mod.rs
+++ b/src/query/pipeline/src/core/mod.rs
@@ -49,6 +49,7 @@ pub use processor::Event;
 pub use processor::EventCause;
 pub use processor::Processor;
 pub use processor::ProcessorPtr;
+pub use processor::check_interrupt;
 pub use profile::PlanProfile;
 pub use profile::PlanScope;
 pub use sync_task::SyncTaskHandle;

--- a/src/query/pipeline/src/core/processor.rs
+++ b/src/query/pipeline/src/core/processor.rs
@@ -20,6 +20,7 @@ use std::cell::UnsafeCell;
 use std::ops::Deref;
 use std::sync::Arc;
 
+use databend_common_base::runtime::ThreadTracker;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use fastrace::prelude::*;
@@ -27,6 +28,17 @@ use futures::FutureExt;
 use futures::future::BoxFuture;
 use petgraph::graph::node_index;
 use petgraph::prelude::NodeIndex;
+
+/// Checks whether the currently executing processor has been interrupted.
+///
+/// The executor installs the processor's tracking payload while polling or processing it. Calls
+/// made outside processor execution are treated as not interrupted.
+pub fn check_interrupt() -> Result<()> {
+    if ThreadTracker::is_interrupted() {
+        return Err(ErrorCode::aborting());
+    }
+    Ok(())
+}
 
 #[derive(Debug)]
 pub enum Event {
@@ -68,9 +80,6 @@ pub trait Processor: Send {
     fn un_reacted(&self, _cause: EventCause, _id: usize) -> Result<()> {
         Ok(())
     }
-
-    // When the synchronization task needs to run for a long time, the interrupt function needs to be implemented.
-    fn interrupt(&self) {}
 
     // Synchronous work.
     fn process(&mut self) -> Result<()> {
@@ -164,11 +173,6 @@ impl ProcessorPtr {
     /// # Safety
     pub unsafe fn un_reacted(&self, cause: EventCause) -> Result<()> {
         unsafe { (*self.inner.get()).un_reacted(cause, self.id().index()) }
-    }
-
-    /// # Safety
-    pub unsafe fn interrupt(&self) {
-        unsafe { (*self.inner.get()).interrupt() }
     }
 
     /// # Safety

--- a/src/query/pipeline/src/sinks/sync_sink.rs
+++ b/src/query/pipeline/src/sinks/sync_sink.rs
@@ -34,8 +34,6 @@ pub trait Sink: Send {
         Ok(())
     }
 
-    fn interrupt(&self) {}
-
     fn consume(&mut self, data_block: DataBlock) -> Result<()>;
 }
 
@@ -111,10 +109,6 @@ impl<T: Sink + 'static> Processor for Sinker<T> {
                 Ok(Event::NeedData)
             }
         }
-    }
-
-    fn interrupt(&self) {
-        self.inner.interrupt()
     }
 
     fn process(&mut self) -> Result<()> {

--- a/src/query/pipeline/transforms/src/processors/transforms/sorts/sort_collect.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sorts/sort_collect.rs
@@ -14,8 +14,6 @@
 
 use std::any::Any;
 use std::sync::Arc;
-use std::sync::atomic;
-use std::sync::atomic::AtomicBool;
 
 use bytesize::ByteSize;
 use databend_common_exception::Result;
@@ -57,8 +55,6 @@ pub struct TransformSortCollect<A: SortAlgorithm, S: SortSpiller> {
     base: Base<S>,
     inner: Inner<A, S>,
 
-    aborting: AtomicBool,
-
     enable_restore_prefetch: bool,
     enable_sort_spill_stream_regroup: bool,
 }
@@ -94,7 +90,6 @@ where
             order_col_converter,
             base,
             inner,
-            aborting: AtomicBool::new(false),
             max_block_size,
             default_num_merge,
             enable_restore_prefetch,
@@ -333,7 +328,7 @@ where
             let total_rows = spill_sort.collect_total_rows();
             log::debug!(incoming_block, incoming_rows = incoming, total_rows, finished; "sort_input_data");
             spill_sort
-                .sort_input_data(std::mem::take(input_data), !finished, &self.aborting)
+                .sort_input_data(std::mem::take(input_data), !finished)
                 .await?;
         }
         if finished {
@@ -341,9 +336,5 @@ where
         } else {
             Ok(())
         }
-    }
-
-    fn interrupt(&self) {
-        self.aborting.store(true, atomic::Ordering::Release);
     }
 }

--- a/src/query/pipeline/transforms/src/processors/transforms/sorts/sort_local_merge.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sorts/sort_local_merge.rs
@@ -16,8 +16,6 @@ use std::any::Any;
 use std::collections::VecDeque;
 use std::hint::unlikely;
 use std::sync::Arc;
-use std::sync::atomic;
-use std::sync::atomic::AtomicBool;
 
 use bytesize::ByteSize;
 use databend_common_exception::Result;
@@ -79,8 +77,6 @@ pub struct TransformSort<A: SortAlgorithm, S: SortSpiller> {
     base: Base<S>,
     inner: Inner<A, S>,
 
-    aborting: AtomicBool,
-
     max_block_size: usize,
     enable_restore_prefetch: bool,
     enable_sort_spill_stream_regroup: bool,
@@ -131,7 +127,6 @@ where
             },
             inner,
             max_block_size,
-            aborting: AtomicBool::new(false),
             enable_restore_prefetch,
             enable_sort_spill_stream_regroup,
         })
@@ -417,7 +412,7 @@ where
                     let total_rows = spill_sort.collect_total_rows();
                     log::debug!(incoming_block, incoming_rows = incoming, total_rows, finished; "sort_input_data");
                     spill_sort
-                        .sort_input_data(std::mem::take(input_data), !finished, &self.aborting)
+                        .sort_input_data(std::mem::take(input_data), !finished)
                         .await?;
                 }
                 if finished {
@@ -441,9 +436,5 @@ where
             }
             _ => unreachable!(),
         }
-    }
-
-    fn interrupt(&self) {
-        self.aborting.store(true, atomic::Ordering::Release);
     }
 }

--- a/src/query/pipeline/transforms/src/processors/transforms/sorts/sort_merge.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sorts/sort_merge.rs
@@ -15,16 +15,14 @@
 use std::hint::unlikely;
 use std::marker::PhantomData;
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering;
 
 use bytesize::ByteSize;
-use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
 use databend_common_expression::DataSchemaRef;
 use databend_common_expression::SortColumnDescription;
+use databend_common_pipeline::core::check_interrupt;
 
 use super::core::Merger;
 use super::core::RowConverter;
@@ -47,8 +45,6 @@ pub struct TransformSortMerge<R: Rows> {
     block_size: usize,
     buffer: Vec<Option<(DataBlock, Column)>>,
 
-    aborting: Arc<AtomicBool>,
-
     /// Record current memory usage.
     num_bytes: ByteSize,
     num_rows: usize,
@@ -63,7 +59,6 @@ impl<R: Rows> TransformSortMerge<R> {
             limit,
             block_size,
             buffer: vec![],
-            aborting: Arc::new(AtomicBool::new(false)),
             num_bytes: ByteSize(0),
             num_rows: 0,
             _r: PhantomData,
@@ -75,10 +70,7 @@ impl<R: Rows> MergeSort<R> for TransformSortMerge<R> {
     const NAME: &'static str = "TransformSortMerge";
 
     fn add_block(&mut self, block: DataBlock, init_rows: R) -> Result<()> {
-        if unlikely(self.aborting.load(Ordering::Relaxed)) {
-            return Err(ErrorCode::aborting());
-        }
-
+        check_interrupt()?;
         if unlikely(block.is_empty()) {
             return Ok(());
         }
@@ -96,10 +88,6 @@ impl<R: Rows> MergeSort<R> for TransformSortMerge<R> {
         } else {
             self.merge_sort(self.block_size)
         }
-    }
-
-    fn interrupt(&self) {
-        self.aborting.store(true, Ordering::Release);
     }
 
     #[inline(always)]
@@ -167,9 +155,7 @@ impl<R: Rows> TransformSortMerge<R> {
         let mut merger = Merger::<A, _>::new(streams, batch_size, self.limit);
 
         while let Some(block) = merger.next_block()? {
-            if unlikely(self.aborting.load(Ordering::Relaxed)) {
-                return Err(ErrorCode::aborting());
-            }
+            check_interrupt()?;
             result.push(block);
         }
 

--- a/src/query/pipeline/transforms/src/processors/transforms/sorts/sort_merge_base.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sorts/sort_merge_base.rs
@@ -83,6 +83,4 @@ pub trait MergeSort<R: Rows> {
     ///
     /// If `all_in_one_block`, the return value is a single block.
     fn on_finish(&mut self, all_in_one_block: bool) -> Result<Vec<DataBlock>>;
-
-    fn interrupt(&self) {}
 }

--- a/src/query/pipeline/transforms/src/processors/transforms/sorts/sort_spill.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sorts/sort_spill.rs
@@ -17,11 +17,8 @@ use std::collections::VecDeque;
 use std::fmt;
 use std::fmt::Debug;
 use std::fmt::Formatter;
-use std::hint::unlikely;
 use std::marker::PhantomData;
 use std::mem;
-use std::sync::atomic;
-use std::sync::atomic::AtomicBool;
 
 use databend_common_base::runtime::JoinHandle;
 use databend_common_base::runtime::spawn;
@@ -33,6 +30,7 @@ use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
 use databend_common_expression::Scalar;
 use databend_common_expression::sampler::FixedRateSampler;
+use databend_common_pipeline::core::check_interrupt;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 
@@ -136,13 +134,12 @@ where
         &mut self,
         input_data: Vec<DataBlock>,
         need_spill: bool,
-        aborting: &AtomicBool,
     ) -> Result<()> {
         let Step::Collect(collect) = &mut self.step else {
             unreachable!()
         };
         collect
-            .sort_input_data(&self.base, input_data, need_spill, aborting)
+            .sort_input_data(&self.base, input_data, need_spill)
             .await
     }
 
@@ -247,7 +244,6 @@ impl<A: SortAlgorithm, S: SortSpiller> StepCollect<A, S> {
         base: &Base<S>,
         mut input_data: Vec<DataBlock>,
         need_spill: bool,
-        aborting: &AtomicBool,
     ) -> Result<()> {
         let batch_rows = self.params.batch_rows;
 
@@ -269,9 +265,7 @@ impl<A: SortAlgorithm, S: SortSpiller> StepCollect<A, S> {
 
             let mut sorted = VecDeque::new();
             while let Some(data) = merger.next_block()? {
-                if unlikely(aborting.load(atomic::Ordering::Relaxed)) {
-                    return Err(ErrorCode::aborting());
-                }
+                check_interrupt()?;
 
                 let mut block = base.new_block(data);
                 if need_spill {

--- a/src/query/pipeline/transforms/src/processors/transforms/transform.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform.rs
@@ -181,8 +181,6 @@ pub trait BlockMetaTransform<B: BlockMetaInfo>: Send + 'static {
     fn on_finish(&mut self) -> Result<()> {
         Ok(())
     }
-
-    fn interrupt(&self) {}
 }
 
 pub struct BlockMetaTransformer<B: BlockMetaInfo, T: BlockMetaTransform<B>> {
@@ -316,9 +314,5 @@ impl<B: BlockMetaInfo, T: BlockMetaTransform<B>> Processor for BlockMetaTransfor
         }
 
         Ok(())
-    }
-
-    fn interrupt(&self) {
-        self.transform.interrupt();
     }
 }

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_accumulating.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_accumulating.rs
@@ -35,8 +35,6 @@ pub trait AccumulatingTransform: Send {
     fn on_finish(&mut self, _output: bool) -> Result<Vec<DataBlock>> {
         Ok(vec![])
     }
-
-    fn interrupt(&self) {}
 }
 
 pub struct AccumulatingTransformer<T: AccumulatingTransform + 'static> {
@@ -138,10 +136,6 @@ impl<T: AccumulatingTransform + 'static> Processor for AccumulatingTransformer<T
         }
 
         Ok(())
-    }
-
-    fn interrupt(&self) {
-        self.inner.interrupt();
     }
 }
 

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_compact_block.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_compact_block.rs
@@ -14,16 +14,13 @@
 
 use std::fmt::Debug;
 use std::fmt::Formatter;
-use std::hint::unlikely;
-use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering;
 
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::BlockMetaInfo;
 use databend_common_expression::DataBlock;
 use databend_common_expression::local_block_meta_serde;
+use databend_common_pipeline::core::check_interrupt;
 
 use crate::processors::BlockMetaTransform;
 use crate::processors::UnknownMode;
@@ -49,9 +46,7 @@ local_block_meta_serde!(BlockCompactMeta);
 impl BlockMetaInfo for BlockCompactMeta {}
 
 #[derive(Default)]
-pub struct TransformCompactBlock {
-    aborting: Arc<AtomicBool>,
-}
+pub struct TransformCompactBlock;
 
 #[async_trait::async_trait]
 impl BlockMetaTransform<BlockCompactMeta> for TransformCompactBlock {
@@ -59,19 +54,12 @@ impl BlockMetaTransform<BlockCompactMeta> for TransformCompactBlock {
     const NAME: &'static str = "TransformCompactBlock";
 
     fn transform(&mut self, meta: BlockCompactMeta) -> Result<Vec<DataBlock>> {
-        if unlikely(self.aborting.load(Ordering::Relaxed)) {
-            return Err(ErrorCode::aborting());
-        }
-
+        check_interrupt()?;
         match meta {
             BlockCompactMeta::Concat(blocks) => Ok(vec![DataBlock::concat(&blocks)?]),
             BlockCompactMeta::Split { blocks, block_num } => Self::split_blocks(blocks, block_num),
             BlockCompactMeta::NoChange(blocks) => Ok(blocks),
         }
-    }
-
-    fn interrupt(&self) {
-        self.aborting.store(true, Ordering::Release);
     }
 }
 

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_compact_builder.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_compact_builder.rs
@@ -30,7 +30,7 @@ pub fn build_compact_block_pipeline(
     pipeline.try_resize(1)?;
     pipeline.add_accumulating_transformer(|| BlockCompactBuilder::new(thresholds));
     pipeline.try_resize(output_len)?;
-    pipeline.add_block_meta_transformer(TransformCompactBlock::default);
+    pipeline.add_block_meta_transformer(|| TransformCompactBlock);
     Ok(())
 }
 

--- a/src/query/pipeline/transforms/src/processors/transforms/transform_ordered_compact_builder.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/transform_ordered_compact_builder.rs
@@ -33,7 +33,7 @@ pub fn build_ordered_compact_pipeline(
         OrderedBlockCompactBuilder::new(thresholds, extra_key_num)
     });
     pipeline.try_resize(max_threads)?;
-    pipeline.add_block_meta_transformer(TransformCompactBlock::default);
+    pipeline.add_block_meta_transformer(|| TransformCompactBlock);
     Ok(())
 }
 
@@ -208,7 +208,7 @@ mod tests {
         let output = builder.on_finish(true)?;
         let meta_block = output.into_iter().next().unwrap();
         let meta = BlockCompactMeta::downcast_from(meta_block.get_owned_meta().unwrap()).unwrap();
-        let output = TransformCompactBlock::default().transform(meta)?;
+        let output = TransformCompactBlock.transform(meta)?;
 
         assert_eq!(output.len(), 1);
         assert_eq!(output[0].num_rows(), 20);
@@ -230,7 +230,7 @@ mod tests {
 
         let meta_block = OrderedBlockCompactBuilder::create_output_data(&mut group, thresholds);
         let meta = BlockCompactMeta::downcast_from(meta_block.get_owned_meta().unwrap()).unwrap();
-        let output = TransformCompactBlock::default().transform(meta)?;
+        let output = TransformCompactBlock.transform(meta)?;
 
         assert_eq!(output.len(), 1);
         assert_eq!(output[0].num_rows(), 1600);
@@ -250,7 +250,7 @@ mod tests {
 
         let meta_block = OrderedBlockCompactBuilder::create_output_data(&mut group, thresholds);
         let meta = BlockCompactMeta::downcast_from(meta_block.get_owned_meta().unwrap()).unwrap();
-        let output = TransformCompactBlock::default().transform(meta)?;
+        let output = TransformCompactBlock.transform(meta)?;
 
         assert_eq!(output.len(), 2);
         assert_eq!(output[0].num_rows(), 1001);
@@ -276,7 +276,7 @@ mod tests {
 
         let meta_block = OrderedBlockCompactBuilder::create_output_data(&mut group, thresholds);
         let meta = BlockCompactMeta::downcast_from(meta_block.get_owned_meta().unwrap()).unwrap();
-        let output = TransformCompactBlock::default().transform(meta)?;
+        let output = TransformCompactBlock.transform(meta)?;
 
         assert_eq!(
             output.iter().map(DataBlock::num_rows).collect::<Vec<_>>(),
@@ -303,7 +303,7 @@ mod tests {
 
         let meta_block = OrderedBlockCompactBuilder::create_output_data(&mut group, thresholds);
         let meta = BlockCompactMeta::downcast_from(meta_block.get_owned_meta().unwrap()).unwrap();
-        let output = TransformCompactBlock::default().transform(meta)?;
+        let output = TransformCompactBlock.transform(meta)?;
 
         assert!(output.len() <= block_num);
         assert!(output.iter().all(|block| block.num_rows() > 1));

--- a/src/query/service/src/pipelines/builders/builder_mutation.rs
+++ b/src/query/service/src/pipelines/builders/builder_mutation.rs
@@ -251,7 +251,7 @@ impl PipelineBuilder {
                 Ok(ProcessorPtr::create(BlockMetaTransformer::create(
                     transform_input_port,
                     transform_output_port,
-                    TransformCompactBlock::default(),
+                    TransformCompactBlock,
                 )))
             },
             transform_len,

--- a/src/query/service/src/pipelines/builders/transform_builder.rs
+++ b/src/query/service/src/pipelines/builders/transform_builder.rs
@@ -110,7 +110,7 @@ impl PipelineBuilder {
             Ok(ProcessorPtr::create(BlockMetaTransformer::create(
                 transform_input_port,
                 transform_output_port,
-                TransformCompactBlock::default(),
+                TransformCompactBlock,
             )))
         })
     }

--- a/src/query/service/src/pipelines/executor/executor_graph.rs
+++ b/src/query/service/src/pipelines/executor/executor_graph.rs
@@ -141,6 +141,7 @@ impl Node {
         outputs_port: &[Arc<OutputPort>],
         time_series_profile: Option<Arc<TimeSeriesProfiles>>,
         plan_mem_stat: Option<Arc<MemStat>>,
+        processor_interrupt: Arc<AtomicBool>,
     ) -> Arc<Node> {
         let p_name = unsafe { processor.name() };
         let tracking_payload = {
@@ -172,6 +173,7 @@ impl Node {
             if let Some(plan_mem_stat) = plan_mem_stat {
                 tracking_payload.mem_stat = Some(plan_mem_stat);
             }
+            tracking_payload.processor_interrupt = Some(processor_interrupt);
 
             tracking_payload
         };
@@ -222,7 +224,7 @@ struct ExecutingGraph {
     points: AtomicU64,
     max_points: AtomicU64,
     query_id: Arc<String>,
-    should_finish: AtomicBool,
+    should_finish: Arc<AtomicBool>,
     finished_notify: Arc<WatchNotify>,
     finish_condvar_notify: Option<Arc<(Mutex<bool>, Condvar)>>,
     finished_error: Mutex<Option<ErrorCode>>,
@@ -248,12 +250,14 @@ impl ExecutingGraph {
         let mut time_series_profile_builder =
             QueryTimeSeriesProfileBuilder::new(query_id.to_string());
         let mut plan_memory_stats = HashMap::new();
+        let should_finish = Arc::new(AtomicBool::new(false));
         Self::init_graph(
             &mut pipeline,
             &mut graph,
             &mut time_series_profile_builder,
             &mut plan_memory_stats,
             perf_enabled,
+            &should_finish,
         );
         let executor_stats = ExecutorStats::new();
         Ok(ExecutingGraph {
@@ -262,7 +266,7 @@ impl ExecutingGraph {
             points: AtomicU64::new((DEFAULT_POINTS << 32) | init_epoch as u64),
             max_points: AtomicU64::new(DEFAULT_POINTS),
             query_id,
-            should_finish: AtomicBool::new(false),
+            should_finish,
             finished_notify: Arc::new(WatchNotify::new()),
             finish_condvar_notify,
             finished_error: Mutex::new(None),
@@ -294,6 +298,7 @@ impl ExecutingGraph {
         let mut time_series_profile_builder =
             QueryTimeSeriesProfileBuilder::new(query_id.to_string());
         let mut plan_memory_stats = HashMap::new();
+        let should_finish = Arc::new(AtomicBool::new(false));
         for pipeline in &mut pipelines {
             Self::init_graph(
                 pipeline,
@@ -301,6 +306,7 @@ impl ExecutingGraph {
                 &mut time_series_profile_builder,
                 &mut plan_memory_stats,
                 perf_enabled,
+                &should_finish,
             );
         }
         let executor_stats = ExecutorStats::new();
@@ -310,7 +316,7 @@ impl ExecutingGraph {
             points: AtomicU64::new((DEFAULT_POINTS << 32) | init_epoch as u64),
             max_points: AtomicU64::new(DEFAULT_POINTS),
             query_id,
-            should_finish: AtomicBool::new(false),
+            should_finish,
             finished_notify: Arc::new(WatchNotify::new()),
             finish_condvar_notify,
             finished_error: Mutex::new(None),
@@ -326,6 +332,7 @@ impl ExecutingGraph {
         time_series_profile_builder: &mut QueryTimeSeriesProfileBuilder,
         plan_memory_stats: &mut HashMap<u32, Arc<MemStat>>,
         perf_enabled: bool,
+        interrupt: &Arc<AtomicBool>,
     ) {
         let offset = graph.node_count();
         for node in pipeline.graph.node_weights() {
@@ -363,6 +370,7 @@ impl ExecutingGraph {
                 &node.outputs,
                 time_series_profile,
                 plan_mem_stat,
+                interrupt.clone(),
             ));
 
             unsafe {
@@ -935,12 +943,8 @@ impl RunningGraph {
         NodePerfCounters { counters }
     }
 
-    pub fn interrupt_running_nodes(&self) {
-        unsafe {
-            for node_index in self.0.graph.node_indices() {
-                self.0.graph[node_index].processor.interrupt();
-            }
-        }
+    pub fn interrupt(&self) {
+        self.0.should_finish.store(true, Ordering::SeqCst);
     }
 
     pub fn assert_finished_graph(&self) -> Result<()> {
@@ -972,7 +976,7 @@ impl RunningGraph {
             log_memory_limit_diagnostics(cause, "memory limit exceeded");
         }
         self.0.finished_notify.notify_waiters();
-        self.interrupt_running_nodes();
+        self.interrupt();
         let mut finished_error = self.0.finished_error.lock();
         if finished_error.is_none() {
             *finished_error = cause.err();

--- a/src/query/service/src/pipelines/executor/query_pipeline_executor.rs
+++ b/src/query/service/src/pipelines/executor/query_pipeline_executor.rs
@@ -272,7 +272,7 @@ impl QueryPipelineExecutor {
 
         drop(finished_error);
         self.global_tasks_queue.finish(self.workers_condvar.clone());
-        self.graph.interrupt_running_nodes();
+        self.graph.interrupt();
         self.finished_notify.notify_waiters();
     }
 

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/row_shuffle_reader_transform.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/row_shuffle_reader_transform.rs
@@ -18,6 +18,7 @@ use databend_common_expression::DataBlock;
 use databend_common_pipeline::core::InputPort;
 use databend_common_pipeline::core::OutputPort;
 use databend_common_pipeline::core::Processor;
+use databend_common_pipeline::core::check_interrupt;
 use databend_common_pipeline_transforms::BlockMetaTransform;
 use databend_common_pipeline_transforms::BlockMetaTransformer;
 
@@ -57,7 +58,10 @@ impl BlockMetaTransform<AggregateMeta> for RowShuffleReaderTransform {
 
         let restored = payloads
             .into_iter()
-            .map(|payload| self.reader.restore(payload))
+            .map(|payload| {
+                check_interrupt()?;
+                self.reader.restore(payload)
+            })
             .collect::<Result<_, _>>()?;
         let meta = AggregateMeta::Partitioned {
             bucket: None,

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_final.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_final.rs
@@ -32,6 +32,7 @@ use databend_common_pipeline::core::Event;
 use databend_common_pipeline::core::InputPort;
 use databend_common_pipeline::core::OutputPort;
 use databend_common_pipeline::core::Processor;
+use databend_common_pipeline::core::check_interrupt;
 use databend_common_pipeline_transforms::MemorySettings;
 
 use crate::pipelines::memory_settings::MemorySettingsExt;
@@ -255,6 +256,7 @@ impl TransformFinalAggregate {
             }
             AggregateMeta::Spilled(payloads) => {
                 for payload in payloads {
+                    check_interrupt()?;
                     let restored = self.spiller.restore(payload)?;
                     self.handle_serialized(restored, need_check_spill)?;
                 }
@@ -267,22 +269,26 @@ impl TransformFinalAggregate {
                 PartitionedData::Empty => {}
                 PartitionedData::Serialized(payloads) => {
                     for payload in payloads {
+                        check_interrupt()?;
                         self.handle_serialized(payload, need_check_spill)?;
                     }
                 }
                 PartitionedData::AggregatePayload(payloads) => {
                     for payload in payloads {
+                        check_interrupt()?;
                         self.handle_aggregate_payload(payload, need_check_spill)?;
                     }
                 }
                 PartitionedData::BucketSpilled(payloads) => {
                     for payload in payloads {
+                        check_interrupt()?;
                         let restored = self.spiller.restore(payload)?;
                         self.handle_serialized(restored, need_check_spill)?;
                     }
                 }
                 PartitionedData::Mixed(items) => {
                     for item in items {
+                        check_interrupt()?;
                         self.handle_meta(AggregateMeta::from(item), need_check_spill)?;
                     }
                 }
@@ -295,6 +301,7 @@ impl TransformFinalAggregate {
         self.spilled_occurred = true;
         if let HashTable::AggregateHashTable(v) = mem::take(&mut self.hashtable) {
             for (bucket, payload) in v.payload.into_non_empty_bucket_payloads() {
+                check_interrupt()?;
                 let data_block = payload.aggregate_flush_all()?.consume_convert_to_full();
                 self.spiller.spill(bucket, data_block)?;
             }
@@ -341,6 +348,7 @@ impl TransformFinalAggregate {
             self.flush_state.clear();
 
             loop {
+                check_interrupt()?;
                 if ht.merge_result(&mut self.flush_state)? {
                     let mut entries = self.flush_state.take_aggregate_results();
                     let group_columns = self.flush_state.take_group_columns();

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_partial.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_partial.rs
@@ -29,6 +29,7 @@ use databend_common_expression::ProjectedBlock;
 use databend_common_pipeline::core::InputPort;
 use databend_common_pipeline::core::OutputPort;
 use databend_common_pipeline::core::Processor;
+use databend_common_pipeline::core::check_interrupt;
 use databend_common_pipeline_transforms::MemorySettings;
 use databend_common_pipeline_transforms::processors::AccumulatingTransform;
 use databend_common_pipeline_transforms::processors::AccumulatingTransformer;
@@ -83,12 +84,14 @@ impl Spiller {
                 .enumerate()
             {
                 for (_, payload) in p.into_non_empty_bucket_payloads() {
+                    check_interrupt()?;
                     let data_block = payload.aggregate_flush_all()?.consume_convert_to_full();
                     self.inner.spill(bucket, data_block)?;
                 }
             }
         } else {
             for (bucket, payload) in partition.into_non_empty_bucket_payloads() {
+                check_interrupt()?;
                 let data_block = payload.aggregate_flush_all()?.consume_convert_to_full();
                 self.inner.spill(bucket, data_block)?;
             }
@@ -268,7 +271,7 @@ impl AccumulatingTransform for TransformPartialAggregate {
 
     fn on_finish(&mut self, output: bool) -> Result<Vec<DataBlock>> {
         Ok(match std::mem::take(&mut self.hash_table) {
-            HashTable::MovedOut => match !output && std::thread::panicking() {
+            HashTable::MovedOut => match !output {
                 true => vec![],
                 false => {
                     unreachable!("[TRANSFORM-AGGREGATOR] Hash table already moved out in finish")

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_build_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_build_state.rs
@@ -42,6 +42,7 @@ use databend_common_expression::RemoteExpr;
 use databend_common_expression::arrow::and_validities;
 use databend_common_expression::types::DataType;
 use databend_common_functions::BUILTIN_FUNCTIONS;
+use databend_common_pipeline::core::check_interrupt;
 use databend_common_pipeline_transforms::MemorySettings;
 use databend_common_sql::plans::JoinType;
 use ethnum::U256;
@@ -440,7 +441,7 @@ impl HashJoinBuildState {
                             build_keys_iter.zip(valids.iter()).enumerate()
                         {
                             if Self::should_check_build_interrupt(row_index)
-                                && self.hash_join_state.interrupt.load(Ordering::Relaxed)
+                                && check_interrupt().is_err()
                             {
                                 is_interrupted = true;
                                 break;
@@ -469,7 +470,7 @@ impl HashJoinBuildState {
                     None => {
                         for (row_index, key) in build_keys_iter.enumerate() {
                             if Self::should_check_build_interrupt(row_index)
-                                && self.hash_join_state.interrupt.load(Ordering::Relaxed)
+                                && check_interrupt().is_err()
                             {
                                 is_interrupted = true;
                                 break;
@@ -533,7 +534,7 @@ impl HashJoinBuildState {
                             build_keys_iter.zip(valids.iter()).enumerate()
                         {
                             if Self::should_check_build_interrupt(row_index)
-                                && self.hash_join_state.interrupt.load(Ordering::Relaxed)
+                                && check_interrupt().is_err()
                             {
                                 is_interrupted = true;
                                 break;
@@ -575,7 +576,7 @@ impl HashJoinBuildState {
                     None => {
                         for (row_index, key) in build_keys_iter.enumerate() {
                             if Self::should_check_build_interrupt(row_index)
-                                && self.hash_join_state.interrupt.load(Ordering::Relaxed)
+                                && check_interrupt().is_err()
                             {
                                 is_interrupted = true;
                                 break;
@@ -621,9 +622,7 @@ impl HashJoinBuildState {
             }};
         }
 
-        if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
-            return Err(ErrorCode::aborting());
-        }
+        check_interrupt()?;
 
         let chunk_index = task;
         let chunk = &mut build_state.generation_state.chunks[chunk_index];

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_probe_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_probe_state.rs
@@ -38,6 +38,7 @@ use databend_common_expression::types::nullable::NullableColumn;
 use databend_common_expression::with_join_hash_method;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_hashtable::Interval;
+use databend_common_pipeline::core::check_interrupt;
 use itertools::Itertools;
 use parking_lot::Mutex;
 use parking_lot::RwLock;
@@ -468,9 +469,7 @@ impl HashJoinProbeState {
         task: usize,
         probe_state: &mut ProbeState,
     ) -> Result<Vec<DataBlock>> {
-        if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
-            return Err(ErrorCode::aborting());
-        }
+        check_interrupt()?;
 
         // Probe states.
         let max_block_size = probe_state.max_block_size;
@@ -512,11 +511,7 @@ impl HashJoinProbeState {
                 row_index += 1;
             }
 
-            if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
-                return Err(ErrorCode::AbortedQuery(
-                    "Aborted query, because the server is shutting down or the query was killed.",
-                ));
-            }
+            check_interrupt()?;
 
             let probe_block = if !projected_probe_fields.is_empty() {
                 // Create null chunk for unmatched rows in probe side
@@ -575,11 +570,7 @@ impl HashJoinProbeState {
         task: usize,
         probe_state: &mut ProbeState,
     ) -> Result<Vec<DataBlock>> {
-        if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
-            return Err(ErrorCode::AbortedQuery(
-                "Aborted query, because the server is shutting down or the query was killed.",
-            ));
-        }
+        check_interrupt()?;
 
         // Probe states.
         let max_block_size = probe_state.max_block_size;
@@ -614,11 +605,7 @@ impl HashJoinProbeState {
                 row_index += 1;
             }
 
-            if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
-                return Err(ErrorCode::AbortedQuery(
-                    "Aborted query, because the server is shutting down or the query was killed.",
-                ));
-            }
+            check_interrupt()?;
 
             result_blocks.push(self.hash_join_state.gather(
                 &build_indexes[0..build_indexes_idx],
@@ -636,11 +623,7 @@ impl HashJoinProbeState {
         task: usize,
         probe_state: &mut ProbeState,
     ) -> Result<Vec<DataBlock>> {
-        if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
-            return Err(ErrorCode::AbortedQuery(
-                "Aborted query, because the server is shutting down or the query was killed.",
-            ));
-        }
+        check_interrupt()?;
 
         // Probe states.
         let max_block_size = probe_state.max_block_size;
@@ -675,11 +658,7 @@ impl HashJoinProbeState {
                 row_index += 1;
             }
 
-            if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
-                return Err(ErrorCode::AbortedQuery(
-                    "Aborted query, because the server is shutting down or the query was killed.",
-                ));
-            }
+            check_interrupt()?;
 
             result_blocks.push(self.hash_join_state.gather(
                 &build_indexes[0..build_indexes_idx],
@@ -697,11 +676,7 @@ impl HashJoinProbeState {
         task: usize,
         probe_state: &mut ProbeState,
     ) -> Result<Vec<DataBlock>> {
-        if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
-            return Err(ErrorCode::AbortedQuery(
-                "Aborted query, because the server is shutting down or the query was killed.",
-            ));
-        }
+        check_interrupt()?;
 
         // Probe states.
         let max_block_size = probe_state.max_block_size;
@@ -759,11 +734,7 @@ impl HashJoinProbeState {
                 row_index += 1;
             }
 
-            if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
-                return Err(ErrorCode::AbortedQuery(
-                    "Aborted query, because the server is shutting down or the query was killed.",
-                ));
-            }
+            check_interrupt()?;
 
             let boolean_column = Column::Boolean(boolean_bit_map.into());
             let marker_column = NullableColumn::new_column(boolean_column, validity.into());

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_state.rs
@@ -109,8 +109,6 @@ pub struct HashJoinState {
     pub(crate) _build_done_dummy_receiver: Receiver<HashTableType>,
     /// Some description of hash join. Such as join type, join keys, etc.
     pub(crate) hash_join_desc: HashJoinDesc,
-    /// Interrupt the build phase or probe phase.
-    pub(crate) interrupt: AtomicBool,
     /// If there is no data in build side, maybe we can fast return.
     pub(crate) fast_return: AtomicBool,
     /// Use the column of probe side to construct build side column.
@@ -190,7 +188,6 @@ impl HashJoinState {
             build_watcher,
             _build_done_dummy_receiver,
             hash_join_desc,
-            interrupt: AtomicBool::new(false),
             fast_return: Default::default(),
             probe_to_build: probe_to_build.to_vec(),
             build_schema,
@@ -212,10 +209,6 @@ impl HashJoinState {
             column_map,
             next_cache_block_index: AtomicUsize::new(0),
         }))
-    }
-
-    pub fn interrupt(&self) {
-        self.interrupt.store(true, Ordering::Release);
     }
 
     /// Used by hash join probe processors, wait for build phase finished.

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/inner_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/inner_join.rs
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering;
 
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
 use databend_common_expression::KeyAccessor;
+use databend_common_pipeline::core::check_interrupt;
 
 use crate::pipelines::processors::transforms::ProcessState;
 use crate::pipelines::processors::transforms::hash_join::HashJoinProbeState;
@@ -195,9 +195,7 @@ impl HashJoinProbeState {
             Some(filter_executor) => {
                 let mut filtered_blocks = Vec::with_capacity(result_blocks.len());
                 for result_block in result_blocks {
-                    if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
-                        return Err(ErrorCode::aborting());
-                    }
+                    check_interrupt()?;
                     let result_block = filter_executor.filter(result_block)?;
                     if !result_block.is_empty() {
                         filtered_blocks.push(result_block);
@@ -220,9 +218,7 @@ impl HashJoinProbeState {
         build_state: &BuildBlockGenerationState,
         right_single_scan_map: &mut [*mut AtomicBool],
     ) -> Result<DataBlock> {
-        if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
-            return Err(ErrorCode::aborting());
-        }
+        check_interrupt()?;
 
         let probe_block = if probe_state.is_probe_projected {
             Some(DataBlock::take(input, &probe_indexes[0..matched_idx])?)

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/left_anti_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/left_anti_join.rs
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::atomic::Ordering;
-
 use databend_common_base::hints::assume;
-use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
 use databend_common_expression::FilterExecutor;
 use databend_common_expression::KeyAccessor;
+use databend_common_pipeline::core::check_interrupt;
 
 use crate::pipelines::processors::transforms::hash_join::HashJoinProbeState;
 use crate::pipelines::processors::transforms::hash_join::ProbeState;
@@ -74,9 +72,7 @@ impl HashJoinProbeState {
             (probe_indexes, unmatched_idx)
         };
 
-        if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
-            return Err(ErrorCode::aborting());
-        }
+        check_interrupt()?;
 
         let result_block = DataBlock::take(&process_state.input, &probe_indexes[0..count])?;
 
@@ -257,9 +253,7 @@ impl HashJoinProbeState {
         row_state: &mut [bool],
         filter_executor: &mut FilterExecutor,
     ) -> Result<()> {
-        if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
-            return Err(ErrorCode::aborting());
-        }
+        check_interrupt()?;
 
         let probe_block = if probe_state.is_probe_projected {
             Some(DataBlock::take(input, &probe_indexes[0..matched_idx])?)

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/left_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/left_join.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::atomic::Ordering;
-
 use databend_common_base::hints::assume;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -22,6 +20,7 @@ use databend_common_expression::DataBlock;
 use databend_common_expression::FilterExecutor;
 use databend_common_expression::KeyAccessor;
 use databend_common_expression::Scalar;
+use databend_common_pipeline::core::check_interrupt;
 
 use crate::pipelines::processors::transforms::hash_join::HashJoinProbeState;
 use crate::pipelines::processors::transforms::hash_join::ProbeState;
@@ -364,9 +363,7 @@ impl HashJoinProbeState {
         probe_state: &mut ProbeBlockGenerationState,
         build_state: &BuildBlockGenerationState,
     ) -> Result<DataBlock> {
-        if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
-            return Err(ErrorCode::aborting());
-        }
+        check_interrupt()?;
 
         let probe_block = if probe_state.is_probe_projected {
             let mut probe_block = DataBlock::take(input, &probe_indexes[0..unmatched_idx])?;
@@ -412,9 +409,7 @@ impl HashJoinProbeState {
         row_state: Option<&mut Vec<usize>>,
         row_state_indexes: Option<&mut Vec<usize>>,
     ) -> Result<()> {
-        if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
-            return Err(ErrorCode::aborting());
-        }
+        check_interrupt()?;
 
         let probe_block = if probe_state.is_probe_projected {
             let mut probe_block = DataBlock::take(input, &probe_indexes[0..matched_idx])?;

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/left_mark_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/left_mark_join.rs
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::atomic::Ordering;
-
-use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
 use databend_common_expression::Expr;
 use databend_common_expression::KeyAccessor;
+use databend_common_pipeline::core::check_interrupt;
 
 use crate::pipelines::processors::transforms::hash_join::HashJoinProbeState;
 use crate::pipelines::processors::transforms::hash_join::ProbeState;
@@ -293,9 +291,7 @@ impl HashJoinProbeState {
         build_indexes: &[RowPtr],
         mark_scan_map: &mut [Vec<u8>],
     ) -> Result<()> {
-        if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
-            return Err(ErrorCode::aborting());
-        }
+        check_interrupt()?;
 
         for probed_row in build_indexes.iter() {
             unsafe {
@@ -321,9 +317,7 @@ impl HashJoinProbeState {
         other_predicate: &Expr,
         mark_scan_map: &mut [Vec<u8>],
     ) -> Result<()> {
-        if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
-            return Err(ErrorCode::aborting());
-        }
+        check_interrupt()?;
 
         let probe_block = if probe_state.is_probe_projected {
             Some(DataBlock::take(input, &probe_indexes[0..matched_idx])?)

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/left_semi_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/left_semi_join.rs
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::atomic::Ordering;
-
-use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
 use databend_common_expression::FilterExecutor;
 use databend_common_expression::KeyAccessor;
+use databend_common_pipeline::core::check_interrupt;
 
 use crate::pipelines::processors::transforms::hash_join::HashJoinProbeState;
 use crate::pipelines::processors::transforms::hash_join::ProbeState;
@@ -72,9 +70,7 @@ impl HashJoinProbeState {
             }
         }
 
-        if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
-            return Err(ErrorCode::aborting());
-        }
+        check_interrupt()?;
 
         if matched_idx > 0 {
             result_blocks.push(DataBlock::take(
@@ -250,9 +246,7 @@ impl HashJoinProbeState {
         row_state: &mut [bool],
         filter_executor: &mut FilterExecutor,
     ) -> Result<()> {
-        if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
-            return Err(ErrorCode::aborting());
-        }
+        check_interrupt()?;
 
         let probe_block = if probe_state.is_probe_projected {
             Some(DataBlock::take(input, &probe_indexes[0..matched_idx])?)

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/right_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/right_join.rs
@@ -20,6 +20,7 @@ use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
 use databend_common_expression::FilterExecutor;
 use databend_common_expression::KeyAccessor;
+use databend_common_pipeline::core::check_interrupt;
 
 use crate::pipelines::processors::transforms::hash_join::HashJoinProbeState;
 use crate::pipelines::processors::transforms::hash_join::ProbeState;
@@ -251,9 +252,7 @@ impl HashJoinProbeState {
         right_single_scan_map: &mut [*mut AtomicBool],
         filter_executor: Option<&mut FilterExecutor>,
     ) -> Result<()> {
-        if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
-            return Err(ErrorCode::aborting());
-        }
+        check_interrupt()?;
 
         let probe_block = if probe_state.is_probe_projected {
             let probe_block = DataBlock::take(input, &probe_indexes[0..matched_idx])?;

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/right_mark_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/right_mark_join.rs
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::atomic::Ordering;
-
-use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
 use databend_common_expression::Expr;
 use databend_common_expression::KeyAccessor;
+use databend_common_pipeline::core::check_interrupt;
 
 use crate::pipelines::processors::transforms::hash_join::HashJoinProbeState;
 use crate::pipelines::processors::transforms::hash_join::ProbeState;
@@ -263,9 +261,7 @@ impl HashJoinProbeState {
         markers: &mut [u8],
         other_predicate: &Expr,
     ) -> Result<()> {
-        if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
-            return Err(ErrorCode::aborting());
-        }
+        check_interrupt()?;
 
         let probe_block = if probe_state.is_probe_projected {
             Some(DataBlock::take(input, &probe_indexes[0..matched_idx])?)

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/right_semi_anti_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/probe_join/right_semi_anti_join.rs
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::atomic::Ordering;
-
-use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
 use databend_common_expression::FilterExecutor;
 use databend_common_expression::KeyAccessor;
+use databend_common_pipeline::core::check_interrupt;
 
 use crate::pipelines::processors::transforms::hash_join::HashJoinProbeState;
 use crate::pipelines::processors::transforms::hash_join::ProbeState;
@@ -245,9 +243,7 @@ impl HashJoinProbeState {
         build_indexes: &[RowPtr],
         outer_scan_map: &mut [Vec<bool>],
     ) -> Result<()> {
-        if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
-            return Err(ErrorCode::aborting());
-        }
+        check_interrupt()?;
 
         for row_ptr in build_indexes.iter() {
             unsafe {
@@ -273,9 +269,7 @@ impl HashJoinProbeState {
         outer_scan_map: &mut [Vec<bool>],
         filter_executor: &mut FilterExecutor,
     ) -> Result<()> {
-        if self.hash_join_state.interrupt.load(Ordering::Relaxed) {
-            return Err(ErrorCode::aborting());
-        }
+        check_interrupt()?;
 
         let probe_block = if probe_state.is_probe_projected {
             Some(DataBlock::take(input, &probe_indexes[0..matched_idx])?)

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/transform_hash_join_build.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/transform_hash_join_build.rs
@@ -249,10 +249,6 @@ impl Processor for TransformHashJoinBuild {
         }
     }
 
-    fn interrupt(&self) {
-        self.build_state.hash_join_state.interrupt()
-    }
-
     fn process(&mut self) -> Result<()> {
         match self.step {
             Step::Sync(SyncStep::Collect) => {

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/transform_hash_join_probe.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/transform_hash_join_probe.rs
@@ -331,10 +331,6 @@ impl Processor for TransformHashJoinProbe {
         }
     }
 
-    fn interrupt(&self) {
-        self.join_probe_state.hash_join_state.interrupt()
-    }
-
     fn process(&mut self) -> Result<()> {
         match self.step {
             Step::Sync(SyncStep::Probe) => {

--- a/src/query/service/src/pipelines/processors/transforms/materialized_cte.rs
+++ b/src/query/service/src/pipelines/processors/transforms/materialized_cte.rs
@@ -33,6 +33,7 @@ use databend_common_pipeline::core::InputPort;
 use databend_common_pipeline::core::OutputPort;
 use databend_common_pipeline::core::Processor;
 use databend_common_pipeline::core::ProcessorPtr;
+use databend_common_pipeline::core::check_interrupt;
 use databend_common_pipeline_transforms::MemorySettings;
 use databend_common_settings::Settings;
 use databend_common_storage::DataOperator;
@@ -86,7 +87,11 @@ impl MaterializedCteSpilledPayload {
         )?;
 
         let mut blocks = Vec::new();
-        while let Some(block) = reader.read()? {
+        loop {
+            check_interrupt()?;
+            let Some(block) = reader.read()? else {
+                break;
+            };
             blocks.push(block);
         }
 
@@ -163,6 +168,7 @@ impl MaterializedCteSink {
         let mut row_group_ranges = Vec::with_capacity(data_blocks.len());
         let mut next_row_group = 0;
         for block in data_blocks {
+            check_interrupt()?;
             writer.write(block)?;
             let row_group_count = writer.flush_row_groups()?;
             row_group_ranges.push(next_row_group..row_group_count);

--- a/src/query/service/src/pipelines/processors/transforms/new_hash_join/grace/grace_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/new_hash_join/grace/grace_join.rs
@@ -24,6 +24,7 @@ use databend_common_expression::BlockPartitionStream;
 use databend_common_expression::DataBlock;
 use databend_common_expression::FunctionContext;
 use databend_common_expression::HashMethodKind;
+use databend_common_pipeline::core::check_interrupt;
 use databend_common_pipeline_transforms::traits::Location;
 use databend_common_storage::DataOperator;
 use databend_common_storages_parquet::ReadSettings;
@@ -85,6 +86,7 @@ impl<T: GraceMemoryJoin> Join for GraceHashJoin<T> {
         };
 
         for (id, data_block) in ready_partitions {
+            check_interrupt()?;
             self.partitions[id].writer.write(data_block)?;
             self.partitions[id].writer.flush()?;
         }
@@ -97,6 +99,7 @@ impl<T: GraceMemoryJoin> Join for GraceHashJoin<T> {
 
         let mut ready_partitions = Vec::with_capacity(self.partitions.len());
         for id in 0..self.partitions.len() {
+            check_interrupt()?;
             let mut partition =
                 GraceJoinPartition::create(&self.location_prefix, self.writer_pool_bytes)?;
 
@@ -105,6 +108,7 @@ impl<T: GraceMemoryJoin> Join for GraceHashJoin<T> {
         }
 
         for (id, partition) in ready_partitions.into_iter().enumerate() {
+            check_interrupt()?;
             let path = partition.path;
             let (written, row_groups) = partition.writer.close()?;
 
@@ -141,6 +145,7 @@ impl<T: GraceMemoryJoin> Join for GraceHashJoin<T> {
         let ready_partitions = self.partition_probe_data(data)?;
 
         for (id, data_block) in ready_partitions {
+            check_interrupt()?;
             self.partitions[id].writer.write(data_block)?;
             self.partitions[id].writer.flush()?;
         }
@@ -166,7 +171,9 @@ impl<T: GraceMemoryJoin> Join for GraceHashJoin<T> {
             }
             RestoreStage::RestoreBuildFinal => {
                 self.stage = RestoreStage::RestoreProbe;
-                while let Some(_x) = self.memory_hash_join.final_build()? {}
+                while let Some(_x) = self.memory_hash_join.final_build()? {
+                    check_interrupt()?;
+                }
                 Ok(Some(Box::new(EmptyJoinStream)))
             }
             RestoreStage::RestoreProbe => {
@@ -294,7 +301,11 @@ impl<T: GraceMemoryJoin> GraceHashJoin<T> {
                 self.read_settings,
             )?;
 
-            while let Some(data_block) = reader.read()? {
+            loop {
+                check_interrupt()?;
+                let Some(data_block) = reader.read()? else {
+                    break;
+                };
                 self.memory_hash_join.add_block(Some(data_block))?;
             }
         }
@@ -359,6 +370,7 @@ impl<T: GraceMemoryJoin> GraceHashJoin<T> {
         let ready_partitions_id = self.probe_partition_stream.partition_ids();
 
         for id in ready_partitions_id {
+            check_interrupt()?;
             if let Some(data_block) = self.probe_partition_stream.finalize_partition(id) {
                 self.partitions[id].writer.write(data_block)?;
                 self.partitions[id].writer.flush()?;
@@ -369,6 +381,7 @@ impl<T: GraceMemoryJoin> GraceHashJoin<T> {
         let mut partitions_meta = Vec::with_capacity(self.partitions.len());
 
         for (id, partition) in ready_partitions.into_iter().enumerate() {
+            check_interrupt()?;
             let path = partition.path;
             let (written, row_groups) = partition.writer.close()?;
 
@@ -518,6 +531,7 @@ impl<'a, T: GraceMemoryJoin> JoinStream for RestoreProbeStream<'a, T> {
 impl<'a, T: GraceMemoryJoin> RestoreProbeStream<'a, T> {
     fn next_probe_block(&mut self) -> Result<Option<DataBlock>> {
         loop {
+            check_interrupt()?;
             if self.spills_reader.is_none() {
                 while let Some(data) = self.steal_restore_probe_task() {
                     if data.row_groups.is_empty() {

--- a/src/query/service/src/pipelines/processors/transforms/new_hash_join/hybrid/hybrid_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/new_hash_join/hybrid/hybrid_join.rs
@@ -21,6 +21,7 @@ use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
 use databend_common_expression::FunctionContext;
 use databend_common_expression::HashMethodKind;
+use databend_common_pipeline::core::check_interrupt;
 use databend_common_pipeline_transforms::MemorySettings;
 use databend_common_sql::plans::JoinType;
 
@@ -136,10 +137,12 @@ impl HybridHashJoin {
     fn do_transition_work(&mut self, finished: bool) -> Result<()> {
         if let HybridJoinMode::Grace(grace_join) = &mut self.mode {
             while let Ok(memory_block) = self.state.transition_queue.pop() {
+                check_interrupt()?;
                 grace_join.add_block(Some(memory_block))?;
             }
 
             if finished {
+                check_interrupt()?;
                 grace_join.add_block(None)?;
             }
         }

--- a/src/query/service/src/pipelines/processors/transforms/window/partition/window_partition_buffer.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/partition/window_partition_buffer.rs
@@ -18,6 +18,7 @@ use databend_base::uniq_id::GlobalUniq;
 use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
 use databend_common_expression::DataSchemaRef;
+use databend_common_pipeline::core::check_interrupt;
 use databend_common_pipeline_transforms::MemorySettings;
 use databend_common_pipeline_transforms::traits::Location;
 use databend_common_storage::DataOperator;
@@ -79,6 +80,7 @@ impl PartitionFileWriter {
 
     fn write_blocks(&mut self, blocks: Vec<DataBlock>) -> Result<usize> {
         for block in blocks {
+            check_interrupt()?;
             if self.schema.is_none() {
                 self.schema = Some(Arc::new(block.infer_schema()));
             }
@@ -142,7 +144,11 @@ impl PartitionFileReader {
             settings,
         )?;
         let mut blocks = Vec::new();
-        while let Some(block) = reader.read()? {
+        loop {
+            check_interrupt()?;
+            let Some(block) = reader.read()? else {
+                break;
+            };
             blocks.push(block);
         }
         Ok(blocks)
@@ -341,6 +347,7 @@ impl WindowPartitionBuffer {
     #[fastrace::trace(name = "WindowPartitionBuffer::restore")]
     pub fn restore(&mut self) -> Result<Vec<DataBlock>> {
         for partition in &mut self.partitions[self.next_to_restore..] {
+            check_interrupt()?;
             self.next_to_restore += 1;
 
             let mut result = Vec::new();

--- a/src/query/service/tests/it/pipelines/executor/executor_graph.rs
+++ b/src/query/service/tests/it/pipelines/executor/executor_graph.rs
@@ -19,6 +19,7 @@ use std::sync::Mutex;
 
 use databend_common_base::runtime::MemStat;
 use databend_common_base::runtime::ThreadTracker;
+use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
 use databend_common_pipeline::core::Event;
@@ -30,6 +31,7 @@ use databend_common_pipeline::core::Pipeline;
 use databend_common_pipeline::core::PlanScope;
 use databend_common_pipeline::core::Processor;
 use databend_common_pipeline::core::ProcessorPtr;
+use databend_common_pipeline::core::check_interrupt;
 use databend_common_pipeline::sinks::SyncSenderSink;
 use databend_common_pipeline::sources::BlocksSource;
 use databend_common_pipeline_transforms::processors::TransformDummy;
@@ -392,6 +394,46 @@ async fn test_schedule_with_two_tasks() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_sync_process_observes_graph_interrupt() -> anyhow::Result<()> {
+    let _fixture = TestFixture::setup().await?;
+
+    let mut pipeline = Pipeline::create();
+    let output = OutputPort::create();
+    pipeline.add_pipe(Pipe::create(0, 1, vec![PipeItem::create(
+        ProcessorPtr::create(Box::new(InterruptCheckingSource)),
+        vec![],
+        vec![output],
+    )]));
+
+    let graph = RunningGraph::create(
+        pipeline,
+        1,
+        Arc::new("test-sync-process-interrupt".to_string()),
+        None,
+        vec![],
+    )?;
+    let mut queue = unsafe { graph.clone().init_schedule_queue(0)? };
+    let processor = queue
+        .sync_queue
+        .pop_front()
+        .expect("interrupt checking processor should be scheduled");
+
+    graph.interrupt();
+
+    let mut context = ExecutorWorkerContext::create(0, WorkersCondvar::create(1));
+    context.set_task(ExecutorTask::Sync(processor));
+    let error = unsafe { context.execute_task(None) }
+        .expect_err("sync process should observe the graph interrupt handle");
+
+    assert_eq!(
+        error.get_error_code().code(),
+        ErrorCode::ABORTED_QUERY,
+        "process must run with the node tracking payload installed"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_schedule_point_simple() -> anyhow::Result<()> {
     let fixture = TestFixture::setup().await?;
     let ctx = fixture.new_query_ctx().await?;
@@ -588,6 +630,26 @@ fn add_memory_tracking_pipe(pipeline: &mut Pipeline, memory_records: &[(i64, i64
 struct MemoryTrackingSource {
     memory_usage: i64,
     release_memory_usage: i64,
+}
+
+struct InterruptCheckingSource;
+
+impl Processor for InterruptCheckingSource {
+    fn name(&self) -> String {
+        "InterruptCheckingSource".to_string()
+    }
+
+    fn as_any(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn event(&mut self) -> Result<Event> {
+        Ok(Event::Sync)
+    }
+
+    fn process(&mut self) -> Result<()> {
+        check_interrupt()
+    }
 }
 
 impl Processor for MemoryTrackingSource {

--- a/src/query/storages/stage/src/append/output.rs
+++ b/src/query/storages/stage/src/append/output.rs
@@ -172,6 +172,4 @@ impl AccumulatingTransform for SumSummaryTransform {
             Ok(vec![])
         }
     }
-
-    fn interrupt(&self) {}
 }

--- a/tests/suites/1_stateful/02_query/02_0000_kill_query.py
+++ b/tests/suites/1_stateful/02_query/02_0000_kill_query.py
@@ -45,3 +45,23 @@ with NativeClient(name="client1>") as client1:
 
     assert res is None
     client1.expect(prompt)
+
+    client1.send(
+        "SETTINGS (force_aggregate_data_spill = 1) SELECT max(number), sum(number) FROM numbers_mt(100000000000) GROUP BY number LIMIT 10;"
+    )
+    time.sleep(0.5)
+
+    mycursor.execute(
+        "SELECT mysql_connection_id FROM system.processes WHERE extra_info LIKE '%force_aggregate_data_spill%' AND extra_info NOT LIKE '%system.processes%';"
+    )
+    res = mycursor.fetchone()
+    kill_query = "kill query " + str(res[0]) + ";"
+    mycursor.execute(kill_query)
+    time.sleep(10)
+    mycursor.execute(
+        "SELECT * FROM system.processes WHERE extra_info LIKE '%force_aggregate_data_spill%' AND extra_info NOT LIKE '%system.processes%';"
+    )
+    res = mycursor.fetchone()
+
+    assert res is None
+    client1.expect(prompt)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Make synchronous spill processors observe query interruption between expensive sub-tasks executed by one process call
- Reuse the existing `ThreadTracker` and `TrackingPayload` execution context instead of storing an abort flag in every processor
- Cover aggregate, window, materialized CTE, new grace/hybrid hash join, sort, compact, and legacy hash join cancellation paths
- Do not attempt to preempt an individual storage I/O operation; the current sub-task completes before cancellation is observed
- Extend the stateful KILL test with a forced aggregate spill query

## Implementation

- Change the execution graph `should_finish` flag to a shared atomic and attach it to every node tracking payload
- Add the pipeline-level `check_interrupt()` checkpoint, which reads the current tracking payload
- Remove the `Processor::interrupt()` hook and its forwarding interfaces; the graph interrupt state is now the single cancellation source
- Remove processor-local abort atomics and abort parameters from aggregate, window, CTE, sort, compact, and hash join implementations
- Remove the legacy and new hash join abort propagation state
- Preserve existing cancellation frequency, except moving ineffective pre-process compact/sort checks into their actual batch loops

Because tracking payloads already scope synchronous processor execution and wrap asynchronous futures, the interrupt state also follows the existing sync, async, and tracked-task propagation paths.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test

Validation performed:

- `cargo test -p databend-common-pipeline --lib`
- `cargo fmt --all`
- `cargo check -p databend-query --lib`
- `cargo clippy -p databend-query --lib -- -D warnings`
- `git diff --check`
- `python3 -m py_compile tests/suites/1_stateful/02_query/02_0000_kill_query.py`

The pipeline unit tests cover synchronous interrupt visibility, nested tracking-payload scoping, and asynchronous tracked-future propagation. The stateful KILL test now runs an aggregate query with query-level `SETTINGS (force_aggregate_data_spill = 1)` and verifies that KILL removes it from `system.processes`. It was syntax-checked locally; the full stateful test was not run because no local query service was available. The pipeline-transforms lib test was stopped because it triggered a nearly full cold test-profile dependency build; its code is covered by query check and clippy.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## Risk

The change only affects query cancellation. Cancellation remains cooperative at synchronous spill or compute batch boundaries, so an individual blocking I/O call still needs to return before the processor exits.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20161)
<!-- Reviewable:end -->
