### PR TITLE
fix(query): pass complete Volnitsky n-grams

### DIFF
--- a/src/query/expression/src/filter/volnitsky.rs
+++ b/src/query/expression/src/filter/volnitsky.rs
@@ -55,7 +55,7 @@ impl<'a> VolnitskyBase<'a> {
         let hash = if !fallback {
             let mut hash = Box::new([0; HASH_SIZE]);
             for i in (0..=needle_size - mem::size_of::<NGram>()).rev() {
-                let ngram = Self::to_ngram(&needle[i..i + 1]);
+                let ngram = Self::to_ngram(&needle[i..i + mem::size_of::<NGram>()]);
                 Self::put_ngram(hash.as_mut(), ngram, i as u8 + 1);
             }
             Some(hash)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fixes #20205.

Volnitsky builds its hash from two-byte n-grams. Hash construction passed a one-byte slice to `to_ngram`, which then read a two-byte `u16` from it. Reading a `u16` from a one-byte slice is undefined behavior.

This PR passes the complete n-gram to `to_ngram`:

```diff
- let ngram = Self::to_ngram(&needle[i..i + 1]);
+ let ngram = Self::to_ngram(&needle[i..i + mem::size_of::<NGram>()]);
```

The loop already stops at `needle.len() - size_of::<NGram>()`, so the slice always contains the two bytes read by `to_ngram`.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20208)
<!-- Reviewable:end -->
