### PR TITLE
fix(storage): read legacy bincode v4 segments

### DIFF
--- a/src/query/expression/src/converts/meta/bincode.rs
+++ b/src/query/expression/src/converts/meta/bincode.rs
@@ -44,7 +44,6 @@ pub enum LegacyScalar {
     Decimal(DecimalScalar),
     Timestamp(i64),
     Date(i32),
-    Interval(months_days_micros),
     Boolean(bool),
     String(Vec<u8>),
     Array(LegacyColumn),
@@ -52,6 +51,8 @@ pub enum LegacyScalar {
     Bitmap(Vec<u8>),
     Tuple(Vec<Scalar>),
     Variant(Vec<u8>),
+    // Interval must be at end: old bincode data did not have this variant
+    Interval(months_days_micros),
 }
 
 #[allow(unused, dead_code)]

--- a/src/query/expression/tests/it/meta_scalar.rs
+++ b/src/query/expression/tests/it/meta_scalar.rs
@@ -17,11 +17,60 @@ use databend_common_expression::Scalar;
 use databend_common_expression::converts::meta::IndexScalar;
 use databend_common_expression::converts::meta::LegacyColumn;
 use databend_common_expression::converts::meta::LegacyScalar;
+use databend_common_expression::types::DecimalScalar;
+use databend_common_expression::types::NumberScalar;
 use databend_common_io::prelude::bincode_deserialize_from_slice;
 use databend_common_io::prelude::bincode_serialize_into_buf;
 
 use crate::DataTypeFilter;
 use crate::rand_block_for_all_types;
+
+#[allow(dead_code)]
+#[derive(serde::Serialize)]
+enum OldLegacyScalar {
+    Null,
+    EmptyArray,
+    EmptyMap,
+    Number(NumberScalar),
+    Decimal(DecimalScalar),
+    Timestamp(i64),
+    Date(i32),
+    Boolean(bool),
+    String(Vec<u8>),
+    Array(()),
+    Map(()),
+    Bitmap(Vec<u8>),
+    Tuple(Vec<Scalar>),
+    Variant(Vec<u8>),
+}
+
+#[test]
+pub fn test_legacy_scalar_reads_old_bincode_layout() -> databend_common_exception::Result<()> {
+    let old_scalars = vec![
+        OldLegacyScalar::Boolean(true),
+        OldLegacyScalar::String(b"abc".to_vec()),
+        OldLegacyScalar::Tuple(vec![Scalar::String("tuple".to_string())]),
+        OldLegacyScalar::Variant(vec![1, 2, 3]),
+    ];
+
+    let mut data = vec![];
+    bincode_serialize_into_buf(&mut data, &old_scalars)?;
+    let new_scalars: Vec<LegacyScalar> = bincode_deserialize_from_slice(&data)?;
+
+    let decoded = new_scalars
+        .into_iter()
+        .map(Scalar::from)
+        .collect::<Vec<_>>();
+    assert_eq!(decoded[0], Scalar::Boolean(true));
+    assert_eq!(decoded[1], Scalar::String("abc".to_string()));
+    assert_eq!(
+        decoded[2],
+        Scalar::Tuple(vec![Scalar::String("tuple".to_string())])
+    );
+    assert!(matches!(&decoded[3], Scalar::Variant(bytes) if bytes == &[1, 2, 3]));
+
+    Ok(())
+}
 
 #[test]
 pub fn test_legacy_converts() -> databend_common_exception::Result<()> {

--- a/src/query/storages/common/table_meta/src/meta/v3/mod.rs
+++ b/src/query/storages/common/table_meta/src/meta/v3/mod.rs
@@ -14,7 +14,7 @@
 
 // we use "frozen" types of table meta, to make sure that the type we used for
 // bincode deserialization is compatible with the type we used for bincode serialization.
-mod frozen;
+pub(crate) mod frozen;
 mod segment;
 mod snapshot;
 mod table_snapshot_statistics;

--- a/src/query/storages/common/table_meta/src/meta/v4/segment.rs
+++ b/src/query/storages/common/table_meta/src/meta/v4/segment.rs
@@ -189,10 +189,8 @@ impl SegmentInfo {
             summary_size,
         } = decode_segment_header(&mut cursor)?;
 
-        let blocks: Vec<Arc<BlockMeta>> =
-            read_and_deserialize(&mut cursor, blocks_size, &encoding, &compression)?;
-        let summary: Statistics =
-            read_and_deserialize(&mut cursor, summary_size, &encoding, &compression)?;
+        let blocks = read_block_metas(&mut cursor, blocks_size, &encoding, &compression)?;
+        let summary = read_statistics(&mut cursor, summary_size, &encoding, &compression)?;
 
         let mut segment = Self::new(blocks, summary);
 
@@ -214,7 +212,7 @@ pub struct RawBlockMeta {
 impl RawBlockMeta {
     pub fn block_metas(&self) -> Result<Vec<Arc<BlockMeta>>> {
         let mut reader = Cursor::new(&self.bytes);
-        read_and_deserialize(
+        read_block_metas(
             &mut reader,
             self.bytes.len() as u64,
             &self.encoding,
@@ -244,8 +242,7 @@ impl CompactSegmentInfo {
         let mut block_metas_raw_bytes = vec![0; blocks_size as usize];
         r.read_exact(&mut block_metas_raw_bytes)?;
 
-        let summary: Statistics =
-            read_and_deserialize(&mut r, summary_size, &encoding, &compression)?;
+        let summary = read_statistics(&mut r, summary_size, &encoding, &compression)?;
 
         let segment = CompactSegmentInfo {
             format_version: version,
@@ -262,6 +259,45 @@ impl CompactSegmentInfo {
     pub fn block_metas(&self) -> Result<Vec<Arc<BlockMeta>>> {
         self.raw_block_metas.block_metas()
     }
+}
+
+fn read_block_metas<R>(
+    reader: &mut R,
+    size: u64,
+    encoding: &MetaEncoding,
+    compression: &MetaCompression,
+) -> Result<Vec<Arc<BlockMeta>>>
+where
+    R: Read,
+{
+    if matches!(encoding, MetaEncoding::Bincode) {
+        let blocks: Vec<v3::frozen::BlockMeta> =
+            read_and_deserialize(reader, size, encoding, compression)?;
+        return Ok(blocks
+            .into_iter()
+            .map(|block| Arc::new(block.into()))
+            .collect());
+    }
+
+    read_and_deserialize(reader, size, encoding, compression)
+}
+
+fn read_statistics<R>(
+    reader: &mut R,
+    size: u64,
+    encoding: &MetaEncoding,
+    compression: &MetaCompression,
+) -> Result<Statistics>
+where
+    R: Read,
+{
+    if matches!(encoding, MetaEncoding::Bincode) {
+        let statistics: v3::frozen::Statistics =
+            read_and_deserialize(reader, size, encoding, compression)?;
+        return Ok(statistics.into());
+    }
+
+    read_and_deserialize(reader, size, encoding, compression)
 }
 
 impl TryFrom<Arc<CompactSegmentInfo>> for SegmentInfo {
@@ -311,5 +347,329 @@ impl TryFrom<SegmentInfo> for CompactSegmentInfo {
             summary: value.summary,
             raw_block_metas: bytes,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use databend_common_column::types::timestamp_tz;
+    use databend_common_expression::Scalar;
+    use databend_common_expression::types::DecimalScalar;
+    use databend_common_expression::types::DecimalSize;
+
+    use super::*;
+    use crate::meta::ColumnMeta;
+    use crate::meta::ColumnStatistics;
+    use crate::meta::Compression;
+
+    #[allow(dead_code)]
+    #[derive(Serialize)]
+    enum OldLegacyScalar {
+        Null,
+        EmptyArray,
+        EmptyMap,
+        Number(databend_common_expression::types::NumberScalar),
+        Decimal(DecimalScalar),
+        Timestamp(i64),
+        Date(i32),
+        Boolean(bool),
+        String(Vec<u8>),
+        Array(()),
+        Map(()),
+        Bitmap(Vec<u8>),
+        Tuple(Vec<Scalar>),
+        Variant(Vec<u8>),
+    }
+
+    #[derive(Serialize)]
+    struct OldColumnStatistics {
+        min: OldLegacyScalar,
+        max: OldLegacyScalar,
+        null_count: u64,
+        in_memory_size: u64,
+        distinct_of_values: Option<u64>,
+    }
+
+    #[derive(Serialize)]
+    struct OldBlockMeta {
+        row_count: u64,
+        block_size: u64,
+        file_size: u64,
+        col_stats: HashMap<u32, OldColumnStatistics>,
+        col_metas: HashMap<u32, v3::frozen::ColumnMeta>,
+        cluster_stats: Option<()>,
+        location: (String, u64),
+        bloom_filter_index_location: Option<(String, u64)>,
+        bloom_filter_index_size: u64,
+        compression: v3::frozen::Compression,
+    }
+
+    #[derive(Serialize)]
+    struct OldStatistics {
+        row_count: u64,
+        block_count: u64,
+        perfect_block_count: u64,
+        uncompressed_byte_size: u64,
+        compressed_byte_size: u64,
+        index_size: u64,
+        col_stats: HashMap<u32, OldColumnStatistics>,
+    }
+
+    fn old_legacy_col_stats() -> HashMap<u32, OldColumnStatistics> {
+        let mut col_stats = HashMap::new();
+        col_stats.insert(1, OldColumnStatistics {
+            min: OldLegacyScalar::String(b"aaa".to_vec()),
+            max: OldLegacyScalar::String(b"zzz".to_vec()),
+            null_count: 0,
+            in_memory_size: 6,
+            distinct_of_values: Some(2),
+        });
+        col_stats
+    }
+
+    fn legacy_segment_bytes() -> Result<Vec<u8>> {
+        let block_col_stats = old_legacy_col_stats();
+        let summary_col_stats = old_legacy_col_stats();
+
+        let mut col_metas = HashMap::new();
+        col_metas.insert(
+            1,
+            v3::frozen::ColumnMeta::Native(v3::frozen::NativeColumnMeta {
+                offset: 0,
+                pages: vec![v3::frozen::PageMeta {
+                    length: 16,
+                    num_values: 3,
+                }],
+            }),
+        );
+
+        let blocks = vec![OldBlockMeta {
+            row_count: 3,
+            block_size: 16,
+            file_size: 16,
+            col_stats: block_col_stats,
+            col_metas,
+            cluster_stats: None,
+            location: ("block.native".to_string(), 0),
+            bloom_filter_index_location: None,
+            bloom_filter_index_size: 0,
+            compression: v3::frozen::Compression::None,
+        }];
+
+        let summary = OldStatistics {
+            row_count: 3,
+            block_count: 1,
+            perfect_block_count: 1,
+            uncompressed_byte_size: 16,
+            compressed_byte_size: 16,
+            index_size: 0,
+            col_stats: summary_col_stats,
+        };
+
+        let encoding = MetaEncoding::Bincode;
+        let compression = MetaCompression::default();
+        let blocks = compress(&compression, encode(&encoding, &blocks)?)?;
+        let summary = compress(&compression, encode(&encoding, &summary)?)?;
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&SegmentInfo::VERSION.to_le_bytes());
+        buf.push(MetaEncoding::Bincode as u8);
+        buf.push(MetaCompression::default() as u8);
+        buf.extend_from_slice(&blocks.len().to_le_bytes());
+        buf.extend_from_slice(&summary.len().to_le_bytes());
+        buf.extend(blocks);
+        buf.extend(summary);
+        Ok(buf)
+    }
+
+    fn current_col_stats() -> HashMap<u32, ColumnStatistics> {
+        let mut col_stats = HashMap::new();
+        col_stats.insert(
+            1,
+            ColumnStatistics::new(
+                Scalar::String("aaa".to_string()),
+                Scalar::String("zzz".to_string()),
+                0,
+                6,
+                Some(2),
+            ),
+        );
+        col_stats.insert(
+            2,
+            ColumnStatistics::new(
+                Scalar::TimestampTz(timestamp_tz::new(1000, 0)),
+                Scalar::TimestampTz(timestamp_tz::new(2000, 0)),
+                0,
+                16,
+                Some(2),
+            ),
+        );
+        col_stats.insert(
+            3,
+            ColumnStatistics::new(
+                Scalar::Decimal(DecimalScalar::Decimal64(
+                    123,
+                    DecimalSize::new_unchecked(10, 2),
+                )),
+                Scalar::Decimal(DecimalScalar::Decimal64(
+                    456,
+                    DecimalSize::new_unchecked(10, 2),
+                )),
+                0,
+                16,
+                Some(2),
+            ),
+        );
+        col_stats
+    }
+
+    fn current_segment() -> SegmentInfo {
+        let block_col_stats = current_col_stats();
+        let summary_col_stats = current_col_stats();
+
+        let mut col_metas = HashMap::new();
+        for column_id in 1..=3 {
+            col_metas.insert(
+                column_id,
+                ColumnMeta::Native(databend_common_native::ColumnMeta {
+                    offset: 0,
+                    pages: vec![databend_common_native::PageMeta {
+                        length: 16,
+                        num_values: 3,
+                    }],
+                }),
+            );
+        }
+
+        let blocks = vec![Arc::new(BlockMeta {
+            row_count: 3,
+            block_size: 16,
+            file_size: 16,
+            col_stats: block_col_stats,
+            col_metas,
+            cluster_stats: None,
+            location: ("block.native".to_string(), 0),
+            bloom_filter_index_location: None,
+            bloom_filter_index_size: 0,
+            inverted_index_size: None,
+            ngram_filter_index_size: None,
+            vector_index_size: None,
+            vector_index_location: None,
+            spatial_index_size: None,
+            spatial_index_location: None,
+            spatial_stats: None,
+            virtual_block_meta: None,
+            compression: Compression::None,
+            create_on: None,
+        })];
+
+        SegmentInfo::new(blocks, Statistics {
+            row_count: 3,
+            block_count: 1,
+            perfect_block_count: 1,
+            uncompressed_byte_size: 16,
+            compressed_byte_size: 16,
+            index_size: 0,
+            col_stats: summary_col_stats,
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn test_read_bincode_segment_with_v3_frozen_meta() -> Result<()> {
+        let bytes = legacy_segment_bytes()?;
+        let segment = SegmentInfo::from_slice(&bytes)?;
+
+        assert_eq!(segment.format_version, SegmentInfo::VERSION);
+        assert_eq!(segment.summary.row_count, 3);
+        assert_eq!(
+            segment.summary.col_stats[&1].min,
+            Scalar::String("aaa".to_string())
+        );
+        assert_eq!(segment.blocks.len(), 1);
+
+        let block = &segment.blocks[0];
+        assert_eq!(block.row_count, 3);
+        assert_eq!(block.location.0, "block.native");
+        assert!(block.col_metas[&1].as_native().is_some());
+        assert_eq!(block.col_stats[&1].max, Scalar::String("zzz".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn test_compact_segment_reads_bincode_blocks_lazily_with_v3_frozen_meta() -> Result<()> {
+        let bytes = legacy_segment_bytes()?;
+        let segment = CompactSegmentInfo::from_reader(Cursor::new(bytes))?;
+
+        assert_eq!(segment.summary.row_count, 3);
+        assert_eq!(
+            segment.summary.col_stats[&1].min,
+            Scalar::String("aaa".to_string())
+        );
+
+        let blocks = segment.block_metas()?;
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].row_count, 3);
+        assert_eq!(
+            blocks[0].col_stats[&1].max,
+            Scalar::String("zzz".to_string())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_read_current_messagepack_segment() -> Result<()> {
+        let bytes = current_segment().to_bytes()?;
+        let segment = SegmentInfo::from_slice(&bytes)?;
+
+        assert_eq!(segment.format_version, SegmentInfo::VERSION);
+        assert_eq!(segment.summary.row_count, 3);
+        assert_eq!(
+            segment.summary.col_stats[&2].max,
+            Scalar::TimestampTz(timestamp_tz::new(2000, 0))
+        );
+        assert_eq!(
+            segment.summary.col_stats[&3].min,
+            Scalar::Decimal(DecimalScalar::Decimal64(
+                123,
+                DecimalSize::new_unchecked(10, 2)
+            ))
+        );
+
+        assert_eq!(segment.blocks.len(), 1);
+        assert_eq!(
+            segment.blocks[0].col_stats[&3].max,
+            Scalar::Decimal(DecimalScalar::Decimal64(
+                456,
+                DecimalSize::new_unchecked(10, 2)
+            ))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_compact_segment_reads_current_messagepack_blocks_lazily() -> Result<()> {
+        let bytes = current_segment().to_bytes()?;
+        let segment = CompactSegmentInfo::from_reader(Cursor::new(bytes))?;
+
+        assert_eq!(segment.raw_block_metas.encoding, MetaEncoding::MessagePack);
+        assert_eq!(segment.summary.row_count, 3);
+        assert_eq!(
+            segment.summary.col_stats[&2].min,
+            Scalar::TimestampTz(timestamp_tz::new(1000, 0))
+        );
+
+        let blocks = segment.block_metas()?;
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(
+            blocks[0].col_stats[&3].max,
+            Scalar::Decimal(DecimalScalar::Decimal64(
+                456,
+                DecimalSize::new_unchecked(10, 2)
+            ))
+        );
+        Ok(())
     }
 }

--- a/src/query/storages/common/table_meta/src/meta/v4/segment.rs
+++ b/src/query/storages/common/table_meta/src/meta/v4/segment.rs
@@ -436,12 +436,10 @@ mod tests {
         let mut col_metas = HashMap::new();
         col_metas.insert(
             1,
-            v3::frozen::ColumnMeta::Native(v3::frozen::NativeColumnMeta {
+            v3::frozen::ColumnMeta::Parquet(v3::frozen::ParquetColumnMeta {
                 offset: 0,
-                pages: vec![v3::frozen::PageMeta {
-                    length: 16,
-                    num_values: 3,
-                }],
+                len: 16,
+                num_values: 3,
             }),
         );
 
@@ -452,7 +450,7 @@ mod tests {
             col_stats: block_col_stats,
             col_metas,
             cluster_stats: None,
-            location: ("block.native".to_string(), 0),
+            location: ("block.parquet".to_string(), 0),
             bloom_filter_index_location: None,
             bloom_filter_index_size: 0,
             compression: v3::frozen::Compression::None,
@@ -533,12 +531,10 @@ mod tests {
         for column_id in 1..=3 {
             col_metas.insert(
                 column_id,
-                ColumnMeta::Native(databend_common_native::ColumnMeta {
+                ColumnMeta::Parquet(crate::meta::v0::ColumnMeta {
                     offset: 0,
-                    pages: vec![databend_common_native::PageMeta {
-                        length: 16,
-                        num_values: 3,
-                    }],
+                    len: 16,
+                    num_values: 3,
                 }),
             );
         }
@@ -550,7 +546,7 @@ mod tests {
             col_stats: block_col_stats,
             col_metas,
             cluster_stats: None,
-            location: ("block.native".to_string(), 0),
+            location: ("block.parquet".to_string(), 0),
             bloom_filter_index_location: None,
             bloom_filter_index_size: 0,
             inverted_index_size: None,
@@ -560,6 +556,7 @@ mod tests {
             spatial_index_size: None,
             spatial_index_location: None,
             spatial_stats: None,
+            vector_stats: None,
             virtual_block_meta: None,
             compression: Compression::None,
             create_on: None,
@@ -592,8 +589,8 @@ mod tests {
 
         let block = &segment.blocks[0];
         assert_eq!(block.row_count, 3);
-        assert_eq!(block.location.0, "block.native");
-        assert!(block.col_metas[&1].as_native().is_some());
+        assert_eq!(block.location.0, "block.parquet");
+        assert!(block.col_metas[&1].as_parquet().is_some());
         assert_eq!(block.col_stats[&1].max, Scalar::String("zzz".to_string()));
         Ok(())
     }

--- a/src/query/storages/fuse/src/table_functions/fuse_segment.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_segment.rs
@@ -26,6 +26,8 @@ use databend_common_expression::types::NumberDataType;
 use databend_common_expression::types::StringType;
 use databend_common_expression::types::UInt64Type;
 use databend_storages_common_table_meta::meta::CompactSegmentInfo;
+use databend_storages_common_table_meta::meta::MetaCompression;
+use databend_storages_common_table_meta::meta::MetaEncoding;
 use databend_storages_common_table_meta::meta::TableSnapshot;
 
 use crate::FuseTable;
@@ -38,6 +40,22 @@ pub struct FuseSegment;
 
 pub type FuseSegmentFunc = TableMetaFuncTemplate<FuseSegment>;
 
+fn encoding_name(encoding: &MetaEncoding) -> &'static str {
+    match encoding {
+        MetaEncoding::Bincode => "Bincode",
+        MetaEncoding::MessagePack => "MessagePack",
+        MetaEncoding::Json => "Json",
+    }
+}
+
+fn compression_name(compression: &MetaCompression) -> &'static str {
+    match compression {
+        MetaCompression::None => "None",
+        MetaCompression::Zstd => "Zstd",
+        MetaCompression::Snappy => "Snappy",
+    }
+}
+
 #[async_trait::async_trait]
 impl TableMetaFunc for FuseSegment {
     fn schema() -> Arc<TableSchema> {
@@ -45,6 +63,12 @@ impl TableMetaFunc for FuseSegment {
             TableField::new("file_location", TableDataType::String),
             TableField::new(
                 "format_version",
+                TableDataType::Number(NumberDataType::UInt64),
+            ),
+            TableField::new("encoding", TableDataType::String),
+            TableField::new("compression", TableDataType::String),
+            TableField::new(
+                "block_meta_size",
                 TableDataType::Number(NumberDataType::UInt64),
             ),
             TableField::new("block_count", TableDataType::Number(NumberDataType::UInt64)),
@@ -100,6 +124,9 @@ impl TableMetaFunc for FuseSegment {
         let len = std::cmp::min(segment_locations.len(), limit);
 
         let mut format_versions: Vec<u64> = Vec::with_capacity(len);
+        let mut encodings: Vec<String> = Vec::with_capacity(len);
+        let mut compressions: Vec<String> = Vec::with_capacity(len);
+        let mut block_meta_size: Vec<u64> = Vec::with_capacity(len);
         let mut block_count: Vec<u64> = Vec::with_capacity(len);
         let mut row_count: Vec<u64> = Vec::with_capacity(len);
         let mut compressed: Vec<u64> = Vec::with_capacity(len);
@@ -128,6 +155,10 @@ impl TableMetaFunc for FuseSegment {
             for segment in segments.into_iter() {
                 let segment = segment?;
                 format_versions.push(segment_locations[row_num].1);
+                encodings.push(encoding_name(&segment.raw_block_metas.encoding).to_string());
+                compressions
+                    .push(compression_name(&segment.raw_block_metas.compression).to_string());
+                block_meta_size.push(segment.raw_block_metas.bytes.len() as u64);
                 block_count.push(segment.summary.block_count);
                 row_count.push(segment.summary.row_count);
                 compressed.push(segment.summary.compressed_byte_size);
@@ -163,6 +194,9 @@ impl TableMetaFunc for FuseSegment {
         Ok(DataBlock::new_from_columns(vec![
             StringType::from_data(file_location),
             UInt64Type::from_data(format_versions),
+            StringType::from_data(encodings),
+            StringType::from_data(compressions),
+            UInt64Type::from_data(block_meta_size),
             UInt64Type::from_data(block_count),
             UInt64Type::from_data(row_count),
             UInt64Type::from_data(uncompressed),

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0051_issue_19679.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0051_issue_19679.test
@@ -52,5 +52,10 @@ select count(distinct file_location), count() from fuse_segment('default', 't_19
 ----
 5 5
 
+query TTB
+select encoding, compression, min(block_meta_size) > 0 from fuse_segment('default', 't_19679') group by encoding, compression
+----
+MessagePack Zstd 1
+
 statement ok
 DROP TABLE t_19679


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Read bincode-encoded v4 segment block metadata and summaries through the frozen v3 metadata layout, preserving compatibility with legacy segment statistics
- Keep `LegacyScalar` bincode variant ordering compatible with data written before `Interval` was added
- Expose segment encoding, compression, and block metadata size through `fuse_segment` for low-cost diagnosis
- Cherry-pick `71f2244afe5cc463f10e5388fe87db6574ffe115` onto the latest `main`, with test fixtures adapted to the current Parquet metadata types

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:

- `cargo fmt --all -- --check`
- `cargo test -p databend-common-expression --test it test_legacy_scalar_reads_old_bincode_layout`
- `cargo test -p databend-storages-common-table-meta meta::v4::segment::tests`
- `cargo clippy -p databend-common-expression -p databend-storages-common-table-meta -p databend-common-storages-fuse --tests -- -D warnings`

The SQL logic coverage extends `09_0051_issue_19679.test` to verify the new diagnostic columns.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20191)
<!-- Reviewable:end -->
