### PR TITLE
refactor(query): reduce short-query execution overhead

### DIFF
--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -756,6 +756,16 @@ impl PrivilegeAccess {
     ) -> Result<()> {
         let session = self.ctx.get_current_session();
 
+        // Direct user grants do not require resolving an ownership object.
+        if self
+            .ctx
+            .get_current_user()?
+            .grants
+            .verify_privilege(grant_object, privilege)
+        {
+            return Ok(());
+        }
+
         let verify_ownership = match grant_object {
             GrantObject::Database(_, _)
             | GrantObject::Table(_, _, _)

--- a/src/query/service/src/interpreters/common/log.rs
+++ b/src/query/service/src/interpreters/common/log.rs
@@ -19,6 +19,7 @@ use std::time::SystemTime;
 use databend_common_base::runtime::profile::ProfileDesc;
 use databend_common_base::runtime::profile::ProfileStatisticsName;
 use databend_common_base::runtime::profile::get_statistics_desc;
+use databend_common_config::GlobalConfig;
 use databend_common_exception::ErrorCode;
 use databend_common_pipeline::core::PlanProfile;
 use log::error;
@@ -42,7 +43,9 @@ pub fn log_query_start(ctx: &QueryContext) {
         SessionManager::instance().status.write().query_start(now);
     }
 
-    if let Err(error) = InterpreterQueryLog::log_start(ctx, now, None) {
+    if InterpreterQueryLog::enabled()
+        && let Err(error) = InterpreterQueryLog::log_start(ctx, now, None)
+    {
         error!("Failed to log query start: {:?}", error)
     }
 }
@@ -52,6 +55,7 @@ pub fn log_query_finished(ctx: &QueryContext, error: Option<ErrorCode>) {
     InterpreterMetrics::record_query_finished(ctx, error.clone());
 
     let now = SystemTime::now();
+    ctx.set_finish_time(now);
     let session = ctx.get_current_session();
 
     session.get_status().write().query_finish();
@@ -72,11 +76,16 @@ pub fn log_query_finished(ctx: &QueryContext, error: Option<ErrorCode>) {
 
     info!(memory:? = ctx.get_node_peek_memory_usage(); "total memory usage");
 
-    // databend::log::profile
-    let query_profiles = ctx.get_query_profiles();
+    let query_log_enabled = InterpreterQueryLog::enabled();
+    let profile_log_enabled = GlobalConfig::instance().log.profile.on;
+    let query_profiles = if query_log_enabled || profile_log_enabled {
+        ctx.get_query_profiles()
+    } else {
+        Vec::new()
+    };
     let has_profiles = !query_profiles.is_empty();
 
-    if has_profiles {
+    if has_profiles && profile_log_enabled {
         #[derive(serde::Serialize)]
         struct QueryProfiles {
             query_id: String,
@@ -98,9 +107,9 @@ pub fn log_query_finished(ctx: &QueryContext, error: Option<ErrorCode>) {
         }
     }
 
-    // databend::log::query
-    if let Err(error) =
-        InterpreterQueryLog::log_finish(ctx, now, error, has_profiles, &query_profiles)
+    if query_log_enabled
+        && let Err(error) =
+            InterpreterQueryLog::log_finish(ctx, now, error, has_profiles, &query_profiles)
     {
         error!("Failed to log query finish: {:?}", error)
     }

--- a/src/query/service/src/interpreters/common/log.rs
+++ b/src/query/service/src/interpreters/common/log.rs
@@ -16,12 +16,14 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::SystemTime;
 
+use databend_common_base::runtime::ThreadTracker;
 use databend_common_base::runtime::profile::ProfileDesc;
 use databend_common_base::runtime::profile::ProfileStatisticsName;
 use databend_common_base::runtime::profile::get_statistics_desc;
 use databend_common_config::GlobalConfig;
 use databend_common_exception::ErrorCode;
 use databend_common_pipeline::core::PlanProfile;
+use databend_common_tracing::HistoryConfig;
 use log::error;
 use log::info;
 
@@ -34,6 +36,43 @@ use crate::sessions::TableContextQueryIdentity;
 use crate::sessions::TableContextQueryProfile;
 use crate::sessions::TableContextSpillProgress;
 
+const QUERY_HISTORY_TABLE: &str = "query_history";
+const PROFILE_HISTORY_TABLE: &str = "profile_history";
+const ACCESS_HISTORY_TABLE: &str = "access_history";
+
+fn history_table_log_enabled(history: &HistoryConfig, history_table_name: &str) -> bool {
+    history.on
+        && history
+            .tables
+            .iter()
+            .any(|table| table.table_name.eq_ignore_ascii_case(history_table_name))
+}
+
+fn captured_info_log_enabled() -> bool {
+    ThreadTracker::capture_log_settings().is_some_and(|settings| {
+        settings.queue.is_some() && settings.level >= log::LevelFilter::Info
+    })
+}
+
+pub(crate) fn query_log_enabled() -> bool {
+    let log = &GlobalConfig::instance().log;
+    log.query.on
+        || history_table_log_enabled(&log.history, QUERY_HISTORY_TABLE)
+        || captured_info_log_enabled()
+}
+
+pub(crate) fn profile_log_enabled() -> bool {
+    let log = &GlobalConfig::instance().log;
+    log.profile.on
+        || history_table_log_enabled(&log.history, PROFILE_HISTORY_TABLE)
+        || captured_info_log_enabled()
+}
+
+pub(crate) fn access_log_enabled() -> bool {
+    let log = &GlobalConfig::instance().log;
+    history_table_log_enabled(&log.history, ACCESS_HISTORY_TABLE) || captured_info_log_enabled()
+}
+
 pub fn log_query_start(ctx: &QueryContext) {
     InterpreterMetrics::record_query_start(ctx);
     let now = SystemTime::now();
@@ -43,7 +82,7 @@ pub fn log_query_start(ctx: &QueryContext) {
         SessionManager::instance().status.write().query_start(now);
     }
 
-    if InterpreterQueryLog::enabled()
+    if query_log_enabled()
         && let Err(error) = InterpreterQueryLog::log_start(ctx, now, None)
     {
         error!("Failed to log query start: {:?}", error)
@@ -76,16 +115,16 @@ pub fn log_query_finished(ctx: &QueryContext, error: Option<ErrorCode>) {
 
     info!(memory:? = ctx.get_node_peek_memory_usage(); "total memory usage");
 
-    let query_log_enabled = InterpreterQueryLog::enabled();
-    let profile_log_enabled = GlobalConfig::instance().log.profile.on;
-    let query_profiles = if query_log_enabled || profile_log_enabled {
+    let query_log_is_enabled = query_log_enabled();
+    let profile_log_is_enabled = profile_log_enabled();
+    let query_profiles = if query_log_is_enabled || profile_log_is_enabled {
         ctx.get_query_profiles()
     } else {
         Vec::new()
     };
     let has_profiles = !query_profiles.is_empty();
 
-    if has_profiles && profile_log_enabled {
+    if has_profiles && profile_log_is_enabled {
         #[derive(serde::Serialize)]
         struct QueryProfiles {
             query_id: String,
@@ -107,10 +146,62 @@ pub fn log_query_finished(ctx: &QueryContext, error: Option<ErrorCode>) {
         }
     }
 
-    if query_log_enabled
+    if query_log_is_enabled
         && let Err(error) =
             InterpreterQueryLog::log_finish(ctx, now, error, has_profiles, &query_profiles)
     {
         error!("Failed to log query finish: {:?}", error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use concurrent_queue::ConcurrentQueue;
+    use databend_common_base::runtime::CaptureLogSettings;
+    use databend_common_base::runtime::ThreadTracker;
+    use databend_common_tracing::HistoryConfig;
+    use databend_common_tracing::HistoryTableConfig;
+    use log::LevelFilter;
+
+    use super::captured_info_log_enabled;
+    use super::history_table_log_enabled;
+
+    #[test]
+    fn test_history_table_log_enabled() {
+        let mut history = HistoryConfig::default();
+        history.tables.push(HistoryTableConfig {
+            table_name: "QUERY_HISTORY".to_string(),
+            ..Default::default()
+        });
+
+        assert!(!history_table_log_enabled(&history, "query_history"));
+
+        history.on = true;
+        assert!(history_table_log_enabled(&history, "query_history"));
+        assert!(!history_table_log_enabled(&history, "profile_history"));
+    }
+
+    #[test]
+    fn test_captured_info_log_enabled() {
+        assert!(!captured_info_log_enabled());
+
+        {
+            let mut payload = ThreadTracker::new_tracking_payload();
+            payload.capture_log_settings = Some(CaptureLogSettings::capture_off());
+            let _guard = ThreadTracker::tracking(payload);
+            assert!(!captured_info_log_enabled());
+        }
+
+        {
+            let mut payload = ThreadTracker::new_tracking_payload();
+            payload.capture_log_settings = Some(CaptureLogSettings::capture_query(
+                LevelFilter::Info,
+                Arc::new(ConcurrentQueue::unbounded()),
+            ));
+            let _guard = ThreadTracker::tracking(payload);
+            assert!(captured_info_log_enabled());
+        }
     }
 }

--- a/src/query/service/src/interpreters/common/query_log.rs
+++ b/src/query/service/src/interpreters/common/query_log.rs
@@ -34,6 +34,7 @@ use log::info;
 use serde_json;
 use serde_json::Value;
 
+use super::query_log_enabled;
 use crate::sessions::QueryContext;
 use crate::sessions::TableContextAuthorization;
 use crate::sessions::TableContextCluster;
@@ -124,7 +125,7 @@ fn resource_usage_query_log(stats: IoStatsSnapshot, profiles: &[PlanProfile]) ->
 
 impl InterpreterQueryLog {
     pub fn enabled() -> bool {
-        GlobalConfig::instance().log.query.on
+        query_log_enabled()
     }
 
     fn write_log(mut event: QueryLogElement) -> Result<()> {

--- a/src/query/service/src/interpreters/common/query_log.rs
+++ b/src/query/service/src/interpreters/common/query_log.rs
@@ -123,21 +123,29 @@ fn resource_usage_query_log(stats: IoStatsSnapshot, profiles: &[PlanProfile]) ->
 }
 
 impl InterpreterQueryLog {
+    pub fn enabled() -> bool {
+        GlobalConfig::instance().log.query.on
+    }
+
     fn write_log(mut event: QueryLogElement) -> Result<()> {
-        // log the query event in the system_history.query_history table
-        let event_str = serde_json::to_string(&event)?;
-        info!(target: "databend::log::query", "{}", event_str);
+        if log::log_enabled!(target: "databend::log::query", log::Level::Info) {
+            // Log the query event in the system_history.query_history table.
+            let event_str = serde_json::to_string(&event)?;
+            info!(target: "databend::log::query", "{}", event_str);
+        }
 
-        // log the query event in `query-details` log file
-        // remove some fields to keep tidy in the log file
-        event.session_settings.clear();
-        event.sql_user_quota.clear();
-        event.sql_user_privileges.clear();
-        let event_str = serde_json::to_string(&event)?;
-        info!(target: "databend::log::query::file", "{}", event_str);
+        if log::log_enabled!(target: "databend::log::query::file", log::Level::Info) {
+            // Remove verbose fields from the query-details file.
+            event.session_settings.clear();
+            event.sql_user_quota.clear();
+            event.sql_user_privileges.clear();
+            let event_str = serde_json::to_string(&event)?;
+            info!(target: "databend::log::query::file", "{}", event_str);
+        }
 
-        // log the query event in the system log
-        info!("query: {} becomes {:?}", event.query_id, event.log_type);
+        if log::log_enabled!(log::Level::Info) {
+            info!("query: {} becomes {:?}", event.query_id, event.log_type);
+        }
         Ok(())
     }
 

--- a/src/query/service/src/interpreters/common/query_log.rs
+++ b/src/query/service/src/interpreters/common/query_log.rs
@@ -128,28 +128,26 @@ impl InterpreterQueryLog {
     }
 
     fn write_log(mut event: QueryLogElement) -> Result<()> {
-        if log::log_enabled!(target: "databend::log::query", log::Level::Info) {
-            // Log the query event in the system_history.query_history table.
-            let event_str = serde_json::to_string(&event)?;
-            info!(target: "databend::log::query", "{}", event_str);
-        }
+        // Normal callers are gated by `enabled()`. The log facade's target check is
+        // not specific enough to tell whether this query sink is configured.
+        let event_str = serde_json::to_string(&event)?;
+        info!(target: "databend::log::query", "{}", event_str);
 
-        if log::log_enabled!(target: "databend::log::query::file", log::Level::Info) {
-            // Remove verbose fields from the query-details file.
-            event.session_settings.clear();
-            event.sql_user_quota.clear();
-            event.sql_user_privileges.clear();
-            let event_str = serde_json::to_string(&event)?;
-            info!(target: "databend::log::query::file", "{}", event_str);
-        }
+        // Remove verbose fields from the query-details file.
+        event.session_settings.clear();
+        event.sql_user_quota.clear();
+        event.sql_user_privileges.clear();
+        let event_str = serde_json::to_string(&event)?;
+        info!(target: "databend::log::query::file", "{}", event_str);
 
-        if log::log_enabled!(log::Level::Info) {
-            info!("query: {} becomes {:?}", event.query_id, event.log_type);
-        }
+        info!("query: {} becomes {:?}", event.query_id, event.log_type);
         Ok(())
     }
 
     pub fn fail_to_start(ctx: Arc<QueryContext>, err: ErrorCode) {
+        if !Self::enabled() {
+            return;
+        }
         InterpreterQueryLog::log_start(&ctx, SystemTime::now(), Some(err))
             .unwrap_or_else(|e| error!("fail to write query_log {:?}", e));
     }

--- a/src/query/service/src/interpreters/interpreter_factory.rs
+++ b/src/query/service/src/interpreters/interpreter_factory.rs
@@ -52,6 +52,7 @@ use crate::interpreters::ShowPublicKeysInterpreter;
 use crate::interpreters::UnsetObjectTagsInterpreter;
 use crate::interpreters::access::Accessor;
 use crate::interpreters::access_log::AccessLogger;
+use crate::interpreters::common::access_log_enabled;
 use crate::interpreters::interpreter_add_warehouse_cluster::AddWarehouseClusterInterpreter;
 use crate::interpreters::interpreter_assign_warehouse_nodes::AssignWarehouseNodesInterpreter;
 use crate::interpreters::interpreter_catalog_drop::DropCatalogInterpreter;
@@ -153,7 +154,7 @@ impl InterpreterFactory {
                 error!("Access.denied(v2): {:?}", e);
             }
         })?;
-        if log::log_enabled!(target: "databend::log::access", log::Level::Info) {
+        if access_log_enabled() {
             let mut access_logger = AccessLogger::create(ctx.clone());
             access_logger.log(plan);
             access_logger.output();

--- a/src/query/service/src/interpreters/interpreter_factory.rs
+++ b/src/query/service/src/interpreters/interpreter_factory.rs
@@ -153,9 +153,11 @@ impl InterpreterFactory {
                 error!("Access.denied(v2): {:?}", e);
             }
         })?;
-        let mut access_logger = AccessLogger::create(ctx.clone());
-        access_logger.log(plan);
-        access_logger.output();
+        if log::log_enabled!(target: "databend::log::access", log::Level::Info) {
+            let mut access_logger = AccessLogger::create(ctx.clone());
+            access_logger.log(plan);
+            access_logger.output();
+        }
         Self::get_warehouses_interpreter(ctx, plan, Self::get_inner)
     }
 

--- a/src/query/service/src/pipelines/executor/query_pipeline_executor.rs
+++ b/src/query/service/src/pipelines/executor/query_pipeline_executor.rs
@@ -286,16 +286,22 @@ impl QueryPipelineExecutor {
 
         self.start_executor_daemon()?;
 
-        // The caller already runs on a dedicated thread for pulling pipelines. Reuse it as one
-        // worker so short queries do not pay for an extra OS thread spawn and join.
-        let mut thread_join_handles = self.execute_threads(self.threads_num - 1);
+        // Pulling and complete pipelines call this from a dedicated OS thread, which can also act
+        // as one worker. Generic callers may invoke the executor from a Tokio runtime, where a
+        // processor using Tokio's blocking APIs would panic if it ran inline.
+        let execute_inline = tokio::runtime::Handle::try_current().is_err();
+        let spawned_threads = self.threads_num - usize::from(execute_inline);
+        let mut thread_join_handles = self.execute_threads(spawned_threads);
 
-        let inline_thread_num = self.threads_num - 1;
-        let inline_thread_name = format!("PipelineExecutor-{}", inline_thread_num);
-        let inline_span = Span::enter_with_local_parent("QueryPipelineExecutor::execute_threads")
-            .with_property(|| ("thread_name", inline_thread_name));
-        let thread_res = self.execute_thread(inline_thread_num, inline_span);
-        self.check_thread_result(thread_res)?;
+        if execute_inline {
+            let inline_thread_num = spawned_threads;
+            let inline_thread_name = format!("PipelineExecutor-{}", inline_thread_num);
+            let inline_span =
+                Span::enter_with_local_parent("QueryPipelineExecutor::execute_threads")
+                    .with_property(|| ("thread_name", inline_thread_name));
+            let thread_res = self.execute_thread(inline_thread_num, inline_span);
+            self.check_thread_result(thread_res)?;
+        }
 
         while let Some(join_handle) = thread_join_handles.pop() {
             let thread_res = join_handle.join().flatten();

--- a/src/query/service/src/pipelines/executor/query_pipeline_executor.rs
+++ b/src/query/service/src/pipelines/executor/query_pipeline_executor.rs
@@ -286,30 +286,20 @@ impl QueryPipelineExecutor {
 
         self.start_executor_daemon()?;
 
-        let mut thread_join_handles = self.execute_threads(self.threads_num);
+        // The caller already runs on a dedicated thread for pulling pipelines. Reuse it as one
+        // worker so short queries do not pay for an extra OS thread spawn and join.
+        let mut thread_join_handles = self.execute_threads(self.threads_num - 1);
+
+        let inline_thread_num = self.threads_num - 1;
+        let inline_thread_name = format!("PipelineExecutor-{}", inline_thread_num);
+        let inline_span = Span::enter_with_local_parent("QueryPipelineExecutor::execute_threads")
+            .with_property(|| ("thread_name", inline_thread_name));
+        let thread_res = self.execute_thread(inline_thread_num, inline_span);
+        self.check_thread_result(thread_res)?;
 
         while let Some(join_handle) = thread_join_handles.pop() {
             let thread_res = join_handle.join().flatten();
-
-            {
-                let finished_error_guard = self.finished_error.lock();
-                if let Some(error) = finished_error_guard.as_ref() {
-                    let may_error = error.clone();
-                    drop(finished_error_guard);
-
-                    let profiling = self.fetch_plans_profile(true);
-                    self.on_finished(ExecutionInfo::create(Err(may_error.clone()), profiling))?;
-                    return Err(may_error);
-                }
-            }
-
-            // We will ignore the abort query error, because returned by finished_error if abort query.
-            if matches!(&thread_res, Err(error) if error.code() != ErrorCode::ABORTED_QUERY) {
-                let may_error = thread_res.unwrap_err();
-                let profiling = self.fetch_plans_profile(true);
-                self.on_finished(ExecutionInfo::create(Err(may_error.clone()), profiling))?;
-                return Err(may_error);
-            }
+            self.check_thread_result(thread_res)?;
         }
 
         if let Err(error) = self.graph.assert_finished_graph() {
@@ -320,6 +310,30 @@ impl QueryPipelineExecutor {
 
         let profiling = self.fetch_plans_profile(true);
         self.on_finished(ExecutionInfo::create(Ok(()), profiling))?;
+        Ok(())
+    }
+
+    fn check_thread_result(&self, thread_res: Result<()>) -> Result<()> {
+        {
+            let finished_error_guard = self.finished_error.lock();
+            if let Some(error) = finished_error_guard.as_ref() {
+                let may_error = error.clone();
+                drop(finished_error_guard);
+
+                let profiling = self.fetch_plans_profile(true);
+                self.on_finished(ExecutionInfo::create(Err(may_error.clone()), profiling))?;
+                return Err(may_error);
+            }
+        }
+
+        // We will ignore the abort query error, because returned by finished_error if abort query.
+        if matches!(&thread_res, Err(error) if error.code() != ErrorCode::ABORTED_QUERY) {
+            let may_error = thread_res.unwrap_err();
+            let profiling = self.fetch_plans_profile(true);
+            self.on_finished(ExecutionInfo::create(Err(may_error.clone()), profiling))?;
+            return Err(may_error);
+        }
+
         Ok(())
     }
 
@@ -417,26 +431,30 @@ impl QueryPipelineExecutor {
 
             let span = Span::enter_with_local_parent("QueryPipelineExecutor::execute_threads")
                 .with_property(|| ("thread_name", name.clone()));
-            thread_join_handles.push(Thread::named_spawn(Some(name), move || unsafe {
-                let _g = span.set_local_parent();
-                let this_clone = this.clone();
-                let try_result = catch_unwind(|| this_clone.execute_single_thread(thread_num));
-
-                // finish the pipeline executor when has error or panic
-                if let Err(cause) = try_result.flatten() {
-                    span.with_property(|| ("error", "true")).add_properties(|| {
-                        [
-                            ("error.type", cause.code().to_string()),
-                            ("error.message", cause.display_text()),
-                        ]
-                    });
-                    this.finish(Some(cause));
-                }
-
-                Ok(())
+            thread_join_handles.push(Thread::named_spawn(Some(name), move || {
+                this.execute_thread(thread_num, span)
             }));
         }
         thread_join_handles
+    }
+
+    fn execute_thread(self: &Arc<Self>, thread_num: usize, span: Span) -> Result<()> {
+        let _g = span.set_local_parent();
+        let this = self.clone();
+        let try_result = catch_unwind(|| unsafe { this.execute_single_thread(thread_num) });
+
+        // Finish the pipeline executor when a worker returns an error or panics.
+        if let Err(cause) = try_result.flatten() {
+            span.with_property(|| ("error", "true")).add_properties(|| {
+                [
+                    ("error.type", cause.code().to_string()),
+                    ("error.message", cause.display_text()),
+                ]
+            });
+            self.finish(Some(cause));
+        }
+
+        Ok(())
     }
 
     /// # Safety

--- a/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
+++ b/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
@@ -23,6 +23,7 @@ use databend_common_base::base::mask_connection_info;
 use databend_common_base::runtime::MemStat;
 use databend_common_base::runtime::ThreadTracker;
 use databend_common_base::runtime::TrackingPayloadExt;
+use databend_common_base::runtime::spawn;
 use databend_common_config::GlobalConfig;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -474,7 +475,9 @@ impl InteractiveWorkerBase {
     )> {
         let instant = Instant::now();
 
-        let query_result = context.try_spawn({
+        // The connection already runs on the shared MySQL query executor. Keep the task boundary
+        // without creating and destroying a dedicated Tokio runtime for every statement.
+        let query_result = spawn({
             let ctx = context.clone();
             async move {
                 let mut data_stream = interpreter.execute(ctx.clone()).await?;
@@ -491,11 +494,11 @@ impl InteractiveWorkerBase {
                 Ok::<_, ErrorCode>(intercepted_stream.boxed())
             }
             .in_span(Span::enter_with_local_parent(func_path!()))
-        })?;
+        });
 
         let query_result = query_result.await.map_err_to_code(
             ErrorCode::TokioError,
-            || "Cannot join handle from context's runtime",
+            || "Cannot join handle from MySQL query executor runtime",
         )?;
         let reporter = Box::new(ContextProgressReporter::new(context.clone(), instant))
             as Box<dyn ProgressReporter + Send>;

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -26,6 +26,7 @@ use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::future::Future;
 use std::sync::Arc;
+use std::sync::Once;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 use std::time::Instant;
@@ -192,6 +193,7 @@ pub struct QueryContext {
     partition_queue: Arc<RwLock<VecDeque<PartInfoPtr>>>,
     shared: Arc<QueryContextShared>,
     query_settings: Arc<Settings>,
+    session_settings_initialized: Once,
     fragment_id: FragmentId,
     // Used by synchronized generate aggregating indexes when new data written.
     written_segment_locs: SegmentLocationsState,
@@ -219,6 +221,7 @@ impl QueryContext {
             mysql_version: format!("{MYSQL_VERSION}-{}", shared.version.commit_detail),
             shared,
             query_settings,
+            session_settings_initialized: Once::new(),
             fragment_id: Default::default(),
             written_segment_locs: Default::default(),
             read_block_thresholds: Default::default(),

--- a/src/query/service/src/sessions/query_ctx/context.rs
+++ b/src/query/service/src/sessions/query_ctx/context.rs
@@ -323,8 +323,8 @@ impl TableContextSettings for QueryContext {
     }
 
     fn get_settings(&self) -> Arc<Settings> {
-        if self.shared.query_settings.is_changed()
-            && self.shared.query_settings.query_level_change()
+        if self.shared.query_settings.query_level_change()
+            && self.shared.query_settings.is_changed()
         {
             let shared_settings = self.shared.query_settings.changes();
             if self.get_session_settings().is_changed() {
@@ -342,10 +342,10 @@ impl TableContextSettings for QueryContext {
                 }
             }
         } else {
-            unsafe {
+            self.session_settings_initialized.call_once(|| unsafe {
                 self.query_settings
-                    .unchecked_apply_changes(self.get_session_settings().changes())
-            }
+                    .unchecked_apply_changes(self.get_session_settings().changes());
+            });
         }
 
         self.query_settings.clone()

--- a/src/query/service/src/sessions/session_ctx.rs
+++ b/src/query/service/src/sessions/session_ctx.rs
@@ -37,6 +37,48 @@ use parking_lot::RwLock;
 
 use crate::sessions::QueryContextShared;
 
+#[derive(Default)]
+struct QueryIdsResults {
+    entries: Vec<(String, Option<String>)>,
+    indices: HashMap<String, usize>,
+}
+
+impl QueryIdsResults {
+    fn get(&self, query_id: &str) -> Option<String> {
+        let index = self.indices.get(&query_id.to_ascii_lowercase())?;
+        self.entries.get(*index)?.1.clone()
+    }
+
+    fn update(&mut self, query_id: String, value: Option<String>) {
+        let normalized_id = query_id.to_ascii_lowercase();
+        if let Some(index) = self.indices.get(&normalized_id).copied() {
+            if let Some(value) = value {
+                self.entries[index] = (query_id, Some(value));
+            }
+            return;
+        }
+
+        let index = self.entries.len();
+        self.entries.push((query_id, value));
+        self.indices.insert(normalized_id, index);
+    }
+
+    fn last(&self, index: i32) -> Option<String> {
+        let len = self.entries.len();
+        let index = if index < 0 { len as i32 + index } else { index };
+
+        if len < 1 || index < 0 || index > (len - 1) as i32 {
+            return None;
+        }
+
+        Some(self.entries[index as usize].0.clone())
+    }
+
+    fn ids(&self) -> HashSet<String> {
+        HashSet::from_iter(self.entries.iter().map(|result| result.0.clone()))
+    }
+}
+
 pub struct SessionContext {
     abort: AtomicBool,
     settings: Arc<Settings>,
@@ -71,7 +113,7 @@ pub struct SessionContext {
     query_context_shared: RwLock<Weak<QueryContextShared>>,
     /// We store `query_id -> query_result_cache_key` to session context, so that we can fetch
     /// query result through previous query_id easily.
-    query_ids_results: RwLock<Vec<(String, Option<String>)>>,
+    query_ids_results: RwLock<QueryIdsResults>,
     // Used in set variables inside session
     variables: Arc<RwLock<HashMap<String, Scalar>>>,
     typ: SessionType,
@@ -306,49 +348,19 @@ impl SessionContext {
     }
 
     pub fn get_query_result_cache_key(&self, query_id: &str) -> Option<String> {
-        let lock = self.query_ids_results.read();
-        for (qid, result_cache_key) in (*lock).iter().rev() {
-            if qid.eq_ignore_ascii_case(query_id) {
-                return result_cache_key.clone();
-            }
-        }
-        None
+        self.query_ids_results.read().get(query_id)
     }
 
     pub fn update_query_ids_results(&self, query_id: String, value: Option<String>) {
-        let mut lock = self.query_ids_results.write();
-        // Here we use reverse iteration, as it is not common to modify elements from earlier.
-        for (idx, (qid, _)) in (*lock).iter().rev().enumerate() {
-            if qid.eq_ignore_ascii_case(&query_id) {
-                // update value iff value is some.
-                if let Some(v) = value {
-                    (*lock)[idx] = (query_id, Some(v))
-                }
-                return;
-            }
-        }
-        lock.push((query_id, value))
+        self.query_ids_results.write().update(query_id, value)
     }
 
     pub fn get_last_query_id(&self, index: i32) -> Option<String> {
-        let lock = self.query_ids_results.read();
-        let query_ids_len = lock.len();
-        let idx = if index < 0 {
-            query_ids_len as i32 + index
-        } else {
-            index
-        };
-
-        if query_ids_len < 1 || idx < 0 || idx > (query_ids_len - 1) as i32 {
-            return None;
-        }
-
-        Some((*lock)[idx as usize].0.clone())
+        self.query_ids_results.read().last(index)
     }
 
     pub fn get_query_id_history(&self) -> HashSet<String> {
-        let lock = self.query_ids_results.read();
-        HashSet::from_iter(lock.iter().map(|result| result.clone().0))
+        self.query_ids_results.read().ids()
     }
 
     pub fn txn_mgr(&self) -> TxnManagerRef {
@@ -412,5 +424,33 @@ impl SessionContext {
             return;
         }
         *self.current_workload_group.write() = Some(workload_group)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::QueryIdsResults;
+
+    #[test]
+    fn test_query_ids_results_updates_the_matching_entry() {
+        let mut history = QueryIdsResults::default();
+        history.update("first".to_string(), None);
+        history.update("second".to_string(), None);
+        history.update("SECOND".to_string(), Some("cache-key".to_string()));
+
+        assert_eq!(history.entries.len(), 2);
+        assert_eq!(history.get("second"), Some("cache-key".to_string()));
+        assert_eq!(history.last(-1), Some("SECOND".to_string()));
+        assert_eq!(history.last(0), Some("first".to_string()));
+    }
+
+    #[test]
+    fn test_query_ids_results_ignores_none_for_an_existing_entry() {
+        let mut history = QueryIdsResults::default();
+        history.update("query".to_string(), Some("existing-cache-key".to_string()));
+        history.update("QUERY".to_string(), None);
+
+        assert_eq!(history.entries.len(), 1);
+        assert_eq!(history.get("query"), Some("existing-cache-key".to_string()));
     }
 }

--- a/src/query/service/tests/it/pipelines/executor/pipeline_executor.rs
+++ b/src/query/service/tests/it/pipelines/executor/pipeline_executor.rs
@@ -14,8 +14,10 @@
 
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
+use databend_common_base::runtime::Thread;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
@@ -93,6 +95,59 @@ async fn test_always_call_on_finished() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_execute_inside_and_outside_tokio_runtime() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup().await?;
+    let ctx = fixture.new_query_ctx().await?;
+    let settings = ExecutorSettings {
+        query_id: Arc::new("worker-mode-test".to_string()),
+        max_execute_time_in_seconds: Default::default(),
+        enable_queries_executor: false,
+        max_threads: 1,
+        executor_node_id: "".to_string(),
+        perf_event_groups: vec![],
+    };
+
+    let (tokio_finished, tokio_executor) =
+        create_closed_source_executor(ctx.clone(), settings.clone())?;
+    tokio_executor.execute()?;
+    assert_eq!(tokio_finished.load(Ordering::SeqCst), 1);
+
+    let (inline_finished, inline_executor) = create_closed_source_executor(ctx, settings)?;
+    Thread::spawn(move || inline_executor.execute())
+        .join()
+        .expect("inline executor thread must not panic")?;
+    assert_eq!(inline_finished.load(Ordering::SeqCst), 1);
+
+    Ok(())
+}
+
+fn create_closed_source_executor(
+    ctx: Arc<QueryContext>,
+    settings: ExecutorSettings,
+) -> Result<(Arc<AtomicUsize>, Arc<QueryPipelineExecutor>)> {
+    let mut pipeline = Pipeline::create();
+    let (source_senders, source_pipe) = create_source_pipe(ctx, 1)?;
+    let (_sink_receivers, sink_pipe) = create_sink_pipe(1)?;
+    drop(source_senders);
+
+    pipeline.add_pipe(source_pipe);
+    pipeline.add_pipe(sink_pipe);
+    pipeline.set_max_threads(1);
+
+    let finished = Arc::new(AtomicUsize::new(0));
+    pipeline.set_on_finished({
+        let finished = finished.clone();
+        move |_info: &ExecutionInfo| {
+            finished.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    });
+
+    let executor = QueryPipelineExecutor::create(pipeline, settings)?;
+    Ok((finished, executor))
 }
 
 fn create_pipeline() -> (Arc<AtomicBool>, Pipeline) {

--- a/src/query/service/tests/it/sessions/session_setting.rs
+++ b/src/query/service/tests/it/sessions/session_setting.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use databend_common_catalog::session_type::SessionType;
+use databend_query::sessions::TableContextSettings;
 use databend_query::test_kits::ConfigBuilder;
 use databend_query::test_kits::TestFixture;
 
@@ -36,6 +37,29 @@ async fn test_session_setting() -> anyhow::Result<()> {
 
         assert_eq!(actual, expect);
     }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_query_context_snapshots_session_settings() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup().await?;
+    let session = fixture.default_session();
+    session
+        .get_settings()
+        .set_setting("max_threads".to_string(), "2".to_string())?;
+
+    let first_ctx = fixture.new_query_ctx().await?;
+    assert_eq!(first_ctx.get_settings().get_max_threads()?, 2);
+
+    session
+        .get_settings()
+        .set_setting("max_threads".to_string(), "3".to_string())?;
+
+    assert_eq!(first_ctx.get_settings().get_max_threads()?, 2);
+
+    let next_ctx = fixture.new_query_ctx().await?;
+    assert_eq!(next_ctx.get_settings().get_max_threads()?, 3);
 
     Ok(())
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Extract the short-query execution changes from #20144 into an independently reviewable PR.

This PR reduces fixed per-statement overhead in the MySQL, session, interpreter, logging, privilege-check, and pipeline executor paths. It does not change storage reads, lazy RowFetch, ordered top-k, or the physical sort implementation.

It adds no planner cache or query-result cache. Benchmarks explicitly use the same pre-existing mainline planner cache setting for baseline and PR (`enable_planner_cache=1`) and disable query-result caching (`enable_query_result_cache=0`).

## Implementation

1. Reuse the shared MySQL query runtime instead of creating and destroying a query-scoped runtime for each statement.
2. Reuse a non-Tokio thread calling `QueryPipelineExecutor::execute()` as one pipeline worker, avoiding one additional OS thread spawn/join. Both `PipelinePullingExecutor` and `PipelineCompleteExecutor` invoke it from their existing dedicated executor threads.
3. Initialize unchanged session settings once per query context.
4. Avoid building query/profile/access log payloads when every applicable sink is off. File logging, history-table sinks, and per-thread dynamic log capture retain their existing behavior.
5. Return immediately for direct user grants before resolving ownership metadata.
6. Keep query-id history order while adding a case-insensitive O(1) lookup index.

The benchmark plans remain `Sort(Single)` plans. None contains `Sort(PresortedMerge)`.

## Benchmark

Driver: https://github.com/dbsid/hbx-web3

Environment:

- EC2 `i4i.4xlarge`, 16 vCPU Intel Xeon Platinum 8375C, single query node, S3 in `us-west-2`;
- release binaries built on the EC2 host with `RUSTFLAGS="-C target-cpu=native"`;
- enterprise license, 100 GiB on-disk table-data cache, and 16 GiB in-memory table-data cache;
- `max_threads=2`, `max_storage_io_requests=16`, distributed pruning off;
- 5 concurrent connections with random parameters, 3,000 measured requests per query, seed `2026071305`;
- round 1 warms the path and round 2 is authoritative;
- independent server restart for `lazy_read_threshold=1000` and `0`.

Binaries:

- baseline `5876b2de8e`: SHA256 `ce15f1261baa0103011abeab12c3e06fc4730deef656b12582affc8b0fa7d4ab`;
- PR `7524fce781`: SHA256 `94d1df99896f11444650a5edd49ec73454d0305188e2228d5868fbde74b57407`.

| Build | lazy threshold | Query | mean ms | p50 ms | p95 ms | p99 ms | QPS |
|---|---:|---|---:|---:|---:|---:|---:|
| baseline | 1000 | Q1 | 128.67 | 107.17 | 195.58 | 312.53 | 38.79 |
| baseline | 1000 | Q2 | 131.41 | 117.87 | 211.36 | 232.26 | 38.03 |
| baseline | 1000 | Flex | 135.45 | 119.52 | 213.17 | 275.63 | 36.89 |
| PR | 1000 | Q1 | 120.56 | 99.03 | 188.01 | 310.27 | 41.45 |
| PR | 1000 | Q2 | 123.20 | 109.69 | 198.67 | 219.62 | 40.57 |
| PR | 1000 | Flex | 128.39 | 112.30 | 207.86 | 271.53 | 38.92 |
| baseline | 0 | Q1 | 33.20 | 33.14 | 38.63 | 40.98 | 150.52 |
| baseline | 0 | Q2 | 45.56 | 45.03 | 57.12 | 61.44 | 109.66 |
| baseline | 0 | Flex | 46.86 | 46.72 | 58.06 | 62.41 | 106.64 |
| PR | 0 | Q1 | 24.29 | 24.22 | 28.64 | 30.70 | 205.74 |
| PR | 0 | Q2 | 37.50 | 36.99 | 48.14 | 53.05 | 133.24 |
| PR | 0 | Flex | 38.23 | 37.99 | 49.17 | 53.93 | 130.69 |

The PR removes 7.05-8.21 ms with default lazy reads and 8.07-8.90 ms with lazy reads disabled. The no-lazy mean improvement is 17.7%-26.8%; the default-lazy mean improvement is 5.2%-6.3%. The similar absolute reduction across both modes is consistent with fixed execution overhead rather than a storage-plan change.

## Correctness

- All six authoritative PR runs completed 3,000 requests with zero errors.
- Full ordered-result comparison between `lazy_read_threshold=0` and `1000`: Q1 200/200, Q2 200/200, Flex 200/200; zero mismatches and zero errors.
- All six captured PR plans use the existing sort path and contain no `PresortedMerge`.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p databend-query --lib --tests -- -D warnings`
- `cargo test -p databend-query --lib -- --test-threads=1` (198 passed)
- focused pipeline executor, session-settings, logging-helper, and k-way merge/fuzz regressions (9 passed)
- release `databend-query` build with `RUSTFLAGS="-C target-cpu=native"`

## Tests

- [x] Unit Test
- [ ] Logic Test
- [x] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20165)
<!-- Reviewable:end -->

## Native protocol validation

The original benchmark table above used the MySQL driver. The same workload was also tested through Databend's non-MySQL HTTP protocol using `lake-go` (`lake://...:8000/default`, HTTP `/v1/query`). This validates the native protocol path with the same 5 concurrent workers, fixed random seed `2026071305`, and 3,000 measured requests per query.

The native HTTP A/B (the native path is unchanged by the follow-up safety commit `40c4cfcaab`) produced the following round-2 results:

| lazy threshold | Query | baseline mean ms | PR mean ms | reduction |
|---:|---|---:|---:|---:|
| 1000 | Q1 | 128.51 | 121.77 | 5.2% |
| 1000 | Q2 | 130.15 | 123.70 | 5.0% |
| 1000 | Flex | 134.99 | 128.39 | 4.9% |
| 0 | Q1 | 34.32 | 25.70 | 25.1% |
| 0 | Q2 | 48.16 | 39.62 | 17.7% |
| 0 | Flex | 48.87 | 40.46 | 17.2% |

All 36,000 native A/B requests succeeded with zero errors. On the final `40c4cfcaab` binary, a fresh no-lazy round also completed 3,000/3,000 requests for each of Q1, Q2, and Flex with means of 26.84, 40.20, and 40.35 ms respectively. Full ordered-result comparison on the final binary returned 100/100 matches for Q1, Q2, and Flex, with zero mismatches and zero errors.

The benchmarked safety-follow-up release binary was built on the EC2 host with `RUSTFLAGS="-C target-cpu=native"`:

- HEAD: `40c4cfcaab47cc907b97a2c5ce374c57df0a6dd5`;
- SHA256: `a754c99d3c3cc0a775d6c8fc34e29d3801a3ddc45eb49ec6884f0ce56f663be6`.

## Applicability and large queries

The native HTTP and FlightSQL handlers both use `InterpreterFactory -> Interpreter::execute -> PipelinePullingExecutor/PipelineCompleteExecutor -> QueryPipelineExecutor`, so the shared executor, session-settings, disabled-log, privilege, and query-id fast paths are protocol-independent. The shared MySQL runtime change in `mysql_interactive_worker.rs` is MySQL-only.

The benchmark plans remain `Sort(Single)`; no result depends on `Sort(PresortedMerge)`, ordered top-k, lazy RowFetch, or storage block pruning. The pulling path keeps the same total worker count (`threads_num - 1` spawned workers plus the caller worker). Complete pipelines retain their dedicated executor thread, but that thread can itself serve as one pipeline worker. Thus the change removes fixed per-statement overhead, but does not reduce scan rows, scanned blocks, or analytical-query parallelism. Empty/no-source pipelines and callers that already run inside a Tokio runtime are not eligible for the inline worker shortcut.

A controlled native HTTP A/B on the final workload used the following broad queries:

- `SELECT count(), sum(number), avg(number) FROM numbers(100000000)`;
- 10M-row group-by and sort with `LIMIT 1000`;
- a broad aggregate over the 100M-row Q1 table;
- a broad Q1 Top-K over the 100M-row table.

| query shape | baseline mean ms | final HEAD mean ms | requests | conclusion |
|---|---:|---:|---:|---|
| numbers(100M) aggregate | 39.61 | 39.39 | 30 | neutral |
| 10M group-by/sort | 101.62 | 107.19 | 10 | within run variance |
| 100M real-table aggregate | 420.87 | 419.61 | 5 | neutral |
| 100M real-table Top-K | 2476.01 | 2458.57 | 3 | neutral; small sample |

All large-query samples completed without errors. These results support applicability to large queries as no-regression/neutral, not as a claim of material scan or execution-speedup.

## Runtime safety follow-up

CI exposed that unconditionally running an inline worker can panic when a generic caller invokes `QueryPipelineExecutor::execute()` inside a Tokio runtime (`SyncSenderSink::blocking_send`). `40c4cfcaab` keeps the inline shortcut only on a non-Tokio thread and falls back to the original all-worker spawn behavior inside a runtime. Regression coverage now exercises both caller modes and verifies that the pipeline finish hook runs exactly once.

## Configured logging follow-up

Deep review found that checking only `log.query.on`, `log.profile.on`, or the tracing target could suppress payload construction when a history-table sink or per-thread dynamic capture was the actual consumer. `eb9c16d925` checks the configured query/profile/access sink explicitly and keeps the disabled-log fast path only when no consumer needs the event. It also adds focused tests for history-only configuration, dynamic capture, executor caller modes, and query-context settings snapshots.

The latest review-fix release binary was built on the EC2 host with `RUSTFLAGS="-C target-cpu=native"`:

- HEAD: `eb9c16d92556a6ab09c09e0e35950ba6b9d6e323`;
- SHA256: `d18d8b82eb5f37e9955951b2f8d1ed1a49a63d70faa5c4e324b956e993bf15c8`.

## Native correctness follow-up

After the service recovered, the final `40c4cfcaab` binary was rechecked through `lake-go` over native HTTP with the same deterministic parameter generator:

```bash
./web3lake -driver lake -dsn "$LAKE_DSN" -mode compare -query both -iterations 500 -seed 2026071305 \
  -compare-off-sql "SET lazy_read_threshold=0; SET max_threads=2; SET max_storage_io_requests=16; SET enable_distributed_pruning=0; SET enable_query_result_cache=0; SET enable_planner_cache=1" \
  -compare-on-sql "SET lazy_read_threshold=1000; SET max_threads=2; SET max_storage_io_requests=16; SET enable_distributed_pruning=0; SET enable_query_result_cache=0; SET enable_planner_cache=1"
./web3lake -driver lake -dsn "$LAKE_DSN" -mode compare -query flex -iterations 500 -seed 2026071305 \
  -compare-off-sql "SET lazy_read_threshold=0; SET max_threads=2; SET max_storage_io_requests=16; SET enable_distributed_pruning=0; SET enable_query_result_cache=0; SET enable_planner_cache=1" \
  -compare-on-sql "SET lazy_read_threshold=1000; SET max_threads=2; SET max_storage_io_requests=16; SET enable_distributed_pruning=0; SET enable_query_result_cache=0; SET enable_planner_cache=1"
```

Q1, Q2, and Flex each returned `500/500` ordered-result matches, with zero mismatches and zero errors (`1,500/1,500` total). The JSON artifacts are `final/native-correctness-i500-seed2026071305.json` and `final/native-correctness-flex-i500-seed2026071305.json` under the benchmark result directory. `go test ./...` for the driver also passed.

## Query-shape qualification

The optimization is protocol-independent for correctness, but its measurable benefit is query-shape dependent:

- Result-set `SELECT` queries that use a pulling pipeline reuse `PipelinePullingExecutor`'s dedicated thread as one worker and receive the shared fixed-overhead reductions.
- `INSERT`, `UPDATE`, `DELETE`, CTAS, and other complete pipelines still use `CompleteExecutor`'s dedicated thread. On a non-Tokio thread it also serves as one pipeline worker, so complete pipelines avoid one additional worker spawn while preserving their dedicated-executor boundary.
- No-source or already-finished statements do not create a pipeline executor, so only the applicable session/logging/privilege fast paths can help.
- A generic caller already running inside a Tokio runtime uses the original all-worker behavior for safety; this avoids `blocking_send` panics.

Therefore “effective for all queries” means the change is safe on the common public execution paths, not that every query shape gets the same speedup. For large search or analytical queries it is suitable as a no-regression refactoring, but the expected absolute gain is small relative to scan, join, aggregation, and sort time. It should not be presented as a block-pruning or analytical-query acceleration.
