### PR TITLE
fix: preserve imperfect block statistics for replace and merge

### DIFF
--- a/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
@@ -22,6 +22,7 @@ use databend_common_base::runtime::execute_futures_in_parallel;
 use databend_common_catalog::plan::BlockMetaWithHLL;
 use databend_common_catalog::table::Table;
 use databend_common_catalog::table_context::TableContext;
+use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::BlockMetaInfoPtr;
 use databend_common_expression::BlockThresholds;
@@ -387,10 +388,19 @@ impl TableMutationAggregator {
                     .collect::<Vec<_>>();
                 Some(SegmentStatistics::new(hlls, Vec::new()).to_bytes()?)
             };
-            let all_perfect = new_blocks.len() > 1;
+            // Only compaction/reclustering output may be force-marked perfect to keep
+            // those operations at a fixed point. REPLACE/MERGE append after-images
+            // must retain the physical perfect-block count from reduce_block_metas.
+            let force_all_blocks_perfect = matches!(
+                self.write_segment_ctx.kind,
+                MutationKind::Compact | MutationKind::Recluster
+            ) && new_blocks.len() > 1;
 
             let ctx = self.write_segment_ctx.clone();
-            tasks.push(async move { ctx.write_segment(new_blocks, new_hlls, all_perfect).await });
+            tasks.push(async move {
+                ctx.write_segment(new_blocks, new_hlls, force_all_blocks_perfect)
+                    .await
+            });
         }
 
         let threads_nums = self.ctx.get_settings().get_max_threads()? as usize;
