### PR TITLE
fix(binder): prevent SELECT alias with grouping() from shadowing columns in GROUPING SETS

### DIFF
--- a/src/query/sql/src/planner/binder/select.rs
+++ b/src/query/sql/src/planner/binder/select.rs
@@ -113,7 +113,11 @@ impl ClauseAliasBindings {
         // With `enable_group_by_column_first`, the first binding pass should
         // use input columns only. Alias fallback is still available for simple
         // names that do not exist in the input scope.
-        if self.group_by_column_first {
+        //
+        // GROUPING SETS items (disable_select_alias_fallback = true) also prefer
+        // input columns: a SELECT alias like `if(grouping(x)=1, 0, x) AS x`
+        // must not shadow the underlying column `x` inside GROUP BY sets.
+        if self.group_by_column_first || disable_select_alias_fallback {
             return (
                 None,
                 (!self.available.is_empty()).then_some(self.available.as_slice()),

--- a/src/query/sql/tests/it/semantic/binder.rs
+++ b/src/query/sql/tests/it/semantic/binder.rs
@@ -580,6 +580,12 @@ async fn test_binder_grouping_and_srf_paths() -> Result<()> {
             setup_sqls: &["CREATE TABLE empsalary(empno UInt64, salary UInt64)"],
             sql: "SELECT listagg(cast(salary as varchar), '|') WITHIN GROUP (ORDER BY empno DESC) FROM empsalary",
         },
+        SqlTestCase {
+            name: "grouping_sets_select_alias_with_grouping_func_does_not_shadow_column",
+            description: "A SELECT alias containing grouping() must not shadow the underlying column in GROUPING SETS items.",
+            setup_sqls: &["CREATE TABLE events(category_id UInt64, label String, amount Decimal(18,6))"],
+            sql: "SELECT if(grouping(category_id)=1, 0, category_id) AS category_id, label, sum(amount) FROM events GROUP BY GROUPING SETS ((label), (category_id, label))",
+        },
     ];
 
     run_binder_cases("binder_grouping.txt", &cases).await
@@ -705,3 +711,4 @@ async fn test_materialized_cte_virtual_column_rewrite() -> Result<()> {
     run_binder_cases_with_commercial_license("binder_materialized_cte_virtual_column.txt", &cases)
         .await
 }
+

--- a/src/query/sql/tests/it/semantic/binder.rs
+++ b/src/query/sql/tests/it/semantic/binder.rs
@@ -583,7 +583,9 @@ async fn test_binder_grouping_and_srf_paths() -> Result<()> {
         SqlTestCase {
             name: "grouping_sets_select_alias_with_grouping_func_does_not_shadow_column",
             description: "A SELECT alias containing grouping() must not shadow the underlying column in GROUPING SETS items.",
-            setup_sqls: &["CREATE TABLE events(category_id UInt64, label String, amount Decimal(18,6))"],
+            setup_sqls: &[
+                "CREATE TABLE events(category_id UInt64, label String, amount Decimal(18,6))",
+            ],
             sql: "SELECT if(grouping(category_id)=1, 0, category_id) AS category_id, label, sum(amount) FROM events GROUP BY GROUPING SETS ((label), (category_id, label))",
         },
     ];
@@ -711,4 +713,3 @@ async fn test_materialized_cte_virtual_column_rewrite() -> Result<()> {
     run_binder_cases_with_commercial_license("binder_materialized_cte_virtual_column.txt", &cases)
         .await
 }
-

--- a/src/query/sql/tests/it/semantic/binder_grouping.txt
+++ b/src/query/sql/tests/it/semantic/binder_grouping.txt
@@ -256,3 +256,21 @@ EvalScalar
             └── limit: NONE
 
 
+=== grouping_sets_select_alias_with_grouping_func_does_not_shadow_column ===
+description: A SELECT alias containing grouping() must not shadow the underlying column in GROUPING SETS items.
+sql: SELECT if(grouping(category_id)=1, 0, category_id) AS category_id, label, sum(amount) FROM events GROUP BY GROUPING SETS ((label), (category_id, label))
+status: ok
+EvalScalar
+├── scalars: [events.label (#1) AS (#1), sum(amount) (#6) AS (#6), if(eq(grouping(1)(_grouping_id (#5)), 1), 0, events.category_id (#0)) AS (#7)]
+└── Aggregate(Initial)
+    ├── group items: [events.label (#1) AS (#1), events.category_id (#0) AS (#0), _grouping_id (#5) AS (#5)]
+    ├── aggregate functions: [sum(events.amount (#2)) AS (#6)]
+    └── EvalScalar
+        ├── scalars: [events.category_id (#0) AS (#0), events.label (#1) AS (#1), events.amount (#2) AS (#2)]
+        └── Scan
+            ├── table: default.events (#0)
+            ├── filters: []
+            ├── order by: []
+            └── limit: NONE
+
+

--- a/tests/sqllogictests/suites/duckdb/sql/aggregate/group/group_by_grouping_sets.test
+++ b/tests/sqllogictests/suites/duckdb/sql/aggregate/group/group_by_grouping_sets.test
@@ -346,3 +346,32 @@ drop table tt all;
 
 statement ok
 drop database grouping_sets;
+
+# Regression: SELECT alias containing grouping() must not shadow column in GROUPING SETS
+statement ok
+create database grouping_alias_regression;
+
+statement ok
+use grouping_alias_regression;
+
+statement ok
+create table events(category_id int, label string, amount int);
+
+statement ok
+insert into events values (1, 'A', 10), (1, 'B', 20), (2, 'A', 30), (2, 'B', 40);
+
+query IIT rowsort
+select if(grouping(category_id)=1, 0, category_id) as category_id, label, sum(amount) from events group by grouping sets ((label), (category_id, label));
+----
+0 A 40
+0 B 60
+1 A 10
+1 B 20
+2 A 30
+2 B 40
+
+statement ok
+drop table events all;
+
+statement ok
+drop database grouping_alias_regression;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

fix(binder): prevent SELECT alias with grouping() from shadowing columns in GROUPING SETS


## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20170)
<!-- Reviewable:end -->
