### PR TITLE
fix(query): avoid buffer retention in K-way merge sort with LIMIT

### DIFF
--- a/src/query/pipeline/transforms/src/processors/transforms/sorts/sort_k_way_merge.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sorts/sort_k_way_merge.rs
@@ -611,15 +611,14 @@ impl KWayMergeCombinerProcessor {
                 None => block,
                 Some(limit) => {
                     let n = block.num_rows();
-                    if *limit >= n {
+                    if *limit > n {
                         *limit -= n;
                         block
                     } else {
                         let range = 0..*limit;
                         *limit = 0;
-                        // String views in a slice keep the source block's buffers alive. The
-                        // boundary block can be much larger than the remaining LIMIT, so compact
-                        // sparse views before sending the final Top-N block downstream.
+                        // String views in a sliced block keep the source buffers alive. Compact
+                        // the boundary block even when it exactly fills the remaining LIMIT.
                         block.slice(range).maybe_gc()
                     }
                 }

--- a/src/query/pipeline/transforms/src/processors/transforms/sorts/sort_k_way_merge.rs
+++ b/src/query/pipeline/transforms/src/processors/transforms/sorts/sort_k_way_merge.rs
@@ -617,7 +617,10 @@ impl KWayMergeCombinerProcessor {
                     } else {
                         let range = 0..*limit;
                         *limit = 0;
-                        block.slice(range)
+                        // String views in a slice keep the source block's buffers alive. The
+                        // boundary block can be much larger than the remaining LIMIT, so compact
+                        // sparse views before sending the final Top-N block downstream.
+                        block.slice(range).maybe_gc()
                     }
                 }
             };

