### PR TITLE
feat(storage): adapt string stats length for common prefixes

### DIFF
--- a/src/query/storages/fuse/src/io/write/stream/column_statistics_builder.rs
+++ b/src/query/storages/fuse/src/io/write/stream/column_statistics_builder.rs
@@ -47,10 +47,7 @@ use databend_common_expression::with_number_type;
 use databend_storages_common_table_meta::meta::ColumnStatistics;
 use enum_dispatch::enum_dispatch;
 
-use crate::statistics::STATS_STRING_PREFIX_LEN;
-use crate::statistics::Trim;
-use crate::statistics::trim_string_max_with_len;
-use crate::statistics::trim_string_min_with_len;
+use crate::statistics::trim_column_min_max;
 
 pub type CommonBuilder<T> = GenericColumnStatisticsBuilder<T, CommonAdapter>;
 pub type DecimalBuilder<T> = GenericColumnStatisticsBuilder<T, DecimalAdapter>;
@@ -105,7 +102,7 @@ where
 
 pub fn create_column_stats_builder(
     data_type: &DataType,
-    string_col_len: usize,
+    string_col_len: Option<usize>,
 ) -> ColumnStatisticsBuilder {
     let inner_type = data_type.remove_nullable();
     macro_rules! match_number_type_create {
@@ -226,7 +223,7 @@ where
     null_count: usize,
     in_memory_size: usize,
     data_type: DataType,
-    string_col_len: usize,
+    string_col_len: Option<usize>,
 
     _phantom: PhantomData<(T, A)>,
 }
@@ -245,12 +242,12 @@ where
             null_count: 0,
             in_memory_size: 0,
             data_type,
-            string_col_len: STATS_STRING_PREFIX_LEN,
+            string_col_len: None,
             _phantom: PhantomData,
         }
     }
 
