### PR TITLE
refactor(query): optimize escaped literal LIKE matching

### DIFF
--- a/src/query/expression/benches/bench.rs
+++ b/src/query/expression/benches/bench.rs
@@ -48,6 +48,10 @@ mod escaped_like {
     const PREFIX_PATTERN: &[u8] = br"request\_processing\%failed%";
     const SUFFIX_PATTERN: &[u8] = br"%request\_processing\%failed";
     const CONTAINS_PATTERN: &[u8] = br"%request\_processing\%failed%";
+    const CONTAINS_LITERAL: &[u8] = b"request_processing%failed";
+    const LOG_FRAGMENT: &[u8] =
+        b"2026-01-01T00:00:00Z INFO synthetic_worker request processed successfully\n\
+        at synthetic.module::run\n";
 
     const EXACT_HIT: &[u8] = b"request_processing%failed";
     const EXACT_MISS: &[u8] = b"request_processing-failed";
@@ -58,19 +62,37 @@ mod escaped_like {
     const CONTAINS_HIT: &[u8] = b"synthetic prefix: request_processing%failed: synthetic suffix";
     const CONTAINS_MISS: &[u8] = b"synthetic prefix: request_processing-failed: synthetic suffix";
 
-    fn bench_general(bencher: divan::Bencher, pattern: &'static [u8], haystack: &'static [u8]) {
+    fn bench_general(bencher: divan::Bencher, pattern: &'static [u8], haystack: &[u8]) {
         let matcher = LikePattern::ComplexPattern(Cow::Borrowed(pattern));
         bencher
             .counter(BytesCount::new(haystack.len()))
             .bench(|| divan::black_box(matcher.compare(divan::black_box(haystack))));
     }
 
-    fn bench_optimized(bencher: divan::Bencher, pattern: &'static [u8], haystack: &'static [u8]) {
+    fn bench_optimized(bencher: divan::Bencher, pattern: &'static [u8], haystack: &[u8]) {
         let matcher = generate_like_pattern(pattern, haystack.len());
         assert!(!matches!(matcher, LikePattern::ComplexPattern(_)));
         bencher
             .counter(BytesCount::new(haystack.len()))
             .bench(|| divan::black_box(matcher.compare(divan::black_box(haystack))));
+    }
+
+    fn synthetic_log_message(len: usize, matched: bool) -> Vec<u8> {
+        assert!(len >= CONTAINS_LITERAL.len() + 16);
+        let mut haystack = Vec::with_capacity(len);
+        while haystack.len() < len {
+            let remaining = len - haystack.len();
+            haystack.extend_from_slice(&LOG_FRAGMENT[..remaining.min(LOG_FRAGMENT.len())]);
+        }
+        if matched {
+            let start = len - CONTAINS_LITERAL.len() - 16;
+            haystack[start..start + CONTAINS_LITERAL.len()].copy_from_slice(CONTAINS_LITERAL);
+        }
+        assert_eq!(
+            LikePattern::complex_pattern(&haystack, CONTAINS_PATTERN),
+            matched
+        );
+        haystack
     }
 
     #[divan::bench(args = [false, true])]
@@ -143,6 +165,30 @@ mod escaped_like {
             CONTAINS_PATTERN,
             if matched { CONTAINS_HIT } else { CONTAINS_MISS },
         );
+    }
+
+    #[divan::bench(args = [1024, 4096, 16384])]
+    fn general_contains_large_miss(bencher: divan::Bencher, len: usize) {
+        let haystack = synthetic_log_message(len, false);
+        bench_general(bencher, CONTAINS_PATTERN, &haystack);
+    }
+
+    #[divan::bench(args = [1024, 4096, 16384])]
+    fn optimized_contains_large_miss(bencher: divan::Bencher, len: usize) {
+        let haystack = synthetic_log_message(len, false);
+        bench_optimized(bencher, CONTAINS_PATTERN, &haystack);
+    }
+
+    #[divan::bench(args = [1024, 4096, 16384])]
+    fn general_contains_large_hit(bencher: divan::Bencher, len: usize) {
+        let haystack = synthetic_log_message(len, true);
+        bench_general(bencher, CONTAINS_PATTERN, &haystack);
+    }
+
+    #[divan::bench(args = [1024, 4096, 16384])]
+    fn optimized_contains_large_hit(bencher: divan::Bencher, len: usize) {
+        let haystack = synthetic_log_message(len, true);
+        bench_optimized(bencher, CONTAINS_PATTERN, &haystack);
     }
 }
 

--- a/src/query/expression/benches/bench.rs
+++ b/src/query/expression/benches/bench.rs
@@ -49,7 +49,7 @@ mod escaped_like {
     const SUFFIX_PATTERN: &[u8] = br"%request\_processing\%failed";
     const CONTAINS_PATTERN: &[u8] = br"%request\_processing\%failed%";
     const CONTAINS_LITERAL: &[u8] = b"request_processing%failed";
-    const COLUMN_SIZE_HINT: usize = 1024 * 1024;
+    const LARGE_COLUMN_TOTAL_BYTES: usize = 1024 * 1024;
     const LOG_FRAGMENT: &[u8] =
         b"2026-01-01T00:00:00Z INFO synthetic_worker request processed successfully\n\
         at synthetic.module::run\n";
@@ -103,6 +103,16 @@ mod escaped_like {
             matched
         );
         haystack
+    }
+
+    #[divan::bench(args = [1, LARGE_COLUMN_TOTAL_BYTES])]
+    fn construct_contains_matcher(bencher: divan::Bencher, column_total_bytes: usize) {
+        bencher.bench(|| {
+            divan::black_box(generate_like_pattern(
+                divan::black_box(CONTAINS_PATTERN),
+                divan::black_box(column_total_bytes),
+            ))
+        });
     }
 
     #[divan::bench(args = [false, true])]
@@ -186,7 +196,12 @@ mod escaped_like {
     #[divan::bench(args = [1024, 4096, 16384])]
     fn optimized_contains_large_miss(bencher: divan::Bencher, len: usize) {
         let haystack = synthetic_log_message(len, false);
-        bench_optimized_with_hint(bencher, CONTAINS_PATTERN, &haystack, COLUMN_SIZE_HINT);
+        bench_optimized_with_hint(
+            bencher,
+            CONTAINS_PATTERN,
+            &haystack,
+            LARGE_COLUMN_TOTAL_BYTES,
+        );
     }
 
     #[divan::bench(args = [1024, 4096, 16384])]
@@ -198,7 +213,12 @@ mod escaped_like {
     #[divan::bench(args = [1024, 4096, 16384])]
     fn optimized_contains_large_hit(bencher: divan::Bencher, len: usize) {
         let haystack = synthetic_log_message(len, true);
-        bench_optimized_with_hint(bencher, CONTAINS_PATTERN, &haystack, COLUMN_SIZE_HINT);
+        bench_optimized_with_hint(
+            bencher,
+            CONTAINS_PATTERN,
+            &haystack,
+            LARGE_COLUMN_TOTAL_BYTES,
+        );
     }
 }
 

--- a/src/query/expression/benches/bench.rs
+++ b/src/query/expression/benches/bench.rs
@@ -105,16 +105,6 @@ mod escaped_like {
         haystack
     }
 
-    #[divan::bench(args = [1, LARGE_COLUMN_TOTAL_BYTES])]
-    fn construct_contains_matcher(bencher: divan::Bencher, column_total_bytes: usize) {
-        bencher.bench(|| {
-            divan::black_box(generate_like_pattern(
-                divan::black_box(CONTAINS_PATTERN),
-                divan::black_box(column_total_bytes),
-            ))
-        });
-    }
-
     #[divan::bench(args = [false, true])]
     fn general_exact(bencher: divan::Bencher, matched: bool) {
         bench_general(

--- a/src/query/expression/benches/bench.rs
+++ b/src/query/expression/benches/bench.rs
@@ -49,6 +49,7 @@ mod escaped_like {
     const SUFFIX_PATTERN: &[u8] = br"%request\_processing\%failed";
     const CONTAINS_PATTERN: &[u8] = br"%request\_processing\%failed%";
     const CONTAINS_LITERAL: &[u8] = b"request_processing%failed";
+    const COLUMN_SIZE_HINT: usize = 1024 * 1024;
     const LOG_FRAGMENT: &[u8] =
         b"2026-01-01T00:00:00Z INFO synthetic_worker request processed successfully\n\
         at synthetic.module::run\n";
@@ -70,7 +71,16 @@ mod escaped_like {
     }
 
     fn bench_optimized(bencher: divan::Bencher, pattern: &'static [u8], haystack: &[u8]) {
-        let matcher = generate_like_pattern(pattern, haystack.len());
+        bench_optimized_with_hint(bencher, pattern, haystack, haystack.len());
+    }
+
+    fn bench_optimized_with_hint(
+        bencher: divan::Bencher,
+        pattern: &'static [u8],
+        haystack: &[u8],
+        haystack_size_hint: usize,
+    ) {
+        let matcher = generate_like_pattern(pattern, haystack_size_hint);
         assert!(!matches!(matcher, LikePattern::ComplexPattern(_)));
         bencher
             .counter(BytesCount::new(haystack.len()))
@@ -78,14 +88,14 @@ mod escaped_like {
     }
 
     fn synthetic_log_message(len: usize, matched: bool) -> Vec<u8> {
-        assert!(len >= CONTAINS_LITERAL.len() + 16);
+        assert!(len >= CONTAINS_LITERAL.len());
         let mut haystack = Vec::with_capacity(len);
         while haystack.len() < len {
             let remaining = len - haystack.len();
             haystack.extend_from_slice(&LOG_FRAGMENT[..remaining.min(LOG_FRAGMENT.len())]);
         }
         if matched {
-            let start = len - CONTAINS_LITERAL.len() - 16;
+            let start = (len - CONTAINS_LITERAL.len()) / 2;
             haystack[start..start + CONTAINS_LITERAL.len()].copy_from_slice(CONTAINS_LITERAL);
         }
         assert_eq!(
@@ -176,7 +186,7 @@ mod escaped_like {
     #[divan::bench(args = [1024, 4096, 16384])]
     fn optimized_contains_large_miss(bencher: divan::Bencher, len: usize) {
         let haystack = synthetic_log_message(len, false);
-        bench_optimized(bencher, CONTAINS_PATTERN, &haystack);
+        bench_optimized_with_hint(bencher, CONTAINS_PATTERN, &haystack, COLUMN_SIZE_HINT);
     }
 
     #[divan::bench(args = [1024, 4096, 16384])]
@@ -188,7 +198,7 @@ mod escaped_like {
     #[divan::bench(args = [1024, 4096, 16384])]
     fn optimized_contains_large_hit(bencher: divan::Bencher, len: usize) {
         let haystack = synthetic_log_message(len, true);
-        bench_optimized(bencher, CONTAINS_PATTERN, &haystack);
+        bench_optimized_with_hint(bencher, CONTAINS_PATTERN, &haystack, COLUMN_SIZE_HINT);
     }
 }
 

--- a/src/query/expression/benches/bench.rs
+++ b/src/query/expression/benches/bench.rs
@@ -36,6 +36,116 @@ fn main() {
     divan::main();
 }
 
+#[divan::bench_group(max_time = 1)]
+mod escaped_like {
+    use std::borrow::Cow;
+
+    use databend_common_expression::LikePattern;
+    use databend_common_expression::generate_like_pattern;
+    use divan::counter::BytesCount;
+
+    const EXACT_PATTERN: &[u8] = br"request\_processing\%failed";
+    const PREFIX_PATTERN: &[u8] = br"request\_processing\%failed%";
+    const SUFFIX_PATTERN: &[u8] = br"%request\_processing\%failed";
+    const CONTAINS_PATTERN: &[u8] = br"%request\_processing\%failed%";
+
+    const EXACT_HIT: &[u8] = b"request_processing%failed";
+    const EXACT_MISS: &[u8] = b"request_processing-failed";
+    const PREFIX_HIT: &[u8] = b"request_processing%failed: synthetic payload after the marker";
+    const PREFIX_MISS: &[u8] = b"request_processing-failed: synthetic payload after the marker";
+    const SUFFIX_HIT: &[u8] = b"synthetic payload before the marker: request_processing%failed";
+    const SUFFIX_MISS: &[u8] = b"synthetic payload before the marker: request_processing-failed";
+    const CONTAINS_HIT: &[u8] = b"synthetic prefix: request_processing%failed: synthetic suffix";
+    const CONTAINS_MISS: &[u8] = b"synthetic prefix: request_processing-failed: synthetic suffix";
+
+    fn bench_general(bencher: divan::Bencher, pattern: &'static [u8], haystack: &'static [u8]) {
+        let matcher = LikePattern::ComplexPattern(Cow::Borrowed(pattern));
+        bencher
+            .counter(BytesCount::new(haystack.len()))
+            .bench(|| divan::black_box(matcher.compare(divan::black_box(haystack))));
+    }
+
+    fn bench_optimized(bencher: divan::Bencher, pattern: &'static [u8], haystack: &'static [u8]) {
+        let matcher = generate_like_pattern(pattern, haystack.len());
+        assert!(!matches!(matcher, LikePattern::ComplexPattern(_)));
+        bencher
+            .counter(BytesCount::new(haystack.len()))
+            .bench(|| divan::black_box(matcher.compare(divan::black_box(haystack))));
+    }
+
+    #[divan::bench(args = [false, true])]
+    fn general_exact(bencher: divan::Bencher, matched: bool) {
+        bench_general(
+            bencher,
+            EXACT_PATTERN,
+            if matched { EXACT_HIT } else { EXACT_MISS },
+        );
+    }
+
+    #[divan::bench(args = [false, true])]
+    fn optimized_exact(bencher: divan::Bencher, matched: bool) {
+        bench_optimized(
+            bencher,
+            EXACT_PATTERN,
+            if matched { EXACT_HIT } else { EXACT_MISS },
+        );
+    }
+
+    #[divan::bench(args = [false, true])]
+    fn general_prefix(bencher: divan::Bencher, matched: bool) {
+        bench_general(
+            bencher,
+            PREFIX_PATTERN,
+            if matched { PREFIX_HIT } else { PREFIX_MISS },
+        );
+    }
+
+    #[divan::bench(args = [false, true])]
+    fn optimized_prefix(bencher: divan::Bencher, matched: bool) {
+        bench_optimized(
+            bencher,
+            PREFIX_PATTERN,
+            if matched { PREFIX_HIT } else { PREFIX_MISS },
+        );
+    }
+
+    #[divan::bench(args = [false, true])]
+    fn general_suffix(bencher: divan::Bencher, matched: bool) {
+        bench_general(
+            bencher,
+            SUFFIX_PATTERN,
+            if matched { SUFFIX_HIT } else { SUFFIX_MISS },
+        );
+    }
+
+    #[divan::bench(args = [false, true])]
+    fn optimized_suffix(bencher: divan::Bencher, matched: bool) {
+        bench_optimized(
+            bencher,
+            SUFFIX_PATTERN,
+            if matched { SUFFIX_HIT } else { SUFFIX_MISS },
+        );
+    }
+
+    #[divan::bench(args = [false, true])]
+    fn general_contains(bencher: divan::Bencher, matched: bool) {
+        bench_general(
+            bencher,
+            CONTAINS_PATTERN,
+            if matched { CONTAINS_HIT } else { CONTAINS_MISS },
+        );
+    }
+
+    #[divan::bench(args = [false, true])]
+    fn optimized_contains(bencher: divan::Bencher, matched: bool) {
+        bench_optimized(
+            bencher,
+            CONTAINS_PATTERN,
+            if matched { CONTAINS_HIT } else { CONTAINS_MISS },
+        );
+    }
+}
+
 // bench                    fastest       │ slowest       │ median        │ mean          │ samples │ iters
 // ├─ concat_string_offset                │               │               │               │         │
 // │  ├─ 12                 22.58 ms      │ 31.43 ms      │ 24.05 ms      │ 24.83 ms      │ 100     │ 100

--- a/src/query/expression/src/filter/like.rs
+++ b/src/query/expression/src/filter/like.rs
@@ -222,6 +222,13 @@ pub fn generate_like_pattern<'a, B: Into<Cow<'a, [u8]>>>(
         return LikePattern::Constant(true);
     }
 
+    if let Some(needle) = unescape_surrounded_literal(&pattern) {
+        return LikePattern::SurroundByPercent(VolnitskyBase::new_cow(
+            Cow::Owned(needle),
+            haystack_size_hint,
+        ));
+    }
+
     let mut index = 0;
     let mut first_non_percent = 0;
     let mut percent_num = 0;
@@ -300,6 +307,43 @@ pub fn generate_like_pattern<'a, B: Into<Cow<'a, [u8]>>>(
             }
         }
     }
+}
+
+/// Extract the literal from a `%literal%` pattern that currently needs the
+/// complex matcher only because it contains escaped LIKE metacharacters.
+///
+/// Keep this deliberately narrow: patterns with an unescaped metacharacter,
+/// an unsupported escape, or anything other than one leading and one trailing
+/// percent continue to use the existing matcher.
+fn unescape_surrounded_literal(pattern: &[u8]) -> Option<Vec<u8>> {
+    if pattern.len() < 4 || pattern[0] != b'%' || pattern[pattern.len() - 1] != b'%' {
+        return None;
+    }
+
+    let end = pattern.len() - 1;
+    let mut index = 1;
+    let mut has_escape = false;
+    let mut literal = Vec::with_capacity(pattern.len() - 2);
+
+    while index < end {
+        match pattern[index] {
+            b'%' | b'_' => return None,
+            b'\\' => {
+                if index + 1 >= end || !is_like_pattern_escape(pattern[index + 1] as char) {
+                    return None;
+                }
+                literal.push(pattern[index + 1]);
+                has_escape = true;
+                index += 2;
+            }
+            byte => {
+                literal.push(byte);
+                index += 1;
+            }
+        }
+    }
+
+    has_escape.then_some(literal)
 }
 
 fn normalize_simple_pattern<'a>(
@@ -439,6 +483,18 @@ fn test_generate_like_pattern() {
             LikePattern::SurroundByPercent(VolnitskyBase::new("databend".as_bytes(), 1)),
         ),
         (
+            "%alpha\\_beta%",
+            LikePattern::SurroundByPercent(VolnitskyBase::new("alpha_beta".as_bytes(), 1)),
+        ),
+        (
+            "%alpha\\%beta%",
+            LikePattern::SurroundByPercent(VolnitskyBase::new("alpha%beta".as_bytes(), 1)),
+        ),
+        (
+            "%alpha\\\\beta%",
+            LikePattern::SurroundByPercent(VolnitskyBase::new("alpha\\beta".as_bytes(), 1)),
+        ),
+        (
             "databend_cloud%data%warehouse",
             LikePattern::ComplexPattern("databend_cloud%data%warehouse".as_bytes().into()),
         ),
@@ -450,9 +506,113 @@ fn test_generate_like_pattern() {
             "databend%cloud_data%warehouse",
             LikePattern::ComplexPattern("databend%cloud_data%warehouse".as_bytes().into()),
         ),
+        (
+            "%alpha\\_beta%gamma%",
+            LikePattern::ComplexPattern("%alpha\\_beta%gamma%".as_bytes().into()),
+        ),
+        (
+            "%alpha\\xbeta%gamma%",
+            LikePattern::ComplexPattern("%alpha\\xbeta%gamma%".as_bytes().into()),
+        ),
+        (
+            "%alpha\\%",
+            LikePattern::ComplexPattern("%alpha\\%".as_bytes().into()),
+        ),
     ];
     for (pattern, pattern_type) in test_cases {
         assert_eq!(pattern_type, generate_like_pattern(pattern.as_bytes(), 1));
+    }
+}
+
+#[test]
+fn test_escaped_surrounded_literal_matches_complex_pattern() {
+    let test_cases = [
+        ("%alpha\\_beta%", [
+            "",
+            "alpha_beta",
+            "prefix alpha_beta suffix",
+            "alpha-beta",
+            "alpha__beta",
+            "α alpha_beta β",
+        ]),
+        ("%alpha\\%beta%", [
+            "",
+            "alpha%beta",
+            "prefix alpha%beta suffix",
+            "alpha_beta",
+            "alpha%%beta",
+            "α alpha%beta β",
+        ]),
+        ("%alpha\\\\beta%", [
+            "",
+            "alpha\\beta",
+            "prefix alpha\\beta suffix",
+            "alpha/beta",
+            "alpha\\\\beta",
+            "α alpha\\beta β",
+        ]),
+    ];
+
+    for (pattern, haystacks) in test_cases {
+        let optimized = generate_like_pattern(pattern.as_bytes(), 0);
+        assert!(matches!(optimized, LikePattern::SurroundByPercent(_)));
+
+        for haystack in haystacks {
+            assert_eq!(
+                optimized.compare(haystack.as_bytes()),
+                LikePattern::complex_pattern(haystack.as_bytes(), pattern.as_bytes()),
+                "{haystack:?} LIKE {pattern:?}"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod property_tests {
+    use proptest::prelude::*;
+
+    use super::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        #[test]
+        fn escaped_surrounded_literal_is_equivalent_to_complex_pattern(
+            escaped_literal in prop::sample::select(vec![b'%', b'_', b'\\']),
+            literal_tail in prop::collection::vec(any::<u8>(), 0..32),
+            prefix in prop::collection::vec(any::<u8>(), 0..64),
+            suffix in prop::collection::vec(any::<u8>(), 0..64),
+            arbitrary in prop::collection::vec(any::<u8>(), 0..128),
+        ) {
+            let mut literal = Vec::with_capacity(literal_tail.len() + 1);
+            literal.push(escaped_literal);
+            literal.extend(literal_tail);
+
+            let mut pattern = Vec::with_capacity(literal.len() * 2 + 2);
+            pattern.push(b'%');
+            for byte in &literal {
+                if matches!(byte, b'%' | b'_' | b'\\') {
+                    pattern.push(b'\\');
+                }
+                pattern.push(*byte);
+            }
+            pattern.push(b'%');
+
+            let optimized = generate_like_pattern(pattern.as_slice(), 0);
+            prop_assert!(matches!(optimized, LikePattern::SurroundByPercent(_)));
+
+            prop_assert_eq!(
+                optimized.compare(&arbitrary),
+                LikePattern::complex_pattern(&arbitrary, &pattern),
+            );
+
+            let matching = [prefix.as_slice(), literal.as_slice(), suffix.as_slice()].concat();
+            prop_assert!(optimized.compare(&matching));
+            prop_assert_eq!(
+                optimized.compare(&matching),
+                LikePattern::complex_pattern(&matching, &pattern),
+            );
+        }
     }
 }
 

--- a/src/query/expression/src/filter/like.rs
+++ b/src/query/expression/src/filter/like.rs
@@ -322,8 +322,7 @@ fn unescape_surrounded_literal(pattern: &[u8]) -> Option<Vec<u8>> {
 
     let end = pattern.len() - 1;
     let mut index = 1;
-    let mut has_escape = false;
-    let mut literal = Vec::with_capacity(pattern.len() - 2);
+    let mut literal = None;
 
     while index < end {
         match pattern[index] {
@@ -332,18 +331,24 @@ fn unescape_surrounded_literal(pattern: &[u8]) -> Option<Vec<u8>> {
                 if index + 1 >= end || !is_like_pattern_escape(pattern[index + 1] as char) {
                     return None;
                 }
+                let literal = literal.get_or_insert_with(|| {
+                    let mut literal = Vec::with_capacity(pattern.len() - 2);
+                    literal.extend_from_slice(&pattern[1..index]);
+                    literal
+                });
                 literal.push(pattern[index + 1]);
-                has_escape = true;
                 index += 2;
             }
             byte => {
-                literal.push(byte);
+                if let Some(literal) = &mut literal {
+                    literal.push(byte);
+                }
                 index += 1;
             }
         }
     }
 
-    has_escape.then_some(literal)
+    literal
 }
 
 fn normalize_simple_pattern<'a>(

--- a/src/query/expression/src/filter/like.rs
+++ b/src/query/expression/src/filter/like.rs
@@ -28,7 +28,7 @@ pub enum LikePattern<'a> {
     EndOfPercent(Cow<'a, [u8]>),
     // e.g. '%Arrow%'.
     SurroundByPercent(VolnitskyBase<'a>),
-    // e.g. 'A%row', 'A_row', 'A\\%row'.
+    // e.g. 'A%row', 'A_row'.
     ComplexPattern(Cow<'a, [u8]>),
     // Only includes %, e.g. 'A%r%w'.
     // SimplePattern is composed of: (has_start_percent, has_end_percent, segments).
@@ -222,13 +222,6 @@ pub fn generate_like_pattern<'a, B: Into<Cow<'a, [u8]>>>(
         return LikePattern::Constant(true);
     }
 
-    if let Some(needle) = unescape_surrounded_literal(&pattern) {
-        return LikePattern::SurroundByPercent(VolnitskyBase::new_cow(
-            Cow::Owned(needle),
-            haystack_size_hint,
-        ));
-    }
-
     let mut index = 0;
     let mut first_non_percent = 0;
     let mut percent_num = 0;
@@ -260,6 +253,11 @@ pub fn generate_like_pattern<'a, B: Into<Cow<'a, [u8]>>>(
                 if index < len - 1 {
                     index += 1;
                     if is_like_pattern_escape(pattern[index] as char) {
+                        if let Some(literal_pattern) =
+                            parse_escaped_literal_pattern(&pattern, haystack_size_hint)
+                        {
+                            return literal_pattern;
+                        }
                         return LikePattern::ComplexPattern(pattern);
                     }
                 }
@@ -309,46 +307,84 @@ pub fn generate_like_pattern<'a, B: Into<Cow<'a, [u8]>>>(
     }
 }
 
-/// Extract the literal from a `%literal%` pattern that currently needs the
-/// complex matcher only because it contains escaped LIKE metacharacters.
+/// Compile a LIKE pattern whose only wildcard is a leading or trailing `%` and
+/// whose escapes all represent literal LIKE metacharacters.
 ///
-/// Keep this deliberately narrow: patterns with an unescaped metacharacter,
-/// an unsupported escape, or anything other than one leading and one trailing
-/// percent continue to use the existing matcher.
-fn unescape_surrounded_literal(pattern: &[u8]) -> Option<Vec<u8>> {
-    if pattern.len() < 4 || pattern[0] != b'%' || pattern[pattern.len() - 1] != b'%' {
-        return None;
+/// This is called only after the regular classifier finds a supported escape,
+/// so patterns without escapes keep the existing zero-copy path.
+fn parse_escaped_literal_pattern<'a>(
+    pattern: &[u8],
+    haystack_size_hint: usize,
+) -> Option<LikePattern<'a>> {
+    #[derive(Clone, Copy)]
+    enum Phase {
+        LeadingPercent,
+        Literal,
+        TrailingPercent,
     }
 
-    let end = pattern.len() - 1;
-    let mut index = 1;
+    let mut phase = Phase::LeadingPercent;
+    let mut has_start_percent = false;
+    let mut has_end_percent = false;
+    let mut literal_start = 0;
+    let mut index = 0;
     let mut literal = None;
 
-    while index < end {
+    while index < pattern.len() {
         match pattern[index] {
-            b'%' | b'_' => return None,
+            b'%' => match phase {
+                Phase::LeadingPercent => {
+                    has_start_percent = true;
+                    literal_start = index + 1;
+                    index += 1;
+                }
+                Phase::Literal => {
+                    has_end_percent = true;
+                    phase = Phase::TrailingPercent;
+                    index += 1;
+                }
+                Phase::TrailingPercent => index += 1,
+            },
+            b'_' => return None,
             b'\\' => {
-                if index + 1 >= end || !is_like_pattern_escape(pattern[index + 1] as char) {
+                if matches!(phase, Phase::TrailingPercent)
+                    || index + 1 >= pattern.len()
+                    || !is_like_pattern_escape(pattern[index + 1] as char)
+                {
                     return None;
                 }
                 let literal = literal.get_or_insert_with(|| {
-                    let mut literal = Vec::with_capacity(pattern.len() - 2);
-                    literal.extend_from_slice(&pattern[1..index]);
+                    let mut literal = Vec::with_capacity(pattern.len());
+                    literal.extend_from_slice(&pattern[literal_start..index]);
                     literal
                 });
                 literal.push(pattern[index + 1]);
+                phase = Phase::Literal;
                 index += 2;
             }
             byte => {
+                if matches!(phase, Phase::TrailingPercent) {
+                    return None;
+                }
                 if let Some(literal) = &mut literal {
                     literal.push(byte);
                 }
+                phase = Phase::Literal;
                 index += 1;
             }
         }
     }
 
-    literal
+    let literal = literal?;
+    Some(match (has_start_percent, has_end_percent) {
+        (false, false) => LikePattern::OrdinalStr(Cow::Owned(literal)),
+        (true, false) => LikePattern::StartOfPercent(Cow::Owned(literal)),
+        (false, true) => LikePattern::EndOfPercent(Cow::Owned(literal)),
+        (true, true) => LikePattern::SurroundByPercent(VolnitskyBase::new_cow(
+            Cow::Owned(literal),
+            haystack_size_hint,
+        )),
+    })
 }
 
 fn normalize_simple_pattern<'a>(
@@ -492,12 +528,36 @@ fn test_generate_like_pattern() {
             LikePattern::SurroundByPercent(VolnitskyBase::new("alpha_beta".as_bytes(), 1)),
         ),
         (
+            "alpha\\_beta",
+            LikePattern::OrdinalStr("alpha_beta".as_bytes().to_vec().into()),
+        ),
+        (
+            "alpha\\_beta%",
+            LikePattern::EndOfPercent("alpha_beta".as_bytes().to_vec().into()),
+        ),
+        (
+            "%alpha\\_beta",
+            LikePattern::StartOfPercent("alpha_beta".as_bytes().to_vec().into()),
+        ),
+        (
             "%alpha\\%beta%",
             LikePattern::SurroundByPercent(VolnitskyBase::new("alpha%beta".as_bytes(), 1)),
         ),
         (
             "%alpha\\\\beta%",
             LikePattern::SurroundByPercent(VolnitskyBase::new("alpha\\beta".as_bytes(), 1)),
+        ),
+        (
+            "\\%alpha%",
+            LikePattern::EndOfPercent("%alpha".as_bytes().to_vec().into()),
+        ),
+        (
+            "%alpha\\%",
+            LikePattern::StartOfPercent("alpha%".as_bytes().to_vec().into()),
+        ),
+        (
+            "%%%alpha\\_beta%%%",
+            LikePattern::SurroundByPercent(VolnitskyBase::new("alpha_beta".as_bytes(), 1)),
         ),
         (
             "databend_cloud%data%warehouse",
@@ -519,10 +579,6 @@ fn test_generate_like_pattern() {
             "%alpha\\xbeta%gamma%",
             LikePattern::ComplexPattern("%alpha\\xbeta%gamma%".as_bytes().into()),
         ),
-        (
-            "%alpha\\%",
-            LikePattern::ComplexPattern("%alpha\\%".as_bytes().into()),
-        ),
     ];
     for (pattern, pattern_type) in test_cases {
         assert_eq!(pattern_type, generate_like_pattern(pattern.as_bytes(), 1));
@@ -530,37 +586,35 @@ fn test_generate_like_pattern() {
 }
 
 #[test]
-fn test_escaped_surrounded_literal_matches_complex_pattern() {
-    let test_cases = [
-        ("%alpha\\_beta%", [
-            "",
-            "alpha_beta",
-            "prefix alpha_beta suffix",
-            "alpha-beta",
-            "alpha__beta",
-            "α alpha_beta β",
-        ]),
-        ("%alpha\\%beta%", [
-            "",
-            "alpha%beta",
-            "prefix alpha%beta suffix",
-            "alpha_beta",
-            "alpha%%beta",
-            "α alpha%beta β",
-        ]),
-        ("%alpha\\\\beta%", [
-            "",
-            "alpha\\beta",
-            "prefix alpha\\beta suffix",
-            "alpha/beta",
-            "alpha\\\\beta",
-            "α alpha\\beta β",
-        ]),
+fn test_escaped_literal_patterns_match_complex_pattern() {
+    let patterns = [
+        "alpha\\_beta",
+        "alpha\\_beta%",
+        "%alpha\\_beta",
+        "%alpha\\_beta%",
+        "%alpha\\%beta%",
+        "%alpha\\\\beta%",
+        "\\%alpha%",
+        "%alpha\\%",
+        "%%%alpha\\_beta%%%",
+    ];
+    let haystacks = [
+        "",
+        "alpha_beta",
+        "prefix alpha_beta suffix",
+        "alpha-beta",
+        "alpha%beta",
+        "prefix alpha%beta suffix",
+        "alpha\\beta",
+        "prefix alpha\\beta suffix",
+        "%alpha suffix",
+        "prefix alpha%",
+        "α alpha_beta β",
     ];
 
-    for (pattern, haystacks) in test_cases {
+    for pattern in patterns {
         let optimized = generate_like_pattern(pattern.as_bytes(), 0);
-        assert!(matches!(optimized, LikePattern::SurroundByPercent(_)));
+        assert!(!matches!(optimized, LikePattern::ComplexPattern(_)));
 
         for haystack in haystacks {
             assert_eq!(
@@ -582,9 +636,11 @@ mod property_tests {
         #![proptest_config(ProptestConfig::with_cases(256))]
 
         #[test]
-        fn escaped_surrounded_literal_is_equivalent_to_complex_pattern(
+        fn escaped_literal_pattern_is_equivalent_to_complex_pattern(
             escaped_literal in prop::sample::select(vec![b'%', b'_', b'\\']),
             literal_tail in prop::collection::vec(any::<u8>(), 0..32),
+            leading_percent_count in 0usize..4,
+            trailing_percent_count in 0usize..4,
             prefix in prop::collection::vec(any::<u8>(), 0..64),
             suffix in prop::collection::vec(any::<u8>(), 0..64),
             arbitrary in prop::collection::vec(any::<u8>(), 0..128),
@@ -593,25 +649,45 @@ mod property_tests {
             literal.push(escaped_literal);
             literal.extend(literal_tail);
 
-            let mut pattern = Vec::with_capacity(literal.len() * 2 + 2);
-            pattern.push(b'%');
+            let mut pattern = Vec::with_capacity(
+                literal.len() * 2 + leading_percent_count + trailing_percent_count,
+            );
+            pattern.extend(std::iter::repeat_n(b'%', leading_percent_count));
             for byte in &literal {
                 if matches!(byte, b'%' | b'_' | b'\\') {
                     pattern.push(b'\\');
                 }
                 pattern.push(*byte);
             }
-            pattern.push(b'%');
+            pattern.extend(std::iter::repeat_n(b'%', trailing_percent_count));
 
             let optimized = generate_like_pattern(pattern.as_slice(), 0);
-            prop_assert!(matches!(optimized, LikePattern::SurroundByPercent(_)));
+            match (leading_percent_count > 0, trailing_percent_count > 0) {
+                (false, false) => prop_assert!(matches!(&optimized, LikePattern::OrdinalStr(_))),
+                (true, false) => {
+                    prop_assert!(matches!(&optimized, LikePattern::StartOfPercent(_)))
+                }
+                (false, true) => {
+                    prop_assert!(matches!(&optimized, LikePattern::EndOfPercent(_)))
+                }
+                (true, true) => {
+                    prop_assert!(matches!(&optimized, LikePattern::SurroundByPercent(_)))
+                }
+            }
 
             prop_assert_eq!(
                 optimized.compare(&arbitrary),
                 LikePattern::complex_pattern(&arbitrary, &pattern),
             );
 
-            let matching = [prefix.as_slice(), literal.as_slice(), suffix.as_slice()].concat();
+            let mut matching = Vec::new();
+            if leading_percent_count > 0 {
+                matching.extend_from_slice(&prefix);
+            }
+            matching.extend_from_slice(&literal);
+            if trailing_percent_count > 0 {
+                matching.extend_from_slice(&suffix);
+            }
             prop_assert!(optimized.compare(&matching));
             prop_assert_eq!(
                 optimized.compare(&matching),

--- a/src/query/functions/src/scalars/comparison.rs
+++ b/src/query/functions/src/scalars/comparison.rs
@@ -2030,11 +2030,17 @@ fn variant_vectorize_like_jsonb() -> impl Fn(
 ) -> Value<BooleanType>
 + Copy
 + Sized {
-    variant_vectorize_like(|val, pattern_type| match pattern_type {
-        LikePattern::OrdinalStr(_)
-        | LikePattern::StartOfPercent(_)
-        | LikePattern::EndOfPercent(_)
-        | LikePattern::Constant(_) => {
+    variant_vectorize_like(|val, pattern_type, requires_traversal| {
+        if requires_traversal {
+            let raw_jsonb = RawJsonb::new(val);
+            match raw_jsonb.traverse_check_string(|v| pattern_type.compare(v)) {
+                Ok(res) => res,
+                Err(_) => {
+                    let s = raw_jsonb.to_string();
+                    pattern_type.compare(s.as_bytes())
+                }
+            }
+        } else {
             let raw_jsonb = RawJsonb::new(val);
             match raw_jsonb.as_str() {
                 Ok(Some(s)) => pattern_type.compare(s.as_bytes()),
@@ -2045,17 +2051,25 @@ fn variant_vectorize_like_jsonb() -> impl Fn(
                 }
             }
         }
-        _ => {
-            let raw_jsonb = RawJsonb::new(val);
-            match raw_jsonb.traverse_check_string(|v| pattern_type.compare(v)) {
-                Ok(res) => res,
-                Err(_) => {
-                    let s = raw_jsonb.to_string();
-                    pattern_type.compare(s.as_bytes())
-                }
-            }
-        }
     })
+}
+
+fn variant_like_requires_traversal(pattern: &[u8], pattern_type: &LikePattern) -> bool {
+    if !matches!(
+        pattern_type,
+        LikePattern::OrdinalStr(_)
+            | LikePattern::StartOfPercent(_)
+            | LikePattern::EndOfPercent(_)
+            | LikePattern::Constant(_)
+    ) {
+        return true;
+    }
+
+    // Escaped exact, prefix, and suffix patterns used ComplexPattern before the
+    // specialized matchers were added, so preserve their nested VARIANT traversal.
+    pattern
+        .windows(2)
+        .any(|window| window[0] == b'\\' && matches!(window[1], b'%' | b'_' | b'\\'))
 }
 
 fn vectorize_like(
@@ -2316,7 +2330,7 @@ fn ilike_any_fn(args: &[Value<AnyType>], ctx: &mut EvalContext) -> Value<AnyType
 }
 
 fn variant_vectorize_like(
-    func: impl Fn(&[u8], &LikePattern) -> bool + Copy,
+    func: impl Fn(&[u8], &LikePattern, bool) -> bool + Copy,
 ) -> impl Fn(
     Value<VariantType>,
     Value<StringType>,
@@ -2332,7 +2346,9 @@ fn variant_vectorize_like(
             (Value::Scalar(arg1), Value::Scalar(arg2)) => {
                 let pattern = convert_escape_pattern(&escape, arg2);
                 let pattern_type = generate_like_pattern(pattern.as_bytes(), 1);
-                Value::Scalar(func(&arg1, &pattern_type))
+                let requires_traversal =
+                    variant_like_requires_traversal(pattern.as_bytes(), &pattern_type);
+                Value::Scalar(func(&arg1, &pattern_type, requires_traversal))
             }
             (Value::Column(arg1), Value::Scalar(arg2)) => {
                 let arg1_iter = VariantType::iter_column(&arg1);
@@ -2340,9 +2356,11 @@ fn variant_vectorize_like(
                 let pattern = convert_escape_pattern(&escape, arg2);
                 let pattern_type =
                     generate_like_pattern(pattern.as_bytes(), arg1.total_bytes_len());
+                let requires_traversal =
+                    variant_like_requires_traversal(pattern.as_bytes(), &pattern_type);
                 let mut builder = MutableBitmap::with_capacity(arg1.len());
                 for arg1 in arg1_iter {
-                    builder.push(func(arg1, &pattern_type));
+                    builder.push(func(arg1, &pattern_type, requires_traversal));
                 }
                 Value::Column(builder.into())
             }
@@ -2352,7 +2370,9 @@ fn variant_vectorize_like(
                 for arg2 in arg2_iter {
                     let pattern = convert_escape_pattern(&escape, arg2.to_string());
                     let pattern_type = generate_like_pattern(pattern.as_bytes(), 1);
-                    builder.push(func(&arg1, &pattern_type));
+                    let requires_traversal =
+                        variant_like_requires_traversal(pattern.as_bytes(), &pattern_type);
+                    builder.push(func(&arg1, &pattern_type, requires_traversal));
                 }
                 Value::Column(builder.into())
             }
@@ -2363,7 +2383,9 @@ fn variant_vectorize_like(
                 for (arg1, arg2) in arg1_iter.zip(arg2_iter) {
                     let pattern = convert_escape_pattern(&escape, arg2.to_string());
                     let pattern_type = generate_like_pattern(pattern.as_bytes(), 1);
-                    builder.push(func(arg1, &pattern_type));
+                    let requires_traversal =
+                        variant_like_requires_traversal(pattern.as_bytes(), &pattern_type);
+                    builder.push(func(arg1, &pattern_type, requires_traversal));
                 }
                 Value::Column(builder.into())
             }
@@ -2476,6 +2498,7 @@ fn compare_bitmap_bytes(lhs: &[u8], rhs: &[u8], ctx: &mut EvalContext, row: usiz
 
 #[cfg(test)]
 mod tests {
+    use databend_common_expression::FromData;
     use databend_common_expression::FunctionContext;
     use databend_common_expression::stat_distribution::BorrowedDistribution;
     use databend_common_expression::stat_distribution::NdvEstimate;
@@ -2490,6 +2513,36 @@ mod tests {
     use jsonb::OwnedJsonb;
 
     use super::*;
+
+    fn jsonb_scalar(value: &str) -> Vec<u8> {
+        value.parse::<OwnedJsonb>().unwrap().to_vec()
+    }
+
+    fn variant_column(values: &[&str]) -> <VariantType as AccessType>::Column {
+        let Column::Variant(column) = VariantType::from_data(
+            values
+                .iter()
+                .map(|value| jsonb_scalar(value))
+                .collect::<Vec<_>>(),
+        ) else {
+            unreachable!()
+        };
+        column
+    }
+
+    fn string_column(values: &[&str]) -> <StringType as AccessType>::Column {
+        let Column::String(column) = StringType::from_data(values.to_vec()) else {
+            unreachable!()
+        };
+        column
+    }
+
+    fn assert_boolean_value(value: Value<BooleanType>, expected: &[bool]) {
+        match value {
+            Value::Scalar(value) => assert_eq!(expected, &[value]),
+            Value::Column(column) => assert_eq!(column.iter().collect::<Vec<_>>(), expected),
+        }
+    }
 
     #[test]
     fn test_numeric_histogram_partial_bucket_reserves_equality_mass() {
@@ -2682,6 +2735,101 @@ mod tests {
             None,
             "empty patterns should not reuse repeated all-% folding"
         );
+    }
+
+    #[test]
+    fn test_variant_escaped_literal_like_preserves_nested_traversal() {
+        let like = variant_vectorize_like_jsonb();
+        let func_ctx = FunctionContext::default();
+        let mut ctx = EvalContext {
+            generics: &[],
+            num_rows: 1,
+            func_ctx: &func_ctx,
+            validity: None,
+            errors: None,
+            suppress_error: false,
+            strict_eval: false,
+        };
+
+        for (value, pattern, escape, expected) in [
+            (r#"{"name":"alpha_beta"}"#, r"alpha\_beta", "", true),
+            (r#"["alpha_beta_tail"]"#, r"alpha\_beta%", "", true),
+            (r#"{"name":"head_alpha_beta"}"#, r"%alpha\_beta", "", true),
+            (
+                r#"{"name":"head_alpha_beta_tail"}"#,
+                r"%alpha\_beta%",
+                "",
+                true,
+            ),
+            (r#"{"name":"alpha%beta"}"#, r"alpha\%beta", "", true),
+            (r#"{"name":"alpha\\beta"}"#, r"alpha\\beta", "", true),
+            (r#"{"name":"alpha_beta"}"#, "alpha$_beta", "$", true),
+            (r#"{"name":"alphaXbeta"}"#, r"alpha\_beta", "", false),
+            (r#""alpha_beta""#, r"alpha\_beta", "", true),
+            (r#"{"name":"alphabeta"}"#, "alphabeta", "", false),
+            (r#"{"name":"alphabetatail"}"#, "alphabeta%", "", false),
+            (r#"{"name":"headalphabeta"}"#, "%alphabeta", "", false),
+        ] {
+            let result = like(
+                Value::<VariantType>::Scalar(jsonb_scalar(value)),
+                Value::<StringType>::Scalar(pattern.to_string()),
+                Value::<StringType>::Scalar(escape.to_string()),
+                &mut ctx,
+            );
+            assert_boolean_value(result, &[expected]);
+        }
+    }
+
+    #[test]
+    fn test_variant_escaped_literal_like_preserves_all_value_layouts() {
+        let like = variant_vectorize_like_jsonb();
+        let func_ctx = FunctionContext::default();
+        let mut ctx = EvalContext {
+            generics: &[],
+            num_rows: 2,
+            func_ctx: &func_ctx,
+            validity: None,
+            errors: None,
+            suppress_error: false,
+            strict_eval: false,
+        };
+        let matching = r#"{"name":"alpha_beta"}"#;
+        let non_matching = r#"{"name":"alphaXbeta"}"#;
+        let pattern = "alpha$_beta";
+        let other_pattern = "other$_value";
+        let escape = Value::<StringType>::Scalar("$".to_string());
+
+        let scalar_scalar = like(
+            Value::<VariantType>::Scalar(jsonb_scalar(matching)),
+            Value::<StringType>::Scalar(pattern.to_string()),
+            escape.clone(),
+            &mut ctx,
+        );
+        assert_boolean_value(scalar_scalar, &[true]);
+
+        let column_scalar = like(
+            Value::<VariantType>::Column(variant_column(&[matching, non_matching])),
+            Value::<StringType>::Scalar(pattern.to_string()),
+            escape.clone(),
+            &mut ctx,
+        );
+        assert_boolean_value(column_scalar, &[true, false]);
+
+        let scalar_column = like(
+            Value::<VariantType>::Scalar(jsonb_scalar(matching)),
+            Value::<StringType>::Column(string_column(&[pattern, other_pattern])),
+            escape.clone(),
+            &mut ctx,
+        );
+        assert_boolean_value(scalar_column, &[true, false]);
+
+        let column_column = like(
+            Value::<VariantType>::Column(variant_column(&[matching, non_matching])),
+            Value::<StringType>::Column(string_column(&[pattern, pattern])),
+            escape,
+            &mut ctx,
+        );
+        assert_boolean_value(column_column, &[true, false]);
     }
 
     #[test]

--- a/src/query/functions/src/scalars/comparison.rs
+++ b/src/query/functions/src/scalars/comparison.rs
@@ -1994,6 +1994,8 @@ fn calc_like_domain(lhs: &StringDomain, pattern: String) -> Option<FunctionDomai
             Some(FunctionDomain::Domain(ALL_TRUE_DOMAIN))
         }
         LikePattern::OrdinalStr(literal) => {
+            // Use the exact literal used by runtime matching. `pattern` may still
+            // contain LIKE escape sequences.
             let literal = String::from_utf8(literal.into_owned()).ok()?;
             Some(lhs.domain_eq(&StringDomain {
                 min: literal.clone(),

--- a/src/query/functions/src/scalars/comparison.rs
+++ b/src/query/functions/src/scalars/comparison.rs
@@ -1993,10 +1993,13 @@ fn calc_like_domain(lhs: &StringDomain, pattern: String) -> Option<FunctionDomai
         LikePattern::Constant(true) if is_all_percent_pattern => {
             Some(FunctionDomain::Domain(ALL_TRUE_DOMAIN))
         }
-        LikePattern::OrdinalStr(_) => Some(lhs.domain_eq(&StringDomain {
-            min: pattern.clone(),
-            max: Some(pattern),
-        })),
+        LikePattern::OrdinalStr(literal) => {
+            let literal = String::from_utf8(literal.into_owned()).ok()?;
+            Some(lhs.domain_eq(&StringDomain {
+                min: literal.clone(),
+                max: Some(literal),
+            }))
+        }
         LikePattern::EndOfPercent(v) => {
             let pat_str = std::str::from_utf8(v.as_ref()).ok()?.to_string();
             let pat_len = pat_str.chars().count();
@@ -2596,6 +2599,59 @@ mod tests {
             calc_like_domain(&non_matching, "abab%".to_string()),
             "non-matching prefixes should also stay consistent"
         );
+    }
+
+    #[test]
+    fn test_calc_like_domain_exact_pattern_matches_equality_domain() {
+        let mut cases = vec![
+            ("plain".to_string(), "plain".to_string()),
+            ("%".to_string(), "\\%".to_string()),
+            ("_".to_string(), "\\_".to_string()),
+            ("\\".to_string(), "\\\\".to_string()),
+            (
+                "alpha%_\\beta".to_string(),
+                "alpha\\%\\_\\\\beta".to_string(),
+            ),
+            ("你好_100%".to_string(), "你好\\_100\\%".to_string()),
+        ];
+        cases.extend([
+            (
+                "alpha_beta".to_string(),
+                type_check::convert_escape_pattern("alpha$_beta", '$'),
+            ),
+            (
+                "100%".to_string(),
+                type_check::convert_escape_pattern("100!%", '!'),
+            ),
+            (
+                "path\\file".to_string(),
+                type_check::convert_escape_pattern("path#\\file", '#'),
+            ),
+        ]);
+
+        for (literal, pattern) in cases {
+            let literal_domain = StringDomain {
+                min: literal.clone(),
+                max: Some(literal.clone()),
+            };
+            for domain in [
+                literal_domain.clone(),
+                StringDomain {
+                    min: "different".to_string(),
+                    max: Some("different".to_string()),
+                },
+                StringDomain {
+                    min: "".to_string(),
+                    max: None,
+                },
+            ] {
+                assert_eq!(
+                    calc_like_domain(&domain, pattern.clone()),
+                    Some(domain.domain_eq(&literal_domain)),
+                    "domain {domain:?} with LIKE pattern {pattern:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/query/functions/tests/it/scalars/comparison.rs
+++ b/src/query/functions/tests/it/scalars/comparison.rs
@@ -487,6 +487,8 @@ fn test_like(file: &mut impl Write) {
     run_ast(file, "'h\n' like 'h_'", &[]);
     run_ast(file, r#"'%' like '\%'"#, &[]);
     run_ast(file, r#"'v%xx' like '_\%%'"#, &[]);
+    run_ast(file, r#""like"('alpha_beta', 'alpha$_beta', '$')"#, &[]);
+    run_ast(file, r#""like"('alphaXbeta', 'alpha$_beta', '$')"#, &[]);
 
     let columns = [(
         "lhs",

--- a/src/query/functions/tests/it/scalars/comparison.rs
+++ b/src/query/functions/tests/it/scalars/comparison.rs
@@ -515,6 +515,31 @@ fn test_like(file: &mut impl Write) {
         "parse_json('{\"k1\":\"abc\",\"k2\":\"def\"}') like '%e%'",
         &[],
     );
+    run_ast(
+        file,
+        r#"parse_json('{"name":"alpha_beta"}') like 'alpha\_beta'"#,
+        &[],
+    );
+    run_ast(
+        file,
+        r#"parse_json('["alpha_beta_tail"]') like 'alpha\_beta%'"#,
+        &[],
+    );
+    run_ast(
+        file,
+        r#"parse_json('{"name":"head_alpha_beta"}') like '%alpha\_beta'"#,
+        &[],
+    );
+    run_ast(
+        file,
+        r#""like"(parse_json('{"name":"alpha_beta"}'), 'alpha$_beta', '$')"#,
+        &[],
+    );
+    run_ast(
+        file,
+        r#"parse_json('{"name":"alphabeta"}') like 'alphabeta'"#,
+        &[],
+    );
 
     let columns = [(
         "lhs",

--- a/src/query/functions/tests/it/scalars/testdata/comparison.txt
+++ b/src/query/functions/tests/it/scalars/testdata/comparison.txt
@@ -1605,6 +1605,24 @@ output domain  : {TRUE}
 output         : true
 
 
+ast            : "like"('alpha_beta', 'alpha$_beta', '$')
+raw expr       : like('alpha_beta', 'alpha$_beta', '$')
+checked expr   : like<String, String, String>("alpha_beta", "alpha$_beta", "$")
+optimized expr : true
+output type    : Boolean
+output domain  : {TRUE}
+output         : true
+
+
+ast            : "like"('alphaXbeta', 'alpha$_beta', '$')
+raw expr       : like('alphaXbeta', 'alpha$_beta', '$')
+checked expr   : like<String, String, String>("alphaXbeta", "alpha$_beta", "$")
+optimized expr : false
+output type    : Boolean
+output domain  : {FALSE}
+output         : false
+
+
 ast            : lhs like 'a%'
 raw expr       : like(lhs::String, 'a%')
 checked expr   : like<String, String>(lhs, "a%")

--- a/src/query/functions/tests/it/scalars/testdata/comparison.txt
+++ b/src/query/functions/tests/it/scalars/testdata/comparison.txt
@@ -1768,6 +1768,51 @@ output domain  : {TRUE}
 output         : true
 
 
+ast            : parse_json('{"name":"alpha_beta"}') like 'alpha\_beta'
+raw expr       : like(parse_json('{"name":"alpha_beta"}'), 'alpha\\_beta')
+checked expr   : like<Variant, String>(CAST<String>("{\"name\":\"alpha_beta\"}" AS Variant), "alpha\\_beta")
+optimized expr : true
+output type    : Boolean
+output domain  : {TRUE}
+output         : true
+
+
+ast            : parse_json('["alpha_beta_tail"]') like 'alpha\_beta%'
+raw expr       : like(parse_json('["alpha_beta_tail"]'), 'alpha\\_beta%')
+checked expr   : like<Variant, String>(CAST<String>("[\"alpha_beta_tail\"]" AS Variant), "alpha\\_beta%")
+optimized expr : true
+output type    : Boolean
+output domain  : {TRUE}
+output         : true
+
+
+ast            : parse_json('{"name":"head_alpha_beta"}') like '%alpha\_beta'
+raw expr       : like(parse_json('{"name":"head_alpha_beta"}'), '%alpha\\_beta')
+checked expr   : like<Variant, String>(CAST<String>("{\"name\":\"head_alpha_beta\"}" AS Variant), "%alpha\\_beta")
+optimized expr : true
+output type    : Boolean
+output domain  : {TRUE}
+output         : true
+
+
+ast            : "like"(parse_json('{"name":"alpha_beta"}'), 'alpha$_beta', '$')
+raw expr       : like(parse_json('{"name":"alpha_beta"}'), 'alpha$_beta', '$')
+checked expr   : like<Variant, String, String>(CAST<String>("{\"name\":\"alpha_beta\"}" AS Variant), "alpha$_beta", "$")
+optimized expr : true
+output type    : Boolean
+output domain  : {TRUE}
+output         : true
+
+
+ast            : parse_json('{"name":"alphabeta"}') like 'alphabeta'
+raw expr       : like(parse_json('{"name":"alphabeta"}'), 'alphabeta')
+checked expr   : like<Variant, String>(CAST<String>("{\"name\":\"alphabeta\"}" AS Variant), "alphabeta")
+optimized expr : false
+output type    : Boolean
+output domain  : {FALSE}
+output         : false
+
+
 ast            : parse_json(lhs) like 'a%'
 raw expr       : like(parse_json(lhs::String), 'a%')
 checked expr   : like<Variant, String>(CAST<String>(lhs AS Variant), "a%")

--- a/src/query/sql/tests/it/optimizer/selectivity_special_predicate.txt
+++ b/src/query/sql/tests/it/optimizer/selectivity_special_predicate.txt
@@ -90,11 +90,11 @@ out stats     :
 
 expr          : s like 'a\_b'
 cardinality   : 100
-estimated     : 12.5
+estimated     : 0
 in stats      :
 0 ColumnStat { min: Bytes([97, 97]), max: Bytes([122, 122]), ndv: 40.0, null_count: 0, histogram: None }
 out stats     :
-0 ColumnStat { min: Bytes([97, 97]), max: Bytes([122, 122]), ndv: ~11.352935632512011[..12.5], null_count: 0, histogram: None }
+0 ColumnStat { min: Bytes([97, 97]), max: Bytes([122, 122]), ndv: 0.0, null_count: 0, histogram: None }
 
 expr          : s like '%%%%'
 cardinality   : 100

--- a/tests/sqllogictests/suites/query/functions/02_0005_function_compare.test
+++ b/tests/sqllogictests/suites/query/functions/02_0005_function_compare.test
@@ -1135,6 +1135,16 @@ select parse_json('{"name":"jcs.sol"}') like '%.sol%';
 ----
 1
 
+query BBBBB
+SELECT
+    parse_json('{"name":"alpha_beta"}') LIKE 'alpha\_beta',
+    parse_json('["alpha_beta_tail"]') LIKE 'alpha\_beta%',
+    parse_json('{"name":"head_alpha_beta"}') LIKE '%alpha\_beta',
+    parse_json('{"name":"alpha_beta"}') LIKE 'alpha$_beta' ESCAPE '$',
+    parse_json('{"name":"alphabeta"}') LIKE 'alphabeta'
+----
+1 1 1 1 0
+
 query B
 SELECT parse_json('"ab"') not like 'ab'
 ----


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

A LIKE pattern can contain escaped metacharacters and still be a fixed-literal check. This PR removes those escapes once and uses a specialized matcher instead of interpreting the LIKE pattern for every value.

For example, these internal pattern bytes are now handled as follows:

```text
error\_code    -> equal to "error_code"
error\_code%   -> starts with "error_code"
%error\_code   -> ends with "error_code"
%error\_code%  -> contains "error_code"
```

Here `\_` means a literal underscore. Escaped `%` and `\` characters are handled in the same way.

The fast path is used when:

- The pattern contains an escaped `%`, `_`, or `\`.
- There is no unescaped `_`.
- Every unescaped `%` belongs to a leading or trailing run of `%` characters.
- Every escape in the pattern is one of `\%`, `\_`, or `\\`.

Patterns with an unescaped `%` between literal parts, an unescaped `_`, or another escape sequence continue through the existing classification and matcher.

## Performance impact

### Runtime change

Before this PR, escaped fixed-literal patterns used `ComplexPattern`. It interprets escapes and wildcards while matching every value.

This PR unescapes the fixed literal before the row loop and selects a simpler matcher:

| Pattern shape | Before | After |
| --- | --- | --- |
| `literal` | `ComplexPattern` | byte equality |
| `literal%` | `ComplexPattern` | prefix check |
| `%literal` | `ComplexPattern` | suffix check |
| `%literal%` | `ComplexPattern` | contains matcher (Volnitsky for large blocks) |

This PR does not change `ComplexPattern` or the substring search algorithms. It routes supported escaped fixed-literal patterns to the existing specialized matchers.

### Benchmark setup

- `Before` runs `ComplexPattern`; `After` runs the matcher selected by this PR on the same pattern and value.
- Hit and miss cases are measured for all four pattern shapes. Short values are 25 to 62 bytes.
- The large contains cases use 1 KiB, 4 KiB, and 16 KiB synthetic log-like values, with hits in the middle.
- For the large cases, a 1 MiB total string-column size selects the existing Volnitsky matcher, as it does for large production blocks.
- Benchmarks use the optimized profile on a 16-vCPU x86_64 VM with an Intel Xeon Platinum 8275CL CPU at 3.00 GHz.
- The tables show divan median times. The large-value table uses the median of three runs.

### Results

Short values across all four pattern shapes:

| Pattern shape | Result | Before (`ComplexPattern`) | After (specialized) | Speedup |
| --- | --- | ---: | ---: | ---: |
| exact | miss | 51.3 ns | 6.2 ns | 8.3x |
| exact | hit | 67.2 ns | 5.9 ns | 11.4x |
| prefix | miss | 51.3 ns | 5.9 ns | 8.6x |
| prefix | hit | 195.1 ns | 6.1 ns | 32.2x |
| suffix | miss | 353.6 ns | 5.8 ns | 60.8x |
| suffix | hit | 249.5 ns | 5.5 ns | 45.1x |
| contains | miss | 358.4 ns | 62.5 ns | 5.7x |
| contains | hit | 217.0 ns | 79.4 ns | 2.7x |

Large contains values:

| Value size | Result | Before (`ComplexPattern`) | After (specialized: Volnitsky) | Speedup |
| --- | --- | ---: | ---: | ---: |
| 1 KiB | miss | 4.909 us | 0.5174 us | 9.5x |
| 1 KiB | hit | 3.984 us | 0.0709 us | 56.2x |
| 4 KiB | miss | 19.55 us | 1.526 us | 12.8x |
| 4 KiB | hit | 15.54 us | 0.2656 us | 58.5x |
| 16 KiB | miss | 78.22 us | 5.603 us | 14.0x |
| 16 KiB | hit | 62.30 us | 1.000 us | 62.3x |

On a miss, the current Volnitsky implementation finishes hash probing and then runs its fallback search again from the start of the value, so misses cost more than hits placed in the middle. These measurements include that behavior; [#20209](https://github.com/databendlabs/databend/pull/20209) removes the repeated scan.

These benchmarks isolate per-value matching. They do not include column iteration, validity and result bitmap work, query scheduling, or I/O. End-to-end query improvement depends on how many values reach LIKE and how much time the query spends outside the matcher.

## Tests

- [x] Unit Test
- [x] Logic Test
- [x] Benchmark Test
- [ ] No Test - _Explain why_

The tests cover:

1. **Pattern classification:** unit cases cover exact, prefix, suffix, and contains shapes; escaped `_`, `%`, and `\` literals; repeated leading and trailing `%`; non-ASCII values; and patterns that must stay on the existing matcher.
2. **Matcher equivalence:** a property test runs 256 generated cases across all four optimized shapes and compares the selected matcher with `LikePattern::complex_pattern`.
3. **Domain inference:** function and selectivity tests verify that exact escaped patterns use the unescaped literal when deriving domains.
4. **VARIANT behavior:** unit tests cover top-level and nested strings, matching and non-matching values, custom escapes, and all four scalar/column layouts. A sqllogic case verifies default and custom `ESCAPE` syntax.
5. **Performance:** divan benchmarks cover hit and miss cases for all four shapes and larger log-like contains values.

Run the benchmarks with:

```text
cargo bench -p databend-common-expression --bench bench escaped_like
```

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20207)
<!-- Reviewable:end -->