@@ -507,7 +517,7 @@ impl TableMutationAggregator {
             let write_segment_ctx = self.write_segment_ctx.clone();
 
             tasks.push(async move {
-                let mut all_perfect = false;
+                let mut force_all_blocks_perfect = false;
                 let (new_blocks, new_hlls, origin_summary) = if let Some(loc) = location {
                     // read the old segment
                     let compact_segment_info = SegmentsIO::read_compact_segment(
@@ -559,11 +569,20 @@ impl TableMutationAggregator {
                     let stats = generate_segment_stats(new_hlls)?;
                     (new_blocks, stats, Some(segment_info.summary))
                 } else {
-                    // use by compact.
+                    // Only compact builds replacement segments without corresponding
+                    // entries in base_segments. Treating a missing base segment from
+                    // any other mutation as compact output could silently corrupt its
+                    // segment statistics.
+                    if !matches!(write_segment_ctx.kind, MutationKind::Compact) {
+                        return Err(ErrorCode::Internal(format!(
+                            "{} mutation references missing base segment index {}",
+                            write_segment_ctx.kind, index
+                        )));
+                    }
                     assert!(segment_mutation.deleted_blocks.is_empty());
                     // There are more than 1 blocks, means that the blocks can no longer be compacted.
                     // They can be marked as perfect blocks.
-                    all_perfect = segment_mutation.replaced_blocks.len() > 1;
+                    force_all_blocks_perfect = segment_mutation.replaced_blocks.len() > 1;
                     let (new_blocks, new_hlls) = segment_mutation
                         .replaced_blocks
                         .into_iter()
@@ -575,7 +594,7 @@ impl TableMutationAggregator {
                 };
 
                 let new_segment_info = write_segment_ctx
-                    .write_segment(new_blocks, new_hlls, all_perfect)
+                    .write_segment(new_blocks, new_hlls, force_all_blocks_perfect)
                     .await?;
 
                 Ok(SegmentLite {
@@ -830,14 +849,14 @@ impl WriteSegmentCtx {
         &self,
         blocks: Vec<Arc<BlockMeta>>,
         stats: Option<Vec<u8>>,
-        all_perfect: bool,
+        force_all_blocks_perfect: bool,
     ) -> Result<(String, Statistics)> {
         let location = self
             .location_gen
             .gen_segment_info_location(self.table_meta_timestamps, false);
         let mut new_summary =
             reduce_block_metas(&blocks, self.thresholds, self.default_cluster_key);
-        if all_perfect {
+        if force_all_blocks_perfect {
             // To fix issue #13217.
             if new_summary.block_count > new_summary.perfect_block_count {
                 warn!(

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0054_issue_20181.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0054_issue_20181.test
@@ -1,0 +1,63 @@
+statement ok
+DROP DATABASE IF EXISTS issue_20181
+
+statement ok
+CREATE DATABASE issue_20181
+
+statement ok
+USE issue_20181
+
+statement ok
+SET max_block_size = 6
+
+# REPLACE append after-images must retain their physical imperfect-block count so
+# the second statement reaches the table-level auto-compaction threshold.
+statement ok
+CREATE TABLE replace_target(id UInt64)
+ROW_PER_BLOCK = 10
+AUTO_COMPACTION_IMPERFECT_BLOCKS_THRESHOLD = 2
+
+statement ok
+REPLACE INTO replace_target ON(id)
+SELECT number FROM numbers(12)
+
+statement ok
+REPLACE INTO replace_target ON(id)
+SELECT number + 12 FROM numbers(12)
+
+query IIB
+SELECT count(), sum(row_count), sum(block_count) < 4
+FROM fuse_segment('issue_20181', 'replace_target')
+----
+1 24 1
+
+# MERGE unmatched inserts use the same AppendBlock segment-generation path.
+statement ok
+CREATE TABLE merge_target(id UInt64)
+ROW_PER_BLOCK = 10
+AUTO_COMPACTION_IMPERFECT_BLOCKS_THRESHOLD = 2
+
+query I
+MERGE INTO merge_target AS t
+USING (SELECT number AS id FROM numbers(12)) AS s
+ON t.id = s.id
+WHEN NOT MATCHED THEN INSERT (id) VALUES (s.id)
+----
+12
+
+query I
+MERGE INTO merge_target AS t
+USING (SELECT number + 12 AS id FROM numbers(12)) AS s
+ON t.id = s.id
+WHEN NOT MATCHED THEN INSERT (id) VALUES (s.id)
+----
+12
+
+query IIB
+SELECT count(), sum(row_count), sum(block_count) < 4
+FROM fuse_segment('issue_20181', 'merge_target')
+----
+1 24 1
+
+statement ok
+DROP DATABASE issue_20181

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0054_issue_20181.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0054_issue_20181.test
@@ -10,6 +10,11 @@ USE issue_20181
 statement ok
 SET max_block_size = 6
 
+# Keep block generation deterministic: each statement writes one perfect block
+# and one imperfect tail block, so compaction is triggered by the second write.
+statement ok
+SET max_threads = 1
+
 # REPLACE append after-images must retain their physical imperfect-block count so
 # the second statement reaches the table-level auto-compaction threshold.
 statement ok
@@ -19,12 +24,18 @@ AUTO_COMPACTION_IMPERFECT_BLOCKS_THRESHOLD = 2
 
 statement ok
 REPLACE INTO replace_target ON(id)
-SELECT number FROM numbers(12)
+SELECT number FROM numbers(10)
+UNION ALL
+SELECT number + 10 FROM numbers(2)
 
 statement ok
 REPLACE INTO replace_target ON(id)
-SELECT number + 12 FROM numbers(12)
+SELECT number + 12 FROM numbers(10)
+UNION ALL
+SELECT number + 22 FROM numbers(2)
 
+# Each REPLACE writes one perfect block and one imperfect tail block. The second
+# tail reaches the threshold, and auto compaction merges both input segments.
 query IIB
 SELECT count(), sum(row_count), sum(block_count) < 4
 FROM fuse_segment('issue_20181', 'replace_target')
@@ -39,7 +50,11 @@ AUTO_COMPACTION_IMPERFECT_BLOCKS_THRESHOLD = 2
 
 query I
 MERGE INTO merge_target AS t
-USING (SELECT number AS id FROM numbers(12)) AS s
+USING (
+    SELECT number AS id FROM numbers(10)
+    UNION ALL
+    SELECT number + 10 AS id FROM numbers(2)
+) AS s
 ON t.id = s.id
 WHEN NOT MATCHED THEN INSERT (id) VALUES (s.id)
 ----
@@ -47,7 +62,11 @@ WHEN NOT MATCHED THEN INSERT (id) VALUES (s.id)
 
 query I
 MERGE INTO merge_target AS t
-USING (SELECT number + 12 AS id FROM numbers(12)) AS s
+USING (
+    SELECT number + 12 AS id FROM numbers(10)
+    UNION ALL
+    SELECT number + 22 AS id FROM numbers(2)
+) AS s
 ON t.id = s.id
 WHEN NOT MATCHED THEN INSERT (id) VALUES (s.id)
 ----


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Prevent `REPLACE INTO` and `MERGE INTO` append after-images from being force-marked as perfect blocks.
- Preserve the physical `perfect_block_count` calculated by `reduce_block_metas()` so imperfect blocks contribute correctly to the auto-compaction threshold.
- Restrict forced-perfect segment summaries to `COMPACT` and `RECLUSTER` output, preserving the fixed-point behavior introduced for `COMPACT LIMIT`.
- Reject missing base segment references from non-compact mutations instead of silently treating them as compact output.
- Rename the related flag to `force_all_blocks_perfect` to clarify that it is a control flag rather than a physical statistics
result.
- Add regression coverage for both `REPLACE INTO` and `MERGE INTO`, and verify the existing compact-limit behavior remains unchanged.

    Previously, a multi-block segment generated from `REPLACE INTO` or `MERGE INTO` append after-images could have:

 ```text
    perfect_block_count = block_count
  ```

  even when reduce_block_metas() identified physically imperfect blocks. Since auto compaction uses:

  ```
    block_count - perfect_block_count
  ```

  these blocks contributed zero to the compaction threshold, potentially preventing auto compaction indefinitely.

  This change keeps the forced-perfect workaround only for compact/recluster output and retains accurate physical block statistics
  for ordinary mutation output.

- fixes: #20181

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20187)
<!-- Reviewable:end -->