-    fn create_with_string_len(data_type: DataType, string_col_len: usize) -> Self {
+    fn create_with_string_len(data_type: DataType, string_col_len: Option<usize>) -> Self {
         Self {
             min: None,
             max: None,
@@ -351,47 +348,25 @@ where
     }
 
     fn finalize(self) -> Result<ColumnStatistics> {
-        let string_col_len = self.string_col_len;
-        let min = if let Some(v) = self.min {
+        let raw_min = if let Some(v) = self.min {
             let v = A::value_to_scalar(v);
-            let scalar = T::upcast_scalar_with_type(v, &self.data_type);
-            match scalar {
-                Scalar::String(s) => trim_string_min_with_len(s, string_col_len)
-                    .map(Scalar::String)
-                    .unwrap_or(Scalar::Null),
-                other => other.trim_min().unwrap_or(Scalar::Null),
-            }
+            T::upcast_scalar_with_type(v, &self.data_type)
         } else {
             Scalar::Null
         };
-        let max = if let Some(v) = self.max {
+        let raw_max = if let Some(v) = self.max {
             let v = A::value_to_scalar(v);
-            let scalar = T::upcast_scalar_with_type(v, &self.data_type);
-            match scalar {
-                Scalar::String(s) => {
-                    if let Some(v) = trim_string_max_with_len(s, string_col_len) {
-                        Scalar::String(v)
-                    } else {
-                        return Err(ErrorCode::Internal(
-                            "Unable to trim string: first chars are all replacement_point"
-                                .to_string(),
-                        ));
-                    }
-                }
-                other => {
-                    if let Some(v) = other.trim_max() {
-                        v
-                    } else {
-                        return Err(ErrorCode::Internal(
-                            "Unable to trim string: first 16 chars are all replacement_point"
-                                .to_string(),
-                        ));
-                    }
-                }
-            }
+            T::upcast_scalar_with_type(v, &self.data_type)
         } else {
             Scalar::Null
         };
+        let (min, max) =
+            trim_column_min_max(raw_min, raw_max, self.string_col_len).ok_or_else(|| {
+                ErrorCode::Internal(
+                    "Unable to trim string: retained prefix is at the end of the Unicode range"
+                        .to_string(),
+                )
+            })?;
 
         Ok(ColumnStatistics::new(
             min,

--- a/src/query/storages/fuse/src/io/write/stream/column_statistics_state.rs
+++ b/src/query/storages/fuse/src/io/write/stream/column_statistics_state.rs
@@ -45,10 +45,7 @@ impl ColumnStatisticsState {
         let col_stats = stats_columns
             .iter()
             .map(|(col_id, data_type)| {
-                let string_len = col_stats_truncate_lens
-                    .get(col_id)
-                    .copied()
-                    .unwrap_or(crate::statistics::STATS_STRING_PREFIX_LEN);
+                let string_len = col_stats_truncate_lens.get(col_id).copied();
                 (*col_id, create_column_stats_builder(data_type, string_len))
             })
             .collect();
@@ -146,6 +143,7 @@ mod tests {
     use databend_storages_common_index::RangeIndex;
 
     use super::*;
+    use crate::statistics::END_OF_UNICODE_RANGE;
     use crate::statistics::gen_columns_statistics;
 
     #[test]
@@ -196,6 +194,35 @@ mod tests {
         let stats_1 = column_stats_state.finalize(HashMap::new())?;
 
         assert_eq!(stats_0, stats_1);
+        Ok(())
+    }
+
+    #[test]
+    fn test_column_stats_state_adaptive_string_prefix() -> Result<()> {
+        let field = TableField::new("a", TableDataType::String);
+        let schema = Arc::new(TableSchema::new(vec![field]));
+        let prefix = "abcdefghijklmnop";
+        let min = format!("{prefix}a-min-suffix");
+        let max = format!("{prefix}z-max-suffix");
+        let block = DataBlock::new_from_columns(vec![StringType::from_data(vec![
+            min.as_str(),
+            max.as_str(),
+        ])]);
+        let stats_columns = vec![(0, DataType::String)];
+
+        let mut state = ColumnStatisticsState::new(&stats_columns, &[], &BTreeMap::new());
+        state.add_block(&schema, &block)?;
+        let stats = state.finalize(HashMap::new())?;
+        let col_stats = stats.get(&0).unwrap();
+
+        assert_eq!(
+            col_stats.min(),
+            &databend_common_expression::Scalar::String(format!("{prefix}a"))
+        );
+        assert_eq!(
+            col_stats.max(),
+            &databend_common_expression::Scalar::String(format!("{prefix}{END_OF_UNICODE_RANGE}"))
+        );
         Ok(())
     }
 }

--- a/src/query/storages/fuse/src/statistics/column_statistic.rs
+++ b/src/query/storages/fuse/src/statistics/column_statistic.rs
@@ -68,11 +68,19 @@ pub fn gen_columns_statistics(
                 let (distinct_of_values, unset_bits) =
                     if s == Scalar::Null { (0, rows) } else { (1, 0) };
 
+                let Some((min, max)) = trim_column_min_max(
+                    s.clone(),
+                    s.clone(),
+                    col_stats_truncate_lens.get(&column_id).copied(),
+                ) else {
+                    continue;
+                };
+
                 // when we read it back from parquet, it is a Column instead of Scalar
                 let in_memory_size = s.as_ref().estimated_scalar_repeat_size(rows, &data_type);
                 let col_stats = ColumnStatistics::new(
-                    s.clone(),
-                    s.clone(),
+                    min,
+                    max,
                     unset_bits as u64,
                     in_memory_size as u64,
                     Some(distinct_of_values),
@@ -82,56 +90,27 @@ pub fn gen_columns_statistics(
             }
             Value::Column(col) => {
                 // later, during the evaluation of expressions, name of field does not matter
-                let mut min = Scalar::Null;
-                let mut max = Scalar::Null;
-
-                if col.len() > 0 {
+                let (min, max) = if col.len() > 0 {
                     let (mins, _) = eval_aggr("min", vec![], &[col.clone().into()], rows, vec![])?;
                     let (maxs, _) = eval_aggr("max", vec![], &[col.clone().into()], rows, vec![])?;
 
-                    let truncate_len = col_stats_truncate_lens
-                        .get(&column_id)
-                        .copied()
-                        .unwrap_or(STATS_STRING_PREFIX_LEN);
-
-                    if mins.len() > 0 {
-                        min = if let Some(v) = mins.index(0) {
-                            let owned = v.to_owned();
-                            let trimmed = match owned {
-                                Scalar::String(s) => {
-                                    trim_string_min_with_len(s, truncate_len).map(Scalar::String)
-                                }
-                                other => other.trim_min(),
-                            };
-                            if let Some(v) = trimmed {
-                                v
-                            } else {
-                                continue;
-                            }
-                        } else {
-                            continue;
-                        }
-                    }
-
-                    if maxs.len() > 0 {
-                        max = if let Some(v) = maxs.index(0) {
-                            let owned = v.to_owned();
-                            let trimmed = match owned {
-                                Scalar::String(s) => {
-                                    trim_string_max_with_len(s, truncate_len).map(Scalar::String)
-                                }
-                                other => other.trim_max(),
-                            };
-                            if let Some(v) = trimmed {
-                                v
-                            } else {
-                                continue;
-                            }
-                        } else {
-                            continue;
-                        }
-                    }
-                }
+                    let Some(raw_min) = mins.index(0).map(|v| v.to_owned()) else {
+                        continue;
+                    };
+                    let Some(raw_max) = maxs.index(0).map(|v| v.to_owned()) else {
+                        continue;
+                    };
+                    let Some(min_max) = trim_column_min_max(
+                        raw_min,
+                        raw_max,
+                        col_stats_truncate_lens.get(&column_id).copied(),
+                    ) else {
+                        continue;
+                    };
+                    min_max
+                } else {
+                    (Scalar::Null, Scalar::Null)
+                };
 
                 let (is_all_null, bitmap) = col.validity();
                 let unset_bits = match (is_all_null, bitmap) {
@@ -190,6 +169,43 @@ pub trait Trim: Sized {
 
 pub const END_OF_UNICODE_RANGE: char = '\u{10FFFF}';
 pub const STATS_STRING_PREFIX_LEN: usize = 16;
+const MAX_AUTO_STATS_STRING_PREFIX_LEN: usize = 32;
+const MAX_AUTO_STATS_STRING_COMMON_PREFIX_LEN: usize = MAX_AUTO_STATS_STRING_PREFIX_LEN - 1;
+
+fn auto_stats_string_prefix_len(min: &str, max: &str) -> usize {
+    let common_prefix_len = min
+        .chars()
+        .zip(max.chars())
+        .take(MAX_AUTO_STATS_STRING_COMMON_PREFIX_LEN)
+        .take_while(|(min_char, max_char)| min_char == max_char)
+        .count();
+
+    if common_prefix_len < STATS_STRING_PREFIX_LEN {
+        STATS_STRING_PREFIX_LEN
+    } else {
+        common_prefix_len
+            .saturating_add(1)
+            .min(MAX_AUTO_STATS_STRING_PREFIX_LEN)
+    }
+}
+
+pub(crate) fn trim_column_min_max(
+    min: Scalar,
+    max: Scalar,
+    string_truncate_len: Option<usize>,
+) -> Option<(Scalar, Scalar)> {
+    match (min, max) {
+        (Scalar::String(min), Scalar::String(max)) => {
+            let truncate_len =
+                string_truncate_len.unwrap_or_else(|| auto_stats_string_prefix_len(&min, &max));
+            Some((
+                Scalar::String(trim_string_min_with_len(min, truncate_len)?),
+                Scalar::String(trim_string_max_with_len(max, truncate_len)?),
+            ))
+        }
+        (min, max) => Some((min.trim_min()?, max.trim_max()?)),
+    }
+}
 
 impl Trim for Scalar {
     fn trim_min(self) -> Option<Self> {
@@ -317,9 +333,47 @@ pub fn trim_string_max_with_len(s: String, len: usize) -> Option<String> {
 mod tests {
     use databend_common_expression::Scalar;
 
+    use super::MAX_AUTO_STATS_STRING_COMMON_PREFIX_LEN;
+    use super::MAX_AUTO_STATS_STRING_PREFIX_LEN;
+    use super::auto_stats_string_prefix_len;
     use crate::statistics::END_OF_UNICODE_RANGE;
     use crate::statistics::STATS_STRING_PREFIX_LEN;
     use crate::statistics::Trim;
+
+    #[test]
+    fn test_auto_stats_string_prefix_len() {
+        assert_eq!(
+            auto_stats_string_prefix_len("abcdefghijklmnoa", "abcdefghijklmnoz"),
+            STATS_STRING_PREFIX_LEN
+        );
+
+        let prefix = "abcdefghijklmnop";
+        assert_eq!(
+            auto_stats_string_prefix_len(
+                &format!("{prefix}a-min-suffix"),
+                &format!("{prefix}z-max-suffix"),
+            ),
+            STATS_STRING_PREFIX_LEN + 1
+        );
+
+        let long_prefix = "a".repeat(MAX_AUTO_STATS_STRING_COMMON_PREFIX_LEN);
+        assert_eq!(
+            auto_stats_string_prefix_len(
+                &format!("{long_prefix}x-min"),
+                &format!("{long_prefix}y-max"),
+            ),
+            MAX_AUTO_STATS_STRING_PREFIX_LEN
+        );
+
+        let capped_prefix = "好".repeat(MAX_AUTO_STATS_STRING_PREFIX_LEN);
+        assert_eq!(
+            auto_stats_string_prefix_len(
+                &format!("{capped_prefix}甲"),
+                &format!("{capped_prefix}乙"),
+            ),
+            MAX_AUTO_STATS_STRING_PREFIX_LEN
+        );
+    }
 
     #[test]
     fn test_trim_max() {

--- a/src/query/storages/fuse/src/statistics/mod.rs
+++ b/src/query/storages/fuse/src/statistics/mod.rs
@@ -41,6 +41,7 @@ pub use column_statistic::Trim;
 pub use column_statistic::calc_column_distinct_of_values;
 pub use column_statistic::gen_columns_statistics;
 pub use column_statistic::scalar_min_max;
+pub(crate) use column_statistic::trim_column_min_max;
 pub use column_statistic::trim_string_max_with_len;
 pub use column_statistic::trim_string_min_with_len;
 pub use reducers::merge_statistics;

--- a/tests/sqllogictests/suites/base/05_ddl/05_0065_ddl_stats_truncate_len.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0065_ddl_stats_truncate_len.test
@@ -28,15 +28,15 @@ SELECT a, b, c FROM t_stats_truncate;
 abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz 1
 
 ## Verify column statistics are truncated correctly via fuse_block_statistics:
-## - column 'a' (STATS_TRUNCATE_LEN 4): min truncated to 4 chars, max has replacement char at position 4
-## - column 'b' (default 16): min truncated to 16 chars, max has replacement char at position 16
+## - column 'a' (STATS_TRUNCATE_LEN 4): min is truncated to 4 chars and max uses U+10FFFF at position 4
+## - column 'b': adaptive truncation keeps the single 26-character value exact
 query IT?
 SELECT column_id, column_name, statistics
 FROM fuse_block_statistics('default', 't_stats_truncate')
 ORDER BY column_id;
 ----
 0 a {"distinct_count":1,"in_memory_size":43,"max":"abc􏿿","min":"abcd","null_count":0}
-1 b {"distinct_count":1,"in_memory_size":43,"max":"abcdefghijklmno􏿿","min":"abcdefghijklmnop","null_count":0}
+1 b {"distinct_count":1,"in_memory_size":43,"max":"abcdefghijklmnopqrstuvwxyz","min":"abcdefghijklmnopqrstuvwxyz","null_count":0}
 2 c {"distinct_count":1,"in_memory_size":5,"max":1,"min":1,"null_count":0}
 
 statement ok
@@ -139,15 +139,15 @@ CREATE TABLE t_trunc40 (
 statement ok
 INSERT INTO t_trunc40 VALUES ('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ');
 
-## column 'a' (STATS_TRUNCATE_LEN 40): min=first 40 chars, max=first 39 chars + replacement
-## column 'b' (default 16): min=first 16 chars, max=first 15 chars + replacement
+## column 'a' (STATS_TRUNCATE_LEN 40): min=first 40 chars, max uses U+10FFFF at position 40
+## column 'b' (adaptive max 32): min=first 32 chars, max uses U+10FFFF at position 32
 query IT?
 SELECT column_id, column_name, statistics
 FROM fuse_block_statistics('default', 't_trunc40')
 ORDER BY column_id;
 ----
 0 a {"distinct_count":1,"in_memory_size":69,"max":"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLM􏿿","min":"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN","null_count":0}
-1 b {"distinct_count":1,"in_memory_size":69,"max":"abcdefghijklmno􏿿","min":"abcdefghijklmnop","null_count":0}
+1 b {"distinct_count":1,"in_memory_size":69,"max":"abcdefghijklmnopqrstuvwxyzABCDE􏿿","min":"abcdefghijklmnopqrstuvwxyzABCDEF","null_count":0}
 
 statement ok
 DROP TABLE t_trunc40;
@@ -214,3 +214,28 @@ ab
 
 statement ok
 DROP TABLE t_short;
+
+## Without an explicit option, a common 16-character prefix enables adaptive
+## truncation. common_prefix + 1 retains the first differing character in the
+## min bound and provides a position for U+10FFFF in the max bound.
+statement ok
+CREATE TABLE t_adaptive_stats_truncate (
+    adaptive STRING,
+    explicit STRING STATS_TRUNCATE_LEN 16
+) row_per_block=100;
+
+statement ok
+INSERT INTO t_adaptive_stats_truncate VALUES
+    ('abcdefghijklmnopa-min-suffix', 'abcdefghijklmnopa-min-suffix'),
+    ('abcdefghijklmnopz-max-suffix', 'abcdefghijklmnopz-max-suffix');
+
+query TTT
+SELECT column_name, statistics:min::string, statistics:max::string
+FROM fuse_block_statistics('default', 't_adaptive_stats_truncate')
+ORDER BY column_id;
+----
+adaptive abcdefghijklmnopa abcdefghijklmnop􏿿
+explicit abcdefghijklmnop abcdefghijklmno􏿿
+
+statement ok
+DROP TABLE t_adaptive_stats_truncate;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fuse normally truncates string min/max statistics to 16 characters. When the values share a prefix of 16 characters or more, the stored bounds lose useful information after that prefix and zone-map pruning becomes too broad.

This PR makes the default truncation length adaptive:

- Keep 16 characters for ordinary string columns
- Grow the length only when the min and max share a long prefix, up to 32 characters
- Apply adaptive truncation only when `STATS_TRUNCATE_LEN` is not set
- Use the same behavior for regular block statistics, streaming statistics, and scalar-valued columns

This improves pruning for strings with long common prefixes without changing the statistics format.

## Implementation

When `STATS_TRUNCATE_LEN` is not set, the length is derived from the original min and max values:

- If the common prefix is shorter than 16 characters, use 16
- Otherwise, use `min(common_prefix + 1, 32)`

All lengths are counted in Unicode characters. The adaptive rule applies only when `STATS_TRUNCATE_LEN` is not set. If a column specifies `STATS_TRUNCATE_LEN N`, its string statistics use N as the truncation length for every block, and the adaptive rule is not applied.

No metadata migration, configuration change, or backfill is required. Existing blocks keep their current statistics; newly written blocks use the adaptive default.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

The logic test covers adaptive and explicit truncation behavior. Focused Rust tests cover only the 31/32-character calculation boundary, Unicode character counting, and the separate streaming statistics path.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20199)

<!-- Reviewable:end -->






