### PR TITLE
fix(query): compact writes with zero block hint

### DIFF
--- a/src/query/service/src/interpreters/hook/compact_hook.rs
+++ b/src/query/service/src/interpreters/hook/compact_hook.rs
@@ -29,6 +29,7 @@ use databend_common_sql::optimizer::ir::SExpr;
 use databend_common_sql::plans::OptimizeCompactBlock;
 use databend_common_sql::plans::ReclusterPlan;
 use databend_common_sql::plans::RelOperator;
+use databend_common_storages_fuse::FUSE_OPT_KEY_AUTO_COMPACTION_IMPERFECT_BLOCKS_THRESHOLD;
 use log::info;
 
 use crate::interpreters::Interpreter;
@@ -148,9 +149,11 @@ pub(crate) async fn execute_compact_hook(
         "Table {} requires compaction of {} blocks",
         compact_target.table, compaction_num_block_hint
     );
-    if compaction_num_block_hint == 0 {
+    if compaction_num_block_hint == 0 && auto_compaction_disabled(&ctx, &compact_target).await? {
         return Ok(());
     }
+    // A zero hint still lets the block compactor inspect the newly written segment and its
+    // neighbor. It also keeps the recluster step reachable for tables with a cluster key.
     let compaction_limits = CompactionLimits {
         segment_limit: None,
         block_limit: Some(compaction_num_block_hint as usize),
@@ -183,6 +186,30 @@ pub(crate) async fn execute_compact_hook(
     );
 
     Ok(())
+}
+
+async fn auto_compaction_disabled(
+    ctx: &Arc<QueryContext>,
+    compact_target: &CompactTargetTableDescription,
+) -> Result<bool> {
+    let table = ctx
+        .get_table(
+            &compact_target.catalog,
+            &compact_target.database,
+            &compact_target.table,
+        )
+        .await?;
+    let threshold = match table
+        .get_table_info()
+        .options()
+        .get(FUSE_OPT_KEY_AUTO_COMPACTION_IMPERFECT_BLOCKS_THRESHOLD)
+    {
+        Some(value) => value.parse::<u64>()?,
+        None => ctx
+            .get_settings()
+            .get_auto_compaction_imperfect_blocks_threshold()?,
+    };
+    Ok(threshold == 0)
 }
 
 /// compact the target table, will do optimize table actions, including:

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0041_auto_compaction.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0041_auto_compaction.test
@@ -58,20 +58,26 @@ replace into t on(c) values(2);
 query III
 select segment_count , block_count , row_count from fuse_snapshot('i15760', 't') limit 20;
 ----
-3 5 11
-2 4 10
-1 3 9
-4 5 9
-3 4 8
+1 3 11
+2 3 11
+1 2 10
+2 3 10
+1 2 9
+2 3 9
+1 2 8
+2 3 8
+1 2 7
 2 3 7
 1 2 6
-4 4 6
-3 3 5
+2 2 6
+1 1 5
+2 2 5
+1 1 4
 2 2 4
 1 1 3
-3 3 3
+2 2 3
+1 1 2
 2 2 2
-1 1 1
 
 
 #ISSUE 16498
@@ -98,7 +104,7 @@ select count() > 4 from fuse_snapshot('i15760', 't1');
 query T
 select info:average_depth from clustering_information('i15760', 't1')
 ----
-1.0
+2.0
 
 #ISSUE 18859
 statement ok
@@ -116,9 +122,7 @@ insert into t2 select number from numbers(2);
 query II
 select block_count, row_count from fuse_segment('i15760', 't2');
 ----
-1 2
-2 12
-1 1
+3 15
 
 statement ok
 insert into t2 select number from numbers(2);
@@ -152,6 +156,42 @@ query I
 select count() from fuse_segment('i15760', 't3');
 ----
 1
+
+# A zero compaction hint should still compact the newly written segment with its neighbor.
+statement ok
+create table zero_hint(a int) row_per_block=100 block_per_segment=100 auto_compaction_imperfect_blocks_threshold=100;
+
+statement ok
+insert into zero_hint values(1);
+
+statement ok
+insert into zero_hint values(2);
+
+query III
+select segment_count, block_count, row_count from fuse_snapshot('i15760', 'zero_hint') limit 1;
+----
+1 1 2
+
+# A zero compaction hint should not prevent reclustering a cluster key table.
+statement ok
+create table zero_hint_cluster(a int) cluster by(a) row_per_block=5 auto_compaction_imperfect_blocks_threshold=100;
+
+statement ok
+insert into zero_hint_cluster values(1),(2),(7);
+
+statement ok
+insert into zero_hint_cluster values(3),(5),(8);
+
+statement ok
+insert into zero_hint_cluster values(4),(6),(10),(11);
+
+statement ok
+insert into zero_hint_cluster values(0),(9),(12);
+
+query T
+select info:average_depth from clustering_information('i15760', 'zero_hint_cluster');
+----
+2.0
 
 statement ok
 set auto_compaction_imperfect_blocks_threshold = 1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Run the after-write compact hook when the configured threshold is positive but the compaction block hint is zero
- Let the block compactor inspect the newly written segment and its neighbor, and keep reclustering reachable for cluster-key tables
- Preserve auto-compaction disablement when the table-level or session-level threshold is explicitly zero
- Add zero-hint regression coverage and refresh the affected auto-compaction snapshot expectations

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validated with:

- cargo test -p databend-query --lib interpreters::hook::compact_hook::tests --no-fail-fast
- databend-sqllogictests --handlers http --run tests/sqllogictests/suites/base/09_fuse_engine/09_0041_auto_compaction.test
- cargo clippy -p databend-query --lib -- -D warnings
- cargo fmt --all -- --check

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20182)
<!-- Reviewable:end -->
