### PR TITLE
fix(storage): avoid applying Parquet fast-read setting to Fuse MergeIO

### DIFF
--- a/src/common/base/src/rangemap/range_merger.rs
+++ b/src/common/base/src/rangemap/range_merger.rs
@@ -46,7 +46,26 @@ pub struct RangeMerger {
 }
 
 impl RangeMerger {
-    pub fn from_iter<I>(
+    /// Merge ranges using only the bounded gap and range-size policy.
+    pub fn from_iter<I>(iter: I, max_gap_size: u64, max_range_size: u64) -> Self
+    where I: IntoIterator<Item = Range<u64>> {
+        Self::from_iter_inner(iter, max_gap_size, max_range_size, None)
+    }
+
+    /// Read the full span when it fits `whole_read_size`; otherwise use the bounded policy.
+    pub fn from_iter_with_whole_read<I>(
+        iter: I,
+        max_gap_size: u64,
+        max_range_size: u64,
+        whole_read_size: u64,
+    ) -> Self
+    where
+        I: IntoIterator<Item = Range<u64>>,
+    {
+        Self::from_iter_inner(iter, max_gap_size, max_range_size, Some(whole_read_size))
+    }
+
+    fn from_iter_inner<I>(
         iter: I,
         max_gap_size: u64,
         max_range_size: u64,

--- a/src/common/base/tests/it/range_merger.rs
+++ b/src/common/base/tests/it/range_merger.rs
@@ -31,7 +31,7 @@ impl fmt::Display for Array {
 fn test_range_merger() -> anyhow::Result<()> {
     let v = [3..6, 1..5, 7..11, 8..9, 9..12, 4..8, 13..15, 18..20];
 
-    let mr = RangeMerger::from_iter(v, 0, 100, None);
+    let mr = RangeMerger::from_iter(v, 0, 100);
     let actual = format!("{}", Array(mr.ranges()));
     let expect = "[1,12] [13,15] [18,20] ";
     assert_eq!(actual, expect);
@@ -46,7 +46,7 @@ fn test_range_merger_with_gap() -> anyhow::Result<()> {
 
     // max_gap_size = 1
     {
-        let mr = RangeMerger::from_iter(v.clone(), 1, 100, None);
+        let mr = RangeMerger::from_iter(v.clone(), 1, 100);
         let actual = format!("{}", Array(mr.ranges()));
         let expect = "[1,15] [18,20] ";
         assert_eq!(actual, expect);
@@ -64,7 +64,7 @@ fn test_range_merger_with_gap() -> anyhow::Result<()> {
 
     // max_gap_size = 2
     {
-        let mr = RangeMerger::from_iter(v.clone(), 2, 100, None);
+        let mr = RangeMerger::from_iter(v.clone(), 2, 100);
         let actual = format!("{}", Array(mr.ranges()));
         let expect = "[1,15] [18,20] ";
         assert_eq!(actual, expect);
@@ -82,7 +82,7 @@ fn test_range_merger_with_gap() -> anyhow::Result<()> {
 
     // max_gap_size = 3
     {
-        let mr = RangeMerger::from_iter(v.clone(), 3, 100, None);
+        let mr = RangeMerger::from_iter(v.clone(), 3, 100);
         let actual = format!("{}", Array(mr.ranges()));
         let expect = "[1,20] ";
         assert_eq!(actual, expect);
@@ -100,7 +100,7 @@ fn test_range_merger_with_gap() -> anyhow::Result<()> {
 
     // max_gap_size = 3, max_range_size = 5
     {
-        let mr = RangeMerger::from_iter(v.clone(), 3, 4, None);
+        let mr = RangeMerger::from_iter(v.clone(), 3, 4);
         let actual = format!("{}", Array(mr.ranges()));
         let expect = "[1,5] [3,8] [7,11] [8,12] [13,20] ";
         assert_eq!(actual, expect);
@@ -117,4 +117,15 @@ fn test_range_merger_with_gap() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[test]
+fn test_range_merger_with_whole_read() {
+    let v = [0..10, 100..110];
+
+    let regular = RangeMerger::from_iter(v.clone(), 0, 1000);
+    assert_eq!(regular.ranges(), vec![0..10, 100..110]);
+
+    let whole_read = RangeMerger::from_iter_with_whole_read(v, 0, 1000, 110);
+    assert_eq!(whole_read.ranges(), vec![0..110]);
 }

--- a/src/query/storages/common/io/src/merge_io_reader.rs
+++ b/src/query/storages/common/io/src/merge_io_reader.rs
@@ -55,16 +55,7 @@ impl MergeIOReader {
         }
 
         // Build merged read ranges.
-        let ranges = raw_ranges
-            .iter()
-            .map(|(_, r)| r.clone())
-            .collect::<Vec<_>>();
-        let range_merger = RangeMerger::from_iter(
-            ranges,
-            read_settings.max_gap_size,
-            read_settings.max_range_size,
-            Some(read_settings.parquet_fast_read_bytes),
-        );
+        let range_merger = Self::merge_ranges(read_settings, raw_ranges);
         let merged_ranges = range_merger.ranges();
 
         // Read merged range data.
@@ -112,5 +103,40 @@ impl MergeIOReader {
             MergeIOReadResult::create(owner_memory, columns_chunk_offsets, location.to_string());
 
         Ok(read_res)
+    }
+
+    fn merge_ranges(
+        read_settings: &ReadSettings,
+        raw_ranges: &[(ColumnId, Range<u64>)],
+    ) -> RangeMerger {
+        let ranges = raw_ranges.iter().map(|(_, range)| range.clone());
+        RangeMerger::from_iter(
+            ranges,
+            read_settings.max_gap_size,
+            read_settings.max_range_size,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fuse_merge_io_does_not_whole_read_disjoint_ranges() {
+        let read_settings = ReadSettings {
+            max_gap_size: 48,
+            max_range_size: 512 * 1024,
+            // A large global fast-read threshold must not override Fuse's MergeIO policy.
+            parquet_fast_read_bytes: u64::MAX,
+        };
+        let raw_ranges = [(0, 0..64), (1, 16 * 1024 * 1024..16 * 1024 * 1024 + 64)];
+
+        let range_merger = MergeIOReader::merge_ranges(&read_settings, &raw_ranges);
+
+        assert_eq!(range_merger.ranges(), vec![
+            0..64,
+            16 * 1024 * 1024..16 * 1024 * 1024 + 64
+        ]);
     }
 }

--- a/src/query/storages/parquet/src/parquet_reader/row_group.rs
+++ b/src/query/storages/parquet/src/parquet_reader/row_group.rs
@@ -154,11 +154,11 @@ pub async fn get_ranges(
     location: &str,
     op: &Operator,
 ) -> Result<(Vec<Bytes>, bool)> {
-    let range_merger = RangeMerger::from_iter(
+    let range_merger = RangeMerger::from_iter_with_whole_read(
         ranges.iter().cloned(),
         read_settings.max_gap_size,
         read_settings.max_range_size,
-        Some(read_settings.parquet_fast_read_bytes),
+        read_settings.parquet_fast_read_bytes,
     );
     let merged_ranges = range_merger.ranges();
     let merged = merged_ranges.len() < ranges.len();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

PR #17787 propagated `parquet_fast_read_bytes` into the common range merger. As a result, Fuse MergeIO could read the full span between disjoint column ranges whenever that span was below the Parquet fast-read threshold, bypassing the existing `storage_io_min_bytes_for_seek` and `storage_io_max_page_bytes_for_read` merge policy. A large global threshold could therefore cause substantial read amplification for Fuse tables.

This PR separates the two policies:

- The default `RangeMerger` path only applies the bounded gap and maximum-range policy used by Fuse MergeIO.
- External Parquet readers explicitly opt into whole-file reads for small files, preserving the intended `parquet_fast_read_bytes` optimization.
- A regression test verifies that Fuse MergeIO continues to honor its gap and range-size limits regardless of `parquet_fast_read_bytes`.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_


## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20171)
<!-- Reviewable:end -->