--- a/src/query/service/tests/it/pipelines/transforms/sort/k_way.rs
+++ b/src/query/service/tests/it/pipelines/transforms/sort/k_way.rs
@@ -183,25 +183,24 @@ async fn test_k_way_merge_sort_fuzz() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_k_way_merge_sort_limit_compacts_string_views() -> anyhow::Result<()> {
-    let fixture = TestFixture::setup().await?;
-    let ctx = fixture.new_query_ctx().await?;
-
+fn make_wide_block(start: i32, rows: i32) -> DataBlock {
     let payload_suffix = "x".repeat(256);
-    let make_block = |start: i32| {
-        let keys = (start..start + 2_000).collect::<Vec<_>>();
-        let payloads = keys
-            .iter()
-            .map(|key| format!("{key:08}-{payload_suffix}"))
-            .collect::<Vec<_>>();
-        DataBlock::new_from_columns(vec![
-            Int32Type::from_data(keys),
-            StringType::from_data(payloads),
-        ])
-    };
-    let data = vec![vec![make_block(0)], vec![make_block(2_000)]];
-    let limit = 10;
+    let keys = (start..start + rows).collect::<Vec<_>>();
+    let payloads = keys
+        .iter()
+        .map(|key| format!("{key:08}-{payload_suffix}"))
+        .collect::<Vec<_>>();
+    DataBlock::new_from_columns(vec![
+        Int32Type::from_data(keys),
+        StringType::from_data(payloads),
+    ])
+}
+
+async fn assert_limit_compacts_string_views(
+    ctx: Arc<QueryContext>,
+    data: Vec<Vec<DataBlock>>,
+    limit: usize,
+) -> anyhow::Result<()> {
     let (executor, mut rx) = create_pipeline(ctx, data, 2, 4_096, Some(limit), true)?;
 
     executor.execute()?;
@@ -229,4 +228,26 @@ async fn test_k_way_merge_sort_limit_compacts_string_views() -> anyhow::Result<(
     );
 
     Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_k_way_merge_sort_limit_compacts_string_views() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup().await?;
+    let ctx = fixture.new_query_ctx().await?;
+    let first = make_wide_block(0, 2_000);
+    let second = make_wide_block(2_000, 2_000);
+    let data = vec![vec![first], vec![second]];
+
+    assert_limit_compacts_string_views(ctx, data, 10).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_k_way_merge_sort_exact_limit_compacts_string_views() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup().await?;
+    let ctx = fixture.new_query_ctx().await?;
+    let first = make_wide_block(0, 2_000).slice(0..10);
+    let second = make_wide_block(2_000, 2_000);
+    let data = vec![vec![first], vec![second]];
+
+    assert_limit_compacts_string_views(ctx, data, 10).await
 }

--- a/src/query/service/tests/it/pipelines/transforms/sort/k_way.rs
+++ b/src/query/service/tests/it/pipelines/transforms/sort/k_way.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use databend_common_expression::Column;
+use databend_common_expression::types::StringType;
 use databend_common_pipeline_transforms::sorts::add_k_way_merge_sort;
 use databend_common_pipeline_transforms::sorts::core::SortKeyDescription;
 
@@ -27,11 +29,17 @@ fn create_pipeline(
 ) -> Result<(Arc<QueryPipelineExecutor>, Receiver<Result<DataBlock>>)> {
     let mut pipeline = Pipeline::create();
 
-    let data_type = data[0][0].data_type(0);
+    let schema = DataSchemaRefExt::create(
+        data[0][0]
+            .columns()
+            .iter()
+            .enumerate()
+            .map(|(index, entry)| DataField::new(&format!("c{index}"), entry.data_type()))
+            .collect(),
+    );
     let source_pipe = create_source_pipe(ctx, data)?;
     pipeline.add_pipe(source_pipe);
 
-    let schema = DataSchemaRefExt::create(vec![DataField::new("a", data_type)]);
     let sort_desc = [SortColumnDescription {
         offset: 0,
         asc: true,
@@ -172,5 +180,53 @@ async fn test_k_way_merge_sort_fuzz() -> anyhow::Result<()> {
         let ctx = fixture.new_query_ctx().await?;
         run_fuzz(ctx, &mut rng, true).await?;
     }
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_k_way_merge_sort_limit_compacts_string_views() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup().await?;
+    let ctx = fixture.new_query_ctx().await?;
+
+    let payload_suffix = "x".repeat(256);
+    let make_block = |start: i32| {
+        let keys = (start..start + 2_000).collect::<Vec<_>>();
+        let payloads = keys
+            .iter()
+            .map(|key| format!("{key:08}-{payload_suffix}"))
+            .collect::<Vec<_>>();
+        DataBlock::new_from_columns(vec![
+            Int32Type::from_data(keys),
+            StringType::from_data(payloads),
+        ])
+    };
+    let data = vec![vec![make_block(0)], vec![make_block(2_000)]];
+    let limit = 10;
+    let (executor, mut rx) = create_pipeline(ctx, data, 2, 4_096, Some(limit), true)?;
+
+    executor.execute()?;
+
+    let mut result = Vec::new();
+    while !rx.is_empty() {
+        result.push(rx.recv().await.unwrap()?);
+    }
+
+    assert_eq!(result.iter().map(DataBlock::num_rows).sum::<usize>(), limit);
+
+    let mut total_bytes_len = 0;
+    let mut total_buffer_len = 0;
+    for block in &result {
+        let Column::String(payloads) = block.get_by_offset(1).to_column() else {
+            unreachable!("expected string payload column")
+        };
+        total_bytes_len += payloads.total_bytes_len();
+        total_buffer_len += payloads.total_buffer_len();
+    }
+    assert_eq!(total_bytes_len, limit * (8 + 1 + 256));
+    assert!(
+        total_buffer_len < 16 * 1024,
+        "LIMIT output retained {total_buffer_len} bytes of source string buffers",
+    );
+
     Ok(())
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

### Purpose

Prevent the final LIMIT output of parallel K-way merge sort from retaining unrelated backing buffers through sparse string views. Without compaction, those retained buffers can inflate query memory, increase spill pressure, and lead to out-of-memory failures.

### Why StringView retains memory

A StringView column stores small view records separately from the buffers that contain the variable-length string bytes. `DataBlock::slice()` trims the array of views, but the sliced column continues to share all backing buffers with the source column. As a result, a final LIMIT block can contain only the required views while keeping unrelated source buffers alive until that block is dropped.

The boundary block can also arrive at the combiner as an existing slice. This is why the exact-limit case must be handled as well as the partial-block case.

### Implementation

- Run `maybe_gc()` on the final boundary block whether it contains a partial block or exactly matches the remaining LIMIT.
- `maybe_gc()` compares the live string bytes with the retained backing buffers. When its existing savings thresholds are met, it rebuilds the live views into smaller buffers so the original shared buffers can be released.
- Add regression coverage for both boundary cases.

### Performance impact

- Reduces retained memory and spill pressure for affected limited sorts by releasing backing buffers that are no longer needed.
- Compaction may copy the live variable-length values in the final boundary block, trading a bounded amount of CPU and memory bandwidth for a smaller retained working set.
- `maybe_gc()` applies its existing savings thresholds, so compact blocks and non-string columns only incur lightweight checks and are not copied.
- Query result semantics are unchanged.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:

- cargo test -p databend-query --test it pipelines::transforms::sort::k_way:: -- --nocapture
- cargo clippy -p databend-query --test it -- -D warnings
- cargo fmt --all --check

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20178)
<!-- Reviewable:end -->