### PR TITLE
feat(query): rewrite outer join exclusion filters as anti joins

### DIFF
--- a/src/query/service/src/physical_plans/physical_eval_scalar.rs
+++ b/src/query/service/src/physical_plans/physical_eval_scalar.rs
@@ -216,11 +216,14 @@ impl PhysicalPlanBuilder {
         let column_projections = required.clone();
         let mut used = vec![];
         // Only keep columns needed by parent plan.
-        for s in eval_scalar.items.iter() {
+        for s in &eval_scalar.items {
             if !required.contains(&s.index) {
                 continue;
             }
             used.push(s.clone());
+            // The item defines this output index. Only request the child column
+            // when the defining expression itself references that index.
+            required.remove(&s.index);
             s.scalar.used_columns().iter().for_each(|c| {
                 required.insert(*c);
             })

--- a/src/query/sql/src/planner/binder/window.rs
+++ b/src/query/sql/src/planner/binder/window.rs
@@ -620,14 +620,16 @@ pub fn bind_window_function_info(
     // eval scalars before sort
     // Generate a `EvalScalar` as the input of `Window`.
     let mut scalar_items: Vec<ScalarItem> = Vec::new();
-    for arg in &window_plan.arguments {
-        scalar_items.push(arg.clone());
-    }
-    for part in &window_plan.partition_by {
-        scalar_items.push(part.clone());
-    }
-    for order in &window_plan.order_by {
-        scalar_items.push(order.order_by_item.clone())
+    let mut scalar_indexes = HashSet::new();
+    for item in std::iter::chain(&window_plan.arguments, &window_plan.partition_by).chain(
+        window_plan
+            .order_by
+            .iter()
+            .map(|order| &order.order_by_item),
+    ) {
+        if scalar_indexes.insert(item.index) {
+            scalar_items.push(item.clone());
+        }
     }
 
     let child = if !scalar_items.is_empty() {

--- a/src/query/sql/src/planner/optimizer/AGENTS.md
+++ b/src/query/sql/src/planner/optimizer/AGENTS.md
@@ -1,0 +1,32 @@
+# Optimizer Guide
+
+This file applies to optimizer work under this directory. Follow the parent
+query and SQL-area guidance for general development and validation rules.
+
+## Rule Testing
+
+- Use [`eager_aggregation.rs`](../../../tests/it/optimizer/eager_aggregation.rs)
+  as the reference pattern for optimizer rule tests.
+- Start rule behavior tests from SQL. Bind the SQL into the raw plan, run the
+  production optimizer pipeline, and record both the raw and optimized plans
+  in a module-local golden file.
+- Treat the raw plan as part of the test evidence: it confirms that preceding
+  optimizer phases in the current codebase can actually produce the pattern
+  consumed by the rule.
+- Review the complete optimized-plan golden. A rule test should cover the
+  intended rewrite together with its interaction with subsequent rules, not
+  only assert the presence of one operator.
+- Include positive and negative SQL cases when a rewrite has semantic
+  preconditions. Give each case a name and description that state the intended
+  optimizer outcome.
+- If changes to preceding phases make an intermediate pattern unreachable,
+  revise or reconsider the SQL case. Do not preserve an obsolete pattern by
+  replacing the test with a manually constructed `SExpr`.
+- Do not use manually constructed complete `SExpr` trees as the primary
+  evidence for rule correctness. Direct Rust unit tests remain appropriate for
+  pure helpers, scalar-expression rewrites, column-set calculations, and local
+  invariants that do not depend on optimizer phase ordering.
+- Use the [shared optimizer replay data](../../../test-support/data/README.md)
+  when a case needs reusable table fixtures, statistics, or physical-plan
+  output. Add SQL logic test coverage when the rewrite affects user-visible
+  results, output columns, or NULL semantics.

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/flatten_plan.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/flatten_plan.rs
@@ -257,28 +257,30 @@ impl SubqueryDecorrelatorOptimizer {
 
         let metadata = self.metadata.clone();
         let metadata = metadata.read();
-        let items: Vec<ScalarItem> = eval_scalar
+        let mut output_columns = ColumnSet::new();
+        let mut items: Vec<ScalarItem> = eval_scalar
             .items
             .iter()
             .filter(|item| !correlated_columns.contains(&item.index))
-            .map(Item::Scalar)
-            .chain(correlated_columns.iter().copied().map(Item::Index))
-            .map(|item| match item {
-                Item::Scalar(item) => Ok(ScalarItem {
+            .map(|item| {
+                output_columns.insert(item.index);
+                Ok(ScalarItem {
                     scalar: self.flatten_scalar(
                         &item.scalar,
                         correlated_columns,
                         &derived_columns,
                     )?,
                     index: item.index,
-                }),
-                Item::Index(old) => Ok(Self::scalar_item_from_index(
-                    derived_columns.must_resolve(old)?,
-                    "outer.",
-                    &metadata,
-                )),
+                })
             })
             .collect::<Result<_>>()?;
+
+        for old in correlated_columns {
+            let index = derived_columns.must_resolve(*old)?;
+            if output_columns.insert(index) {
+                items.push(Self::scalar_item_from_index(index, "outer.", &metadata));
+            }
+        }
 
         // Eg1. SELECT c_id, (SELECT count() FROM o WHERE o.c_id=c.c_id) FROM c ORDER BY c_id;
         // Eg2. SELECT

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_push_down_filter_join.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_push_down_filter_join.rs
@@ -31,6 +31,7 @@ use crate::optimizer::optimizers::rule::can_filter_null;
 use crate::optimizer::optimizers::rule::constant::false_constant;
 use crate::optimizer::optimizers::rule::constant::is_falsy;
 use crate::optimizer::optimizers::rule::convert_mark_to_semi_join;
+use crate::optimizer::optimizers::rule::outer_join_to_anti_join;
 use crate::optimizer::optimizers::rule::outer_join_to_inner_join;
 use crate::optimizer::optimizers::rule::rewrite_predicates;
 use crate::plans::ComparisonOp;
@@ -45,7 +46,6 @@ use crate::plans::ScalarExpr;
 use crate::plans::VisitorMut;
 
 pub struct RulePushDownFilterJoin {
-    id: RuleID,
     matchers: Vec<Matcher>,
     metadata: MetadataRef,
 }
@@ -53,7 +53,6 @@ pub struct RulePushDownFilterJoin {
 impl RulePushDownFilterJoin {
     pub fn new(metadata: MetadataRef) -> Self {
         Self {
-            id: RuleID::PushDownFilterJoin,
             // Filter
             //  \
             //   Join
@@ -74,14 +73,21 @@ impl RulePushDownFilterJoin {
 
 impl Rule for RulePushDownFilterJoin {
     fn id(&self) -> RuleID {
-        self.id
+        RuleID::PushDownFilterJoin
     }
 
     fn apply(&self, s_expr: &SExpr, state: &mut TransformResult) -> Result<()> {
-        // First, try to convert outer join to inner join
+        // First, try to convert the outer join exclusion pattern to an anti join.
+        if let Some(mut result) = outer_join_to_anti_join(s_expr, self.metadata.clone())? {
+            result.set_applied_rule(&self.id());
+            state.add_result(result);
+            return Ok(());
+        }
+
+        // Second, try to convert outer join to inner join
         let (s_expr, outer_to_inner) = outer_join_to_inner_join(s_expr, self.metadata.clone())?;
 
-        // Second, check if can convert mark join to semi join
+        // Third, check if can convert mark join to semi join
         let (s_expr, mark_to_semi) = convert_mark_to_semi_join(&s_expr, self.metadata.clone())?;
         if s_expr.plan().rel_op() != RelOp::Filter {
             state.add_result(s_expr);
@@ -99,7 +105,7 @@ impl Rule for RulePushDownFilterJoin {
             return Ok(());
         }
 
-        result.set_applied_rule(&self.id);
+        result.set_applied_rule(&self.id());
         state.add_result(result);
 
         Ok(())

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/push_down_filter_join/mod.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/push_down_filter_join/mod.rs
@@ -14,9 +14,11 @@
 
 mod extract_or_predicates;
 mod mark_join_to_semi_join;
+mod outer_join_to_anti_join;
 mod outer_join_to_inner_join;
 
 pub use extract_or_predicates::rewrite_predicates;
 pub use mark_join_to_semi_join::convert_mark_to_semi_join;
+pub use outer_join_to_anti_join::outer_join_to_anti_join;
 pub use outer_join_to_inner_join::can_filter_null;
 pub use outer_join_to_inner_join::outer_join_to_inner_join;

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/push_down_filter_join/outer_join_to_anti_join.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/push_down_filter_join/outer_join_to_anti_join.rs
@@ -1,0 +1,123 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_exception::Result;
+use databend_common_expression::Scalar;
+
+use crate::MetadataRef;
+use crate::optimizer::ir::SExpr;
+use crate::plans::ConstantExpr;
+use crate::plans::EvalScalar;
+use crate::plans::Join;
+use crate::plans::JoinType;
+use crate::plans::ScalarExpr;
+use crate::plans::ScalarItem;
+
+/// Convert an outer-join exclusion pattern to the corresponding anti join when
+/// the null-tested expression is a regular equi-key on the null-extended side:
+///
+/// ```text
+/// Filter(right_key IS NULL)
+///   LeftOuterJoin(left_key = right_key)
+///
+/// Filter(left_key IS NULL)
+///   RightOuterJoin(left_key = right_key)
+/// ```
+///
+/// A matched row cannot have a NULL regular equi-join key, even when the source
+/// column itself is nullable. Therefore the filter keeps exactly the preserved
+/// side's unmatched rows. Null-equal join conditions are deliberately excluded.
+pub fn outer_join_to_anti_join(s_expr: &SExpr, metadata: MetadataRef) -> Result<Option<SExpr>> {
+    let filter = s_expr.plan().as_filter().unwrap();
+    let join_expr = s_expr.unary_child();
+    let join = join_expr.plan().as_join().unwrap();
+    let anti_join_type = match join.join_type {
+        JoinType::Left => JoinType::LeftAnti,
+        JoinType::Right => JoinType::RightAnti,
+        _ => return Ok(None),
+    };
+
+    let Some(predicate_index) = filter.predicates.iter().position(|predicate| {
+        let Some(null_tested_expr) = null_tested_expr(predicate) else {
+            return false;
+        };
+
+        join.equi_conditions.iter().any(|condition| {
+            !condition.is_null_equal
+                && match join.join_type {
+                    JoinType::Left => condition.right == *null_tested_expr,
+                    JoinType::Right => condition.left == *null_tested_expr,
+                    _ => unreachable!(),
+                }
+        })
+    }) else {
+        return Ok(None);
+    };
+
+    // An anti join outputs only its preserved side, while the original
+    // outer-join/filter shape still exposes the other side as NULL. Recreate
+    // those symbols so upper operators preserve their schema.
+    let null_extended_prop = match join.join_type {
+        JoinType::Left => join_expr.right_child().derive_relational_prop()?,
+        JoinType::Right => join_expr.left_child().derive_relational_prop()?,
+        _ => unreachable!(),
+    };
+    let metadata = metadata.read();
+    let null_items = null_extended_prop
+        .output_columns
+        .iter()
+        .map(|index| ScalarItem {
+            scalar: ScalarExpr::TypedConstantExpr(
+                ConstantExpr {
+                    span: None,
+                    value: Scalar::Null,
+                },
+                metadata.column(*index).data_type().wrap_nullable(),
+            ),
+            index: *index,
+        })
+        .collect();
+    drop(metadata);
+
+    let result = SExpr::create_binary(
+        Join {
+            join_type: anti_join_type,
+            ..join.clone()
+        },
+        join_expr.left_child_arc(),
+        join_expr.right_child_arc(),
+    )
+    .build_unary(EvalScalar { items: null_items });
+
+    Ok(Some(if filter.predicates.len() > 1 {
+        let mut filter = filter.clone();
+        filter.predicates.remove(predicate_index);
+        result.build_unary(filter)
+    } else {
+        result
+    }))
+}
+
+fn null_tested_expr(predicate: &ScalarExpr) -> Option<&ScalarExpr> {
+    if let ScalarExpr::FunctionCall(not) = predicate
+        && not.func_name == "not"
+        && let [ScalarExpr::FunctionCall(is_not_null)] = not.arguments.as_slice()
+        && is_not_null.func_name == "is_not_null"
+        && let [expr] = is_not_null.arguments.as_slice()
+    {
+        Some(expr)
+    } else {
+        None
+    }
+}

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/scalar_rules/rule_eliminate_eval_scalar.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/scalar_rules/rule_eliminate_eval_scalar.rs
@@ -79,6 +79,11 @@ impl Rule for RuleEliminateEvalScalar {
             // check if there's f(#x) as #x, if so we can't eliminate the eval scalar
             for item in eval_scalar.items {
                 match item.scalar {
+                    ScalarExpr::ConstantExpr(_) | ScalarExpr::TypedConstantExpr(_, _) => {
+                        // A constant with an existing output index shadows the child column.
+                        // It cannot be eliminated as an identity projection.
+                        return Ok(());
+                    }
                     ScalarExpr::FunctionCall(func) => {
                         if func.arguments.len() == 1 {
                             if let ScalarExpr::BoundColumnRef(bound_column_ref) = &func.arguments[0]

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/scalar_rules/rule_merge_eval_scalar.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/scalar_rules/rule_merge_eval_scalar.rs
@@ -25,6 +25,10 @@ use crate::optimizer::optimizers::rule::RuleID;
 use crate::optimizer::optimizers::rule::TransformResult;
 use crate::plans::EvalScalar;
 use crate::plans::RelOp;
+use crate::plans::ScalarExpr;
+use crate::plans::ScalarItem;
+use crate::plans::VisitorMut;
+use crate::plans::walk_expr_mut;
 
 // Merge two adjacent `EvalScalar`s into one
 pub struct RuleMergeEvalScalar {
@@ -52,6 +56,100 @@ impl RuleMergeEvalScalar {
     }
 }
 
+/// Compose lower scalar definitions into upper expressions when doing so does
+/// not duplicate a non-trivial computation. Both item lists in a merged
+/// EvalScalar are evaluated against the same input, so an unresolved reference
+/// to a lower output would change evaluation order.
+fn try_merge_eval_scalars(
+    up_eval_scalar: &EvalScalar,
+    down_eval_scalar: &EvalScalar,
+    input_columns: &ColumnSet,
+) -> Result<Option<EvalScalar>> {
+    let down_output_columns: ColumnSet = down_eval_scalar
+        .items
+        .iter()
+        .map(|item| item.index)
+        .collect();
+
+    let mut up_items = Vec::with_capacity(up_eval_scalar.items.len());
+    for item in up_eval_scalar.items.iter().filter(|item| {
+        // `#x AS #x` over a lower definition of `#x` is an identity layer.
+        // Keeping the lower item directly preserves even non-trivial or
+        // non-deterministic lower expressions without evaluating them twice.
+        !matches!(
+            &item.scalar,
+            ScalarExpr::BoundColumnRef(column)
+                if column.column.index == item.index
+                    && down_output_columns.contains(&item.index)
+        )
+    }) {
+        let mut composer = TrivialComposer {
+            down_items: &down_eval_scalar.items,
+            supported: true,
+        };
+        let mut scalar = item.scalar.clone();
+        composer.visit(&mut scalar)?;
+        if !composer.supported {
+            return Ok(None);
+        }
+        up_items.push(ScalarItem {
+            scalar,
+            index: item.index,
+        });
+    }
+
+    let used_columns: ColumnSet = up_items
+        .iter()
+        .flat_map(|item| item.scalar.used_columns())
+        .collect();
+    if !used_columns.is_subset(input_columns) {
+        return Ok(None);
+    }
+
+    // An upper definition shadows the lower item with the same output index.
+    // All upper references have already been composed against the lower value.
+    let up_output_columns: ColumnSet = up_items.iter().map(|item| item.index).collect();
+    let items = up_items
+        .into_iter()
+        .chain(
+            down_eval_scalar
+                .items
+                .iter()
+                .filter(|item| !up_output_columns.contains(&item.index))
+                .cloned(),
+        )
+        .collect();
+
+    Ok(Some(EvalScalar { items }))
+}
+
+struct TrivialComposer<'a> {
+    down_items: &'a [ScalarItem],
+    supported: bool,
+}
+
+impl<'a> VisitorMut<'a> for TrivialComposer<'_> {
+    fn visit(&mut self, expr: &'a mut ScalarExpr) -> Result<()> {
+        if let ScalarExpr::BoundColumnRef(column) = expr
+            && let Some(item) = self
+                .down_items
+                .iter()
+                .find(|item| item.index == column.column.index)
+        {
+            match &item.scalar {
+                ScalarExpr::BoundColumnRef(_)
+                | ScalarExpr::ConstantExpr(_)
+                | ScalarExpr::TypedConstantExpr(_, _) => {
+                    *expr = item.scalar.clone();
+                }
+                _ => self.supported = false,
+            }
+            return Ok(());
+        }
+        walk_expr_mut(self, expr)
+    }
+}
+
 impl Rule for RuleMergeEvalScalar {
     fn id(&self) -> RuleID {
         self.id
@@ -60,26 +158,13 @@ impl Rule for RuleMergeEvalScalar {
     fn apply(&self, s_expr: &SExpr, state: &mut TransformResult) -> Result<()> {
         let up_eval_scalar: EvalScalar = s_expr.plan().clone().try_into()?;
         let down_eval_scalar: EvalScalar = s_expr.child(0)?.plan().clone().try_into()?;
-        let mut used_columns = ColumnSet::new();
-        for item in up_eval_scalar.items.iter() {
-            used_columns = used_columns
-                .union(&item.scalar.used_columns())
-                .cloned()
-                .collect();
-        }
-
         let rel_expr = RelExpr::with_s_expr(s_expr.child(0)?);
         let input_prop = rel_expr.derive_relational_prop_child(0)?;
-        // Check if the up EvalScalar depends on the down EvalScalar
-        if used_columns.is_subset(&input_prop.output_columns) {
-            // TODO(leiysky): eliminate duplicated scalars
-            let items = up_eval_scalar
-                .items
-                .into_iter()
-                .chain(down_eval_scalar.items)
-                .collect();
-            let merged = EvalScalar { items };
-
+        if let Some(merged) = try_merge_eval_scalars(
+            &up_eval_scalar,
+            &down_eval_scalar,
+            &input_prop.output_columns,
+        )? {
             let new_expr = SExpr::create_unary(
                 Arc::new(merged.into()),
                 Arc::new(s_expr.child(0)?.child(0)?.clone()),
@@ -98,5 +183,187 @@ impl Rule for RuleMergeEvalScalar {
 impl Default for RuleMergeEvalScalar {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_expression::Scalar;
+    use databend_common_expression::types::DataType;
+    use databend_common_expression::types::NumberDataType;
+
+    use super::*;
+    use crate::ColumnBindingBuilder;
+    use crate::Symbol;
+    use crate::Visibility;
+    use crate::plans::BoundColumnRef;
+    use crate::plans::ConstantExpr;
+    use crate::plans::FunctionCall;
+
+    fn int_type() -> DataType {
+        DataType::Number(NumberDataType::Int64)
+    }
+
+    fn column(index: Symbol) -> ScalarExpr {
+        BoundColumnRef {
+            span: None,
+            column: ColumnBindingBuilder::new(
+                index.to_string(),
+                index,
+                Box::new(int_type().wrap_nullable()),
+                Visibility::Visible,
+            )
+            .build(),
+        }
+        .into()
+    }
+
+    fn null_item(index: Symbol) -> ScalarItem {
+        ScalarItem {
+            scalar: ScalarExpr::TypedConstantExpr(
+                ConstantExpr {
+                    span: None,
+                    value: Scalar::Null,
+                },
+                int_type().wrap_nullable(),
+            ),
+            index,
+        }
+    }
+
+    #[test]
+    fn merges_identity_over_lower_definition() -> Result<()> {
+        let input = ColumnSet::new();
+        let index = Symbol::new(1);
+        let down = EvalScalar {
+            items: vec![null_item(index)],
+        };
+        let up = EvalScalar {
+            items: vec![ScalarItem {
+                scalar: column(index),
+                index,
+            }],
+        };
+
+        let merged = try_merge_eval_scalars(&up, &down, &input)?.unwrap();
+        assert_eq!(merged.items.len(), 1);
+        assert_eq!(merged.items[0].index, index);
+        assert!(matches!(
+            merged.items[0].scalar,
+            ScalarExpr::TypedConstantExpr(
+                ConstantExpr {
+                    value: Scalar::Null,
+                    ..
+                },
+                _
+            )
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn composes_column_reference_into_upper_expression() -> Result<()> {
+        let input_index = Symbol::new(0);
+        let lower_index = Symbol::new(1);
+        let output_index = Symbol::new(2);
+        let input = [input_index].into_iter().collect();
+        let down = EvalScalar {
+            items: vec![ScalarItem {
+                scalar: column(input_index),
+                index: lower_index,
+            }],
+        };
+        let up = EvalScalar {
+            items: vec![ScalarItem {
+                scalar: ScalarExpr::FunctionCall(FunctionCall {
+                    span: None,
+                    func_name: "is_not_null".to_string(),
+                    params: vec![],
+                    arguments: vec![column(lower_index)],
+                }),
+                index: output_index,
+            }],
+        };
+
+        let merged = try_merge_eval_scalars(&up, &down, &input)?.unwrap();
+        let ScalarExpr::FunctionCall(function) = &merged.items[0].scalar else {
+            panic!("expected the upper function to remain")
+        };
+        assert!(matches!(
+            &function.arguments[0],
+            ScalarExpr::BoundColumnRef(column) if column.column.index == input_index
+        ));
+        assert_eq!(merged.items[1].index, lower_index);
+        Ok(())
+    }
+
+    #[test]
+    fn composes_constant_into_upper_expression() -> Result<()> {
+        let input = ColumnSet::new();
+        let lower_index = Symbol::new(1);
+        let output_index = Symbol::new(2);
+        let down = EvalScalar {
+            items: vec![null_item(lower_index)],
+        };
+        let up = EvalScalar {
+            items: vec![ScalarItem {
+                scalar: ScalarExpr::FunctionCall(FunctionCall {
+                    span: None,
+                    func_name: "is_not_null".to_string(),
+                    params: vec![],
+                    arguments: vec![column(lower_index)],
+                }),
+                index: output_index,
+            }],
+        };
+
+        let merged = try_merge_eval_scalars(&up, &down, &input)?.unwrap();
+        let ScalarExpr::FunctionCall(function) = &merged.items[0].scalar else {
+            panic!("expected the upper function to remain")
+        };
+        assert!(matches!(
+            function.arguments[0],
+            ScalarExpr::TypedConstantExpr(_, _)
+        ));
+        assert_eq!(merged.items[1].index, lower_index);
+        assert!(matches!(
+            merged.items[1].scalar,
+            ScalarExpr::TypedConstantExpr(
+                ConstantExpr {
+                    value: Scalar::Null,
+                    ..
+                },
+                _
+            )
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn keeps_layers_for_non_trivial_dependency() -> Result<()> {
+        let input_index = Symbol::new(0);
+        let lower_index = Symbol::new(1);
+        let output_index = Symbol::new(2);
+        let input = [input_index].into_iter().collect();
+        let down = EvalScalar {
+            items: vec![ScalarItem {
+                scalar: ScalarExpr::FunctionCall(FunctionCall {
+                    span: None,
+                    func_name: "is_not_null".to_string(),
+                    params: vec![],
+                    arguments: vec![column(input_index)],
+                }),
+                index: lower_index,
+            }],
+        };
+        let up = EvalScalar {
+            items: vec![ScalarItem {
+                scalar: column(lower_index),
+                index: output_index,
+            }],
+        };
+
+        assert!(try_merge_eval_scalars(&up, &down, &input)?.is_none());
+        Ok(())
     }
 }

--- a/src/query/sql/src/planner/plans/eval_scalar.rs
+++ b/src/query/sql/src/planner/plans/eval_scalar.rs
@@ -12,18 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use databend_common_exception::Result;
+use databend_common_expression::Domain;
+use databend_common_expression::FunctionContext;
+use databend_common_expression::StatEvaluator;
+use databend_common_expression::stat_distribution::OwnedDistribution;
+use databend_common_expression::stat_distribution::ReturnStat;
+use databend_common_expression::stat_distribution::StatCardinality;
+use databend_common_functions::BUILTIN_FUNCTIONS;
 
 use crate::ColumnBinding;
 use crate::ColumnBindingBuilder;
 use crate::ColumnSet;
 use crate::Symbol;
 use crate::Visibility;
+use crate::optimizer::ir::ColumnStat;
 use crate::optimizer::ir::RelExpr;
 use crate::optimizer::ir::RelationalProperty;
 use crate::optimizer::ir::StatInfo;
+use crate::optimizer::ir::Statistics;
 use crate::plans::BoundColumnRef;
 use crate::plans::Operator;
 use crate::plans::RelOp;
@@ -76,6 +86,61 @@ impl EvalScalar {
         }
         Ok(used_columns)
     }
+
+    fn derive_item_stat(
+        scalar: &ScalarExpr,
+        input_statistics: &Statistics,
+        cardinality: StatCardinality,
+    ) -> Result<Option<ColumnStat>> {
+        let expr = scalar.as_symbol_expr()?;
+        let column_refs = expr.column_refs();
+        let mut input_stats = HashMap::with_capacity(column_refs.len());
+        for (index, data_type) in column_refs {
+            let Some(column_stat) = input_statistics.column_stats.get(&index) else {
+                return Ok(None);
+            };
+            let Ok(arg_stat) = column_stat.to_arg_stat(&data_type) else {
+                return Ok(None);
+            };
+            input_stats.insert(index, arg_stat);
+        }
+
+        let Some(stat) = StatEvaluator::run(
+            &expr,
+            &FunctionContext::default(),
+            &BUILTIN_FUNCTIONS,
+            cardinality,
+            &input_stats,
+        )?
+        else {
+            return Ok(None);
+        };
+        Ok(Self::column_stat_from_return_stat(stat.into_owned()))
+    }
+
+    fn column_stat_from_return_stat(stat: ReturnStat) -> Option<ColumnStat> {
+        // `ColumnStat` has no representation for an all-NULL column because its
+        // min/max fields are non-optional. Do not retain the shadowed input stat
+        // in that case; unknown is safer than a stale non-NULL distribution.
+        let value_domain = match &stat.domain {
+            Domain::Nullable(domain) => domain.value.as_deref()?,
+            domain => domain,
+        };
+        let (min, max) = value_domain.to_minmax();
+        let min = min.to_datum()?;
+        let max = max.to_datum()?;
+        let histogram = match stat.distribution {
+            OwnedDistribution::Histogram(histogram) => Some(histogram),
+            OwnedDistribution::Unknown | OwnedDistribution::Boolean(_) => None,
+        };
+        Some(ColumnStat {
+            min,
+            max,
+            ndv: stat.ndv,
+            null_count: stat.null_count,
+            histogram,
+        })
+    }
 }
 
 impl Operator for EvalScalar {
@@ -126,6 +191,338 @@ impl Operator for EvalScalar {
     }
 
     fn derive_stats(&self, rel_expr: &RelExpr) -> Result<Arc<StatInfo>> {
-        rel_expr.derive_cardinality_child(0)
+        let input = rel_expr.derive_cardinality_child(0)?;
+        if self.items.iter().all(|item| {
+            matches!(
+                &item.scalar,
+                ScalarExpr::BoundColumnRef(column) if column.column.index == item.index
+            )
+        }) {
+            return Ok(input);
+        }
+
+        let cardinality = input
+            .statistics
+            .precise_cardinality
+            .map(StatCardinality::exact)
+            .unwrap_or_else(|| StatCardinality::estimate(input.cardinality));
+        let defined_columns = self
+            .items
+            .iter()
+            .map(|item| item.index)
+            .collect::<ColumnSet>();
+        debug_assert_eq!(
+            defined_columns.len(),
+            self.items.len(),
+            "EvalScalar output indexes must be unique"
+        );
+        let Statistics {
+            column_stats,
+            top_n,
+            count_min_sketch,
+            ..
+        } = &input.statistics;
+        let item_column_stats = self
+            .items
+            .iter()
+            .map(|item| {
+                let stat = if let ScalarExpr::BoundColumnRef(column) = &item.scalar {
+                    column_stats.get(&column.column.index).cloned()
+                } else {
+                    Self::derive_item_stat(&item.scalar, &input.statistics, cardinality)?
+                };
+                Ok(stat.map(|stat| (item.index, stat)))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let column_stats = item_column_stats
+            .into_iter()
+            .flatten()
+            .chain(column_stats.iter().filter_map(|(index, stat)| {
+                if defined_columns.contains(index) {
+                    None
+                } else {
+                    Some((*index, stat.clone()))
+                }
+            }))
+            .collect();
+        let top_n = self
+            .items
+            .iter()
+            .filter_map(|item| {
+                let ScalarExpr::BoundColumnRef(column) = &item.scalar else {
+                    return None;
+                };
+                top_n
+                    .get(&column.column.index)
+                    .cloned()
+                    .map(|top_n| (item.index, top_n))
+            })
+            .chain(top_n.iter().filter_map(|(index, top_n)| {
+                if defined_columns.contains(index) {
+                    None
+                } else {
+                    Some((*index, top_n.clone()))
+                }
+            }))
+            .collect();
+        let count_min_sketch = self
+            .items
+            .iter()
+            .filter_map(|item| {
+                let ScalarExpr::BoundColumnRef(column) = &item.scalar else {
+                    return None;
+                };
+                count_min_sketch
+                    .get(&column.column.index)
+                    .cloned()
+                    .map(|sketch| (item.index, sketch))
+            })
+            .chain(count_min_sketch.iter().filter_map(|(index, sketch)| {
+                if defined_columns.contains(index) {
+                    None
+                } else {
+                    Some((*index, sketch.clone()))
+                }
+            }))
+            .collect();
+
+        Ok(Arc::new(StatInfo {
+            cardinality: input.cardinality,
+            statistics: Statistics {
+                precise_cardinality: input.statistics.precise_cardinality,
+                column_stats,
+                top_n,
+                count_min_sketch,
+            },
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_expression::Scalar;
+    use databend_common_expression::stat_distribution::NdvEstimate;
+    use databend_common_expression::stat_distribution::StatCount;
+    use databend_common_expression::types::DataType;
+    use databend_common_expression::types::NumberDataType;
+    use databend_common_expression::types::NumberScalar;
+    use databend_common_statistics::Datum;
+
+    use super::*;
+    use crate::Visibility;
+    use crate::optimizer::ir::SExpr;
+    use crate::plans::CastExpr;
+    use crate::plans::ConstantExpr;
+    use crate::plans::DummyTableScan;
+    use crate::plans::FunctionCall;
+
+    fn int_type() -> DataType {
+        DataType::Number(NumberDataType::Int64)
+    }
+
+    fn column_with_type(index: usize, data_type: DataType) -> ScalarExpr {
+        BoundColumnRef {
+            span: None,
+            column: ColumnBindingBuilder::new(
+                format!("c{index}"),
+                Symbol::new(index),
+                Box::new(data_type),
+                Visibility::Visible,
+            )
+            .build(),
+        }
+        .into()
+    }
+
+    fn column(index: usize) -> ScalarExpr {
+        column_with_type(index, int_type())
+    }
+
+    fn int_constant(value: i64) -> ScalarExpr {
+        ConstantExpr {
+            span: None,
+            value: Scalar::Number(NumberScalar::Int64(value)),
+        }
+        .into()
+    }
+
+    fn typed_int_constant(value: i64, data_type: DataType) -> ScalarExpr {
+        ScalarExpr::TypedConstantExpr(
+            ConstantExpr {
+                span: None,
+                value: Scalar::Number(NumberScalar::Int64(value)),
+            },
+            data_type,
+        )
+    }
+
+    fn column_stat(min: i64, max: i64, ndv: f64) -> ColumnStat {
+        column_stat_with_nulls(min, max, ndv, 0)
+    }
+
+    fn column_stat_with_nulls(min: i64, max: i64, ndv: f64, null_count: u64) -> ColumnStat {
+        ColumnStat {
+            min: Datum::Int(min),
+            max: Datum::Int(max),
+            ndv: NdvEstimate::exact(ndv),
+            null_count: StatCount::exact(null_count),
+            histogram: None,
+        }
+    }
+
+    fn derive(items: Vec<ScalarItem>, column_stats: HashMap<Symbol, ColumnStat>) -> Arc<StatInfo> {
+        let input = SExpr::create(
+            DummyTableScan::new(),
+            vec![],
+            None,
+            None,
+            Some(Arc::new(StatInfo {
+                cardinality: 10.0,
+                statistics: Statistics {
+                    precise_cardinality: Some(10),
+                    column_stats,
+                    top_n: Default::default(),
+                    count_min_sketch: Default::default(),
+                },
+            })),
+        );
+        let eval = SExpr::create_unary(EvalScalar { items }, input);
+        RelExpr::with_s_expr(&eval).derive_cardinality().unwrap()
+    }
+
+    #[test]
+    fn test_identity_projection_reuses_input_stats() {
+        let input_stats = Arc::new(StatInfo {
+            cardinality: 10.0,
+            statistics: Statistics {
+                precise_cardinality: Some(10),
+                column_stats: HashMap::from([(Symbol::new(0), column_stat(1, 3, 3.0))]),
+                top_n: Default::default(),
+                count_min_sketch: Default::default(),
+            },
+        });
+        let input = SExpr::create(
+            DummyTableScan::new(),
+            vec![],
+            None,
+            None,
+            Some(input_stats.clone()),
+        );
+        let eval = SExpr::create_unary(
+            EvalScalar {
+                items: vec![ScalarItem {
+                    scalar: column(0),
+                    index: Symbol::new(0),
+                }],
+            },
+            input,
+        );
+
+        let derived = RelExpr::with_s_expr(&eval).derive_cardinality().unwrap();
+        assert!(Arc::ptr_eq(&derived, &input_stats));
+    }
+
+    #[test]
+    fn test_derive_stats_copies_alias_and_derives_constant() {
+        let stats = derive(
+            vec![
+                ScalarItem {
+                    scalar: column(0),
+                    index: Symbol::new(1),
+                },
+                ScalarItem {
+                    scalar: int_constant(7),
+                    index: Symbol::new(2),
+                },
+            ],
+            HashMap::from([
+                (Symbol::new(0), column_stat(1, 3, 3.0)),
+                (Symbol::new(1), column_stat(100, 200, 10.0)),
+                (Symbol::new(2), column_stat(300, 400, 10.0)),
+            ]),
+        );
+
+        assert_eq!(stats.cardinality, 10.0);
+        assert_eq!(stats.statistics.precise_cardinality, Some(10));
+        let alias = &stats.statistics.column_stats[&Symbol::new(1)];
+        assert_eq!(
+            (alias.min.clone(), alias.max.clone()),
+            (Datum::Int(1), Datum::Int(3))
+        );
+        assert_eq!(alias.ndv, NdvEstimate::exact(3.0));
+        let constant = &stats.statistics.column_stats[&Symbol::new(2)];
+        assert_eq!(
+            (constant.min.clone(), constant.max.clone()),
+            (Datum::Int(7), Datum::Int(7))
+        );
+        assert_eq!(constant.ndv, NdvEstimate::exact(1.0));
+        assert_eq!(constant.null_count, StatCount::exact(0));
+    }
+
+    #[test]
+    fn test_derive_stats_for_supported_function() {
+        let nullable_int = DataType::Nullable(Box::new(int_type()));
+        let stats = derive(
+            vec![ScalarItem {
+                scalar: ScalarExpr::FunctionCall(FunctionCall {
+                    span: None,
+                    func_name: "plus".to_string(),
+                    params: vec![],
+                    arguments: vec![
+                        column_with_type(0, nullable_int.clone()),
+                        typed_int_constant(10, nullable_int),
+                    ],
+                }),
+                index: Symbol::new(1),
+            }],
+            HashMap::from([
+                (Symbol::new(0), column_stat_with_nulls(1, 3, 3.0, 2)),
+                (Symbol::new(1), column_stat(100, 200, 10.0)),
+            ]),
+        );
+
+        let derived = &stats.statistics.column_stats[&Symbol::new(1)];
+        assert_eq!(
+            (derived.min.clone(), derived.max.clone()),
+            (Datum::Int(11), Datum::Int(13))
+        );
+        assert_eq!(derived.ndv, NdvEstimate::exact(3.0));
+        assert_eq!(derived.null_count, StatCount::exact(2));
+    }
+
+    #[test]
+    fn test_derive_stats_removes_stale_shadowed_stats() {
+        let stats = derive(
+            vec![
+                ScalarItem {
+                    scalar: ScalarExpr::TypedConstantExpr(
+                        ConstantExpr {
+                            span: None,
+                            value: Scalar::Null,
+                        },
+                        DataType::Nullable(Box::new(int_type())),
+                    ),
+                    index: Symbol::new(1),
+                },
+                ScalarItem {
+                    scalar: ScalarExpr::CastExpr(CastExpr {
+                        span: None,
+                        is_try: false,
+                        argument: Box::new(column(0)),
+                        target_type: Box::new(DataType::Number(NumberDataType::Int32)),
+                    }),
+                    index: Symbol::new(2),
+                },
+            ],
+            HashMap::from([
+                (Symbol::new(0), column_stat(1, 3, 3.0)),
+                (Symbol::new(1), column_stat(100, 200, 10.0)),
+                (Symbol::new(2), column_stat(300, 400, 10.0)),
+            ]),
+        );
+
+        assert!(!stats.statistics.column_stats.contains_key(&Symbol::new(1)));
+        assert!(!stats.statistics.column_stats.contains_key(&Symbol::new(2)));
+        assert!(stats.statistics.column_stats.contains_key(&Symbol::new(0)));
     }
 }

--- a/src/query/sql/test-support/data/results/obfuscated/01_multi_join_sum_case_expression_physical.txt
+++ b/src/query/sql/test-support/data/results/obfuscated/01_multi_join_sum_case_expression_physical.txt
@@ -3,7 +3,7 @@ Exchange
 ├── exchange type: Merge
 └── EvalScalar
     ├── output columns: [sell_mnt = 0 (#168)]
-    ├── expressions: [t.sell_mnt (#167) = 0]
+    ├── expressions: [sum(CASE WHEN d.a1v = '603020' THEN 1 ELSE 0 END) (#167) = 0]
     ├── estimated rows: 729765643534.22
     └── AggregateFinal
         ├── output columns: [sum(CASE WHEN d.a1v = '603020' THEN 1 ELSE 0 END) (#167), a.a0d (#0), a.a0k (#7), a.a0m (#9), c.a5m (#144)]

--- a/src/query/sql/tests/it/optimizer/decorrelate_correlated_aliases.txt
+++ b/src/query/sql/tests/it/optimizer/decorrelate_correlated_aliases.txt
@@ -136,7 +136,7 @@ Exchange(Merge)
             │   └── EvalScalar
             │       ├── scalars: [a (#2) AS (#2), b (#3) AS (#3), 1 AS (#5), a (#7) AS (#8)]
             │       └── EvalScalar
-            │           ├── scalars: [a (#2) AS (#2), a (#2) AS (#2), b (#3) AS (#3), a (#0) AS (#7)]
+            │           ├── scalars: [a (#2) AS (#2), b (#3) AS (#3), a (#0) AS (#7)]
             │           └── Filter
             │               ├── filters: [eq(a (#2), a (#0))]
             │               └── Join(Cross)

--- a/src/query/sql/tests/it/optimizer/mod.rs
+++ b/src/query/sql/tests/it/optimizer/mod.rs
@@ -17,6 +17,7 @@ mod decorrelate_correlated_aliases;
 mod eager_aggregation;
 mod join_cardinality;
 mod normalize_scalar;
+mod outer_join_to_anti;
 mod push_down_filter_project_set;
 mod selectivity;
 mod selectivity_smoke;

--- a/src/query/sql/tests/it/optimizer/outer_join_to_anti.rs
+++ b/src/query/sql/tests/it/optimizer/outer_join_to_anti.rs
@@ -1,0 +1,150 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_exception::Result;
+
+use crate::framework::golden::SqlTestCase;
+use crate::framework::golden::open_golden_file;
+use crate::framework::golden::setup_context;
+use crate::framework::golden::write_case_header;
+
+async fn write_optimized_case(file: &mut impl std::io::Write, case: &SqlTestCase) -> Result<()> {
+    let ctx = setup_context(case).await?;
+    let raw_plan = ctx.bind_sql(case.sql).await?;
+    let optimized_plan = ctx.optimize_plan(raw_plan.clone()).await?;
+
+    write_case_header(file, case)?;
+    writeln!(file, "raw_plan:")?;
+    writeln!(file, "{}", raw_plan.format_indent(Default::default())?)?;
+    writeln!(file, "optimized_plan:")?;
+    writeln!(
+        file,
+        "{}",
+        optimized_plan.format_indent(Default::default())?
+    )?;
+    writeln!(file)?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_outer_join_to_anti_optimizer_outcomes() -> Result<()> {
+    let mut file = open_golden_file("optimizer", "outer_join_to_anti.txt")?;
+
+    let cases = [
+        SqlTestCase {
+            name: "regular_right_key_becomes_left_anti",
+            description: "A NULL filter on a regular right equi-key should become a left anti join.",
+            setup_sqls: &[LEFT_TABLE, RIGHT_TABLE],
+            sql: "SELECT l.k
+FROM outer_to_anti_left AS l
+LEFT JOIN outer_to_anti_right AS r ON l.k = r.k
+WHERE r.k IS NULL",
+        },
+        SqlTestCase {
+            name: "right_outputs_are_reconstructed_as_nulls",
+            description: "Right outputs observed above the rewrite should remain available as typed NULL expressions.",
+            setup_sqls: &[LEFT_TABLE, RIGHT_TABLE],
+            sql: "SELECT l.k, r.k, r.payload
+FROM outer_to_anti_left AS l
+LEFT JOIN outer_to_anti_right AS r ON l.k = r.k
+WHERE r.k IS NULL",
+        },
+        SqlTestCase {
+            name: "remaining_filter_and_limit_optimize_through_reconstruction",
+            description: "Multiple equi-conditions, a remaining left filter, and LIMIT should continue optimizing around the NULL reconstruction.",
+            setup_sqls: &[LEFT_TABLE, RIGHT_TABLE],
+            sql: "SELECT l.k, r.payload
+FROM outer_to_anti_left AS l
+LEFT JOIN outer_to_anti_right AS r ON l.k = r.k AND l.item = r.item
+WHERE r.k IS NULL AND l.keep > 0
+LIMIT 10",
+        },
+        SqlTestCase {
+            name: "nullable_payload_test_keeps_left_outer",
+            description: "A nullable non-key payload can be NULL on matched rows, so it must not become an anti join.",
+            setup_sqls: &[LEFT_TABLE, RIGHT_TABLE],
+            sql: "SELECT l.k, r.payload
+FROM outer_to_anti_left AS l
+LEFT JOIN outer_to_anti_right AS r ON l.k = r.k
+WHERE r.payload IS NULL",
+        },
+        SqlTestCase {
+            name: "right_outer_exclusion_becomes_anti",
+            description: "A NULL filter on a regular left equi-key should become an anti join; later join commutation may canonicalize it to a left anti join with swapped inputs.",
+            setup_sqls: &[LEFT_TABLE, RIGHT_TABLE],
+            sql: "SELECT r.k
+FROM outer_to_anti_left AS l
+RIGHT JOIN outer_to_anti_right AS r ON l.k = r.k
+WHERE l.k IS NULL",
+        },
+        SqlTestCase {
+            name: "left_outputs_are_reconstructed_as_nulls",
+            description: "Left outputs observed above a right anti rewrite should remain available as typed NULL expressions.",
+            setup_sqls: &[LEFT_TABLE, RIGHT_TABLE],
+            sql: "SELECT l.k, l.keep, r.k
+FROM outer_to_anti_left AS l
+RIGHT JOIN outer_to_anti_right AS r ON l.k = r.k
+WHERE l.k IS NULL",
+        },
+        SqlTestCase {
+            name: "right_filter_and_limit_optimize_through_reconstruction",
+            description: "A remaining right filter and LIMIT should continue optimizing around left-side NULL reconstruction.",
+            setup_sqls: &[LEFT_TABLE, RIGHT_TABLE],
+            sql: "SELECT l.keep, r.k
+FROM outer_to_anti_left AS l
+RIGHT JOIN outer_to_anti_right AS r ON l.k = r.k AND l.item = r.item
+WHERE l.k IS NULL AND r.payload > 0
+LIMIT 10",
+        },
+        SqlTestCase {
+            name: "nullable_left_payload_test_keeps_outer_join",
+            description: "A nullable non-key left payload can be NULL on matched rows, so the right outer join must remain an outer join even if later canonicalized with swapped inputs.",
+            setup_sqls: &[LEFT_TABLE, RIGHT_TABLE],
+            sql: "SELECT l.keep, r.k
+FROM outer_to_anti_left AS l
+RIGHT JOIN outer_to_anti_right AS r ON l.k = r.k
+WHERE l.keep IS NULL",
+        },
+        SqlTestCase {
+            name: "null_safe_condition_keeps_left_outer",
+            description: "A null-safe condition is not a regular equi-key in the raw plan and must remain a left outer join.",
+            setup_sqls: &[LEFT_TABLE, RIGHT_TABLE],
+            sql: "SELECT l.k, r.k
+FROM outer_to_anti_left AS l
+LEFT JOIN outer_to_anti_right AS r ON l.k IS NOT DISTINCT FROM r.k
+WHERE r.k IS NULL",
+        },
+    ];
+
+    for case in &cases {
+        write_optimized_case(&mut file, case).await?;
+    }
+
+    Ok(())
+}
+
+const LEFT_TABLE: &str = "CREATE TABLE outer_to_anti_left
+(
+    k INTEGER,
+    item INTEGER,
+    keep INTEGER
+)";
+
+const RIGHT_TABLE: &str = "CREATE TABLE outer_to_anti_right
+(
+    k INTEGER,
+    item INTEGER,
+    payload INTEGER
+)";

--- a/src/query/sql/tests/it/optimizer/outer_join_to_anti.txt
+++ b/src/query/sql/tests/it/optimizer/outer_join_to_anti.txt
@@ -1,0 +1,419 @@
+=== regular_right_key_becomes_left_anti ===
+description: A NULL filter on a regular right equi-key should become a left anti join.
+sql: SELECT l.k
+FROM outer_to_anti_left AS l
+LEFT JOIN outer_to_anti_right AS r ON l.k = r.k
+WHERE r.k IS NULL
+raw_plan:
+EvalScalar
+├── scalars: [outer_to_anti_left.k (#0) AS (#0)]
+└── Filter
+    ├── filters: [not(is_not_null(outer_to_anti_right.k (#3)))]
+    └── Join(Left)
+        ├── build keys: [outer_to_anti_right.k (#3)]
+        ├── probe keys: [outer_to_anti_left.k (#0)]
+        ├── other filters: []
+        ├── Scan
+        │   ├── table: default.outer_to_anti_right (#1)
+        │   ├── filters: []
+        │   ├── order by: []
+        │   └── limit: NONE
+        └── Scan
+            ├── table: default.outer_to_anti_left (#0)
+            ├── filters: []
+            ├── order by: []
+            └── limit: NONE
+
+optimized_plan:
+EvalScalar
+├── scalars: [outer_to_anti_left.k (#0) AS (#0), NULL AS (#3), NULL AS (#4), NULL AS (#5), NULL AS (#6)]
+└── Join(LeftAnti)
+    ├── build keys: [outer_to_anti_right.k (#3)]
+    ├── probe keys: [outer_to_anti_left.k (#0)]
+    ├── other filters: []
+    ├── Scan
+    │   ├── table: default.outer_to_anti_right (#1)
+    │   ├── filters: []
+    │   ├── order by: []
+    │   └── limit: NONE
+    └── Scan
+        ├── table: default.outer_to_anti_left (#0)
+        ├── filters: []
+        ├── order by: []
+        └── limit: NONE
+
+
+=== right_outputs_are_reconstructed_as_nulls ===
+description: Right outputs observed above the rewrite should remain available as typed NULL expressions.
+sql: SELECT l.k, r.k, r.payload
+FROM outer_to_anti_left AS l
+LEFT JOIN outer_to_anti_right AS r ON l.k = r.k
+WHERE r.k IS NULL
+raw_plan:
+EvalScalar
+├── scalars: [outer_to_anti_left.k (#0) AS (#0), outer_to_anti_right.k (#3) AS (#3), outer_to_anti_right.payload (#5) AS (#5)]
+└── Filter
+    ├── filters: [not(is_not_null(outer_to_anti_right.k (#3)))]
+    └── Join(Left)
+        ├── build keys: [outer_to_anti_right.k (#3)]
+        ├── probe keys: [outer_to_anti_left.k (#0)]
+        ├── other filters: []
+        ├── Scan
+        │   ├── table: default.outer_to_anti_right (#1)
+        │   ├── filters: []
+        │   ├── order by: []
+        │   └── limit: NONE
+        └── Scan
+            ├── table: default.outer_to_anti_left (#0)
+            ├── filters: []
+            ├── order by: []
+            └── limit: NONE
+
+optimized_plan:
+EvalScalar
+├── scalars: [outer_to_anti_left.k (#0) AS (#0), NULL AS (#3), NULL AS (#4), NULL AS (#5)]
+└── Join(LeftAnti)
+    ├── build keys: [outer_to_anti_right.k (#3)]
+    ├── probe keys: [outer_to_anti_left.k (#0)]
+    ├── other filters: []
+    ├── Scan
+    │   ├── table: default.outer_to_anti_right (#1)
+    │   ├── filters: []
+    │   ├── order by: []
+    │   └── limit: NONE
+    └── Scan
+        ├── table: default.outer_to_anti_left (#0)
+        ├── filters: []
+        ├── order by: []
+        └── limit: NONE
+
+
+=== remaining_filter_and_limit_optimize_through_reconstruction ===
+description: Multiple equi-conditions, a remaining left filter, and LIMIT should continue optimizing around the NULL reconstruction.
+sql: SELECT l.k, r.payload
+FROM outer_to_anti_left AS l
+LEFT JOIN outer_to_anti_right AS r ON l.k = r.k AND l.item = r.item
+WHERE r.k IS NULL AND l.keep > 0
+LIMIT 10
+raw_plan:
+Limit
+├── limit: [10]
+├── offset: [0]
+└── EvalScalar
+    ├── scalars: [outer_to_anti_left.k (#0) AS (#0), outer_to_anti_right.payload (#5) AS (#5)]
+    └── Filter
+        ├── filters: [not(is_not_null(outer_to_anti_right.k (#3))), gt(outer_to_anti_left.keep (#2), 0)]
+        └── Join(Left)
+            ├── build keys: [outer_to_anti_right.k (#3), outer_to_anti_right.item (#4)]
+            ├── probe keys: [outer_to_anti_left.k (#0), outer_to_anti_left.item (#1)]
+            ├── other filters: []
+            ├── Scan
+            │   ├── table: default.outer_to_anti_right (#1)
+            │   ├── filters: []
+            │   ├── order by: []
+            │   └── limit: NONE
+            └── Scan
+                ├── table: default.outer_to_anti_left (#0)
+                ├── filters: []
+                ├── order by: []
+                └── limit: NONE
+
+optimized_plan:
+EvalScalar
+├── scalars: [outer_to_anti_left.k (#0) AS (#0), NULL AS (#3), NULL AS (#4), NULL AS (#5), NULL AS (#6), outer_to_anti_left.keep (#2) AS (#7)]
+└── Limit
+    ├── limit: [10]
+    ├── offset: [0]
+    └── Join(LeftAnti)
+        ├── build keys: [outer_to_anti_right.k (#3), outer_to_anti_right.item (#4)]
+        ├── probe keys: [outer_to_anti_left.k (#0), outer_to_anti_left.item (#1)]
+        ├── other filters: []
+        ├── Scan
+        │   ├── table: default.outer_to_anti_right (#1)
+        │   ├── filters: []
+        │   ├── order by: []
+        │   └── limit: NONE
+        └── Scan
+            ├── table: default.outer_to_anti_left (#0)
+            ├── filters: [gt(outer_to_anti_left.keep (#2), 0)]
+            ├── order by: []
+            └── limit: NONE
+
+
+=== nullable_payload_test_keeps_left_outer ===
+description: A nullable non-key payload can be NULL on matched rows, so it must not become an anti join.
+sql: SELECT l.k, r.payload
+FROM outer_to_anti_left AS l
+LEFT JOIN outer_to_anti_right AS r ON l.k = r.k
+WHERE r.payload IS NULL
+raw_plan:
+EvalScalar
+├── scalars: [outer_to_anti_left.k (#0) AS (#0), outer_to_anti_right.payload (#5) AS (#5)]
+└── Filter
+    ├── filters: [not(is_not_null(outer_to_anti_right.payload (#5)))]
+    └── Join(Left)
+        ├── build keys: [outer_to_anti_right.k (#3)]
+        ├── probe keys: [outer_to_anti_left.k (#0)]
+        ├── other filters: []
+        ├── Scan
+        │   ├── table: default.outer_to_anti_right (#1)
+        │   ├── filters: []
+        │   ├── order by: []
+        │   └── limit: NONE
+        └── Scan
+            ├── table: default.outer_to_anti_left (#0)
+            ├── filters: []
+            ├── order by: []
+            └── limit: NONE
+
+optimized_plan:
+Filter
+├── filters: [not(is_not_null(outer_to_anti_right.payload (#5)))]
+└── Join(Left)
+    ├── build keys: [outer_to_anti_right.k (#3)]
+    ├── probe keys: [outer_to_anti_left.k (#0)]
+    ├── other filters: []
+    ├── Scan
+    │   ├── table: default.outer_to_anti_right (#1)
+    │   ├── filters: []
+    │   ├── order by: []
+    │   └── limit: NONE
+    └── Scan
+        ├── table: default.outer_to_anti_left (#0)
+        ├── filters: []
+        ├── order by: []
+        └── limit: NONE
+
+
+=== right_outer_exclusion_becomes_anti ===
+description: A NULL filter on a regular left equi-key should become an anti join; later join commutation may canonicalize it to a left anti join with swapped inputs.
+sql: SELECT r.k
+FROM outer_to_anti_left AS l
+RIGHT JOIN outer_to_anti_right AS r ON l.k = r.k
+WHERE l.k IS NULL
+raw_plan:
+EvalScalar
+├── scalars: [outer_to_anti_right.k (#3) AS (#3)]
+└── Filter
+    ├── filters: [not(is_not_null(outer_to_anti_left.k (#0)))]
+    └── Join(Right)
+        ├── build keys: [outer_to_anti_right.k (#3)]
+        ├── probe keys: [outer_to_anti_left.k (#0)]
+        ├── other filters: []
+        ├── Scan
+        │   ├── table: default.outer_to_anti_right (#1)
+        │   ├── filters: []
+        │   ├── order by: []
+        │   └── limit: NONE
+        └── Scan
+            ├── table: default.outer_to_anti_left (#0)
+            ├── filters: []
+            ├── order by: []
+            └── limit: NONE
+
+optimized_plan:
+EvalScalar
+├── scalars: [NULL AS (#0), NULL AS (#1), NULL AS (#2), outer_to_anti_right.k (#3) AS (#3), NULL AS (#6)]
+└── Join(LeftAnti)
+    ├── build keys: [outer_to_anti_left.k (#0)]
+    ├── probe keys: [outer_to_anti_right.k (#3)]
+    ├── other filters: []
+    ├── Scan
+    │   ├── table: default.outer_to_anti_left (#0)
+    │   ├── filters: []
+    │   ├── order by: []
+    │   └── limit: NONE
+    └── Scan
+        ├── table: default.outer_to_anti_right (#1)
+        ├── filters: []
+        ├── order by: []
+        └── limit: NONE
+
+
+=== left_outputs_are_reconstructed_as_nulls ===
+description: Left outputs observed above a right anti rewrite should remain available as typed NULL expressions.
+sql: SELECT l.k, l.keep, r.k
+FROM outer_to_anti_left AS l
+RIGHT JOIN outer_to_anti_right AS r ON l.k = r.k
+WHERE l.k IS NULL
+raw_plan:
+EvalScalar
+├── scalars: [outer_to_anti_left.k (#0) AS (#0), outer_to_anti_left.keep (#2) AS (#2), outer_to_anti_right.k (#3) AS (#3)]
+└── Filter
+    ├── filters: [not(is_not_null(outer_to_anti_left.k (#0)))]
+    └── Join(Right)
+        ├── build keys: [outer_to_anti_right.k (#3)]
+        ├── probe keys: [outer_to_anti_left.k (#0)]
+        ├── other filters: []
+        ├── Scan
+        │   ├── table: default.outer_to_anti_right (#1)
+        │   ├── filters: []
+        │   ├── order by: []
+        │   └── limit: NONE
+        └── Scan
+            ├── table: default.outer_to_anti_left (#0)
+            ├── filters: []
+            ├── order by: []
+            └── limit: NONE
+
+optimized_plan:
+EvalScalar
+├── scalars: [NULL AS (#0), NULL AS (#1), NULL AS (#2), outer_to_anti_right.k (#3) AS (#3)]
+└── Join(LeftAnti)
+    ├── build keys: [outer_to_anti_left.k (#0)]
+    ├── probe keys: [outer_to_anti_right.k (#3)]
+    ├── other filters: []
+    ├── Scan
+    │   ├── table: default.outer_to_anti_left (#0)
+    │   ├── filters: []
+    │   ├── order by: []
+    │   └── limit: NONE
+    └── Scan
+        ├── table: default.outer_to_anti_right (#1)
+        ├── filters: []
+        ├── order by: []
+        └── limit: NONE
+
+
+=== right_filter_and_limit_optimize_through_reconstruction ===
+description: A remaining right filter and LIMIT should continue optimizing around left-side NULL reconstruction.
+sql: SELECT l.keep, r.k
+FROM outer_to_anti_left AS l
+RIGHT JOIN outer_to_anti_right AS r ON l.k = r.k AND l.item = r.item
+WHERE l.k IS NULL AND r.payload > 0
+LIMIT 10
+raw_plan:
+Limit
+├── limit: [10]
+├── offset: [0]
+└── EvalScalar
+    ├── scalars: [outer_to_anti_left.keep (#2) AS (#2), outer_to_anti_right.k (#3) AS (#3)]
+    └── Filter
+        ├── filters: [not(is_not_null(outer_to_anti_left.k (#0))), gt(outer_to_anti_right.payload (#5), 0)]
+        └── Join(Right)
+            ├── build keys: [outer_to_anti_right.k (#3), outer_to_anti_right.item (#4)]
+            ├── probe keys: [outer_to_anti_left.k (#0), outer_to_anti_left.item (#1)]
+            ├── other filters: []
+            ├── Scan
+            │   ├── table: default.outer_to_anti_right (#1)
+            │   ├── filters: []
+            │   ├── order by: []
+            │   └── limit: NONE
+            └── Scan
+                ├── table: default.outer_to_anti_left (#0)
+                ├── filters: []
+                ├── order by: []
+                └── limit: NONE
+
+optimized_plan:
+EvalScalar
+├── scalars: [NULL AS (#0), NULL AS (#1), NULL AS (#2), outer_to_anti_right.k (#3) AS (#3), NULL AS (#6), outer_to_anti_right.payload (#5) AS (#7)]
+└── Limit
+    ├── limit: [10]
+    ├── offset: [0]
+    └── Join(LeftAnti)
+        ├── build keys: [outer_to_anti_left.k (#0), outer_to_anti_left.item (#1)]
+        ├── probe keys: [outer_to_anti_right.k (#3), outer_to_anti_right.item (#4)]
+        ├── other filters: []
+        ├── Scan
+        │   ├── table: default.outer_to_anti_left (#0)
+        │   ├── filters: []
+        │   ├── order by: []
+        │   └── limit: NONE
+        └── Scan
+            ├── table: default.outer_to_anti_right (#1)
+            ├── filters: [gt(outer_to_anti_right.payload (#5), 0)]
+            ├── order by: []
+            └── limit: NONE
+
+
+=== nullable_left_payload_test_keeps_outer_join ===
+description: A nullable non-key left payload can be NULL on matched rows, so the right outer join must remain an outer join even if later canonicalized with swapped inputs.
+sql: SELECT l.keep, r.k
+FROM outer_to_anti_left AS l
+RIGHT JOIN outer_to_anti_right AS r ON l.k = r.k
+WHERE l.keep IS NULL
+raw_plan:
+EvalScalar
+├── scalars: [outer_to_anti_left.keep (#2) AS (#2), outer_to_anti_right.k (#3) AS (#3)]
+└── Filter
+    ├── filters: [not(is_not_null(outer_to_anti_left.keep (#2)))]
+    └── Join(Right)
+        ├── build keys: [outer_to_anti_right.k (#3)]
+        ├── probe keys: [outer_to_anti_left.k (#0)]
+        ├── other filters: []
+        ├── Scan
+        │   ├── table: default.outer_to_anti_right (#1)
+        │   ├── filters: []
+        │   ├── order by: []
+        │   └── limit: NONE
+        └── Scan
+            ├── table: default.outer_to_anti_left (#0)
+            ├── filters: []
+            ├── order by: []
+            └── limit: NONE
+
+optimized_plan:
+Filter
+├── filters: [not(is_not_null(outer_to_anti_left.keep (#2)))]
+└── Join(Left)
+    ├── build keys: [outer_to_anti_left.k (#0)]
+    ├── probe keys: [outer_to_anti_right.k (#3)]
+    ├── other filters: []
+    ├── Scan
+    │   ├── table: default.outer_to_anti_left (#0)
+    │   ├── filters: []
+    │   ├── order by: []
+    │   └── limit: NONE
+    └── Scan
+        ├── table: default.outer_to_anti_right (#1)
+        ├── filters: []
+        ├── order by: []
+        └── limit: NONE
+
+
+=== null_safe_condition_keeps_left_outer ===
+description: A null-safe condition is not a regular equi-key in the raw plan and must remain a left outer join.
+sql: SELECT l.k, r.k
+FROM outer_to_anti_left AS l
+LEFT JOIN outer_to_anti_right AS r ON l.k IS NOT DISTINCT FROM r.k
+WHERE r.k IS NULL
+raw_plan:
+EvalScalar
+├── scalars: [outer_to_anti_left.k (#0) AS (#0), outer_to_anti_right.k (#3) AS (#3)]
+└── Filter
+    ├── filters: [not(is_not_null(outer_to_anti_right.k (#3)))]
+    └── Join(Left)
+        ├── build keys: []
+        ├── probe keys: []
+        ├── other filters: [assume_not_null(if(and(not(is_not_null(outer_to_anti_left.k (#0))), not(is_not_null(outer_to_anti_right.k (#3)))), true, or(not(is_not_null(outer_to_anti_left.k (#0))), not(is_not_null(outer_to_anti_right.k (#3)))), false, eq(outer_to_anti_left.k (#0), outer_to_anti_right.k (#3))))]
+        ├── Scan
+        │   ├── table: default.outer_to_anti_right (#1)
+        │   ├── filters: []
+        │   ├── order by: []
+        │   └── limit: NONE
+        └── Scan
+            ├── table: default.outer_to_anti_left (#0)
+            ├── filters: []
+            ├── order by: []
+            └── limit: NONE
+
+optimized_plan:
+Filter
+├── filters: [not(is_not_null(outer_to_anti_right.k (#3)))]
+└── Join(Left)
+    ├── build keys: []
+    ├── probe keys: []
+    ├── other filters: [assume_not_null(if(and(not(is_not_null(outer_to_anti_left.k (#0))), not(is_not_null(outer_to_anti_right.k (#3)))), true, or(not(is_not_null(outer_to_anti_left.k (#0))), not(is_not_null(outer_to_anti_right.k (#3)))), false, eq(outer_to_anti_left.k (#0), outer_to_anti_right.k (#3))))]
+    ├── Scan
+    │   ├── table: default.outer_to_anti_right (#1)
+    │   ├── filters: []
+    │   ├── order by: []
+    │   └── limit: NONE
+    └── Scan
+        ├── table: default.outer_to_anti_left (#0)
+        ├── filters: []
+        ├── order by: []
+        └── limit: NONE
+
+

--- a/src/query/sql/tests/it/semantic/binder_window_core.txt
+++ b/src/query/sql/tests/it/semantic/binder_window_core.txt
@@ -240,7 +240,7 @@ EvalScalar
         ├── sort keys: [t.number (#0) ASC NULLS LAST]
         ├── limit: [NONE]
         └── EvalScalar
-            ├── scalars: [t.number (#0) AS (#0), t.number (#0) AS (#0)]
+            ├── scalars: [t.number (#0) AS (#0)]
             └── Scan
                 ├── table: default.t (#0)
                 ├── filters: []
@@ -265,7 +265,7 @@ EvalScalar
         ├── window top: NONE
         ├── window function: Aggregate(AggregateFunction { span: Some(7..122), func_name: "listagg", distinct: false, params: [String("|")], args: [BoundColumnRef(BoundColumnRef { span: Some(20..26), column: ColumnBinding { database_name: None, table_name: None, column_position: None, table_index: None, column_name: "listagg_arg_0", column_name_lower: None, index: 3, data_type: Nullable(String), visibility: Visible, virtual_expr: None, is_srf: false } })], return_type: Nullable(String), sort_descs: [AggregateFunctionScalarSortDesc { expr: BoundColumnRef(BoundColumnRef { span: Some(68..73), column: ColumnBinding { database_name: Some("default"), table_name: Some("empsalary"), column_position: Some(2), table_index: Some(0), column_name: "empno", column_name_lower: None, index: 1, data_type: Nullable(Number(UInt64)), visibility: Visible, virtual_expr: None, is_srf: false } }), is_reuse_index: false, nulls_first: false, asc: false }], display_name: "listagg(CAST(salary AS STRING), '|') WITHIN GROUP ( ORDER BY empno DESC ) OVER (PARTITION BY depname ORDER BY empno)" })
         └── EvalScalar
-            ├── scalars: [empsalary.depname (#0) AS (#0), empsalary.empno (#1) AS (#1), empsalary.empno (#1) AS (#1), CAST(empsalary.salary (#2) AS String NULL) AS (#3)]
+            ├── scalars: [empsalary.depname (#0) AS (#0), empsalary.empno (#1) AS (#1), CAST(empsalary.salary (#2) AS String NULL) AS (#3)]
             └── Scan
                 ├── table: default.empsalary (#0)
                 ├── filters: []

--- a/src/query/sql/tests/it/semantic/binder_window_named.txt
+++ b/src/query/sql/tests/it/semantic/binder_window_named.txt
@@ -40,7 +40,7 @@ EvalScalar
         ├── window top: NONE
         ├── window function: Aggregate(AggregateFunction { span: Some(16..39), func_name: "sum", distinct: false, params: [], args: [BoundColumnRef(BoundColumnRef { span: None, column: ColumnBinding { database_name: None, table_name: None, column_position: None, table_index: None, column_name: "sum(salary)", column_name_lower: None, index: 2, data_type: Nullable(Number(UInt64)), visibility: Visible, virtual_expr: None, is_srf: false } })], return_type: Nullable(Number(UInt64)), sort_descs: [], display_name: "sum(sum(salary)) OVER w" })
         └── EvalScalar
-            ├── scalars: [sum(salary) (#2) AS (#2), sum(salary) (#2) AS (#2), 1 AS (#3)]
+            ├── scalars: [sum(salary) (#2) AS (#2), 1 AS (#3)]
             └── Aggregate(Initial)
                 ├── group items: [empsalary.depname (#0) AS (#0)]
                 ├── aggregate functions: [sum(empsalary.salary (#1)) AS (#2)]
@@ -70,7 +70,7 @@ EvalScalar
         ├── window top: NONE
         ├── window function: Aggregate(AggregateFunction { span: Some(16..39), func_name: "sum", distinct: false, params: [], args: [BoundColumnRef(BoundColumnRef { span: None, column: ColumnBinding { database_name: None, table_name: None, column_position: None, table_index: None, column_name: "sum(salary)", column_name_lower: None, index: 2, data_type: Nullable(Number(UInt64)), visibility: Visible, virtual_expr: None, is_srf: false } })], return_type: Nullable(Number(UInt64)), sort_descs: [], display_name: "sum(sum(salary)) OVER w" })
         └── EvalScalar
-            ├── scalars: [sum(salary) (#2) AS (#2), sum(salary) (#2) AS (#2), 1 AS (#3)]
+            ├── scalars: [sum(salary) (#2) AS (#2), 1 AS (#3)]
             └── Aggregate(Initial)
                 ├── group items: [empsalary.depname (#0) AS (#0)]
                 ├── aggregate functions: [sum(empsalary.salary (#1)) AS (#2)]

--- a/tests/sqllogictests/suites/mode/cluster/explain_v2.test
+++ b/tests/sqllogictests/suites/mode/cluster/explain_v2.test
@@ -172,27 +172,19 @@ query T
 explain select count(1) as c, count(b) as d, max(a) as e from t1 order by c, e, d limit 10;
 ----
 Limit
-├── output columns: [count(1) (#2), count(b) (#3), max(a) (#4)]
+├── output columns: [max(a) (#4), count(b) (#3), count(1) (#2)]
 ├── limit: 10
 ├── offset: 0
 ├── estimated rows: 1.00
 └── Sort(Single)
-    ├── output columns: [count(1) (#2), count(b) (#3), max(a) (#4)]
+    ├── output columns: [max(a) (#4), count(b) (#3), count(1) (#2)]
     ├── sort keys: [count(1) ASC NULLS LAST, max(a) ASC NULLS LAST, count(b) ASC NULLS LAST]
     ├── estimated rows: 1.00
     └── EvalScalar
-        ├── output columns: [count(1) (#2), count(b) (#3), max(a) (#4)]
-        ├── expressions: [99]
+        ├── output columns: [max(a) (#4), count(b) (#3), count(1) (#2)]
+        ├── expressions: [99, 100, 100]
         ├── estimated rows: 1.00
-        └── EvalScalar
-            ├── output columns: [count(1) (#2), count(b) (#3)]
-            ├── expressions: [count(1) (#2)]
-            ├── estimated rows: 1.00
-            └── EvalScalar
-                ├── output columns: [count(1) (#2)]
-                ├── expressions: [100]
-                ├── estimated rows: 1.00
-                └── DummyTableScan
+        └── DummyTableScan
 
 query T
 explain select (t1.a + 1) as c,(t1.b+1) as d, (t2.a+1) as e from t1 join t2 on t1.a = t2.a order by c, d, e limit 10;
@@ -374,7 +366,7 @@ AggregateFinal
                 ├── exchange type: Hash(x.a (#2))
                 └── EvalScalar
                     ├── output columns: [a (#2)]
-                    ├── expressions: [CAST(x.a (#0) AS UInt64 NULL)]
+                    ├── expressions: [CAST(numbers.number (#0) AS UInt64 NULL)]
                     ├── estimated rows: 10.00
                     └── TableScan
                         ├── table: default.system.numbers

--- a/tests/sqllogictests/suites/mode/standalone/explain/aggregate.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/aggregate.test
@@ -53,16 +53,16 @@ explain select 1 a from numbers(10) group by a;
 EvalScalar
 ├── output columns: [a (#2)]
 ├── expressions: [group_item (#1)]
-├── estimated rows: 3.33
+├── estimated rows: 1.00
 └── AggregateFinal
     ├── output columns: [a (#1)]
     ├── group by: [a]
     ├── aggregate functions: []
-    ├── estimated rows: 3.33
+    ├── estimated rows: 1.00
     └── AggregatePartial
         ├── group by: [a]
         ├── aggregate functions: []
-        ├── estimated rows: 3.33
+        ├── estimated rows: 1.00
         └── EvalScalar
             ├── output columns: [a (#1)]
             ├── expressions: [1]
@@ -445,32 +445,28 @@ query T
 EXPLAIN SELECT referer, avg(isrefresh), count(distinct referer) FROM t GROUP BY referer;
 ----
 EvalScalar
-├── output columns: [t.referer (#0), count(DISTINCT referer) (#4), sum(isrefresh) / if(count(isrefresh) = 0, 1, count(isrefresh)) (#5)]
-├── expressions: [sum(isrefresh) (#2) / CAST(if(CAST(count(isrefresh) (#3) = 0 AS Boolean NULL), 1, count(isrefresh) (#3)) AS UInt64 NULL)]
+├── output columns: [t.referer (#0), sum(isrefresh) / if(count(isrefresh) = 0, 1, count(isrefresh)) (#5), count(DISTINCT referer) (#4)]
+├── expressions: [sum(isrefresh) (#2) / CAST(if(CAST(count(isrefresh) (#3) = 0 AS Boolean NULL), 1, count(isrefresh) (#3)) AS UInt64 NULL), 1]
 ├── estimated rows: 1.00
-└── EvalScalar
-    ├── output columns: [sum(isrefresh) (#2), count(isrefresh) (#3), t.referer (#0), count(DISTINCT referer) (#4)]
-    ├── expressions: [1]
+└── AggregateFinal
+    ├── output columns: [sum(isrefresh) (#2), count(isrefresh) (#3), t.referer (#0)]
+    ├── group by: [referer]
+    ├── aggregate functions: [sum(isrefresh), count()]
     ├── estimated rows: 1.00
-    └── AggregateFinal
-        ├── output columns: [sum(isrefresh) (#2), count(isrefresh) (#3), t.referer (#0)]
+    └── AggregatePartial
         ├── group by: [referer]
         ├── aggregate functions: [sum(isrefresh), count()]
         ├── estimated rows: 1.00
-        └── AggregatePartial
-            ├── group by: [referer]
-            ├── aggregate functions: [sum(isrefresh), count()]
-            ├── estimated rows: 1.00
-            └── TableScan
-                ├── table: default.default.t
-                ├── scan id: 0
-                ├── output columns: [referer (#0), isrefresh (#1)]
-                ├── read rows: 0
-                ├── read size: 0
-                ├── partitions total: 0
-                ├── partitions scanned: 0
-                ├── push downs: [filters: [], limit: NONE]
-                └── estimated rows: 0.00
+        └── TableScan
+            ├── table: default.default.t
+            ├── scan id: 0
+            ├── output columns: [referer (#0), isrefresh (#1)]
+            ├── read rows: 0
+            ├── read size: 0
+            ├── partitions total: 0
+            ├── partitions scanned: 0
+            ├── push downs: [filters: [], limit: NONE]
+            └── estimated rows: 0.00
 
 query T
 EXPLAIN SELECT referer, isrefresh, count() FROM t GROUP BY referer, isrefresh order by referer, isrefresh desc limit 10;

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -1754,13 +1754,9 @@ EvalScalar
     │               │                           ├── estimated rows: 1.00
     │               │                           ├── EvalScalar
     │               │                           │   ├── output columns: [0 (#47), SUBSTRING(i FROM 1 FOR POSITION('\n' IN i) - 1) (#48), SUBSTRING(i FROM POSITION('\n' IN i) + 1) (#49)]
-    │               │                           │   ├── expressions: [0, substr(aoc10_input.i (#46), 1, CAST(locate('\n', aoc10_input.i (#46)) - 1 AS UInt64)), substr(aoc10_input.i (#46), CAST(locate('\n', aoc10_input.i (#46)) + 1 AS Int64))]
+    │               │                           │   ├── expressions: [0, '', '89010123\n78121874\n87430965\n96549874\n45678903\n32019012\n01329801\n10456732\n']
     │               │                           │   ├── estimated rows: 1.00
-    │               │                           │   └── EvalScalar
-    │               │                           │       ├── output columns: ['\n89010123\n78121874\n87430965\n96549874\n45678903\n32019012\n01329801\n10456732\n' (#46)]
-    │               │                           │       ├── expressions: ['\n89010123\n78121874\n87430965\n96549874\n45678903\n32019012\n01329801\n10456732\n']
-    │               │                           │       ├── estimated rows: 1.00
-    │               │                           │       └── DummyTableScan
+    │               │                           │   └── DummyTableScan
     │               │                           └── EvalScalar
     │               │                               ├── output columns: [y + 1::UInt64 (#53), SUBSTRING(rest FROM 1 FOR POSITION('\n' IN rest) - 1) (#54), SUBSTRING(rest FROM POSITION('\n' IN rest) + 1) (#55)]
     │               │                               ├── expressions: [lines.y (#50) + 1, substr(lines.rest (#52), 1, CAST(locate('\n', lines.rest (#52)) - 1 AS UInt64)), substr(lines.rest (#52), CAST(locate('\n', lines.rest (#52)) + 1 AS Int64))]
@@ -1808,13 +1804,9 @@ EvalScalar
     │                                           ├── estimated rows: 1.00
     │                                           ├── EvalScalar
     │                                           │   ├── output columns: [0 (#65), SUBSTRING(i FROM 1 FOR POSITION('\n' IN i) - 1) (#66), SUBSTRING(i FROM POSITION('\n' IN i) + 1) (#67)]
-    │                                           │   ├── expressions: [0, substr(aoc10_input.i (#64), 1, CAST(locate('\n', aoc10_input.i (#64)) - 1 AS UInt64)), substr(aoc10_input.i (#64), CAST(locate('\n', aoc10_input.i (#64)) + 1 AS Int64))]
+    │                                           │   ├── expressions: [0, '', '89010123\n78121874\n87430965\n96549874\n45678903\n32019012\n01329801\n10456732\n']
     │                                           │   ├── estimated rows: 1.00
-    │                                           │   └── EvalScalar
-    │                                           │       ├── output columns: ['\n89010123\n78121874\n87430965\n96549874\n45678903\n32019012\n01329801\n10456732\n' (#64)]
-    │                                           │       ├── expressions: ['\n89010123\n78121874\n87430965\n96549874\n45678903\n32019012\n01329801\n10456732\n']
-    │                                           │       ├── estimated rows: 1.00
-    │                                           │       └── DummyTableScan
+    │                                           │   └── DummyTableScan
     │                                           └── EvalScalar
     │                                               ├── output columns: [y + 1::UInt64 (#71), SUBSTRING(rest FROM 1 FOR POSITION('\n' IN rest) - 1) (#72), SUBSTRING(rest FROM POSITION('\n' IN rest) + 1) (#73)]
     │                                               ├── expressions: [lines.y (#68) + 1, substr(lines.rest (#70), 1, CAST(locate('\n', lines.rest (#70)) - 1 AS UInt64)), substr(lines.rest (#70), CAST(locate('\n', lines.rest (#70)) + 1 AS Int64))]
@@ -1852,7 +1844,7 @@ EvalScalar
         │               ├── estimated rows: 1.00
         │               └── Filter
         │                   ├── output columns: [x (#40), y (#41), 9 (#42), x (#43), y (#44)]
-        │                   ├── filters: [results.v (#42) = 0]
+        │                   ├── filters: [paths.v (#42) = 0]
         │                   ├── estimated rows: 0.15
         │                   └── UnionAll(recursive cte)
         │                       ├── output columns: [x (#40), y (#41), 9 (#42), x (#43), y (#44)]
@@ -1886,13 +1878,9 @@ EvalScalar
         │                       │                           ├── estimated rows: 1.00
         │                       │                           ├── EvalScalar
         │                       │                           │   ├── output columns: [0 (#1), SUBSTRING(i FROM 1 FOR POSITION('\n' IN i) - 1) (#2), SUBSTRING(i FROM POSITION('\n' IN i) + 1) (#3)]
-        │                       │                           │   ├── expressions: [0, substr(aoc10_input.i (#0), 1, CAST(locate('\n', aoc10_input.i (#0)) - 1 AS UInt64)), substr(aoc10_input.i (#0), CAST(locate('\n', aoc10_input.i (#0)) + 1 AS Int64))]
+        │                       │                           │   ├── expressions: [0, '', '89010123\n78121874\n87430965\n96549874\n45678903\n32019012\n01329801\n10456732\n']
         │                       │                           │   ├── estimated rows: 1.00
-        │                       │                           │   └── EvalScalar
-        │                       │                           │       ├── output columns: ['\n89010123\n78121874\n87430965\n96549874\n45678903\n32019012\n01329801\n10456732\n' (#0)]
-        │                       │                           │       ├── expressions: ['\n89010123\n78121874\n87430965\n96549874\n45678903\n32019012\n01329801\n10456732\n']
-        │                       │                           │       ├── estimated rows: 1.00
-        │                       │                           │       └── DummyTableScan
+        │                       │                           │   └── DummyTableScan
         │                       │                           └── EvalScalar
         │                       │                               ├── output columns: [y + 1::UInt64 (#7), SUBSTRING(rest FROM 1 FOR POSITION('\n' IN rest) - 1) (#8), SUBSTRING(rest FROM POSITION('\n' IN rest) + 1) (#9)]
         │                       │                               ├── expressions: [lines.y (#4) + 1, substr(lines.rest (#6), 1, CAST(locate('\n', lines.rest (#6)) - 1 AS UInt64)), substr(lines.rest (#6), CAST(locate('\n', lines.rest (#6)) + 1 AS Int64))]
@@ -1940,13 +1928,9 @@ EvalScalar
         │                                                   ├── estimated rows: 1.00
         │                                                   ├── EvalScalar
         │                                                   │   ├── output columns: [0 (#19), SUBSTRING(i FROM 1 FOR POSITION('\n' IN i) - 1) (#20), SUBSTRING(i FROM POSITION('\n' IN i) + 1) (#21)]
-        │                                                   │   ├── expressions: [0, substr(aoc10_input.i (#18), 1, CAST(locate('\n', aoc10_input.i (#18)) - 1 AS UInt64)), substr(aoc10_input.i (#18), CAST(locate('\n', aoc10_input.i (#18)) + 1 AS Int64))]
+        │                                                   │   ├── expressions: [0, '', '89010123\n78121874\n87430965\n96549874\n45678903\n32019012\n01329801\n10456732\n']
         │                                                   │   ├── estimated rows: 1.00
-        │                                                   │   └── EvalScalar
-        │                                                   │       ├── output columns: ['\n89010123\n78121874\n87430965\n96549874\n45678903\n32019012\n01329801\n10456732\n' (#18)]
-        │                                                   │       ├── expressions: ['\n89010123\n78121874\n87430965\n96549874\n45678903\n32019012\n01329801\n10456732\n']
-        │                                                   │       ├── estimated rows: 1.00
-        │                                                   │       └── DummyTableScan
+        │                                                   │   └── DummyTableScan
         │                                                   └── EvalScalar
         │                                                       ├── output columns: [y + 1::UInt64 (#25), SUBSTRING(rest FROM 1 FOR POSITION('\n' IN rest) - 1) (#26), SUBSTRING(rest FROM POSITION('\n' IN rest) + 1) (#27)]
         │                                                       ├── expressions: [lines.y (#22) + 1, substr(lines.rest (#24), 1, CAST(locate('\n', lines.rest (#24)) - 1 AS UInt64)), substr(lines.rest (#24), CAST(locate('\n', lines.rest (#24)) + 1 AS Int64))]

--- a/tests/sqllogictests/suites/mode/standalone/explain/fold_agg.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/fold_agg.test
@@ -117,18 +117,14 @@ query T
 explain select count(), max(number) + 3, min(day) from t;
 ----
 EvalScalar
-├── output columns: [count() (#5), min(day) (#7), max(number) + 3 (#8)]
+├── output columns: [min(day) (#7), count() (#5), max(number) + 3 (#8)]
 ├── expressions: [max(number) (#6) + 3]
 ├── estimated rows: 1.00
 └── EvalScalar
-    ├── output columns: [count() (#5), max(number) (#6), min(day) (#7)]
-    ├── expressions: [1999, '2024-01-01']
+    ├── output columns: [max(number) (#6), min(day) (#7), count() (#5)]
+    ├── expressions: [1999, '2024-01-01', 3000]
     ├── estimated rows: 1.00
-    └── EvalScalar
-        ├── output columns: [count() (#5)]
-        ├── expressions: [3000]
-        ├── estimated rows: 1.00
-        └── DummyTableScan
+    └── DummyTableScan
 
 query T
 explain select  count(), max(number) + 4, sum_if(number + 4 , number > 3 ), min(day), max(ts), min(money), 8, min(ts), sum(money) from t;
@@ -170,18 +166,10 @@ query T
 explain select 5, count(), min(number), max(ts), min(money), 4 from t;
 ----
 EvalScalar
-├── output columns: [count() (#5), min(number) (#6), max(ts) (#7), min(money) (#8), 5 (#9), 4 (#10)]
-├── expressions: [5, 4]
+├── output columns: [5 (#9), 4 (#10), min(number) (#6), max(ts) (#7), min(money) (#8), count() (#5)]
+├── expressions: [5, 4, 0, '2024-01-01 00:33:19.000000', 0.00, 3000]
 ├── estimated rows: 1.00
-└── EvalScalar
-    ├── output columns: [count() (#5), min(number) (#6), max(ts) (#7), min(money) (#8)]
-    ├── expressions: [0, '2024-01-01 00:33:19.000000', 0.00]
-    ├── estimated rows: 1.00
-    └── EvalScalar
-        ├── output columns: [count() (#5)]
-        ├── expressions: [3000]
-        ├── estimated rows: 1.00
-        └── DummyTableScan
+└── DummyTableScan
 
 query T
 ----

--- a/tests/sqllogictests/suites/mode/standalone/explain/limit.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/limit.test
@@ -216,7 +216,7 @@ Limit
         ├── estimated rows: 1.00
         ├── EvalScalar(Build)
         │   ├── output columns: [c (#4)]
-        │   ├── expressions: [CAST(t4.c (#3) AS UInt64 NULL)]
+        │   ├── expressions: [CAST(count(t.number) (#3) AS UInt64 NULL)]
         │   ├── estimated rows: 1.00
         │   └── AggregateFinal
         │       ├── output columns: [count(t.number) (#3), t.number (#2)]

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_self_join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_self_join.test
@@ -30,7 +30,7 @@ Sequence
     ├── build keys: [b2.a (#4)]
     ├── probe keys: [b1.a (#2)]
     ├── keys is null equal: [false]
-    ├── filters: [d.b (#3) < d.b (#5)]
+    ├── filters: [b1.b (#3) < b2.b (#5)]
     ├── build join filters:
     │   └── filter id:0, build key:b2.a (#4), probe targets:[b1.a (#2)@scan1], filter type:bloom,inlist,min_max
     ├── estimated rows: 40.00

--- a/tests/sqllogictests/suites/mode/standalone/explain/select.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/select.test
@@ -17,7 +17,7 @@ explain select * from (select * from numbers(1)) as t1 where number = 1
 ----
 Filter
 ├── output columns: [numbers.number (#0)]
-├── filters: [t1.number (#0) = 1]
+├── filters: [numbers.number (#0) = 1]
 ├── estimated rows: 0.50
 └── TableScan
     ├── table: default.system.numbers

--- a/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
@@ -572,7 +572,7 @@ explain select * from (select number as a from numbers(10)) as t(b) where t.b > 
 ----
 Filter
 ├── output columns: [numbers.number (#0)]
-├── filters: [t.b (#0) > 5]
+├── filters: [numbers.number (#0) > 5]
 ├── estimated rows: 5.00
 └── TableScan
     ├── table: default.system.numbers

--- a/tests/sqllogictests/suites/mode/standalone/explain/window.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/window.test
@@ -180,7 +180,7 @@ explain SELECT k, v FROM (SELECT *, rank() OVER (PARTITION BY k ORDER BY v DESC)
 ----
 Filter
 ├── output columns: [k (#4), v (#5)]
-├── filters: [t2.rank (#6) = 1]
+├── filters: [rank() OVER (PARTITION BY k ORDER BY v DESC) (#6) = 1]
 ├── estimated rows: 0.00
 └── Window
     ├── output columns: [k (#4), v (#5), rank() OVER (PARTITION BY k ORDER BY v DESC) (#6)]
@@ -223,7 +223,7 @@ explain SELECT k, v FROM (SELECT *, rank() OVER (PARTITION BY v ORDER BY v DESC)
 ----
 Filter
 ├── output columns: [k (#4), v (#5)]
-├── filters: [t2.rank (#6) = 1, is_true(t2.k (#4) = 12)]
+├── filters: [rank() OVER (PARTITION BY v ORDER BY v DESC) (#6) = 1, is_true(t1.k (#4) = 12)]
 ├── estimated rows: 0.00
 └── Window
     ├── output columns: [k (#4), v (#5), rank() OVER (PARTITION BY v ORDER BY v DESC) (#6)]
@@ -266,7 +266,7 @@ explain SELECT k, v FROM (SELECT *, rank() OVER (ORDER BY v DESC) AS rank FROM (
 ----
 Filter
 ├── output columns: [k (#4), v (#5)]
-├── filters: [t2.rank (#6) = 1, is_true(t2.k (#4) = 12)]
+├── filters: [rank() OVER (ORDER BY v DESC) (#6) = 1, is_true(t1.k (#4) = 12)]
 ├── estimated rows: 0.00
 └── Window
     ├── output columns: [k (#4), v (#5), rank() OVER (ORDER BY v DESC) (#6)]
@@ -378,7 +378,7 @@ explain select * from vwpush where b > 3;
 ----
 Filter
 ├── output columns: [tbpush.b (#0), rnum (#1)]
-├── filters: [is_true(vwpush.b (#0) > 3)]
+├── filters: [is_true(tbpush.b (#0) > 3)]
 ├── estimated rows: 0.00
 └── Window
     ├── output columns: [tbpush.b (#0), rnum (#1)]
@@ -772,7 +772,7 @@ query T
 explain optimized select time, rowkey from (select *, row_number() over(partition by rowkey order by time desc) as rn from table43764_orc) a where rn < 1
 ----
 EvalScalar
-├── scalars: [table43764_orc.rowkey (#0) AS (#0), table43764_orc.rowkey (#0) AS (#0), table43764_orc.time (#1) AS (#1), table43764_orc.time (#1) AS (#1), table43764_orc.sirc_action (#2) AS (#2), table43764_orc.sirc_operation_count (#3) AS (#3), table43764_orc.akc087 (#4) AS (#4), table43764_orc.aae035 (#5) AS (#5), row_number() OVER (PARTITION BY rowkey ORDER BY time DESC) (#6) AS (#6), row_number() OVER (PARTITION BY rowkey ORDER BY time DESC) (#6) AS (#7)]
+├── scalars: [table43764_orc.rowkey (#0) AS (#0), table43764_orc.time (#1) AS (#1), table43764_orc.sirc_action (#2) AS (#2), table43764_orc.sirc_operation_count (#3) AS (#3), table43764_orc.akc087 (#4) AS (#4), table43764_orc.aae035 (#5) AS (#5), row_number() OVER (PARTITION BY rowkey ORDER BY time DESC) (#6) AS (#6), row_number() OVER (PARTITION BY rowkey ORDER BY time DESC) (#6) AS (#7)]
 └── EmptyResultScan
 
 # same order multi window
@@ -997,7 +997,7 @@ Window
     ├── estimated rows: 50.00
     └── EvalScalar
         ├── output columns: [numbers.number (#0), rank() OVER (PARTITION BY number % 3 ORDER BY number) (#2), sum_arg_0 (#3), sum_part_0 (#4)]
-        ├── expressions: [t.number (#0) - 1, t.number (#0) % 3]
+        ├── expressions: [numbers.number (#0) - 1, numbers.number (#0) % 3]
         ├── estimated rows: 50.00
         └── Window
             ├── output columns: [numbers.number (#0), rank_part_0 (#1), rank() OVER (PARTITION BY number % 3 ORDER BY number) (#2)]

--- a/tests/sqllogictests/suites/query/join/outer_join_to_anti.test
+++ b/tests/sqllogictests/suites/query/join/outer_join_to_anti.test
@@ -1,0 +1,81 @@
+statement ok
+create or replace table outer_to_anti_left(k int, payload int);
+
+statement ok
+create or replace table outer_to_anti_right(k int, payload int);
+
+statement ok
+insert into outer_to_anti_left values (null, 90), (1, 10), (2, 20), (3, 30);
+
+statement ok
+insert into outer_to_anti_right values (null, null), (1, null), (1, 10), (2, 20);
+
+# A null test on a regular right equi-join key is an anti join. Right-side
+# columns remain observable as NULL after the rewrite.
+query III rowsort
+select l.k, r.k, r.payload
+from outer_to_anti_left l
+left join outer_to_anti_right r on l.k = r.k
+where r.k is null;
+----
+3 NULL NULL
+NULL NULL NULL
+
+# An unrelated left-side predicate remains above the anti join.
+query I rowsort
+select l.k
+from outer_to_anti_left l
+left join outer_to_anti_right r on l.k = r.k
+where r.k is null and l.k is not null;
+----
+3
+
+# The symmetric right outer pattern is a right anti join. Left-side columns
+# remain observable as NULL after the rewrite.
+query III rowsort
+select l.k, l.payload, r.k
+from outer_to_anti_left l
+right join outer_to_anti_right r on l.k = r.k
+where l.k is null;
+----
+NULL NULL NULL
+
+# A nullable payload is not an anti-join indicator: the matched k=1 row with
+# a NULL payload must remain, including the duplicate match with payload=10
+# being filtered independently.
+query III rowsort
+select l.k, r.k, r.payload
+from outer_to_anti_left l
+left join outer_to_anti_right r on l.k = r.k
+where r.payload is null;
+----
+1 1 NULL
+3 NULL NULL
+NULL NULL NULL
+
+# Null-equal join keys are not safe: the matched NULL key must survive the
+# original outer join plus null filter.
+query II rowsort
+select l.k, r.k
+from outer_to_anti_left l
+left join outer_to_anti_right r on l.k is not distinct from r.k
+where r.k is null;
+----
+3 NULL
+NULL NULL
+
+# A null-safe right join condition can match the two NULL keys, so it must
+# remain an outer join rather than becoming a right anti join.
+query III rowsort
+select l.k, l.payload, r.k
+from outer_to_anti_left l
+right join outer_to_anti_right r on l.k is not distinct from r.k
+where l.k is null;
+----
+NULL 90 NULL
+
+statement ok
+drop table outer_to_anti_left;
+
+statement ok
+drop table outer_to_anti_right;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Rewrite LEFT/RIGHT OUTER JOIN exclusion patterns into anti joins when `IS NULL` targets a regular equi-join key on the null-extended side.
- Preserve residual filters and output schemas by reconstructing removed-side columns as typed NULL values; exclude nullable payload tests and null-safe join conditions.
- Harden EvalScalar behavior with correct physical column pruning, dependency-safe merging, constant-overwrite preservation, and derived statistics without stale ColumnStat,
  TopN, or CMS data.
- Add SQL-driven optimizer goldens, SQL logic coverage for LEFT/RIGHT JOIN and NULL semantics, focused EvalScalar unit tests, and optimizer rule-testing guidance.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20189)
<!-- Reviewable:end -->
