### PR TITLE
fix(query): skip inactive rows in vectorized LIKE

### DIFF
--- a/src/query/functions/src/scalars/comparison.rs
+++ b/src/query/functions/src/scalars/comparison.rs
@@ -2081,7 +2081,7 @@ fn vectorize_like(
     &mut EvalContext,
 ) -> Value<BooleanType>
 + Copy {
-    move |arg1, arg2, arg3, _ctx| {
+    move |arg1, arg2, arg3, ctx| {
         let Value::Scalar(escape) = arg3 else {
             unreachable!()
         };
@@ -2097,7 +2097,26 @@ fn vectorize_like(
                 let pattern = convert_escape_pattern(&escape, arg2);
                 let pattern_type =
                     generate_like_pattern(pattern.as_bytes(), arg1.total_bytes_len());
-                if let LikePattern::SurroundByPercent(searcher) = pattern_type {
+                let sparse_validity = ctx
+                    .validity
+                    .as_ref()
+                    .filter(|validity| validity.null_count() > 0);
+                if let Some(validity) = sparse_validity {
+                    if let LikePattern::SurroundByPercent(searcher) = pattern_type {
+                        for (index, arg1) in arg1_iter.enumerate() {
+                            builder.push(
+                                validity.get_bit(index)
+                                    && searcher.search(arg1.as_bytes()).is_some(),
+                            );
+                        }
+                    } else {
+                        for (index, arg1) in arg1_iter.enumerate() {
+                            builder.push(
+                                validity.get_bit(index) && func(arg1.as_bytes(), &pattern_type),
+                            );
+                        }
+                    }
+                } else if let LikePattern::SurroundByPercent(searcher) = pattern_type {
                     for arg1 in arg1_iter {
                         builder.push(searcher.search(arg1.as_bytes()).is_some());
                     }
@@ -2112,7 +2131,18 @@ fn vectorize_like(
             (Value::Scalar(arg1), Value::Column(arg2)) => {
                 let arg2_iter = StringType::iter_column(&arg2);
                 let mut builder = MutableBitmap::with_capacity(arg2.len());
-                for arg2 in arg2_iter {
+                let sparse_validity = ctx
+                    .validity
+                    .as_ref()
+                    .filter(|validity| validity.null_count() > 0);
+                for (index, arg2) in arg2_iter.enumerate() {
+                    if sparse_validity
+                        .map(|validity| !validity.get_bit(index))
+                        .unwrap_or(false)
+                    {
+                        builder.push(false);
+                        continue;
+                    }
                     let pattern = convert_escape_pattern(&escape, arg2.to_string());
                     let pattern_type = generate_like_pattern(pattern.as_bytes(), 1);
                     builder.push(func(arg1.as_bytes(), &pattern_type));
@@ -2123,7 +2153,18 @@ fn vectorize_like(
                 let arg1_iter = StringType::iter_column(&arg1);
                 let arg2_iter = StringType::iter_column(&arg2);
                 let mut builder = MutableBitmap::with_capacity(arg2.len());
-                for (arg1, arg2) in arg1_iter.zip(arg2_iter) {
+                let sparse_validity = ctx
+                    .validity
+                    .as_ref()
+                    .filter(|validity| validity.null_count() > 0);
+                for (index, (arg1, arg2)) in arg1_iter.zip(arg2_iter).enumerate() {
+                    if sparse_validity
+                        .map(|validity| !validity.get_bit(index))
+                        .unwrap_or(false)
+                    {
+                        builder.push(false);
+                        continue;
+                    }
                     let pattern = convert_escape_pattern(&escape, arg2.to_string());
                     let pattern_type = generate_like_pattern(pattern.as_bytes(), 1);
                     builder.push(func(arg1.as_bytes(), &pattern_type));
@@ -2498,6 +2539,9 @@ fn compare_bitmap_bytes(lhs: &[u8], rhs: &[u8], ctx: &mut EvalContext, row: usiz
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering as AtomicOrdering;
+
     use databend_common_expression::FromData;
     use databend_common_expression::FunctionContext;
     use databend_common_expression::stat_distribution::BorrowedDistribution;
@@ -2511,6 +2555,7 @@ mod tests {
     use databend_common_expression::types::nullable::NullableDomain;
     use databend_common_expression::types::string::StringDomain;
     use jsonb::OwnedJsonb;
+    use proptest::prelude::*;
 
     use super::*;
 
@@ -2541,6 +2586,157 @@ mod tests {
         match value {
             Value::Scalar(value) => assert_eq!(expected, &[value]),
             Value::Column(column) => assert_eq!(column.iter().collect::<Vec<_>>(), expected),
+        }
+    }
+
+    #[test]
+    fn test_vectorized_like_skips_rows_excluded_by_validity() {
+        let calls = AtomicUsize::new(0);
+        let like = vectorize_like(|value, pattern| {
+            calls.fetch_add(1, AtomicOrdering::Relaxed);
+            pattern.compare(value)
+        });
+        let func_ctx = FunctionContext::default();
+        let mut ctx = EvalContext {
+            generics: &[],
+            num_rows: 4,
+            func_ctx: &func_ctx,
+            validity: Some(Bitmap::from_iter([true, false, true, false])),
+            errors: None,
+            suppress_error: false,
+            strict_eval: false,
+        };
+        let escape = Value::<StringType>::Scalar("".to_string());
+
+        let result = like(
+            Value::<StringType>::Column(string_column(&[
+                "prefix-abc-suffix",
+                "prefix-abc-suffix",
+                "prefix-axc-suffix",
+                "prefix-axc-suffix",
+            ])),
+            Value::<StringType>::Scalar("%a_c%".to_string()),
+            escape.clone(),
+            &mut ctx,
+        );
+        assert_boolean_value(result, &[true, false, true, false]);
+        assert_eq!(calls.load(AtomicOrdering::Relaxed), 2);
+
+        calls.store(0, AtomicOrdering::Relaxed);
+        let result = like(
+            Value::<StringType>::Scalar("prefix-abc-suffix".to_string()),
+            Value::<StringType>::Column(string_column(&[
+                "%a_c%", "%a_c%", "%z_z%", "%a_c%",
+            ])),
+            escape.clone(),
+            &mut ctx,
+        );
+        assert_boolean_value(result, &[true, false, false, false]);
+        assert_eq!(calls.load(AtomicOrdering::Relaxed), 2);
+
+        calls.store(0, AtomicOrdering::Relaxed);
+        let result = like(
+            Value::<StringType>::Column(string_column(&[
+                "prefix-abc-suffix",
+                "prefix-abc-suffix",
+                "prefix-zzz-suffix",
+                "prefix-abc-suffix",
+            ])),
+            Value::<StringType>::Column(string_column(&[
+                "%a_c%", "%a_c%", "%z_z%", "%a_c%",
+            ])),
+            escape,
+            &mut ctx,
+        );
+        assert_boolean_value(result, &[true, false, true, false]);
+        assert_eq!(calls.load(AtomicOrdering::Relaxed), 2);
+    }
+
+    #[test]
+    fn test_vectorized_like_keeps_dense_and_surround_paths() {
+        let calls = AtomicUsize::new(0);
+        let like = vectorize_like(|value, pattern| {
+            calls.fetch_add(1, AtomicOrdering::Relaxed);
+            pattern.compare(value)
+        });
+        let func_ctx = FunctionContext::default();
+        let mut ctx = EvalContext {
+            generics: &[],
+            num_rows: 4,
+            func_ctx: &func_ctx,
+            validity: Some(Bitmap::new_constant(true, 4)),
+            errors: None,
+            suppress_error: false,
+            strict_eval: false,
+        };
+        let values = ["prefix-abc-suffix", "zzzz", "abc", "yyyy"];
+
+        let result = like(
+            Value::<StringType>::Column(string_column(&values)),
+            Value::<StringType>::Scalar("%a_c%".to_string()),
+            Value::<StringType>::Scalar("".to_string()),
+            &mut ctx,
+        );
+        assert_boolean_value(result, &[true, false, true, false]);
+        assert_eq!(calls.load(AtomicOrdering::Relaxed), 4);
+
+        calls.store(0, AtomicOrdering::Relaxed);
+        ctx.validity = Some(Bitmap::from_iter([true, false, true, false]));
+        let result = like(
+            Value::<StringType>::Column(string_column(&values)),
+            Value::<StringType>::Scalar("%abc%".to_string()),
+            Value::<StringType>::Scalar("".to_string()),
+            &mut ctx,
+        );
+        assert_boolean_value(result, &[true, false, true, false]);
+        assert_eq!(calls.load(AtomicOrdering::Relaxed), 0);
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(128))]
+
+        #[test]
+        fn vectorized_like_validity_preserves_active_row_results(
+            rows in prop::collection::vec(("[a-z]{0,48}", any::<bool>()), 1..64),
+            pattern in "[a-z_%\\\\]{0,24}",
+        ) {
+            let values = rows.iter().map(|(value, _)| value.as_str()).collect::<Vec<_>>();
+            let validity = rows.iter().map(|(_, valid)| *valid).collect::<Vec<_>>();
+            let like = vectorize_like(|value, pattern| pattern.compare(value));
+            let func_ctx = FunctionContext::default();
+            let mut dense_ctx = EvalContext {
+                generics: &[],
+                num_rows: rows.len(),
+                func_ctx: &func_ctx,
+                validity: None,
+                errors: None,
+                suppress_error: false,
+                strict_eval: false,
+            };
+            let mut sparse_ctx = EvalContext {
+                validity: Some(Bitmap::from_iter(validity.iter().copied())),
+                ..dense_ctx.clone()
+            };
+
+            let dense = like(
+                Value::<StringType>::Column(string_column(&values)),
+                Value::<StringType>::Scalar(pattern.clone()),
+                Value::<StringType>::Scalar("".to_string()),
+                &mut dense_ctx,
+            );
+            let sparse = like(
+                Value::<StringType>::Column(string_column(&values)),
+                Value::<StringType>::Scalar(pattern),
+                Value::<StringType>::Scalar("".to_string()),
+                &mut sparse_ctx,
+            );
+            let (Value::Column(dense), Value::Column(sparse)) = (dense, sparse) else {
+                unreachable!()
+            };
+
+            for (index, dense_result) in dense.iter().enumerate() {
+                prop_assert_eq!(sparse.get_bit(index), validity[index] && dense_result);
+            }
         }
     }
 

--- a/src/query/functions/src/scalars/comparison.rs
+++ b/src/query/functions/src/scalars/comparison.rs
@@ -2625,9 +2625,7 @@ mod tests {
         calls.store(0, AtomicOrdering::Relaxed);
         let result = like(
             Value::<StringType>::Scalar("prefix-abc-suffix".to_string()),
-            Value::<StringType>::Column(string_column(&[
-                "%a_c%", "%a_c%", "%z_z%", "%a_c%",
-            ])),
+            Value::<StringType>::Column(string_column(&["%a_c%", "%a_c%", "%z_z%", "%a_c%"])),
             escape.clone(),
             &mut ctx,
         );
@@ -2642,9 +2640,7 @@ mod tests {
                 "prefix-zzz-suffix",
                 "prefix-abc-suffix",
             ])),
-            Value::<StringType>::Column(string_column(&[
-                "%a_c%", "%a_c%", "%z_z%", "%a_c%",
-            ])),
+            Value::<StringType>::Column(string_column(&["%a_c%", "%a_c%", "%z_z%", "%a_c%"])),
             escape,
             &mut ctx,
         );

--- a/src/query/functions/tests/it/scalars/comparison.rs
+++ b/src/query/functions/tests/it/scalars/comparison.rs
@@ -557,6 +557,44 @@ fn test_like(file: &mut impl Write) {
         ("rhs", StringType::from_data(vec!["aA%", "aA%"])),
     ];
     run_ast(file, r#""ilike"(lhs, rhs, 'A')"#, &columns);
+
+    let columns = [
+        (
+            "cond",
+            BooleanType::from_data(vec![true, false, true, false, true, false]),
+        ),
+        (
+            "lhs",
+            StringType::from_data_with_validity(
+                vec!["alpha", "", "beta", "zeta", "", "omega"],
+                vec![true, false, true, true, false, true],
+            ),
+        ),
+    ];
+    run_ast(file, "if(cond, lhs like '%', not(lhs like '%'))", &columns);
+    run_ast(
+        file,
+        "not(if(cond, lhs like '%', not(lhs like '%')))",
+        &columns,
+    );
+    run_ast(
+        file,
+        "is_true(if(cond, lhs like '%', not(lhs like '%')))",
+        &columns,
+    );
+    run_ast(
+        file,
+        // The SQL binder lowers COALESCE(nullable, fallback) to this guarded form.
+        "if(is_not_null(if(cond, lhs like '%', not(lhs like '%'))), \
+         assume_not_null(if(cond, lhs like '%', not(lhs like '%'))), false)",
+        &columns,
+    );
+    run_ast(
+        file,
+        "if(cond, if(is_not_null(lhs like '%'), assume_not_null(lhs like '%'), false), \
+         is_true(not(lhs like '%')))",
+        &columns,
+    );
 }
 
 fn test_regexp(file: &mut impl Write) {

--- a/src/query/functions/tests/it/scalars/testdata/comparison.txt
+++ b/src/query/functions/tests/it/scalars/testdata/comparison.txt
@@ -1916,6 +1916,141 @@ evaluation (internal):
 +--------+--------------------------------+
 
 
+ast            : if(cond, lhs like '%', not(lhs like '%'))
+raw expr       : if(cond::Boolean, like(lhs::String NULL, '%'), not(like(lhs::String NULL, '%')))
+checked expr   : if<T0=Boolean NULL><Boolean NULL, T0, T0>(CAST<Boolean>(cond AS Boolean NULL), like<String NULL, String NULL>(lhs, CAST<String>("%" AS String NULL)), not<Boolean NULL>(like<String NULL, String NULL>(lhs, CAST<String>("%" AS String NULL))))
+optimized expr : if<T0=Boolean NULL><Boolean NULL, T0, T0>(CAST<Boolean>(cond AS Boolean NULL), like<String NULL, String NULL>(lhs, "%"), not<Boolean NULL>(like<String NULL, String NULL>(lhs, "%")))
+evaluation:
++--------+---------------+-----------------------------+------------------------+
+|        | cond          | lhs                         | Output                 |
++--------+---------------+-----------------------------+------------------------+
+| Type   | Boolean       | String NULL                 | Boolean NULL           |
+| Domain | {FALSE, TRUE} | {"alpha"..="zeta"} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | true          | 'alpha'                     | true                   |
+| Row 1  | false         | NULL                        | NULL                   |
+| Row 2  | true          | 'beta'                      | true                   |
+| Row 3  | false         | 'zeta'                      | false                  |
+| Row 4  | true          | NULL                        | NULL                   |
+| Row 5  | false         | 'omega'                     | false                  |
++--------+---------------+-----------------------------+------------------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                  |
++--------+-------------------------------------------------------------------------------------------------------+
+| cond   | Column(Boolean([0b__010101]))                                                                         |
+| lhs    | Column(NullableColumn { column: StringColumn[alpha, , beta, zeta, , omega], validity: [0b__101101] }) |
+| Output | NullableColumn { column: Boolean([0b__000101]), validity: [0b__101101] }                              |
++--------+-------------------------------------------------------------------------------------------------------+
+
+
+ast            : not(if(cond, lhs like '%', not(lhs like '%')))
+raw expr       : not(if(cond::Boolean, like(lhs::String NULL, '%'), not(like(lhs::String NULL, '%'))))
+checked expr   : not<Boolean NULL>(if<T0=Boolean NULL><Boolean NULL, T0, T0>(CAST<Boolean>(cond AS Boolean NULL), like<String NULL, String NULL>(lhs, CAST<String>("%" AS String NULL)), not<Boolean NULL>(like<String NULL, String NULL>(lhs, CAST<String>("%" AS String NULL)))))
+optimized expr : not<Boolean NULL>(if<T0=Boolean NULL><Boolean NULL, T0, T0>(CAST<Boolean>(cond AS Boolean NULL), like<String NULL, String NULL>(lhs, "%"), not<Boolean NULL>(like<String NULL, String NULL>(lhs, "%"))))
+evaluation:
++--------+---------------+-----------------------------+------------------------+
+|        | cond          | lhs                         | Output                 |
++--------+---------------+-----------------------------+------------------------+
+| Type   | Boolean       | String NULL                 | Boolean NULL           |
+| Domain | {FALSE, TRUE} | {"alpha"..="zeta"} ∪ {NULL} | {FALSE, TRUE} ∪ {NULL} |
+| Row 0  | true          | 'alpha'                     | false                  |
+| Row 1  | false         | NULL                        | NULL                   |
+| Row 2  | true          | 'beta'                      | false                  |
+| Row 3  | false         | 'zeta'                      | true                   |
+| Row 4  | true          | NULL                        | NULL                   |
+| Row 5  | false         | 'omega'                     | true                   |
++--------+---------------+-----------------------------+------------------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                  |
++--------+-------------------------------------------------------------------------------------------------------+
+| cond   | Column(Boolean([0b__010101]))                                                                         |
+| lhs    | Column(NullableColumn { column: StringColumn[alpha, , beta, zeta, , omega], validity: [0b__101101] }) |
+| Output | NullableColumn { column: Boolean([0b__111010]), validity: [0b__101101] }                              |
++--------+-------------------------------------------------------------------------------------------------------+
+
+
+ast            : is_true(if(cond, lhs like '%', not(lhs like '%')))
+raw expr       : is_true(if(cond::Boolean, like(lhs::String NULL, '%'), not(like(lhs::String NULL, '%'))))
+checked expr   : is_true<Boolean NULL>(if<T0=Boolean NULL><Boolean NULL, T0, T0>(CAST<Boolean>(cond AS Boolean NULL), like<String NULL, String NULL>(lhs, CAST<String>("%" AS String NULL)), not<Boolean NULL>(like<String NULL, String NULL>(lhs, CAST<String>("%" AS String NULL)))))
+optimized expr : is_true<Boolean NULL>(if<T0=Boolean NULL><Boolean NULL, T0, T0>(CAST<Boolean>(cond AS Boolean NULL), like<String NULL, String NULL>(lhs, "%"), not<Boolean NULL>(like<String NULL, String NULL>(lhs, "%"))))
+evaluation:
++--------+---------------+-----------------------------+---------------+
+|        | cond          | lhs                         | Output        |
++--------+---------------+-----------------------------+---------------+
+| Type   | Boolean       | String NULL                 | Boolean       |
+| Domain | {FALSE, TRUE} | {"alpha"..="zeta"} ∪ {NULL} | {FALSE, TRUE} |
+| Row 0  | true          | 'alpha'                     | true          |
+| Row 1  | false         | NULL                        | false         |
+| Row 2  | true          | 'beta'                      | true          |
+| Row 3  | false         | 'zeta'                      | false         |
+| Row 4  | true          | NULL                        | false         |
+| Row 5  | false         | 'omega'                     | false         |
++--------+---------------+-----------------------------+---------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                  |
++--------+-------------------------------------------------------------------------------------------------------+
+| cond   | Column(Boolean([0b__010101]))                                                                         |
+| lhs    | Column(NullableColumn { column: StringColumn[alpha, , beta, zeta, , omega], validity: [0b__101101] }) |
+| Output | Boolean([0b__000101])                                                                                 |
++--------+-------------------------------------------------------------------------------------------------------+
+
+
+ast            : if(is_not_null(if(cond, lhs like '%', not(lhs like '%'))), assume_not_null(if(cond, lhs like '%', not(lhs like '%'))), false)
+raw expr       : if(is_not_null(if(cond::Boolean, like(lhs::String NULL, '%'), not(like(lhs::String NULL, '%')))), assume_not_null(if(cond::Boolean, like(lhs::String NULL, '%'), not(like(lhs::String NULL, '%')))), false)
+checked expr   : if<T0=Boolean><Boolean NULL, T0, T0>(CAST<Boolean>(is_not_null<T0=Boolean><T0 NULL>(if<T0=Boolean NULL><Boolean NULL, T0, T0>(CAST<Boolean>(cond AS Boolean NULL), like<String NULL, String NULL>(lhs, CAST<String>("%" AS String NULL)), not<Boolean NULL>(like<String NULL, String NULL>(lhs, CAST<String>("%" AS String NULL))))) AS Boolean NULL), assume_not_null<T0=Boolean><T0 NULL>(if<T0=Boolean NULL><Boolean NULL, T0, T0>(CAST<Boolean>(cond AS Boolean NULL), like<String NULL, String NULL>(lhs, CAST<String>("%" AS String NULL)), not<Boolean NULL>(like<String NULL, String NULL>(lhs, CAST<String>("%" AS String NULL))))), false)
+optimized expr : if<T0=Boolean><Boolean NULL, T0, T0>(CAST<Boolean>(is_not_null<T0=Boolean><T0 NULL>(if<T0=Boolean NULL><Boolean NULL, T0, T0>(CAST<Boolean>(cond AS Boolean NULL), like<String NULL, String NULL>(lhs, "%"), not<Boolean NULL>(like<String NULL, String NULL>(lhs, "%")))) AS Boolean NULL), assume_not_null<T0=Boolean><T0 NULL>(if<T0=Boolean NULL><Boolean NULL, T0, T0>(CAST<Boolean>(cond AS Boolean NULL), like<String NULL, String NULL>(lhs, "%"), not<Boolean NULL>(like<String NULL, String NULL>(lhs, "%")))), false)
+evaluation:
++--------+---------------+-----------------------------+---------------+
+|        | cond          | lhs                         | Output        |
++--------+---------------+-----------------------------+---------------+
+| Type   | Boolean       | String NULL                 | Boolean       |
+| Domain | {FALSE, TRUE} | {"alpha"..="zeta"} ∪ {NULL} | {FALSE, TRUE} |
+| Row 0  | true          | 'alpha'                     | true          |
+| Row 1  | false         | NULL                        | false         |
+| Row 2  | true          | 'beta'                      | true          |
+| Row 3  | false         | 'zeta'                      | false         |
+| Row 4  | true          | NULL                        | false         |
+| Row 5  | false         | 'omega'                     | false         |
++--------+---------------+-----------------------------+---------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                  |
++--------+-------------------------------------------------------------------------------------------------------+
+| cond   | Column(Boolean([0b__010101]))                                                                         |
+| lhs    | Column(NullableColumn { column: StringColumn[alpha, , beta, zeta, , omega], validity: [0b__101101] }) |
+| Output | Boolean([0b__000101])                                                                                 |
++--------+-------------------------------------------------------------------------------------------------------+
+
+
+ast            : if(cond, if(is_not_null(lhs like '%'), assume_not_null(lhs like '%'), false), is_true(not(lhs like '%')))
+raw expr       : if(cond::Boolean, if(is_not_null(like(lhs::String NULL, '%')), assume_not_null(like(lhs::String NULL, '%')), false), is_true(not(like(lhs::String NULL, '%'))))
+checked expr   : if<T0=Boolean><Boolean NULL, T0, T0>(CAST<Boolean>(cond AS Boolean NULL), if<T0=Boolean><Boolean NULL, T0, T0>(CAST<Boolean>(is_not_null<T0=Boolean><T0 NULL>(like<String NULL, String NULL>(lhs, CAST<String>("%" AS String NULL))) AS Boolean NULL), assume_not_null<T0=Boolean><T0 NULL>(like<String NULL, String NULL>(lhs, CAST<String>("%" AS String NULL))), false), is_true<Boolean NULL>(not<Boolean NULL>(like<String NULL, String NULL>(lhs, CAST<String>("%" AS String NULL)))))
+optimized expr : if<T0=Boolean><Boolean NULL, T0, T0>(CAST<Boolean>(cond AS Boolean NULL), if<T0=Boolean><Boolean NULL, T0, T0>(CAST<Boolean>(is_not_null<T0=Boolean><T0 NULL>(like<String NULL, String NULL>(lhs, "%")) AS Boolean NULL), true, false), false)
+evaluation:
++--------+---------------+-----------------------------+---------------+
+|        | cond          | lhs                         | Output        |
++--------+---------------+-----------------------------+---------------+
+| Type   | Boolean       | String NULL                 | Boolean       |
+| Domain | {FALSE, TRUE} | {"alpha"..="zeta"} ∪ {NULL} | {FALSE, TRUE} |
+| Row 0  | true          | 'alpha'                     | true          |
+| Row 1  | false         | NULL                        | false         |
+| Row 2  | true          | 'beta'                      | true          |
+| Row 3  | false         | 'zeta'                      | false         |
+| Row 4  | true          | NULL                        | false         |
+| Row 5  | false         | 'omega'                     | false         |
++--------+---------------+-----------------------------+---------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------------------------------------+
+| Column | Data                                                                                                  |
++--------+-------------------------------------------------------------------------------------------------------+
+| cond   | Column(Boolean([0b__010101]))                                                                         |
+| lhs    | Column(NullableColumn { column: StringColumn[alpha, , beta, zeta, , omega], validity: [0b__101101] }) |
+| Output | Boolean([0b__000101])                                                                                 |
++--------+-------------------------------------------------------------------------------------------------------+
+
+
 ast            : lhs regexp rhs
 raw expr       : regexp(lhs::String, rhs::String)
 checked expr   : regexp<String, String>(lhs, rhs)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

`AND` evaluation passes rows selected by earlier predicates through `EvalContext.validity`. The
custom vectorized string `LIKE` implementation ignored this bitmap and still ran the matcher for
every row in the input column. This is especially expensive when FUSE Parquet Prewhere combines a
selective predicate with one or more LIKE predicates.

For example:

```sql
SELECT event_time, payload
FROM benchmark_events
WHERE worker = 'worker-7'
  AND payload NOT LIKE '%absent_token%'
  AND category NOT LIKE '%controller.module%'
ORDER BY event_time DESC
LIMIT 50;
```

If `worker = 'worker-7'` selects 1/64 of the rows, the two LIKE predicates previously still
processed the complete columns. They now process only rows whose validity bit is true.

The change covers `column LIKE scalar`, `scalar LIKE column`, and `column LIKE column`. It keeps the
existing full-column path when validity is absent or all true, and retains the specialized
`%literal%` substring search path.

On an S3-backed synthetic FUSE table with 10 million rows and approximately 2 KiB strings, the
query above improved from a 13.50 s median to 1.60-1.74 s with default settings. Both plans read the
same 10 million rows; LIKE evaluations dropped from 10 million to 156,250 per predicate. Aggregate
results and the Top-50 result fingerprint were identical before and after the change.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [x] Benchmark Test
- [ ] No Test - _Explain why_

Added tests for:

- sparse validity across all three vector argument shapes;
- matcher call counts for inactive rows;
- all-true validity and the specialized substring path;
- 128 property-test cases comparing sparse and full evaluation for active rows.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20211)
<!-- Reviewable:end -->
