### PR TITLE
refactor(query): read geometry SRID from EWKB header via geozero

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8436,21 +8436,21 @@ dependencies = [
 
 [[package]]
 name = "geojson"
-version = "0.24.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d728c1df1fbf328d74151efe6cb0586f79ee813346ea981add69bd22c9241b"
+checksum = "510c094bfc76ea34d02eee00833254945b70491d79a9c0b050abed6eaa799ffb"
 dependencies = [
  "log",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
+ "tinyvec",
 ]
 
 [[package]]
 name = "geozero"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db5eda63aa99ac06160fd53328ed75c34f14e3196d3f56a3649e247ed796e54b"
+version = "0.14.0"
+source = "git+https://github.com/georust/geozero.git?rev=bda4d03#bda4d03ff5005f0dde3b666e74eb25ab97fce46c"
 dependencies = [
  "geo-types",
  "geojson",
@@ -17872,10 +17872,11 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.9.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
+ "serde_core",
  "tinyvec_macros",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -275,7 +275,13 @@ futures-util = "0.3.24"
 geo = { version = "0.32.0", features = ["use-serde"] }
 geo-index = "0.3.4"
 geohash = "0.13.1"
-geozero = { version = "0.15.1", features = ["with-geo", "with-geojson", "with-wkb", "with-wkt"] }
+# Pinned to a git rev to include https://github.com/georust/geozero/pull/278
+geozero = { git = "https://github.com/georust/geozero.git", rev = "bda4d03", features = [
+    "with-geo",
+    "with-geojson",
+    "with-wkb",
+    "with-wkt",
+] }
 gimli = "0.31.0"
 glob = "0.3.0"
 globiter = "0.1"

--- a/src/common/io/src/geometry.rs
+++ b/src/common/io/src/geometry.rs
@@ -111,27 +111,15 @@ pub fn parse_bytes_to_ewkb(buf: &[u8], srid: Option<i32>) -> Result<Vec<u8>> {
 /// # Example
 ///
 /// ```
-/// let geo_json = r#"
-///         {
-///           "type": "Feature",
-///           "geometry": {
-///             "type": "Point",
-///             "coordinates": [125.6, 10.1]
-///           },
-///           "properties": {
-///             "name": "Dinagat Islands"
-///           }
-///         }
-///     "#;
+/// use databend_common_io::geometry::geometry_from_str;
 ///
-/// let wkt: &[u8] = "LINESTRING(0 0 1, 1 1 1, 2 1 2)".as_bytes();
-/// let wkb: &[u8] = "0101000020797f000066666666a9cb17411f85ebc19e325641".as_bytes();
-/// println!(
-///     "wkt:{ } wkb:{ } json: { }",
-///     geometry_from_str(wkt).unwrap(),
-///     geometry_from_str(wkb).unwrap(),
-///     geometry_from_str(geo_json.as_bytes()).unwrap()
-/// );
+/// // WKT input without SRID
+/// let ewkb = geometry_from_str("POINT(125.6 10.1)", None).unwrap();
+/// assert_eq!(ewkb.len(), 21); // endian(1) + type(4) + x/y(16)
+///
+/// // EWKT input with SRID
+/// let ewkb = geometry_from_str("SRID=4326;POINT(125.6 10.1)", None).unwrap();
+/// assert_eq!(ewkb.len(), 25); // endian(1) + type(4) + srid(4) + x/y(16)
 /// ```
 pub fn geometry_from_str(input: &str, srid: Option<i32>) -> Result<Vec<u8>> {
     let input = input.trim();

--- a/src/query/functions/src/scalars/geographic/src/geometry.rs
+++ b/src/query/functions/src/scalars/geographic/src/geometry.rs
@@ -42,7 +42,6 @@ use databend_common_io::Axis;
 use databend_common_io::Extremum;
 use databend_common_io::GEOGRAPHY_SRID;
 use databend_common_io::UNKNOWN_SRID;
-use databend_common_io::ewkb_to_bbox;
 use databend_common_io::ewkb_to_geo;
 use databend_common_io::geo_to_ewkb;
 use databend_common_io::geo_to_ewkt;
@@ -752,9 +751,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                 }
             }
 
-            let srid = ewkb_to_bbox(ewkb)
-                .and_then(|result| result.srid)
-                .unwrap_or(UNKNOWN_SRID);
+            let srid = Ewkb(ewkb).srid().unwrap_or(UNKNOWN_SRID);
             output.push(srid);
         }),
     );
@@ -772,9 +769,7 @@ pub fn register(registry: &mut FunctionRegistry) {
                     }
                 }
 
-                // All representations of the geo types supported by crates under the GeoRust organization, have not implemented srid().
-                // Currently, the srid() of all types returns the default value `None`, so we need to parse it manually here.
-                let Some(from_srid) = ewkb_to_bbox(original).and_then(|result| result.srid) else {
+                let Some(from_srid) = Ewkb(original).srid() else {
                     ctx.set_error(row, "input geometry must has the correct SRID".to_string());
                     builder.commit_row();
                     return;
@@ -1083,9 +1078,10 @@ fn st_transform_impl(
     .map_err(|_| ErrorCode::GeometryError("invalid to srid"))?;
 
     let old = Ewkb(original.to_vec());
-    let res = Ewkb(old.to_ewkb(old.dims(), Some(from_srid)).unwrap())
-        .to_geo()
+    let res = old
+        .to_ewkb(old.dims(), Some(from_srid))
         .map_err(Box::new(ErrorCode::from))
+        .and_then(|ewkb| Ewkb(ewkb).to_geo().map_err(Box::new(ErrorCode::from)))
         .and_then(|mut geom| {
             // EPSG:4326 WGS84 in proj4rs is in radians, not degrees.
             if from_srid == GEOGRAPHY_SRID {

--- a/tests/sqllogictests/suites/query/functions/02_0076_function_geography.test
+++ b/tests/sqllogictests/suites/query/functions/02_0076_function_geography.test
@@ -132,7 +132,7 @@ SELECT st_x(st_geogfromwkt('POINT(37.5 45.5)')), st_y(st_geogfromwkt('POINT(37.5
 ----
 37.5 45.5
 
-query ?
+query RR
 SELECT st_x(st_geogfromwkt(NULL)), st_y(st_geogfromwkt(NULL));
 ----
 NULL NULL


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- `st_srid` and 2-arg `st_transform` now read the SRID directly from the EWKB header instead of scanning all coordinates to compute a bbox they don't need.
- Pin geozero to a git rev to pick up the upstream fix for georust/geozero#195


<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20174)
<!-- Reviewable:end -->
