### PR TITLE
fix(stream): speed up append-only batch snapshot lookup

### DIFF
--- a/src/query/service/src/sessions/query_ctx_shared.rs
+++ b/src/query/service/src/sessions/query_ctx_shared.rs
@@ -521,6 +521,8 @@ impl QueryContextShared {
                                     &source_database_name,
                                     &source_table_name,
                                     max_batch_size,
+                                    self.get_settings()
+                                        .get_enable_stream_batch_snapshot_forward_scan()?,
                                     self.get_settings().get_s3_storage_class()?,
                                 )
                                 .await?;

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -1507,6 +1507,13 @@ impl DefaultSettings {
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(0..=u64::MAX)),
                 }),
+                ("enable_stream_batch_snapshot_forward_scan", DefaultSettingValue {
+                    value: UserSettingValue::UInt64(0),
+                    desc: "Enable forward UUID-v7 snapshot scanning when applying a stream batch size hint.",
+                    mode: SettingMode::Both,
+                    scope: SettingScope::Both,
+                    range: Some(SettingRange::Numeric(0..=1)),
+                }),
                 ("warehouse", DefaultSettingValue {
                     value: UserSettingValue::String("".to_string()),
                     desc: "Please use the <use warehouse> statement to set the warehouse, this settings is only used to synchronize the warehouse status between the client and the server.",

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -1095,6 +1095,10 @@ impl Settings {
         Ok(if v == 0 { None } else { Some(v) })
     }
 
+    pub fn get_enable_stream_batch_snapshot_forward_scan(&self) -> Result<bool> {
+        Ok(self.try_get_u64("enable_stream_batch_snapshot_forward_scan")? != 0)
+    }
+
     /// # Safety
     pub unsafe fn set_warehouse(&self, warehouse: String) -> Result<()> {
         unsafe { self.unchecked_set_setting(String::from("warehouse"), warehouse) }

--- a/src/query/storages/fuse/src/operations/mod.rs
+++ b/src/query/storages/fuse/src/operations/mod.rs
@@ -34,6 +34,7 @@ mod replace;
 mod replace_into;
 mod revert;
 mod snapshot_hint;
+mod stream_batch;
 mod table_index;
 mod truncate;
 mod util;

--- a/src/query/storages/fuse/src/operations/stream_batch.rs
+++ b/src/query/storages/fuse/src/operations/stream_batch.rs
@@ -1,0 +1,376 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use databend_common_exception::Result;
+use databend_storages_common_table_meta::meta::FormatVersion;
+use databend_storages_common_table_meta::meta::SnapshotId;
+use databend_storages_common_table_meta::meta::TableSnapshot;
+use databend_storages_common_table_meta::meta::VACUUM2_OBJECT_KEY_PREFIX;
+use databend_storages_common_table_meta::meta::Versioned;
+use databend_storages_common_table_meta::meta::is_uuid_v7;
+use futures::TryStreamExt;
+use opendal::EntryMode;
+
+use crate::FUSE_TBL_SNAPSHOT_PREFIX;
+use crate::FuseTable;
+use crate::io::SnapshotsIO;
+use crate::io::TableMetaLocationGenerator;
+
+const V4_SNAPSHOT_SUFFIX: &str = "_v4.mpk";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct StreamBatchCandidate {
+    snapshot_id: SnapshotId,
+    prev_snapshot_id: Option<(SnapshotId, FormatVersion)>,
+    row_count: u64,
+    location: String,
+    format_version: FormatVersion,
+}
+
+impl StreamBatchCandidate {
+    fn new(snapshot: &TableSnapshot, location: String, format_version: FormatVersion) -> Self {
+        Self {
+            snapshot_id: snapshot.snapshot_id,
+            prev_snapshot_id: snapshot.prev_snapshot_id,
+            row_count: snapshot.summary.row_count,
+            location,
+            format_version,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ObserveResult {
+    Continue,
+    Selected(StreamBatchCandidate),
+    Fallback,
+}
+
+struct StreamBatchSelector {
+    base_snapshot_id: Option<SnapshotId>,
+    base_row_count: u64,
+    batch_limit: u64,
+    latest_snapshot_id: SnapshotId,
+    scanned: HashMap<SnapshotId, StreamBatchCandidate>,
+    proven_committed: HashSet<SnapshotId>,
+    selected: Option<StreamBatchCandidate>,
+}
+
+impl StreamBatchSelector {
+    fn new(
+        base_snapshot_id: Option<SnapshotId>,
+        base_row_count: u64,
+        batch_limit: u64,
+        latest_snapshot_id: SnapshotId,
+    ) -> Self {
+        let mut proven_committed = HashSet::new();
+        if let Some(base_snapshot_id) = base_snapshot_id {
+            proven_committed.insert(base_snapshot_id);
+        }
+
+        Self {
+            base_snapshot_id,
+            base_row_count,
+            batch_limit,
+            latest_snapshot_id,
+            scanned: HashMap::new(),
+            proven_committed,
+            selected: None,
+        }
+    }
+
+    fn observe(&mut self, candidate: StreamBatchCandidate) -> ObserveResult {
+        let snapshot_id = candidate.snapshot_id;
+        let prev_snapshot_id = candidate.prev_snapshot_id;
+        self.scanned.insert(snapshot_id, candidate.clone());
+
+        // Every snapshot written by Databend is based on a committed previous snapshot.
+        // Thus, seeing a child proves that its previous snapshot is a legal batch boundary,
+        // even when the child itself is an orphan left by a failed optimistic commit.
+        // This assumes the table has not been FLASHBACKed: flashback can leave committed
+        // snapshots on an abandoned branch. Detecting that history is intentionally out of
+        // scope for this optimization; keep the setting disabled for tables using flashback.
+        if let Some((prev_snapshot_id, _)) = prev_snapshot_id {
+            if let Some(previous) = self.scanned.get(&prev_snapshot_id).cloned() {
+                let result = self.consider_committed(previous);
+                if result != ObserveResult::Continue {
+                    return result;
+                }
+            }
+        }
+
+        // The catalog pointer independently proves that the latest snapshot is committed.
+        if snapshot_id == self.latest_snapshot_id {
+            let result = self.consider_committed(candidate);
+            if result != ObserveResult::Continue {
+                return result;
+            }
+            return self
+                .selected
+                .clone()
+                .map_or(ObserveResult::Fallback, ObserveResult::Selected);
+        }
+
+        ObserveResult::Continue
+    }
+
+    fn consider_committed(&mut self, candidate: StreamBatchCandidate) -> ObserveResult {
+        if Some(candidate.snapshot_id) == self.base_snapshot_id
+            || !self.proven_committed.insert(candidate.snapshot_id)
+        {
+            return ObserveResult::Continue;
+        }
+
+        // A committed V4 snapshot pointing to an older-format snapshot means the requested
+        // interval crosses the UUID-v7 history boundary. Let the linked-list fallback handle it.
+        if candidate
+            .prev_snapshot_id
+            .is_some_and(|(_, version)| version < TableSnapshot::VERSION)
+        {
+            return ObserveResult::Fallback;
+        }
+
+        let change_row_count = candidate.row_count.abs_diff(self.base_row_count);
+        if change_row_count <= self.batch_limit {
+            self.selected = Some(candidate);
+            ObserveResult::Continue
+        } else {
+            // The limit is a hint. If one commit is already larger than it, select that commit
+            // so the stream can still make progress.
+            ObserveResult::Selected(self.selected.clone().unwrap_or(candidate))
+        }
+    }
+}
+
+impl FuseTable {
+    /// Find a committed V4 snapshot after `base_snapshot` by listing UUID-v7 snapshot keys in
+    /// chronological order. Returns `None` when the fast path is unavailable or cannot establish
+    /// a boundary; callers should fall back to traversing `prev_snapshot_id` from the latest.
+    pub async fn try_find_stream_batch_snapshot_v4(
+        &self,
+        base_snapshot: Option<&TableSnapshot>,
+        batch_limit: u64,
+    ) -> Result<Option<(Arc<TableSnapshot>, FormatVersion)>> {
+        let Some(latest_location) = self.snapshot_loc() else {
+            return Ok(None);
+        };
+        let latest_version = TableMetaLocationGenerator::snapshot_version(&latest_location);
+        if latest_version != TableSnapshot::VERSION {
+            return Ok(None);
+        }
+
+        let Some(latest_snapshot) = self.read_table_snapshot().await? else {
+            return Ok(None);
+        };
+        if !is_uuid_v7(&latest_snapshot.snapshot_id) {
+            return Ok(None);
+        }
+
+        let (base_snapshot_id, base_row_count, start_after) = match base_snapshot {
+            Some(base) => {
+                if base.format_version != TableSnapshot::VERSION || !is_uuid_v7(&base.snapshot_id) {
+                    return Ok(None);
+                }
+                if base.snapshot_id == latest_snapshot.snapshot_id {
+                    return Ok(Some((latest_snapshot, latest_version)));
+                }
+                let location = self
+                    .meta_location_generator()
+                    .gen_snapshot_location(&base.snapshot_id, TableSnapshot::VERSION)?;
+                (Some(base.snapshot_id), base.summary.row_count, location)
+            }
+            None => {
+                let snapshot_prefix = format!(
+                    "{}/{}/",
+                    self.meta_location_generator().prefix(),
+                    FUSE_TBL_SNAPSHOT_PREFIX
+                );
+                (
+                    None,
+                    0,
+                    format!("{}{}", snapshot_prefix, VACUUM2_OBJECT_KEY_PREFIX),
+                )
+            }
+        };
+
+        let operator = self.get_operator();
+        if !operator.info().full_capability().list_with_start_after {
+            return Ok(None);
+        }
+
+        let snapshot_prefix = format!(
+            "{}/{}/",
+            self.meta_location_generator().prefix(),
+            FUSE_TBL_SNAPSHOT_PREFIX
+        );
+        let mut lister = operator
+            .lister_with(&snapshot_prefix)
+            .start_after(&start_after)
+            .await?;
+        let mut selector = StreamBatchSelector::new(
+            base_snapshot_id,
+            base_row_count,
+            batch_limit,
+            latest_snapshot.snapshot_id,
+        );
+
+        while let Some(entry) = lister.try_next().await? {
+            if entry.metadata().mode() != EntryMode::FILE {
+                continue;
+            }
+
+            let location = entry.path().to_string();
+            if location.as_str() > latest_location.as_str() {
+                break;
+            }
+            if !location.ends_with(V4_SNAPSHOT_SUFFIX) {
+                continue;
+            }
+
+            let (snapshot, format_version) = if location == latest_location {
+                (latest_snapshot.clone(), latest_version)
+            } else {
+                SnapshotsIO::read_snapshot(location.clone(), operator.clone(), true).await?
+            };
+            if format_version != TableSnapshot::VERSION || !is_uuid_v7(&snapshot.snapshot_id) {
+                return Ok(None);
+            }
+
+            let candidate = StreamBatchCandidate::new(&snapshot, location.clone(), format_version);
+            match selector.observe(candidate) {
+                ObserveResult::Continue => {}
+                ObserveResult::Fallback => return Ok(None),
+                ObserveResult::Selected(candidate) => {
+                    if candidate.snapshot_id == latest_snapshot.snapshot_id {
+                        return Ok(Some((latest_snapshot, latest_version)));
+                    }
+                    let (snapshot, _) =
+                        SnapshotsIO::read_snapshot(candidate.location, operator.clone(), true)
+                            .await?;
+                    return Ok(Some((snapshot, candidate.format_version)));
+                }
+            }
+
+            if location == latest_location {
+                break;
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Builder;
+
+    use super::*;
+
+    fn snapshot_id(millis: u64) -> SnapshotId {
+        Builder::from_unix_timestamp_millis(millis, &[0; 10]).into_uuid()
+    }
+
+    fn candidate(millis: u64, prev_millis: Option<u64>, row_count: u64) -> StreamBatchCandidate {
+        let id = snapshot_id(millis);
+        StreamBatchCandidate {
+            snapshot_id: id,
+            prev_snapshot_id: prev_millis.map(|prev| (snapshot_id(prev), TableSnapshot::VERSION)),
+            row_count,
+            location: id.to_string(),
+            format_version: TableSnapshot::VERSION,
+        }
+    }
+
+    #[test]
+    fn test_selects_proven_committed_snapshot_and_ignores_orphan() {
+        let base = snapshot_id(1);
+        let latest = snapshot_id(5);
+        let mut selector = StreamBatchSelector::new(Some(base), 0, 2, latest);
+
+        assert_eq!(
+            selector.observe(candidate(2, Some(1), 100)),
+            ObserveResult::Continue
+        );
+        assert_eq!(
+            selector.observe(candidate(3, Some(1), 1)),
+            ObserveResult::Continue
+        );
+        assert_eq!(
+            selector.observe(candidate(4, Some(3), 2)),
+            ObserveResult::Continue
+        );
+        assert_eq!(
+            selector.observe(candidate(5, Some(4), 3)),
+            ObserveResult::Selected(candidate(4, Some(3), 2))
+        );
+    }
+
+    #[test]
+    fn test_oversized_first_commit_still_makes_progress() {
+        let base = snapshot_id(1);
+        let latest = snapshot_id(4);
+        let mut selector = StreamBatchSelector::new(Some(base), 0, 1, latest);
+
+        assert_eq!(
+            selector.observe(candidate(2, Some(1), 3)),
+            ObserveResult::Continue
+        );
+        assert_eq!(
+            selector.observe(candidate(3, Some(2), 4)),
+            ObserveResult::Selected(candidate(2, Some(1), 3))
+        );
+    }
+
+    #[test]
+    fn test_mixed_snapshot_history_falls_back() {
+        let base = snapshot_id(1);
+        let latest = snapshot_id(2);
+        let mut selector = StreamBatchSelector::new(Some(base), 0, 1, latest);
+        let mut latest_candidate = candidate(2, Some(1), 1);
+        latest_candidate.prev_snapshot_id = Some((base, TableSnapshot::VERSION - 1));
+
+        assert_eq!(selector.observe(latest_candidate), ObserveResult::Fallback);
+    }
+
+    #[test]
+    fn test_catalog_proves_latest_snapshot() {
+        let base = snapshot_id(1);
+        let latest = snapshot_id(2);
+        let mut selector = StreamBatchSelector::new(Some(base), 0, 1, latest);
+
+        assert_eq!(
+            selector.observe(candidate(2, Some(1), 1)),
+            ObserveResult::Selected(candidate(2, Some(1), 1))
+        );
+    }
+
+    #[test]
+    fn test_stream_without_base_snapshot() {
+        let latest = snapshot_id(2);
+        let mut selector = StreamBatchSelector::new(None, 0, 1, latest);
+
+        assert_eq!(
+            selector.observe(candidate(1, None, 1)),
+            ObserveResult::Continue
+        );
+        assert_eq!(
+            selector.observe(candidate(2, Some(1), 2)),
+            ObserveResult::Selected(candidate(1, None, 1))
+        );
+    }
+}

--- a/src/query/storages/stream/src/stream_table.rs
+++ b/src/query/storages/stream/src/stream_table.rs
@@ -138,6 +138,7 @@ impl StreamTable {
         source_db_name: &str,
         source_tb_name: &str,
         batch_limit: Option<u64>,
+        enable_snapshot_forward_scan: bool,
         s3_storage_class: S3StorageClass,
     ) -> Result<Arc<dyn Table>> {
         let stream_desc = &self.info.desc;
@@ -169,12 +170,49 @@ impl StreamTable {
         let fuse_table = FuseTable::try_from_table(source.as_ref())?;
         fuse_table.check_changes_valid(source_desc, self.offset()?)?;
 
-        let (base_row_count, base_timsestamp) = if let Some(base_loc) = self.snapshot_loc() {
+        let base_snapshot = if let Some(base_loc) = self.snapshot_loc() {
             let base = fuse_table.changes_read_offset_snapshot(&base_loc).await?;
-            (base.summary.row_count, base.timestamp)
+            Some(base)
         } else {
-            (0, None)
+            None
         };
+        let base_row_count = base_snapshot
+            .as_ref()
+            .map_or(0, |snapshot| snapshot.summary.row_count);
+        let base_timestamp = base_snapshot
+            .as_ref()
+            .and_then(|snapshot| snapshot.timestamp);
+
+        let start = Instant::now();
+        if enable_snapshot_forward_scan && self.mode() == StreamMode::AppendOnly {
+            match fuse_table
+                .try_find_stream_batch_snapshot_v4(base_snapshot.as_deref(), batch_limit)
+                .await
+            {
+                Ok(Some((snapshot, format_version))) => {
+                    log::info!(
+                        "Stream {} searched UUID-v7 snapshots of source table {} forward, cost:{:?}",
+                        stream_desc,
+                        source_desc,
+                        start.elapsed(),
+                    );
+                    return Ok(fuse_table.load_table_by_snapshot(
+                        snapshot.as_ref(),
+                        format_version,
+                        s3_storage_class,
+                    )?);
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    log::warn!(
+                        "Stream {} failed to search UUID-v7 snapshots of source table {} forward, fallback to snapshot history traversal: {}",
+                        stream_desc,
+                        source_desc,
+                        error
+                    );
+                }
+            }
+        }
 
         let Some(location) = fuse_table.snapshot_loc() else {
             return Ok(source);
@@ -188,9 +226,8 @@ impl StreamTable {
         );
 
         let mut instant = None;
-        let start = Instant::now();
         while let Some(snapshot_with_version) = snapshot_stream.try_next().await? {
-            if snapshot_with_version.0.timestamp <= base_timsestamp {
+            if snapshot_with_version.0.timestamp <= base_timestamp {
                 break;
             }
 

--- a/tests/suites/5_ee/05_stream/05_0005_stream_batch_forward_scan.result
+++ b/tests/suites/5_ee/05_stream/05_0005_stream_batch_forward_scan.result
@@ -1,0 +1,8 @@
+batch 1
+1
+2
+batch 2
+3
+4
+remaining
+5

--- a/tests/suites/5_ee/05_stream/05_0005_stream_batch_forward_scan.sh
+++ b/tests/suites/5_ee/05_stream/05_0005_stream_batch_forward_scan.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../../../shell_env.sh
+
+# The EE sqllogic job uses local FS, which does not advertise
+# list_with_start_after and would only exercise the fallback path. This EE
+# functional suite runs on MinIO/S3 so the forward-scan path is covered.
+
+echo "drop database if exists db_stream_forward_batch" | bendsql_connect_root_null
+echo "create database db_stream_forward_batch" | bendsql_connect_root_null
+echo "create table db_stream_forward_batch.t(c int)" | bendsql_connect_root_null
+echo "create stream db_stream_forward_batch.s on table db_stream_forward_batch.t append_only = true" | bendsql_connect_root_null
+
+for i in {1..5}; do
+  echo "insert into db_stream_forward_batch.t values ($i)" | bendsql_connect_root_null
+done
+
+echo "batch 1"
+echo "set enable_stream_batch_snapshot_forward_scan = 1; select c from db_stream_forward_batch.s with (consume = true, max_batch_size = 2) order by c" | bendsql_connect_root
+
+echo "batch 2"
+echo "set enable_stream_batch_snapshot_forward_scan = 1; select c from db_stream_forward_batch.s with (consume = true, max_batch_size = 2) order by c" | bendsql_connect_root
+
+echo "remaining"
+echo "select c from db_stream_forward_batch.s order by c" | bendsql_connect_root
+
+echo "drop database if exists db_stream_forward_batch" | bendsql_connect_root_null


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Speed up append-only stream batch lookup by listing UUID-v7 V4 snapshot keys forward from the stream offset instead of traversing the full snapshot history backward from the latest snapshot
- Select only snapshots proven committed by the catalog pointer or a child reference, so orphan snapshots left by failed optimistic commits are not used as batch boundaries
- Fall back to the existing history traversal for unsupported object-store listing, legacy or mixed snapshot histories, and fast-path errors
- Use a MinIO-backed EE functional test instead of a logic test because the EE sqllogic job uses local FS, which does not support `list_with_start_after` and would only exercise the fallback path

## Implementation

- Add a forward snapshot selector for append-only streams with `max_batch_size`
- Gate the fast path behind settings **`enable_stream_batch_snapshot_forward_scan`**; the global/session setting **defaults to `0` (disabled)**
- Consume the whole first post-offset commit when it exceeds `max_batch_size`, because the limit is a hint and a snapshot cannot be split
- Keep the existing snapshot cache behavior and retain only lightweight scan metadata locally
- Add selector coverage for committed snapshots, orphan snapshots, oversized commits, mixed versions, the latest snapshot, and streams created on empty tables (no base snapshot)
- Add a MinIO-backed EE regression that consumes a stale stream across multiple batches on storage supporting `list_with_start_after`

## Known limitation

Forward snapshot scanning assumes the source table has not been `FLASHBACK`ed after the stream offset. Flashback can leave committed snapshots on an abandoned history branch; this PR does not attempt to detect such branches or prove ancestry to the current catalog snapshot.

Keep `enable_stream_batch_snapshot_forward_scan` disabled for tables using flashback. The optimization is opt-in and does not change default behavior.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [x] Integration Test (MinIO/S3 functional test)
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Completed local validation:

- `cargo fmt --all -- --check`
- `cargo test -p databend-common-storages-fuse stream_batch --lib`
- Dev CI: [29685452860](https://github.com/databendlabs/databend/actions/runs/29685452860), including the MinIO-backed `linux / test_ee_standalone` regression

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20173)

<!-- Reviewable:end -->


