### PR TITLE
fix(query): distinguish proven-empty plans from zero estimates

### DIFF
--- a/src/query/sql/src/planner/optimizer/ir/stats/constraint.rs
+++ b/src/query/sql/src/planner/optimizer/ir/stats/constraint.rs
@@ -65,14 +65,10 @@ impl ValueConstraint {
                 column_stat.set_null_count(StatCount::exact(0));
             }
             ValueConstraint::Eq(datum) => {
-                if column_stat
-                    .bounds()
-                    .is_some_and(|bounds| bounds.contains_datum(datum))
-                {
-                    *column_stat = ColumnStat::from_const(datum.clone());
-                } else {
-                    clear_for_empty_result(column_stat);
-                }
+                // The stored range may be stale. Every surviving row still
+                // equals the predicate value, so record that exact output fact
+                // without treating an old disjoint range as proof of emptiness.
+                *column_stat = ColumnStat::from_const(datum.clone());
             }
             ValueConstraint::NotEq => {}
             ValueConstraint::Range { lower, upper } => {
@@ -80,19 +76,32 @@ impl ValueConstraint {
                     clear_for_empty_result(column_stat);
                     return Ok(());
                 };
-                let bounds = bounds.restrict_by_range(lower, upper);
-                match bounds {
-                    StatRangeBounds::Bounds(bounds) => {
-                        apply_range_bounds(column_stat, bounds)?;
-                    }
-                    StatRangeBounds::Empty => {
-                        clear_for_empty_result(column_stat);
-                    }
-                    StatRangeBounds::Imprecise => {}
+                match bounds.restrict_by_range(lower, upper) {
+                    StatRangeBounds::Bounds(bounds) => apply_range_bounds(column_stat, bounds)?,
+                    // A disjoint stored range may be stale. There is no safe
+                    // non-empty range refinement, so retain the coarse input
+                    // statistics instead of manufacturing an empty result.
+                    StatRangeBounds::Empty | StatRangeBounds::Imprecise => {}
                 }
             }
         }
         Ok(())
+    }
+
+    pub(super) fn is_disjoint_from(&self, column_stat: &ColumnStat) -> bool {
+        let Some(bounds) = column_stat.bounds() else {
+            return true;
+        };
+        match self {
+            ValueConstraint::Eq(datum) => !bounds.contains_datum(datum),
+            ValueConstraint::Range { lower, upper } => {
+                matches!(
+                    bounds.restrict_by_range(lower, upper),
+                    StatRangeBounds::Empty
+                )
+            }
+            ValueConstraint::NotEq | ValueConstraint::NotNull => false,
+        }
     }
 
     pub(super) fn apply_all(

--- a/src/query/sql/src/planner/optimizer/ir/stats/join.rs
+++ b/src/query/sql/src/planner/optimizer/ir/stats/join.rs
@@ -420,8 +420,42 @@ impl JoinStatsEstimator {
     pub(crate) fn finish(self) -> Result<Arc<StatInfo>> {
         let mut stats = self.finish_join_stats()?;
         let output_rows = stats.output_rows;
-        let column_stats = if output_rows == 0.0 {
+        let left_proven_empty = self.left_input.statistics.precise_cardinality == Some(0);
+        let right_proven_empty = self.right_input.statistics.precise_cardinality == Some(0);
+        let proven_empty = match self.join_type {
+            JoinType::Inner
+            | JoinType::InnerAny
+            | JoinType::Asof
+            | JoinType::Cross
+            | JoinType::LeftSemi
+            | JoinType::RightSemi => left_proven_empty || right_proven_empty,
+            JoinType::Left
+            | JoinType::LeftAny
+            | JoinType::LeftSingle
+            | JoinType::RightMark
+            | JoinType::LeftAnti => left_proven_empty,
+            JoinType::Right
+            | JoinType::RightAny
+            | JoinType::RightSingle
+            | JoinType::LeftMark
+            | JoinType::RightAnti => right_proven_empty,
+            // ASOF plans swap their logical children.
+            JoinType::LeftAsof => right_proven_empty,
+            JoinType::RightAsof => left_proven_empty,
+            JoinType::Full | JoinType::FullAsof => left_proven_empty && right_proven_empty,
+        };
+        let column_stats = if proven_empty {
             HashMap::new()
+        } else if output_rows == 0.0 {
+            // Potentially stale distributions can estimate zero without proving
+            // emptiness. Preserve them for downstream estimation in that case.
+            self.left_input
+                .statistics
+                .column_stats
+                .iter()
+                .chain(&self.right_input.statistics.column_stats)
+                .map(|(column, stat)| (*column, stat.clone()))
+                .collect()
         } else {
             std::iter::chain(
                 stats.output_column_stats(&self.left_input.statistics.column_stats, Side::Left)?,
@@ -433,7 +467,7 @@ impl JoinStatsEstimator {
         Ok(Arc::new(StatInfo {
             cardinality: output_rows,
             statistics: Statistics {
-                precise_cardinality: None,
+                precise_cardinality: proven_empty.then_some(0),
                 column_stats,
                 top_n: Default::default(),
                 count_min_sketch: Default::default(),

--- a/src/query/sql/src/planner/optimizer/ir/stats/selectivity.rs
+++ b/src/query/sql/src/planner/optimizer/ir/stats/selectivity.rs
@@ -22,6 +22,7 @@ use databend_common_expression::ConstantFolder;
 use databend_common_expression::Domain;
 use databend_common_expression::Expr;
 use databend_common_expression::FunctionContext;
+use databend_common_expression::FunctionRegistry;
 use databend_common_expression::Scalar;
 use databend_common_expression::StatEvaluator;
 use databend_common_expression::stat_distribution::ArgStat;
@@ -68,6 +69,7 @@ pub struct SelectivityEstimator {
     top_n: TopNSet,
     count_min_sketch: CountMinSketchSet,
     overrides: ColumnStatSet,
+    proven_empty: bool,
 }
 
 impl SelectivityEstimator {
@@ -78,6 +80,7 @@ impl SelectivityEstimator {
             top_n: TopNSet::new(),
             count_min_sketch: CountMinSketchSet::new(),
             overrides: ColumnStatSet::new(),
+            proven_empty: cardinality == StatCardinality::Exact(0),
         }
     }
 
@@ -89,6 +92,13 @@ impl SelectivityEstimator {
     pub fn with_count_min_sketch(mut self, count_min_sketch: CountMinSketchSet) -> Self {
         self.count_min_sketch = count_min_sketch;
         self
+    }
+
+    /// Returns true when the predicates deterministically produce no rows.
+    ///
+    /// This is deliberately stronger than an estimated cardinality of zero.
+    pub fn is_proven_empty(&self) -> bool {
+        self.proven_empty
     }
 
     fn merged_column_stats(&self) -> ColumnStatSet {
@@ -127,8 +137,9 @@ impl SelectivityEstimator {
             }),
         };
         let expr = scalar_expr.as_expr()?;
-        let input_domains = self.build_input_domains(&expr)?;
-        let (expr, output_domain) = ConstantFolder::fold_with_domain(
+        let input_domains =
+            build_constraint_domains(&expr, &self.column_stats, self.cardinality, None)?;
+        let (expr, output_domain) = fold_for_proven_empty(
             Cow::Owned(expr),
             &input_domains,
             func_ctx,
@@ -143,6 +154,7 @@ impl SelectivityEstimator {
             return match constant_filter_truthiness(&constant.scalar) {
                 Some(true) => Ok(self.cardinality.value()),
                 Some(false) => {
+                    self.proven_empty = true;
                     self.clear_column_stats_for_empty_result();
                     Ok(0.0)
                 }
@@ -163,6 +175,10 @@ impl SelectivityEstimator {
             }) => !domain.has_true,
             _ => false,
         }) {
+            // These domains contain only type constraints and exact all-null
+            // facts, so an expression with no true result is deterministically
+            // false for every input row.
+            self.proven_empty = true;
             self.clear_column_stats_for_empty_result();
             return Ok(0.0);
         }
@@ -193,13 +209,6 @@ impl SelectivityEstimator {
         Ok(output_cardinality)
     }
 
-    fn build_input_domains(
-        &self,
-        expr: &Expr<ColumnBinding>,
-    ) -> Result<HashMap<ColumnBinding, Domain>> {
-        build_input_domains(expr, &self.column_stats)
-    }
-
     fn clear_column_stats_for_empty_result(&mut self) {
         for (index, column_stat) in &self.column_stats {
             let mut column_stat = column_stat.clone();
@@ -219,6 +228,7 @@ impl SelectivityEstimator {
             Selectivity::Unknown => DEFAULT_SELECTIVITY,
             Selectivity::LowerBound => UNKNOWN_COL_STATS_FILTER_SEL_LOWER_BOUND,
             Selectivity::Zero => {
+                self.proven_empty = true;
                 self.clear_column_stats_for_empty_result();
                 return 0.0;
             }
@@ -377,41 +387,39 @@ impl SelectivityEstimator {
     }
 }
 
-fn build_input_domains(
+// Domains used for deterministic folding must not inherit potentially stale
+// min/max or NDV bounds. Only type constraints and exact all-NULL inputs prove
+// predicate truth. Join residuals express side-local null counts in pair rows.
+fn build_constraint_domains(
     expr: &Expr<ColumnBinding>,
     column_stats: &ColumnStatSet,
+    cardinality: StatCardinality,
+    column_row_scales: Option<&HashMap<Symbol, StatCardinality>>,
 ) -> Result<HashMap<ColumnBinding, Domain>> {
     expr.column_refs()
         .into_iter()
         .map(|(binding, data_type)| {
-            let Some(column_stat) = column_stats.get(&binding.index) else {
-                return Ok((binding, Domain::full(&data_type)));
-            };
-
-            if !matches!(
-                data_type.remove_nullable(),
-                DataType::Boolean
-                    | DataType::String
-                    | DataType::Number(_)
-                    | DataType::Decimal(_)
-                    | DataType::Date
-                    | DataType::Timestamp
-            ) {
-                return Ok((binding, Domain::full(&data_type)));
+            let scale = column_row_scales
+                .and_then(|scales| scales.get(&binding.index))
+                .copied()
+                .unwrap_or_else(|| StatCardinality::exact(1));
+            if matches!(data_type, DataType::Nullable(_))
+                && let StatCardinality::Exact(cardinality) = cardinality
+                && let StatCardinality::Exact(scale) = scale
+                && let Some(ColumnStat::AllNull {
+                    null_count: StatCount::Exact(null_count),
+                }) = column_stats.get(&binding.index)
+                && null_count.checked_mul(scale) == Some(cardinality)
+            {
+                return Ok((
+                    binding,
+                    Domain::Nullable(NullableDomain {
+                        has_null: true,
+                        value: None,
+                    }),
+                ));
             }
-
-            match column_stat.to_arg_stat(&data_type) {
-                Ok(arg_stat) => Ok((binding, arg_stat.domain)),
-                Err(msg) => {
-                    log::warn!(
-                        data_type:?,
-                        column_stat:?,
-                        msg;
-                        "Failed to build input domain"
-                    );
-                    Ok((binding, Domain::full(&data_type)))
-                }
-            }
+            Ok((binding, Domain::full(&data_type)))
         })
         .collect()
 }
@@ -551,6 +559,158 @@ fn deterministic_folded_selectivity(
     }
 }
 
+fn fold_for_proven_empty<'e>(
+    expr: Cow<'e, Expr<ColumnBinding>>,
+    input_domains: &HashMap<ColumnBinding, Domain>,
+    func_ctx: &FunctionContext,
+    fn_registry: &FunctionRegistry,
+) -> (Cow<'e, Expr<ColumnBinding>>, Option<Domain>) {
+    if !contains_modulo(expr.as_ref()) {
+        return ConstantFolder::fold_with_domain(expr, input_domains, func_ctx, fn_registry);
+    }
+
+    let Cow::Owned(Expr::FunctionCall(mut call)) = expr else {
+        return (expr, None);
+    };
+    if !matches!(
+        call.function.signature.name.as_str(),
+        "and_filters" | "or_filters"
+    ) {
+        return (Cow::Owned(Expr::FunctionCall(call)), None);
+    }
+
+    let is_or = call.function.signature.name == "or_filters";
+    let args = std::mem::take(&mut call.args);
+    let mut folded_args = Vec::with_capacity(args.len());
+    let mut safe_segment = Vec::new();
+    let mut blocked_seen = false;
+
+    for arg in args {
+        if !contains_modulo(&arg) {
+            safe_segment.push(arg);
+            continue;
+        }
+
+        if let Some(result) = flush_safe_filter_segment(
+            &call,
+            &mut safe_segment,
+            &mut folded_args,
+            blocked_seen,
+            is_or,
+            input_domains,
+            func_ctx,
+            fn_registry,
+        ) {
+            return result;
+        }
+
+        let (arg, _) = fold_for_proven_empty(Cow::Owned(arg), input_domains, func_ctx, fn_registry);
+        folded_args.push(arg.into_owned());
+        blocked_seen = true;
+    }
+
+    flush_safe_filter_segment(
+        &call,
+        &mut safe_segment,
+        &mut folded_args,
+        blocked_seen,
+        is_or,
+        input_domains,
+        func_ctx,
+        fn_registry,
+    );
+
+    call.args = folded_args;
+    (Cow::Owned(Expr::FunctionCall(call)), None)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn flush_safe_filter_segment<'e>(
+    call: &databend_common_expression::FunctionCall<ColumnBinding>,
+    safe_segment: &mut Vec<Expr<ColumnBinding>>,
+    folded_args: &mut Vec<Expr<ColumnBinding>>,
+    blocked_seen: bool,
+    is_or: bool,
+    input_domains: &HashMap<ColumnBinding, Domain>,
+    func_ctx: &FunctionContext,
+    fn_registry: &FunctionRegistry,
+) -> Option<(Cow<'e, Expr<ColumnBinding>>, Option<Domain>)> {
+    if safe_segment.is_empty() {
+        return None;
+    }
+
+    let segment = fold_filter_segment(
+        call,
+        std::mem::take(safe_segment),
+        input_domains,
+        func_ctx,
+        fn_registry,
+    );
+    if is_decisive_filter_constant(&segment, is_or) && !blocked_seen {
+        return Some((
+            Cow::Owned(Expr::Constant(Constant {
+                span: call.span,
+                scalar: Scalar::Boolean(is_or),
+                data_type: DataType::Boolean,
+            })),
+            None,
+        ));
+    }
+    folded_args.push(segment);
+    None
+}
+
+fn fold_filter_segment(
+    call: &databend_common_expression::FunctionCall<ColumnBinding>,
+    mut args: Vec<Expr<ColumnBinding>>,
+    input_domains: &HashMap<ColumnBinding, Domain>,
+    func_ctx: &FunctionContext,
+    fn_registry: &FunctionRegistry,
+) -> Expr<ColumnBinding> {
+    if args.len() == 1 {
+        return ConstantFolder::fold_with_domain(
+            Cow::Owned(args.pop().unwrap()),
+            input_domains,
+            func_ctx,
+            fn_registry,
+        )
+        .0
+        .into_owned();
+    }
+
+    let mut segment_call = call.clone();
+    segment_call.args = args;
+    ConstantFolder::fold_with_domain(
+        Cow::Owned(Expr::FunctionCall(segment_call)),
+        input_domains,
+        func_ctx,
+        fn_registry,
+    )
+    .0
+    .into_owned()
+}
+
+fn is_decisive_filter_constant(expr: &Expr<ColumnBinding>, is_or: bool) -> bool {
+    matches!(
+        expr,
+        Expr::Constant(Constant {
+            scalar: Scalar::Boolean(value),
+            ..
+        }) if *value == is_or
+    )
+}
+
+fn contains_modulo(expr: &Expr<ColumnBinding>) -> bool {
+    match expr {
+        Expr::Constant(_) | Expr::ColumnRef(_) => false,
+        Expr::Cast(cast) => contains_modulo(&cast.expr),
+        Expr::FunctionCall(call) => {
+            call.function.signature.name == "modulo" || call.args.iter().any(contains_modulo)
+        }
+        Expr::LambdaFunctionCall(call) => call.args.iter().any(contains_modulo),
+    }
+}
+
 // SelectivityVisitor consumes the expression after ConstantFolder has applied
 // expression/domain reasoning. Deterministic predicate truth, boolean
 // short-circuiting, and contradictions visible from input domains should already
@@ -613,6 +773,13 @@ impl ValueConstraintState {
         if !column_stats.contains_key(&index) {
             return Ok(());
         }
+        if matches!(constraint, ValueConstraint::Range { .. })
+            && constraint.is_disjoint_from(&column_stats[&index])
+        {
+            // A range that misses stored bounds may match newer data. Do not
+            // materialize the stale contradiction into output statistics.
+            return Ok(());
+        }
         let mut constraints = self.pending.get(&index).cloned().unwrap_or_default();
         constraints.push(constraint);
         self.pending.insert(index, constraints);
@@ -650,6 +817,12 @@ type ExprCall = databend_common_expression::FunctionCall<ColumnBinding>;
 
 impl Selectivity {
     fn checked_estimate(value: f64) -> Result<Self> {
+        // Column distributions are estimates and may lag behind appended data.
+        // Reserve exact zero for expression-local facts and exact constraints;
+        // a statistics-derived zero falls back to the unknown-filter heuristic.
+        if value == 0.0 {
+            return Ok(Selectivity::Unknown);
+        }
         if value.is_finite() && (0.0..=1.0).contains(&value) {
             return Ok(Selectivity::N(value));
         }
@@ -694,15 +867,16 @@ impl SelectivityVisitor<'_> {
         column_row_scales: &HashMap<Symbol, StatCardinality>,
         func_ctx: &FunctionContext,
     ) -> Result<Selectivity> {
-        if cardinality.is_zero() {
+        if cardinality == StatCardinality::Exact(0) {
             return Ok(Selectivity::Zero);
         }
         let expr = predicate.as_expr()?;
-        // This direct visitor entry is used for Join residuals, which do not pass through
-        // SelectivityEstimator::apply. Fold here so domain contradictions and tautologies retain
-        // their deterministic Zero/All semantics instead of becoming probability estimates.
-        let input_domains = build_input_domains(&expr, column_stats)?;
-        let (expr, output_domain) = ConstantFolder::fold_with_domain(
+        // Join residuals bypass SelectivityEstimator::apply, but must use the
+        // same proof domains and modulo safeguards. Zero/All here are consumed
+        // as confirmed matches by JoinStatsEstimator, not just numeric estimates.
+        let input_domains =
+            build_constraint_domains(&expr, column_stats, cardinality, Some(column_row_scales))?;
+        let (expr, output_domain) = fold_for_proven_empty(
             Cow::Owned(expr),
             &input_domains,
             func_ctx,
@@ -885,6 +1059,8 @@ impl SelectivityVisitor<'_> {
                 let Some(const_datum) = constant.scalar.clone().to_datum() else {
                     return self.derive_function_selectivity(func);
                 };
+                let constraint = ValueConstraint::from_comparison(op, const_datum.clone());
+                let disjoint_from_stored_range = constraint.is_disjoint_from(column_stat);
 
                 let histogram_is_range_distorted = column_stat
                     .histogram()
@@ -894,17 +1070,17 @@ impl SelectivityVisitor<'_> {
                     ComparisonOp::GT | ComparisonOp::GTE | ComparisonOp::LT | ComparisonOp::LTE
                 ) && histogram_is_range_distorted;
                 if matches!(self.constraint_context, ConstraintContext::And) {
-                    self.constraints.add(
-                        self.column_stats,
-                        column_index,
-                        ValueConstraint::from_comparison(op, const_datum.clone()),
-                    )?;
+                    self.constraints
+                        .add(self.column_stats, column_index, constraint)?;
                     if let Some(selectivity) = self.derive_frequency_equality_selectivity(
                         column_index,
                         op,
                         &constant.scalar,
                     )? {
                         return Ok(selectivity);
+                    }
+                    if disjoint_from_stored_range {
+                        return Ok(Selectivity::Unknown);
                     }
                     if distorted_range {
                         return Ok(Selectivity::LowerBound);
@@ -1230,6 +1406,7 @@ impl SelectivityVisitor<'_> {
                 let mut has_lower_bound = false;
                 let mut has_zero = false;
                 let mut has_n = false;
+                let mut error_sensitive_seen = false;
                 let mut acc = 1.0_f64;
                 for arg in &func.args {
                     let mut sub_visitor = self.spawn_child(ConstraintContext::And);
@@ -1242,10 +1419,11 @@ impl SelectivityVisitor<'_> {
                     match selectivity {
                         Selectivity::Unknown => has_unknown = true,
                         Selectivity::LowerBound => has_lower_bound = true,
-                        Selectivity::Zero => {
+                        Selectivity::Zero if !error_sensitive_seen => {
                             has_zero = true;
                             acc = 0.0;
                         }
+                        Selectivity::Zero => {}
                         Selectivity::All => {}
                         Selectivity::N(n) => {
                             has_n = true;
@@ -1260,6 +1438,7 @@ impl SelectivityVisitor<'_> {
                             acc = acc.min(n);
                         }
                     }
+                    error_sensitive_seen |= contains_modulo(arg);
                     self.constraints = constraints;
                 }
 
@@ -1372,4 +1551,117 @@ fn boolean_comparison_selectivity(op: ComparisonOp, constant: bool) -> Selectivi
         (ComparisonOp::GTE, false) | (ComparisonOp::LTE, true) => MAX_SELECTIVITY,
     };
     Selectivity::N(selectivity)
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_expression::types::NumberDataType;
+    use databend_common_expression::types::NumberScalar;
+
+    use super::*;
+    use crate::ColumnBindingBuilder;
+    use crate::Visibility;
+    use crate::plans::BoundColumnRef;
+    use crate::plans::ConstantExpr;
+
+    #[test]
+    fn join_residuals_distinguish_estimates_from_proofs() -> Result<()> {
+        let index = Symbol::new(0);
+        let column = ScalarExpr::BoundColumnRef(BoundColumnRef {
+            span: None,
+            column: ColumnBindingBuilder::new(
+                "k".to_string(),
+                index,
+                Box::new(DataType::Nullable(Box::new(DataType::Number(
+                    NumberDataType::UInt64,
+                )))),
+                Visibility::Visible,
+            )
+            .build(),
+        });
+        let predicate = ScalarExpr::FunctionCall(FunctionCall {
+            span: None,
+            func_name: "gt".to_string(),
+            params: vec![],
+            arguments: vec![
+                column.clone(),
+                ScalarExpr::ConstantExpr(ConstantExpr {
+                    span: None,
+                    value: Scalar::Number(NumberScalar::UInt64(10)),
+                }),
+            ],
+            return_type: Box::new(DataType::Nullable(Box::new(DataType::Boolean))),
+        });
+        let stats = ColumnStatSet::from_iter([(index, ColumnStat::UInt {
+            min: 0,
+            max: 5,
+            ndv: NdvEstimate::exact(6.0),
+            null_count: StatCount::exact(0),
+            histogram: None,
+        })]);
+        let estimate = |predicate: &ScalarExpr,
+                        cardinality,
+                        stats: &ColumnStatSet,
+                        scales: &HashMap<Symbol, StatCardinality>| {
+            SelectivityVisitor::estimate(
+                predicate,
+                cardinality,
+                stats,
+                &TopNSet::new(),
+                &CountMinSketchSet::new(),
+                scales,
+                &FunctionContext::default(),
+            )
+        };
+        assert!(matches!(
+            estimate(
+                &predicate,
+                StatCardinality::exact(80),
+                &stats,
+                &HashMap::new()
+            )?,
+            Selectivity::Unknown
+        ));
+        // A numeric zero input cannot upgrade a statistical predicate to a proof.
+        assert!(!matches!(
+            estimate(
+                &predicate,
+                StatCardinality::estimate(0.0),
+                &stats,
+                &HashMap::new()
+            )?,
+            Selectivity::Zero
+        ));
+        assert!(matches!(
+            estimate(
+                &predicate,
+                StatCardinality::exact(0),
+                &stats,
+                &HashMap::new()
+            )?,
+            Selectivity::Zero
+        ));
+
+        let not_null = ScalarExpr::FunctionCall(FunctionCall {
+            span: None,
+            func_name: "is_not_null".to_string(),
+            params: vec![],
+            arguments: vec![column],
+            return_type: Box::new(DataType::Boolean),
+        });
+        let stats = ColumnStatSet::from_iter([(index, ColumnStat::AllNull {
+            null_count: StatCount::exact(8),
+        })]);
+        let scales = HashMap::from([(index, StatCardinality::exact(10))]);
+        assert!(matches!(
+            estimate(&not_null, StatCardinality::exact(80), &stats, &scales)?,
+            Selectivity::Zero
+        ));
+        let scales = HashMap::from([(index, StatCardinality::estimate(10.0))]);
+        assert!(!matches!(
+            estimate(&not_null, StatCardinality::estimate(80.0), &stats, &scales)?,
+            Selectivity::Zero
+        ));
+        Ok(())
+    }
 }

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_commute_join.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_commute_join.rs
@@ -19,6 +19,7 @@ use databend_common_exception::Result;
 use crate::optimizer::ir::Matcher;
 use crate::optimizer::ir::RelExpr;
 use crate::optimizer::ir::SExpr;
+use crate::optimizer::ir::StatInfo;
 use crate::optimizer::optimizers::rule::Rule;
 use crate::optimizer::optimizers::rule::RuleID;
 use crate::optimizer::optimizers::rule::TransformResult;
@@ -30,6 +31,45 @@ use crate::plans::RelOperator;
 fn contains_recursive_cte(expr: &SExpr) -> bool {
     matches!(expr.plan(), RelOperator::RecursiveCteScan(_))
         || expr.children().any(contains_recursive_cte)
+}
+
+fn should_commute(join_type: JoinType, left: &StatInfo, right: &StatInfo) -> bool {
+    if left.cardinality < right.cardinality {
+        return matches!(
+            join_type,
+            JoinType::Inner
+                | JoinType::Cross
+                | JoinType::Left
+                | JoinType::Right
+                | JoinType::LeftSingle
+                | JoinType::RightSingle
+                | JoinType::LeftSemi
+                | JoinType::RightSemi
+                | JoinType::LeftAnti
+                | JoinType::RightAnti
+                | JoinType::LeftMark
+                | JoinType::RightMark
+        );
+    }
+
+    if left.cardinality != right.cardinality {
+        return false;
+    }
+
+    if left.cardinality == 0.0 && matches!(join_type, JoinType::Left | JoinType::Right) {
+        let left_proven_empty = left.statistics.precise_cardinality == Some(0);
+        let right_proven_empty = right.statistics.precise_cardinality == Some(0);
+        if left_proven_empty != right_proven_empty {
+            // The right child is the hash-build side. Prefer the input that is
+            // known to be empty over one whose zero cardinality is only estimated.
+            return left_proven_empty;
+        }
+    }
+
+    matches!(
+        join_type,
+        JoinType::Right | JoinType::RightSingle | JoinType::RightSemi | JoinType::RightAnti
+    )
 }
 
 /// Rule to apply commutativity of join operator.
@@ -79,33 +119,9 @@ impl Rule for RuleCommuteJoin {
 
         let left_rel_expr = RelExpr::with_s_expr(left_child);
         let right_rel_expr = RelExpr::with_s_expr(right_child);
-        let left_card = left_rel_expr.derive_cardinality()?.cardinality;
-        let right_card = right_rel_expr.derive_cardinality()?.cardinality;
-
-        let need_commute = if left_card < right_card {
-            matches!(
-                join.join_type,
-                JoinType::Inner
-                    | JoinType::Cross
-                    | JoinType::Left
-                    | JoinType::Right
-                    | JoinType::LeftSingle
-                    | JoinType::RightSingle
-                    | JoinType::LeftSemi
-                    | JoinType::RightSemi
-                    | JoinType::LeftAnti
-                    | JoinType::RightAnti
-                    | JoinType::LeftMark
-                    | JoinType::RightMark
-            )
-        } else if left_card == right_card {
-            matches!(
-                join.join_type,
-                JoinType::Right | JoinType::RightSingle | JoinType::RightSemi | JoinType::RightAnti
-            )
-        } else {
-            false
-        };
+        let left_stat = left_rel_expr.derive_cardinality()?;
+        let right_stat = right_rel_expr.derive_cardinality()?;
+        let need_commute = should_commute(join.join_type, &left_stat, &right_stat);
         if need_commute {
             // Swap the join conditions side
             for condition in join.equi_conditions.iter_mut() {
@@ -133,5 +149,59 @@ impl Rule for RuleCommuteJoin {
 impl Default for RuleCommuteJoin {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::optimizer::ir::Statistics;
+
+    fn empty_stat(precise: bool) -> StatInfo {
+        StatInfo {
+            cardinality: 0.0,
+            statistics: Statistics {
+                precise_cardinality: precise.then_some(0),
+                column_stats: Default::default(),
+                top_n: Default::default(),
+                count_min_sketch: Default::default(),
+            },
+        }
+    }
+
+    #[test]
+    fn test_outer_join_zero_tie_prefers_proven_empty_build_side() {
+        let proven_empty = empty_stat(true);
+        let estimated_empty = empty_stat(false);
+
+        assert!(should_commute(
+            JoinType::Left,
+            &proven_empty,
+            &estimated_empty
+        ));
+        assert!(!should_commute(
+            JoinType::Left,
+            &estimated_empty,
+            &proven_empty
+        ));
+        assert!(should_commute(
+            JoinType::Right,
+            &proven_empty,
+            &estimated_empty
+        ));
+        assert!(!should_commute(
+            JoinType::Right,
+            &estimated_empty,
+            &proven_empty
+        ));
+    }
+
+    #[test]
+    fn test_outer_join_zero_tie_preserves_existing_canonicalization() {
+        let left = empty_stat(false);
+        let right = empty_stat(false);
+
+        assert!(!should_commute(JoinType::Left, &left, &right));
+        assert!(should_commute(JoinType::Right, &left, &right));
     }
 }

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_commute_join.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/rule_commute_join.rs
@@ -20,6 +20,7 @@ use crate::optimizer::ir::Matcher;
 use crate::optimizer::ir::RelExpr;
 use crate::optimizer::ir::SExpr;
 use crate::optimizer::ir::StatContext;
+use crate::optimizer::ir::StatInfo;
 use crate::optimizer::optimizers::rule::Rule;
 use crate::optimizer::optimizers::rule::RuleID;
 use crate::optimizer::optimizers::rule::TransformResult;
@@ -31,6 +32,45 @@ use crate::plans::RelOperator;
 fn contains_recursive_cte(expr: &SExpr) -> bool {
     matches!(expr.plan(), RelOperator::RecursiveCteScan(_))
         || expr.children().any(contains_recursive_cte)
+}
+
+fn should_commute(join_type: JoinType, left: &StatInfo, right: &StatInfo) -> bool {
+    if left.cardinality < right.cardinality {
+        return matches!(
+            join_type,
+            JoinType::Inner
+                | JoinType::Cross
+                | JoinType::Left
+                | JoinType::Right
+                | JoinType::LeftSingle
+                | JoinType::RightSingle
+                | JoinType::LeftSemi
+                | JoinType::RightSemi
+                | JoinType::LeftAnti
+                | JoinType::RightAnti
+                | JoinType::LeftMark
+                | JoinType::RightMark
+        );
+    }
+
+    if left.cardinality != right.cardinality {
+        return false;
+    }
+
+    if left.cardinality == 0.0 && matches!(join_type, JoinType::Left | JoinType::Right) {
+        let left_proven_empty = left.statistics.precise_cardinality == Some(0);
+        let right_proven_empty = right.statistics.precise_cardinality == Some(0);
+        if left_proven_empty != right_proven_empty {
+            // The right child is the hash-build side. Prefer the input that is
+            // known to be empty over one whose zero cardinality is only estimated.
+            return left_proven_empty;
+        }
+    }
+
+    matches!(
+        join_type,
+        JoinType::Right | JoinType::RightSingle | JoinType::RightSemi | JoinType::RightAnti
+    )
 }
 
 /// Rule to apply commutativity of join operator.
@@ -82,37 +122,9 @@ impl Rule for RuleCommuteJoin {
 
         let left_rel_expr = RelExpr::with_s_expr(left_child);
         let right_rel_expr = RelExpr::with_s_expr(right_child);
-        let left_card = left_rel_expr
-            .derive_cardinality(&self.stat_context)?
-            .cardinality;
-        let right_card = right_rel_expr
-            .derive_cardinality(&self.stat_context)?
-            .cardinality;
-
-        let need_commute = if left_card < right_card {
-            matches!(
-                join.join_type,
-                JoinType::Inner
-                    | JoinType::Cross
-                    | JoinType::Left
-                    | JoinType::Right
-                    | JoinType::LeftSingle
-                    | JoinType::RightSingle
-                    | JoinType::LeftSemi
-                    | JoinType::RightSemi
-                    | JoinType::LeftAnti
-                    | JoinType::RightAnti
-                    | JoinType::LeftMark
-                    | JoinType::RightMark
-            )
-        } else if left_card == right_card {
-            matches!(
-                join.join_type,
-                JoinType::Right | JoinType::RightSingle | JoinType::RightSemi | JoinType::RightAnti
-            )
-        } else {
-            false
-        };
+        let left_stat = left_rel_expr.derive_cardinality(&self.stat_context)?;
+        let right_stat = right_rel_expr.derive_cardinality(&self.stat_context)?;
+        let need_commute = should_commute(join.join_type, &left_stat, &right_stat);
         if need_commute {
             // Swap the join conditions side
             for condition in join.equi_conditions.iter_mut() {
@@ -140,5 +152,59 @@ impl Rule for RuleCommuteJoin {
 impl Default for RuleCommuteJoin {
     fn default() -> Self {
         Self::new(StatContext::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::optimizer::ir::Statistics;
+
+    fn empty_stat(precise: bool) -> StatInfo {
+        StatInfo {
+            cardinality: 0.0,
+            statistics: Statistics {
+                precise_cardinality: precise.then_some(0),
+                column_stats: Default::default(),
+                top_n: Default::default(),
+                count_min_sketch: Default::default(),
+            },
+        }
+    }
+
+    #[test]
+    fn test_outer_join_zero_tie_prefers_proven_empty_build_side() {
+        let proven_empty = empty_stat(true);
+        let estimated_empty = empty_stat(false);
+
+        assert!(should_commute(
+            JoinType::Left,
+            &proven_empty,
+            &estimated_empty
+        ));
+        assert!(!should_commute(
+            JoinType::Left,
+            &estimated_empty,
+            &proven_empty
+        ));
+        assert!(should_commute(
+            JoinType::Right,
+            &proven_empty,
+            &estimated_empty
+        ));
+        assert!(!should_commute(
+            JoinType::Right,
+            &estimated_empty,
+            &proven_empty
+        ));
+    }
+
+    #[test]
+    fn test_outer_join_zero_tie_preserves_existing_canonicalization() {
+        let left = empty_stat(false);
+        let right = empty_stat(false);
+
+        assert!(!should_commute(JoinType::Left, &left, &right));
+        assert!(should_commute(JoinType::Right, &left, &right));
     }
 }

--- a/src/query/sql/src/planner/plans/filter.rs
+++ b/src/query/sql/src/planner/plans/filter.rs
@@ -94,8 +94,9 @@ impl Operator for Filter {
                 .with_top_n(stat_info.statistics.top_n.clone())
                 .with_count_min_sketch(stat_info.statistics.count_min_sketch.clone());
         let cardinality = sb.apply(&self.predicates, &stat_ctx.function_context)?;
+        let precise_cardinality = sb.is_proven_empty().then_some(0);
         // Derive column statistics
-        let column_stats = if cardinality == 0.0 {
+        let column_stats = if precise_cardinality == Some(0) {
             HashMap::new()
         } else {
             sb.into_column_stats()
@@ -103,11 +104,54 @@ impl Operator for Filter {
         Ok(Arc::new(StatInfo {
             cardinality,
             statistics: Statistics {
-                precise_cardinality: None,
+                precise_cardinality,
                 column_stats,
                 top_n: Default::default(),
                 count_min_sketch: Default::default(),
             },
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_expression::Scalar;
+
+    use super::*;
+    use crate::optimizer::ir::SExpr;
+    use crate::plans::ConstantExpr;
+    use crate::plans::DummyTableScan;
+    use crate::plans::MutationSource;
+
+    fn constant_filter(value: bool, input: SExpr) -> SExpr {
+        SExpr::create_unary(
+            Filter {
+                predicates: vec![ScalarExpr::ConstantExpr(ConstantExpr {
+                    span: None,
+                    value: Scalar::Boolean(value),
+                })],
+            },
+            input,
+        )
+    }
+
+    #[test]
+    fn test_filter_preserves_proven_empty_cardinality() -> Result<()> {
+        let expr = constant_filter(false, SExpr::create_leaf(DummyTableScan::default()));
+        let stat = RelExpr::with_s_expr(&expr).derive_cardinality(&StatContext::default())?;
+
+        assert_eq!(stat.cardinality, 0.0);
+        assert_eq!(stat.statistics.precise_cardinality, Some(0));
+        Ok(())
+    }
+
+    #[test]
+    fn test_filter_does_not_promote_estimated_zero_to_precise() -> Result<()> {
+        let expr = constant_filter(true, SExpr::create_leaf(MutationSource::default()));
+        let stat = RelExpr::with_s_expr(&expr).derive_cardinality(&StatContext::default())?;
+
+        assert_eq!(stat.cardinality, 0.0);
+        assert_eq!(stat.statistics.precise_cardinality, None);
+        Ok(())
     }
 }

--- a/src/query/sql/src/planner/plans/join.rs
+++ b/src/query/sql/src/planner/plans/join.rs
@@ -847,13 +847,19 @@ impl Operator for Join {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
+    use databend_common_expression::stat_distribution::NdvEstimate;
+    use databend_common_expression::stat_distribution::StatCount;
     use databend_common_expression::types::DataType;
     use databend_common_expression::types::NumberDataType;
 
     use super::*;
     use crate::ColumnBindingBuilder;
     use crate::Visibility;
+    use crate::optimizer::ir::ColumnStat;
     use crate::optimizer::ir::SExpr;
+    use crate::optimizer::ir::Statistics;
     use crate::plans::BoundColumnRef;
     use crate::plans::Exchange;
     use crate::plans::FunctionCall;
@@ -951,6 +957,144 @@ mod tests {
         let physical_prop = RelExpr::with_s_expr(&s_expr).derive_physical_prop()?;
 
         assert_eq!(physical_prop.distribution, Distribution::Random);
+        Ok(())
+    }
+
+    fn zero_stat(precise: bool, column_index: usize) -> Arc<StatInfo> {
+        Arc::new(StatInfo {
+            cardinality: 0.0,
+            statistics: Statistics {
+                precise_cardinality: precise.then_some(0),
+                column_stats: HashMap::from([(Symbol::new(column_index), ColumnStat::Int {
+                    min: 1,
+                    max: 10,
+                    ndv: NdvEstimate::exact(10.0),
+                    null_count: StatCount::exact(0),
+                    histogram: None,
+                })]),
+                top_n: Default::default(),
+                count_min_sketch: Default::default(),
+            },
+        })
+    }
+
+    #[test]
+    fn test_join_type_proven_empty_propagation() -> Result<()> {
+        let cases = [
+            (JoinType::Cross, true, true),
+            (JoinType::Inner, true, true),
+            (JoinType::InnerAny, true, true),
+            (JoinType::Asof, true, true),
+            (JoinType::Left, true, false),
+            (JoinType::LeftAny, true, false),
+            (JoinType::LeftAsof, false, true),
+            (JoinType::Right, false, true),
+            (JoinType::RightAny, false, true),
+            (JoinType::RightAsof, true, false),
+            (JoinType::Full, false, false),
+            (JoinType::FullAsof, false, false),
+            (JoinType::LeftSemi, true, true),
+            (JoinType::RightSemi, true, true),
+            (JoinType::LeftSingle, true, false),
+            (JoinType::RightMark, true, false),
+            (JoinType::LeftAnti, true, false),
+            (JoinType::RightSingle, false, true),
+            (JoinType::LeftMark, false, true),
+            (JoinType::RightAnti, false, true),
+        ];
+
+        for (join_type, left_propagates, right_propagates) in cases {
+            let join = Join {
+                join_type,
+                ..Default::default()
+            };
+            let left_only = join.derive_join_stats(
+                zero_stat(true, 0),
+                zero_stat(false, 1),
+                &StatContext::default(),
+            )?;
+            assert_eq!(
+                left_only.statistics.precise_cardinality,
+                left_propagates.then_some(0),
+                "left proven-empty input for {join_type:?}"
+            );
+
+            let right_only = join.derive_join_stats(
+                zero_stat(false, 0),
+                zero_stat(true, 1),
+                &StatContext::default(),
+            )?;
+            assert_eq!(
+                right_only.statistics.precise_cardinality,
+                right_propagates.then_some(0),
+                "right proven-empty input for {join_type:?}"
+            );
+
+            let non_empty = Arc::new(StatInfo {
+                cardinality: 10.0,
+                statistics: Statistics {
+                    precise_cardinality: Some(10),
+                    ..Default::default()
+                },
+            });
+            for (left, right, propagates) in [
+                (zero_stat(true, 0), non_empty.clone(), left_propagates),
+                (non_empty, zero_stat(true, 1), right_propagates),
+            ] {
+                let stat = join.derive_join_stats(left, right, &StatContext::default())?;
+                assert_eq!(
+                    stat.statistics.precise_cardinality,
+                    propagates.then_some(0),
+                    "non-empty peer for {join_type:?}"
+                );
+                if propagates {
+                    assert_eq!(stat.cardinality, 0.0, "proven-empty {join_type:?}");
+                    assert!(stat.statistics.column_stats.is_empty());
+                } else {
+                    assert_eq!(
+                        stat.cardinality, 10.0,
+                        "preserved non-empty input for {join_type:?}"
+                    );
+                }
+            }
+
+            let both = join.derive_join_stats(
+                zero_stat(true, 0),
+                zero_stat(true, 1),
+                &StatContext::default(),
+            )?;
+            assert_eq!(
+                both.statistics.precise_cardinality,
+                Some(0),
+                "both proven-empty inputs for {join_type:?}"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_join_estimated_zero_keeps_column_distributions() -> Result<()> {
+        let join = Join {
+            join_type: JoinType::Inner,
+            ..Default::default()
+        };
+        let stat = join.derive_join_stats(
+            zero_stat(false, 0),
+            zero_stat(false, 1),
+            &StatContext::default(),
+        )?;
+
+        assert_eq!(stat.cardinality, 0.0);
+        assert_eq!(stat.statistics.precise_cardinality, None);
+        assert_eq!(stat.statistics.column_stats.len(), 2);
+        assert_eq!(
+            stat.statistics.column_stats[&Symbol::new(0)].ndv(),
+            NdvEstimate::exact(10.0)
+        );
+        assert_eq!(
+            stat.statistics.column_stats[&Symbol::new(1)].ndv(),
+            NdvEstimate::exact(10.0)
+        );
         Ok(())
     }
 }

--- a/src/query/sql/src/planner/plans/scan.rs
+++ b/src/query/sql/src/planner/plans/scan.rs
@@ -324,12 +324,20 @@ impl Operator for Scan {
                 continue;
             }
             if let Some(col_stat) = v {
-                let null_count = StatCount::exact(col_stat.null_count);
-                if num_rows.is_some_and(|num_rows| num_rows > 0 && col_stat.null_count == num_rows)
+                // Catalog column statistics can lag behind the current table
+                // snapshot. Keep the count for numeric estimation, but never
+                // turn `null_count == num_rows` into an exact all-NULL proof.
+                // Only locally proven all-NULL facts may carry an exact count.
+                let null_count = if col_stat.null_count == 0
+                    || num_rows.is_none_or(|rows| col_stat.null_count < rows)
                 {
-                    column_stats.insert(*k, ColumnStat::AllNull { null_count });
-                    continue;
-                }
+                    StatCount::exact(col_stat.null_count)
+                } else {
+                    // Equality with the catalog row count is the only value
+                    // that could masquerade as an all-NULL proof. Preserve the
+                    // estimate while removing that exactness marker.
+                    StatCount::estimate(col_stat.null_count as f64, col_stat.null_count as f64)
+                };
                 let (Some(min), Some(max)) = (col_stat.min.clone(), col_stat.max.clone()) else {
                     continue;
                 };
@@ -373,6 +381,7 @@ impl Operator for Scan {
             .as_ref()
             .and_then(|stat| stat.num_rows);
 
+        let mut proven_empty = false;
         let cardinality = match (precise_cardinality, &self.prewhere) {
             (Some(precise_cardinality), Some(prewhere)) => {
                 // Derive cardinality
@@ -383,6 +392,7 @@ impl Operator for Scan {
                 .with_top_n(std::mem::take(&mut output_top_n))
                 .with_count_min_sketch(std::mem::take(&mut output_count_min_sketch));
                 let cardinality = sb.apply(&prewhere.predicates, &stat_ctx.function_context)?;
+                proven_empty = sb.is_proven_empty();
                 column_stats = sb.into_column_stats();
                 cardinality
             }
@@ -391,7 +401,9 @@ impl Operator for Scan {
         };
 
         // If prewhere is not none, we can't get precise cardinality
-        let precise_cardinality = if self.prewhere.is_none() && self.sample.is_none() {
+        let precise_cardinality = if proven_empty {
+            Some(0)
+        } else if self.prewhere.is_none() && self.sample.is_none() {
             precise_cardinality
         } else {
             None
@@ -406,22 +418,25 @@ impl Operator for Scan {
         // join ordering), then suppress column statistics to prevent data
         // leakage through statistical inference.
         if self.secure_predicates.is_some() {
+            let mut proven_empty = precise_cardinality == Some(0);
             let cardinality = match &self.secure_predicates {
                 Some(preds) if !preds.is_empty() => {
                     let input_cardinality = precise_cardinality
                         .map(StatCardinality::exact)
                         .unwrap_or_else(|| StatCardinality::estimate(cardinality));
-                    SelectivityEstimator::new(column_stats, input_cardinality)
+                    let mut estimator = SelectivityEstimator::new(column_stats, input_cardinality)
                         .with_top_n(output_top_n)
-                        .with_count_min_sketch(output_count_min_sketch)
-                        .apply(preds, &stat_ctx.function_context)?
+                        .with_count_min_sketch(output_count_min_sketch);
+                    let cardinality = estimator.apply(preds, &stat_ctx.function_context)?;
+                    proven_empty |= estimator.is_proven_empty();
+                    cardinality
                 }
                 _ => cardinality,
             };
             return Ok(Arc::new(StatInfo {
                 cardinality,
                 statistics: OpStatistics {
-                    precise_cardinality: None,
+                    precise_cardinality: proven_empty.then_some(0),
                     column_stats: Default::default(),
                     top_n: Default::default(),
                     count_min_sketch: Default::default(),
@@ -457,13 +472,40 @@ impl Operator for Scan {
 #[cfg(test)]
 mod tests {
     use databend_common_expression::Scalar;
+    use databend_common_expression::types::DataType;
+    use databend_common_expression::types::NumberDataType;
     use databend_common_expression::types::NumberScalar;
     use databend_storages_common_table_meta::meta::ColumnTopNEntry;
 
     use super::*;
+    use crate::ColumnBindingBuilder;
+    use crate::Visibility;
     use crate::optimizer::ir::RelExpr;
     use crate::optimizer::ir::SExpr;
+    use crate::plans::BoundColumnRef;
+    use crate::plans::FunctionCall;
     use crate::plans::RelOperator;
+
+    fn is_not_null(column: Symbol) -> ScalarExpr {
+        ScalarExpr::FunctionCall(FunctionCall {
+            span: None,
+            func_name: "is_not_null".to_string(),
+            params: vec![],
+            arguments: vec![ScalarExpr::BoundColumnRef(BoundColumnRef {
+                span: None,
+                column: ColumnBindingBuilder::new(
+                    "nullable_column".to_string(),
+                    column,
+                    Box::new(DataType::Nullable(Box::new(DataType::Number(
+                        NumberDataType::UInt64,
+                    )))),
+                    Visibility::Visible,
+                )
+                .build(),
+            })],
+            return_type: Box::new(DataType::Boolean),
+        })
+    }
 
     #[test]
     fn test_derive_scan_preserves_bind_time_metadata() {
@@ -518,6 +560,50 @@ mod tests {
         assert!(derived.limit.is_none());
         assert!(derived.order_by.is_none());
         assert!(derived.prewhere.is_none());
+    }
+
+    #[test]
+    fn test_catalog_all_null_statistics_are_not_a_proof() -> Result<()> {
+        let column = Symbol::new(1);
+        let rows = 8;
+        let scan = Scan {
+            columns: [column].into_iter().collect(),
+            prewhere: Some(Prewhere {
+                output_columns: [column].into_iter().collect(),
+                prewhere_columns: [column].into_iter().collect(),
+                predicates: vec![is_not_null(column)],
+            }),
+            statistics: Arc::new(Statistics {
+                table_stats: Some(TableStatistics {
+                    num_rows: Some(rows),
+                    ..Default::default()
+                }),
+                column_stats: HashMap::from([(
+                    column,
+                    Some(BasicColumnStatistics {
+                        // Stale value bounds can coexist with an all-NULL count
+                        // after independent statistics updates. Neither fact is
+                        // trusted as a proof at the Scan boundary.
+                        min: Some(databend_common_statistics::Datum::UInt(0)),
+                        max: Some(databend_common_statistics::Datum::UInt(5)),
+                        ndv: Some(0),
+                        null_count: rows,
+                        in_memory_size: 0,
+                    }),
+                )]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let s_expr = SExpr::create_leaf(RelOperator::Scan(scan.clone()));
+        let stat = scan.derive_stats(&RelExpr::with_s_expr(&s_expr), &StatContext::default())?;
+
+        assert_eq!(stat.cardinality, rows as f64 / 5.0);
+        assert_eq!(stat.statistics.precise_cardinality, None);
+        let column_stat = &stat.statistics.column_stats[&column];
+        assert!(!matches!(column_stat, ColumnStat::AllNull { .. }));
+        assert_eq!(column_stat.null_count(), StatCount::exact(0));
+        Ok(())
     }
 
     #[test]

--- a/src/query/sql/test-support/data/cases/basic/02_outer_join_stale_statistics.yaml
+++ b/src/query/sql/test-support/data/cases/basic/02_outer_join_stale_statistics.yaml
@@ -1,0 +1,53 @@
+name: "02_outer_join_stale_statistics"
+description: "Stale range statistics must not hide a more selective preserved input"
+
+sql: |
+  SELECT p.join_key
+  FROM (
+      SELECT join_key
+      FROM outer_join_preserved
+      WHERE range_value > 10 AND selective_value = 42
+  ) AS p
+  LEFT OUTER JOIN (
+      SELECT join_key
+      FROM outer_join_other
+      WHERE range_value > 10
+  ) AS o
+  ON p.join_key = o.join_key;
+
+table_statistics:
+  outer_join_preserved:
+    num_rows: 100
+  outer_join_other:
+    num_rows: 100
+
+column_statistics:
+  outer_join_preserved.join_key:
+    min: 0
+    max: 99
+    ndv: 100
+    null_count: 0
+  outer_join_preserved.range_value:
+    min: 0
+    max: 5
+    ndv: 6
+    null_count: 0
+  outer_join_preserved.selective_value:
+    min: 0
+    max: 99
+    ndv: 100
+    null_count: 0
+  outer_join_other.join_key:
+    min: 0
+    max: 99
+    ndv: 100
+    null_count: 0
+  outer_join_other.range_value:
+    min: 0
+    max: 5
+    ndv: 6
+    null_count: 0
+
+tables:
+  outer_join_preserved: basic/02_outer_join_preserved.sql
+  outer_join_other: basic/02_outer_join_other.sql

--- a/src/query/sql/test-support/data/results/basic/02_outer_join_stale_statistics_optimized.txt
+++ b/src/query/sql/test-support/data/results/basic/02_outer_join_stale_statistics_optimized.txt
@@ -1,0 +1,26 @@
+Exchange(Merge)
+└── EvalScalar
+    ├── scalars: [outer_join_preserved.join_key (#0) AS (#0), range_value (#5) AS (#8), selective_value (#6) AS (#9)]
+    └── Join(Right)
+        ├── build keys: [outer_join_preserved.join_key (#0)]
+        ├── probe keys: [outer_join_other.join_key (#3)]
+        ├── other filters: []
+        ├── Exchange(Hash)
+        │   ├── Exchange(Hash): keys: [outer_join_preserved.join_key (#0)]
+        │   └── EvalScalar
+        │       ├── scalars: [outer_join_preserved.join_key (#0) AS (#0), outer_join_preserved.range_value (#1) AS (#5), outer_join_preserved.selective_value (#2) AS (#6)]
+        │       └── Scan
+        │           ├── table: default.outer_join_preserved (#0)
+        │           ├── filters: [gt(outer_join_preserved.range_value (#1), 10), eq(outer_join_preserved.selective_value (#2), 42)]
+        │           ├── order by: []
+        │           └── limit: NONE
+        └── Exchange(Hash)
+            ├── Exchange(Hash): keys: [outer_join_other.join_key (#3)]
+            └── EvalScalar
+                ├── scalars: [outer_join_other.join_key (#3) AS (#3), outer_join_other.range_value (#4) AS (#7)]
+                └── Scan
+                    ├── table: default.outer_join_other (#1)
+                    ├── filters: [gt(outer_join_other.range_value (#4), 10)]
+                    ├── order by: []
+                    └── limit: NONE
+

--- a/src/query/sql/test-support/data/results/basic/02_outer_join_stale_statistics_physical.txt
+++ b/src/query/sql/test-support/data/results/basic/02_outer_join_stale_statistics_physical.txt
@@ -1,0 +1,41 @@
+Exchange
+├── output columns: [outer_join_preserved.join_key (#0)]
+├── exchange type: Merge
+└── HashJoin
+    ├── output columns: [outer_join_preserved.join_key (#0)]
+    ├── join type: RIGHT OUTER
+    ├── build keys: [p.join_key (#0)]
+    ├── probe keys: [o.join_key (#3)]
+    ├── keys is null equal: [false]
+    ├── filters: []
+    ├── build join filters(distributed):
+    │   └── filter id:0, build key:p.join_key (#0), probe targets:[o.join_key (#3)@scan1], filter type:bloom,inlist,min_max
+    ├── estimated rows: 1.00
+    ├── Exchange(Build)
+    │   ├── output columns: [outer_join_preserved.join_key (#0)]
+    │   ├── exchange type: Hash(p.join_key (#0))
+    │   └── TableScan
+    │       ├── table: default.default.outer_join_preserved
+    │       ├── scan id: 0
+    │       ├── output columns: [join_key (#0)]
+    │       ├── read rows: 0
+    │       ├── read size: 0
+    │       ├── partitions total: 0
+    │       ├── partitions scanned: 0
+    │       ├── push downs: [filters: [outer_join_preserved.range_value (#1) > 10 and outer_join_preserved.selective_value (#2) = 42], limit: NONE]
+    │       └── estimated rows: 1.00
+    └── Exchange(Probe)
+        ├── output columns: [outer_join_other.join_key (#3)]
+        ├── exchange type: Hash(o.join_key (#3))
+        └── TableScan
+            ├── table: default.default.outer_join_other
+            ├── scan id: 1
+            ├── output columns: [join_key (#3)]
+            ├── read rows: 0
+            ├── read size: 0
+            ├── partitions total: 0
+            ├── partitions scanned: 0
+            ├── push downs: [filters: [is_true(outer_join_other.range_value (#4) > 10)], limit: NONE]
+            ├── apply join filters: [#0]
+            └── estimated rows: 20.00
+

--- a/src/query/sql/test-support/data/results/basic/02_outer_join_stale_statistics_raw.txt
+++ b/src/query/sql/test-support/data/results/basic/02_outer_join_stale_statistics_raw.txt
@@ -1,0 +1,25 @@
+EvalScalar
+├── scalars: [outer_join_preserved.join_key (#0) AS (#0)]
+└── Join(Left)
+    ├── build keys: [outer_join_other.join_key (#3)]
+    ├── probe keys: [outer_join_preserved.join_key (#0)]
+    ├── other filters: []
+    ├── EvalScalar
+    │   ├── scalars: [outer_join_other.join_key (#3) AS (#3)]
+    │   └── Filter
+    │       ├── filters: [gt(outer_join_other.range_value (#4), 10)]
+    │       └── Scan
+    │           ├── table: default.outer_join_other (#1)
+    │           ├── filters: []
+    │           ├── order by: []
+    │           └── limit: NONE
+    └── EvalScalar
+        ├── scalars: [outer_join_preserved.join_key (#0) AS (#0)]
+        └── Filter
+            ├── filters: [gt(outer_join_preserved.range_value (#1), 10), eq(outer_join_preserved.selective_value (#2), 42)]
+            └── Scan
+                ├── table: default.outer_join_preserved (#0)
+                ├── filters: []
+                ├── order by: []
+                └── limit: NONE
+

--- a/src/query/sql/test-support/data/tables/basic/02_outer_join_other.sql
+++ b/src/query/sql/test-support/data/tables/basic/02_outer_join_other.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE TABLE outer_join_other (
+    join_key INT64,
+    range_value INT64
+);

--- a/src/query/sql/test-support/data/tables/basic/02_outer_join_preserved.sql
+++ b/src/query/sql/test-support/data/tables/basic/02_outer_join_preserved.sql
@@ -1,0 +1,5 @@
+CREATE OR REPLACE TABLE outer_join_preserved (
+    join_key INT64,
+    range_value INT64,
+    selective_value INT64
+);

--- a/src/query/sql/tests/it/optimizer/join_cardinality/histogram/decimal.txt
+++ b/src/query/sql/tests/it/optimizer/join_cardinality/histogram/decimal.txt
@@ -22,4 +22,6 @@ left stats    : rows=9, min=1.25, max=4.75, ndv=3, histogram_input=present
 right stats   : rows=13, min=20, max=23, ndv=2, histogram_input=present
 sql           : SELECT * FROM l INNER JOIN r ON l.k = r.k
 join          : INNER cardinality=0.000
+stat          : l.k (#0) min=1.25, max=4.75, ndv=3.000, null=0.000, histogram=rows=9.000, ndv=3.000, buckets=[1.25..1.25:2.000/1.000, 2.5..2.5:4.000/1.000, 4.75..4.75:3.000/1.000]
+stat          : r.k (#2) min=20, max=23, ndv=2.000, null=0.000, histogram=rows=13.000, ndv=2.000, buckets=[20..20:5.000/1.000, 23..23:8.000/1.000]
 

--- a/src/query/sql/tests/it/optimizer/join_cardinality/histogram/inner.txt
+++ b/src/query/sql/tests/it/optimizer/join_cardinality/histogram/inner.txt
@@ -108,6 +108,8 @@ right stats   : rows=26, min=20, max=23, ndv=4, histogram_input=present
 query         : inner_join
 sql           : SELECT * FROM l INNER JOIN r ON l.k = r.k
 join          : INNER cardinality=0.000
+stat          : l.k (#0) min=1, max=5, ndv=3.000, null=0.000, histogram=rows=9.000, ndv=3.000, buckets=[1..1:2.000/1.000, 3..3:4.000/1.000, 5..5:3.000/1.000]
+stat          : r.k (#2) min=20, max=23, ndv=4.000, null=0.000, histogram=rows=26.000, ndv=4.000, buckets=[20..20:5.000/1.000, 21..21:7.000/1.000, 22..22:6.000/1.000, 23..23:8.000/1.000]
 
 case          : inner_any_join_overlap
 description   : Join-key histograms overlap, so the inner estimate has non-zero matches when this join type uses it.

--- a/src/query/sql/tests/it/optimizer/join_cardinality/histogram/semi.txt
+++ b/src/query/sql/tests/it/optimizer/join_cardinality/histogram/semi.txt
@@ -38,6 +38,8 @@ right stats   : rows=26, min=20, max=23, ndv=4, histogram_input=present
 query         : right_semi_join
 sql           : SELECT * FROM l RIGHT SEMI JOIN r ON l.k = r.k
 join          : LEFT SEMI cardinality=0.000
+stat          : l.k (#0) min=1, max=5, ndv=3.000, null=0.000, histogram=rows=9.000, ndv=3.000, buckets=[1..1:2.000/1.000, 3..3:4.000/1.000, 5..5:3.000/1.000]
+stat          : r.k (#2) min=20, max=23, ndv=4.000, null=0.000, histogram=rows=26.000, ndv=4.000, buckets=[20..20:5.000/1.000, 21..21:7.000/1.000, 22..22:6.000/1.000, 23..23:8.000/1.000]
 
 case          : right_semi_join_overlap
 description   : Join-key histograms overlap, so the inner estimate has non-zero matches when this join type uses it.
@@ -56,5 +58,8 @@ right stats   : rows=26, min=20, max=23, ndv=4, histogram_input=present
 query         : exists
 sql           : SELECT * FROM l WHERE EXISTS (SELECT 1 FROM r WHERE l.k = r.k)
 join          : RIGHT SEMI cardinality=0.000
+stat          : l.k (#0) min=1, max=5, ndv=3.000, null=0.000, histogram=rows=9.000, ndv=3.000, buckets=[1..1:2.000/1.000, 3..3:4.000/1.000, 5..5:3.000/1.000]
+stat          : r.k (#2) min=20, max=23, ndv=4.000, null=0.000, histogram=rows=26.000, ndv=4.000, buckets=[20..20:5.000/1.000, 21..21:7.000/1.000, 22..22:6.000/1.000, 23..23:8.000/1.000]
+stat          : 1 (#4) min=1, max=1, ndv=1.000, null=0.000, histogram=none
 
 

--- a/src/query/sql/tests/it/optimizer/join_cardinality/statistics.rs
+++ b/src/query/sql/tests/it/optimizer/join_cardinality/statistics.rs
@@ -687,8 +687,8 @@ fn sql_join_statistics_cases() -> Result<Vec<SqlJoinStatisticsCase>> {
             )])?,
         },
         SqlJoinStatisticsCase {
-            name: "inner_domain_true_non_equi",
-            description: "Domain folding proves a cross-side predicate true for every pair and bypasses probabilistic residual estimation.",
+            name: "inner_stale_range_non_equi",
+            description: "Disjoint statistics ranges do not prove a cross-side predicate true for every pair; use residual estimation rather than confirmed matches.",
             sql: "SELECT * FROM l INNER JOIN r ON l.k < r.c",
             expected_join_type: JoinType::Inner,
             left: sql_join_table("CREATE TABLE l(k INT NOT NULL)", 10, [(
@@ -1353,8 +1353,8 @@ fn sql_join_statistics_cases() -> Result<Vec<SqlJoinStatisticsCase>> {
             )])?,
         },
         SqlJoinStatisticsCase {
-            name: "inner_all_null_equality",
-            description: "Regular equality with an all-NULL key produces no matches through the scan-to-join statistics path.",
+            name: "inner_catalog_all_null_is_not_a_proof",
+            description: "Catalog all-NULL statistics may be stale, so regular equality keeps a non-zero fallback estimate instead of proving no matches.",
             sql: "SELECT * FROM l INNER JOIN r ON l.k = r.k",
             expected_join_type: JoinType::Inner,
             left: sql_join_table("CREATE TABLE l(k INT NULL)", 4, [(

--- a/src/query/sql/tests/it/optimizer/join_cardinality/statistics.txt
+++ b/src/query/sql/tests/it/optimizer/join_cardinality/statistics.txt
@@ -48,8 +48,7 @@ right ddl      : CREATE TABLE r(k INT NULL)
 right rows     : 10
 input stat    : right.k min=1, max=3, ndv=Some(3), null=2
 join          : RIGHT SEMI cardinality=4.000
-stat          : l.k (#0) all_null=true, null=4.000, histogram=none
-stat          : r.k (#1) all_null=true, null=4.000, histogram=none
+stat          : r.k (#1) min=1, max=3, ndv=3.000, null=2.000, histogram=none
 
 === intersect_nullable_key_combines_value_and_null_matches ===
 description: A null-safe equality from INTERSECT combines ordinary value matches with NULL-to-NULL matches when estimating matched rows.
@@ -88,9 +87,8 @@ right ddl      : CREATE TABLE r(a INT NULL, b INT NULL)
 right rows     : 2
 input stat    : right.a all_null=true, ndv=Some(0), null=2
 input stat    : right.b min=1, max=1, ndv=Some(1), null=1
-join          : LEFT SEMI cardinality=1.000
-stat          : l.k (#0) all_null=true, null=1.000, histogram=none
-stat          : r.a (#1) all_null=true, null=1.000, histogram=none
+join          : LEFT SEMI cardinality=2.000
+stat          : l.k (#0) min=1, max=1, ndv=1.000, null=1.000, histogram=rows=1.000, ndv=1.000, buckets=[1..1:1.000/1.000]
 stat          : r.b (#2) min=1, max=1, ndv=1.000, null=1.000, histogram=none
 
 === intersect_missing_peer_statistics_uses_null_safe_fallback ===
@@ -144,6 +142,8 @@ right ddl      : CREATE TABLE r(k INT NOT NULL)
 right rows     : 5
 input stat    : right.k min=10, max=14, ndv=Some(5), null=0
 join          : INNER cardinality=0.000
+stat          : l.k (#0) min=1, max=3, ndv=3.000, null=0.000, histogram=rows=4.000, ndv=3.000, buckets=[1..1:1.333/1.000, 2..2:1.333/1.000, 3..3:1.333/1.000]
+stat          : r.k (#1) min=10, max=14, ndv=5.000, null=0.000, histogram=rows=5.000, ndv=5.000, buckets=[10..10:1.000/1.000, 11..11:1.000/1.000, 12..12:1.000/1.000, 13..13:1.000/1.000, 14..14:1.000/1.000]
 
 === left_outer_disjoint_bounds ===
 description: A disjoint LEFT join preserves its outer input and NULL-extends every column on the nullable side, including non-key payloads.
@@ -260,6 +260,10 @@ right rows     : 100
 input stat    : right.k1 min=1, max=10, ndv=Some(10), null=0
 input stat    : right.k2 min=20, max=21, ndv=Some(2), null=0
 join          : INNER cardinality=0.000
+stat          : l.k1 (#0) min=1, max=10, ndv=10.000, null=0.000, histogram=rows=100.000, ndv=10.000, buckets=[1..1:10.000/1.000, 2..2:10.000/1.000, 3..3:10.000/1.000, 4..4:10.000/1.000, 5..5:10.000/1.000, 6..6:10.000/1.000, 7..7:10.000/1.000, 8..8:10.000/1.000, 9..9:10.000/1.000, 10..10:10.000/1.000]
+stat          : l.k2 (#1) min=1, max=2, ndv=2.000, null=0.000, histogram=rows=100.000, ndv=2.000, buckets=[1..1:50.000/1.000, 2..2:50.000/1.000]
+stat          : r.k1 (#2) min=1, max=10, ndv=10.000, null=0.000, histogram=rows=100.000, ndv=10.000, buckets=[1..1:10.000/1.000, 2..2:10.000/1.000, 3..3:10.000/1.000, 4..4:10.000/1.000, 5..5:10.000/1.000, 6..6:10.000/1.000, 7..7:10.000/1.000, 8..8:10.000/1.000, 9..9:10.000/1.000, 10..10:10.000/1.000]
+stat          : r.k2 (#3) min=20, max=21, ndv=2.000, null=0.000, histogram=rows=100.000, ndv=2.000, buckets=[20..20:50.000/1.000, 21..21:50.000/1.000]
 
 === inner_three_key_strongest_condition ===
 description: Three non-zero equality estimates use the strongest condition, then retain and scale every estimated equality-key histogram to the output cardinality.
@@ -395,8 +399,8 @@ join          : INNER cardinality=950.000
 stat          : l.k (#0) min=1, max=100, ndv=100.000, null=0.000, histogram=none
 stat          : r.c (#1) min=5, max=5, ndv=1.000, null=0.000, histogram=none
 
-=== inner_domain_true_non_equi ===
-description: Domain folding proves a cross-side predicate true for every pair and bypasses probabilistic residual estimation.
+=== inner_stale_range_non_equi ===
+description: Disjoint statistics ranges do not prove a cross-side predicate true for every pair; use residual estimation rather than confirmed matches.
 sql           : SELECT * FROM l INNER JOIN r ON l.k < r.c
 left ddl      : CREATE TABLE l(k INT NOT NULL)
 left rows     : 10
@@ -404,7 +408,7 @@ input stat    : left.k min=1, max=10, ndv=Some(10), null=0
 right ddl      : CREATE TABLE r(c INT NOT NULL)
 right rows     : 20
 input stat    : right.c min=100, max=200, ndv=Some(20), null=0
-join          : INNER cardinality=200.000
+join          : INNER cardinality=100.000
 stat          : l.k (#0) min=1, max=10, ndv=10.000, null=0.000, histogram=none
 stat          : r.c (#1) min=100, max=200, ndv=20.000, null=0.000, histogram=none
 
@@ -557,7 +561,12 @@ right ddl      : CREATE TABLE r(id INT NOT NULL, t INT NOT NULL)
 right rows     : 100
 input stat    : right.id min=1, max=100, ndv=Some(100), null=0
 input stat    : right.t min=100, max=200, ndv=Some(100), null=0
-join          : ASOF cardinality=0.000
+join          : ASOF cardinality=100.000
+stat          : l.id (#0) min=1, max=100, ndv=100.000, null=0.000, histogram=none
+stat          : l.t (#1) min=1, max=10, ndv=10.000, null=0.000, histogram=none
+stat          : r.id (#2) min=1, max=100, ndv=100.000, null=0.000, histogram=none
+stat          : r.t (#3) min=100, max=200, ndv=100.000, null=0.000, histogram=none
+stat          : lead (#4) min=100, max=200, ndv=0.000, null=100.000, histogram=none
 
 === inner_unsupported_multicolumn_expression_uses_partial_stats ===
 description: When a two-column arithmetic key has no derived distribution, the direct peer's available statistics still participate in NULL-aware fallback and output propagation.
@@ -689,6 +698,8 @@ right rows     : 2
 input stat    : right.k min=9007199254740992, max=9007199254741002, ndv=Some(1), null=0
 input hist    : right.k present
 join          : INNER cardinality=0.000
+stat          : l.k (#0) min=9007199254740992, max=9007199254741002, ndv=1.000, null=0.000, histogram=rows=3.000, ndv=1.000, buckets=[9007199254740992..9007199254740992:3.000/1.000]
+stat          : r.k (#1) min=9007199254740992, max=9007199254741002, ndv=1.000, null=0.000, histogram=rows=2.000, ndv=1.000, buckets=[9007199254740993..9007199254740993:2.000/1.000]
 
 === inner_mixed_integer_upper_only_extremes ===
 description: Upper-only UInt64 and Int64 statistics at opposite numeric extremes produce no overlap without overflowing conversion.
@@ -700,6 +711,8 @@ right ddl      : CREATE TABLE r(k BIGINT NOT NULL)
 right rows     : 1
 input stat    : right.k min=0, max=0, ndv=None, null=0
 join          : INNER cardinality=0.000
+stat          : l.k (#0) min=18446744073709551615, max=18446744073709551615, ndv=unknown (upper=1.000), null=0.000, histogram=none
+stat          : r.k (#1) min=0, max=0, ndv=unknown (upper=1.000), null=0.000, histogram=none
 
 === inner_float_cast_adjacent_large_integers ===
 description: Explicit Float64 comparison casts make adjacent integers above 2^53 collide, and the SQL estimate reflects that comparison domain.
@@ -884,8 +897,8 @@ join          : INNER cardinality=1.000
 stat          : l.k (#0) min=1, max=1000, ndv=unknown (upper=1.000), null=0.000, histogram=none
 stat          : r.k (#1) min=1, max=1000, ndv=unknown (upper=1.000), null=0.000, histogram=none
 
-=== inner_all_null_equality ===
-description: Regular equality with an all-NULL key produces no matches through the scan-to-join statistics path.
+=== inner_catalog_all_null_is_not_a_proof ===
+description: Catalog all-NULL statistics may be stale, so regular equality keeps a non-zero fallback estimate instead of proving no matches.
 sql           : SELECT * FROM l INNER JOIN r ON l.k = r.k
 left ddl      : CREATE TABLE l(k INT NULL)
 left rows     : 4
@@ -893,5 +906,6 @@ input stat    : left.k all_null=true, ndv=Some(0), null=4
 right ddl      : CREATE TABLE r(k INT NULL)
 right rows     : 10
 input stat    : right.k min=1, max=3, ndv=Some(3), null=2
-join          : INNER cardinality=0.000
+join          : INNER cardinality=32.000
+stat          : r.k (#1) min=1, max=3, ndv=3.000, null=0.000, histogram=none
 

--- a/src/query/sql/tests/it/optimizer/mod.rs
+++ b/src/query/sql/tests/it/optimizer/mod.rs
@@ -25,6 +25,7 @@ mod decorrelate_correlated_aliases;
 mod eager_aggregation;
 mod join_cardinality;
 mod normalize_scalar;
+mod outer_join_empty_cardinality;
 mod outer_join_to_anti;
 mod push_down_filter_project_set;
 mod selectivity;

--- a/src/query/sql/tests/it/optimizer/mod.rs
+++ b/src/query/sql/tests/it/optimizer/mod.rs
@@ -27,6 +27,7 @@ mod hierarchical_grouping_sets;
 mod join_cardinality;
 mod materialized_cte_distribution;
 mod normalize_scalar;
+mod outer_join_empty_cardinality;
 mod outer_join_to_anti;
 mod planning_context;
 mod push_down_filter_project_set;

--- a/src/query/sql/tests/it/optimizer/outer_join_empty_cardinality.rs
+++ b/src/query/sql/tests/it/optimizer/outer_join_empty_cardinality.rs
@@ -1,0 +1,68 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use databend_common_exception::Result;
+use databend_common_sql::FormatOptions;
+
+use super::table_statistics;
+use crate::framework::LiteTableContext;
+use crate::framework::golden::SqlTestCase;
+use crate::framework::golden::open_golden_file;
+use crate::framework::golden::write_case_header;
+
+async fn write_optimized_case(file: &mut impl std::io::Write, case: &SqlTestCase) -> Result<()> {
+    let ctx = LiteTableContext::create().await?;
+    ctx.register_table_sql_with_stats(
+        PROVEN_EMPTY_TABLE,
+        Some(table_statistics(0)),
+        HashMap::new(),
+        HashMap::new(),
+    )
+    .await?;
+    ctx.register_table_sql(ESTIMATED_EMPTY_TABLE).await?;
+
+    let raw_plan = ctx.bind_sql(case.sql).await?;
+    let optimized_plan = ctx.optimize_plan(raw_plan.clone()).await?;
+    let format_options = FormatOptions { verbose: true };
+
+    write_case_header(file, case)?;
+    writeln!(file, "raw_plan:")?;
+    writeln!(file, "{}", raw_plan.format_indent(format_options.clone())?)?;
+    writeln!(file, "optimized_plan:")?;
+    writeln!(file, "{}", optimized_plan.format_indent(format_options)?)?;
+    writeln!(file)?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_outer_join_empty_cardinality_optimizer_outcome() -> Result<()> {
+    let mut file = open_golden_file("optimizer", "outer_join_empty_cardinality.txt")?;
+    let case = SqlTestCase {
+        name: "commute_proven_empty_probe_to_build",
+        description: "When both LEFT JOIN inputs estimate to zero, commute the proven-empty probe input to the hash-build side.",
+        setup_sqls: &[],
+        sql: "SELECT p.k, e.k
+FROM proven_empty AS p
+LEFT JOIN estimated_empty AS e ON p.k = e.k",
+    };
+    write_optimized_case(&mut file, &case).await?;
+
+    Ok(())
+}
+
+const PROVEN_EMPTY_TABLE: &str = "CREATE TABLE proven_empty(k BIGINT)";
+const ESTIMATED_EMPTY_TABLE: &str = "CREATE TABLE estimated_empty(k BIGINT)";

--- a/src/query/sql/tests/it/optimizer/outer_join_empty_cardinality.rs
+++ b/src/query/sql/tests/it/optimizer/outer_join_empty_cardinality.rs
@@ -1,0 +1,168 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use databend_common_catalog::BasicColumnStatistics;
+use databend_common_catalog::TableStatistics;
+use databend_common_exception::Result;
+use databend_common_sql::FormatOptions;
+use databend_common_sql::optimizer::ir::StatContext;
+use databend_common_statistics::Datum;
+
+use crate::framework::LiteTableContext;
+use crate::framework::golden::SqlTestCase;
+use crate::framework::golden::open_golden_file;
+use crate::framework::golden::write_case_header;
+
+fn empty_table_statistics() -> TableStatistics {
+    table_statistics(0)
+}
+
+fn table_statistics(rows: u64) -> TableStatistics {
+    TableStatistics {
+        num_rows: Some(rows),
+        data_size: Some(rows.saturating_mul(8)),
+        data_size_compressed: None,
+        index_size: None,
+        bloom_index_size: None,
+        ngram_index_size: None,
+        inverted_index_size: None,
+        vector_index_size: None,
+        virtual_column_size: None,
+        number_of_blocks: Some(0),
+        number_of_segments: Some(0),
+    }
+}
+
+async fn write_optimized_case(file: &mut impl std::io::Write, case: &SqlTestCase) -> Result<()> {
+    let ctx = LiteTableContext::create().await?;
+    ctx.register_table_sql_with_stats(
+        PROVEN_EMPTY_TABLE,
+        Some(empty_table_statistics()),
+        HashMap::new(),
+        HashMap::new(),
+    )
+    .await?;
+    ctx.register_table_sql(ESTIMATED_EMPTY_TABLE).await?;
+    for (ddl, min, max) in [
+        ("CREATE TABLE residual_left(k BIGINT NOT NULL)", 0, 5),
+        ("CREATE TABLE residual_right(k BIGINT NOT NULL)", 10, 15),
+    ] {
+        ctx.register_table_sql_with_stats(
+            ddl,
+            Some(table_statistics(8)),
+            HashMap::from([("k".to_string(), BasicColumnStatistics {
+                min: Some(Datum::Int(min)),
+                max: Some(Datum::Int(max)),
+                ndv: Some(6),
+                null_count: 0,
+                in_memory_size: 64,
+            })]),
+            HashMap::new(),
+        )
+        .await?;
+    }
+    ctx.register_table_sql_with_stats(
+        STALE_ALL_NULL_TABLE,
+        Some(table_statistics(8)),
+        HashMap::from([("k".to_string(), BasicColumnStatistics {
+            min: Some(Datum::Int(0)),
+            max: Some(Datum::Int(5)),
+            ndv: Some(0),
+            null_count: 8,
+            in_memory_size: 64,
+        })]),
+        HashMap::new(),
+    )
+    .await?;
+
+    let raw_plan = ctx.bind_sql(case.sql).await?;
+    let optimized_plan = ctx.optimize_plan(raw_plan.clone()).await?;
+    let format_options = FormatOptions { verbose: true };
+
+    write_case_header(file, case)?;
+    writeln!(file, "raw_plan:")?;
+    writeln!(
+        file,
+        "{}",
+        raw_plan.format_indent(format_options.clone(), &StatContext::default())?
+    )?;
+    writeln!(file, "optimized_plan:")?;
+    writeln!(
+        file,
+        "{}",
+        optimized_plan.format_indent(format_options, &StatContext::default())?
+    )?;
+    writeln!(file)?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_outer_join_empty_cardinality_optimizer_outcomes() -> Result<()> {
+    let mut file = open_golden_file("optimizer", "outer_join_empty_cardinality.txt")?;
+    let cases = [
+        SqlTestCase {
+            name: "commute_proven_empty_probe_to_build",
+            description: "When both LEFT JOIN inputs estimate to zero, commute the proven-empty probe input to the hash-build side.",
+            setup_sqls: &[],
+            sql: "SELECT p.k, e.k
+FROM proven_empty AS p
+LEFT JOIN estimated_empty AS e ON p.k = e.k",
+        },
+        SqlTestCase {
+            name: "keep_proven_empty_build_side",
+            description: "When the proven-empty input is already the hash-build side, keep the LEFT JOIN orientation.",
+            setup_sqls: &[],
+            sql: "SELECT e.k, p.k
+FROM estimated_empty AS e
+LEFT JOIN proven_empty AS p ON e.k = p.k",
+        },
+        SqlTestCase {
+            name: "catalog_all_null_does_not_fold_count",
+            description: "Potentially stale catalog all-NULL statistics must not fold an IS NOT NULL count to a constant zero.",
+            setup_sqls: &[],
+            sql: "SELECT count(*) FROM stale_all_null WHERE k IS NOT NULL",
+        },
+        SqlTestCase {
+            name: "stale_residual_range_is_not_proven_false",
+            description: "Disjoint column ranges may be stale: a cross-side residual must not prove that an INNER join has no matches.",
+            setup_sqls: &[],
+            sql: "SELECT l.k, r.k FROM residual_left l INNER JOIN residual_right r ON l.k > r.k",
+        },
+        SqlTestCase {
+            name: "stale_residual_range_is_not_proven_true",
+            description: "An apparently always-true residual from stale ranges must not count as confirmed matches that eliminate every ANTI join row.",
+            setup_sqls: &[],
+            sql: "SELECT l.k FROM residual_left l LEFT ANTI JOIN residual_right r ON l.k < r.k",
+        },
+        SqlTestCase {
+            name: "residual_modulo_signedness",
+            description: "The non-equi Join estimation entry must preserve the modulo safeguards used by ordinary filters.",
+            setup_sqls: &[],
+            sql: "SELECT l.k FROM residual_left l LEFT ANTI JOIN residual_right r ON l.k % -2 = r.k",
+        },
+    ];
+
+    for case in &cases {
+        write_optimized_case(&mut file, case).await?;
+    }
+
+    Ok(())
+}
+
+const PROVEN_EMPTY_TABLE: &str = "CREATE TABLE proven_empty(k BIGINT)";
+const ESTIMATED_EMPTY_TABLE: &str = "CREATE TABLE estimated_empty(k BIGINT)";
+const STALE_ALL_NULL_TABLE: &str = "CREATE TABLE stale_all_null(k BIGINT NULL)";

--- a/src/query/sql/tests/it/optimizer/outer_join_empty_cardinality.txt
+++ b/src/query/sql/tests/it/optimizer/outer_join_empty_cardinality.txt
@@ -1,0 +1,82 @@
+=== commute_proven_empty_probe_to_build ===
+description: When both LEFT JOIN inputs estimate to zero, commute the proven-empty probe input to the hash-build side.
+sql: SELECT p.k, e.k
+FROM proven_empty AS p
+LEFT JOIN estimated_empty AS e ON p.k = e.k
+raw_plan:
+EvalScalar
+├── scalars: [proven_empty.k (#0) AS (#0), estimated_empty.k (#1) AS (#1)]
+├── output columns: [estimated_empty.k (#1), proven_empty.k (#0)]
+├── outer columns: []
+├── used columns: [estimated_empty.k (#1), proven_empty.k (#0)]
+├── cardinality: 0.000
+├── precise cardinality: N/A
+├── statistics
+└── Join(Left)
+    ├── build keys: [estimated_empty.k (#1)]
+    ├── probe keys: [proven_empty.k (#0)]
+    ├── other filters: []
+    ├── output columns: [estimated_empty.k (#1), proven_empty.k (#0)]
+    ├── outer columns: []
+    ├── used columns: [estimated_empty.k (#1), proven_empty.k (#0)]
+    ├── cardinality: 0.000
+    ├── precise cardinality: N/A
+    ├── statistics
+    ├── Scan
+    │   ├── table: default.estimated_empty (#1)
+    │   ├── filters: []
+    │   ├── order by: []
+    │   ├── limit: NONE
+    │   ├── output columns: [estimated_empty.k (#1)]
+    │   ├── outer columns: []
+    │   ├── used columns: [estimated_empty.k (#1)]
+    │   ├── cardinality: 0.000
+    │   ├── precise cardinality: N/A
+    │   └── statistics
+    └── Scan
+        ├── table: default.proven_empty (#0)
+        ├── filters: []
+        ├── order by: []
+        ├── limit: NONE
+        ├── output columns: [proven_empty.k (#0)]
+        ├── outer columns: []
+        ├── used columns: [proven_empty.k (#0)]
+        ├── cardinality: 0.000
+        ├── precise cardinality: N/A
+        └── statistics
+
+optimized_plan:
+Join(Right)
+├── build keys: [proven_empty.k (#0)]
+├── probe keys: [estimated_empty.k (#1)]
+├── other filters: []
+├── output columns: [estimated_empty.k (#1), proven_empty.k (#0)]
+├── outer columns: []
+├── used columns: [estimated_empty.k (#1), proven_empty.k (#0)]
+├── cardinality: 0.000
+├── precise cardinality: N/A
+├── statistics
+├── Scan
+│   ├── table: default.proven_empty (#0)
+│   ├── filters: []
+│   ├── order by: []
+│   ├── limit: NONE
+│   ├── output columns: [proven_empty.k (#0)]
+│   ├── outer columns: []
+│   ├── used columns: [proven_empty.k (#0)]
+│   ├── cardinality: 0.000
+│   ├── precise cardinality: 0
+│   └── statistics
+└── Scan
+    ├── table: default.estimated_empty (#1)
+    ├── filters: []
+    ├── order by: []
+    ├── limit: NONE
+    ├── output columns: [estimated_empty.k (#1)]
+    ├── outer columns: []
+    ├── used columns: [estimated_empty.k (#1)]
+    ├── cardinality: 0.000
+    ├── precise cardinality: N/A
+    └── statistics
+
+

--- a/src/query/sql/tests/it/optimizer/outer_join_empty_cardinality.txt
+++ b/src/query/sql/tests/it/optimizer/outer_join_empty_cardinality.txt
@@ -1,0 +1,492 @@
+=== commute_proven_empty_probe_to_build ===
+description: When both LEFT JOIN inputs estimate to zero, commute the proven-empty probe input to the hash-build side.
+sql: SELECT p.k, e.k
+FROM proven_empty AS p
+LEFT JOIN estimated_empty AS e ON p.k = e.k
+raw_plan:
+EvalScalar
+├── scalars: [proven_empty.k (#0) AS (#0), estimated_empty.k (#1) AS (#1)]
+├── output columns: [estimated_empty.k (#1), proven_empty.k (#0)]
+├── outer columns: []
+├── used columns: [estimated_empty.k (#1), proven_empty.k (#0)]
+├── cardinality: 0.000
+├── precise cardinality: N/A
+├── statistics
+└── Join(Left)
+    ├── build keys: [estimated_empty.k (#1)]
+    ├── probe keys: [proven_empty.k (#0)]
+    ├── other filters: []
+    ├── output columns: [estimated_empty.k (#1), proven_empty.k (#0)]
+    ├── outer columns: []
+    ├── used columns: [estimated_empty.k (#1), proven_empty.k (#0)]
+    ├── cardinality: 0.000
+    ├── precise cardinality: N/A
+    ├── statistics
+    ├── Scan
+    │   ├── table: default.estimated_empty (#1)
+    │   ├── filters: []
+    │   ├── order by: []
+    │   ├── limit: NONE
+    │   ├── output columns: [estimated_empty.k (#1)]
+    │   ├── outer columns: []
+    │   ├── used columns: [estimated_empty.k (#1)]
+    │   ├── cardinality: 0.000
+    │   ├── precise cardinality: N/A
+    │   └── statistics
+    └── Scan
+        ├── table: default.proven_empty (#0)
+        ├── filters: []
+        ├── order by: []
+        ├── limit: NONE
+        ├── output columns: [proven_empty.k (#0)]
+        ├── outer columns: []
+        ├── used columns: [proven_empty.k (#0)]
+        ├── cardinality: 0.000
+        ├── precise cardinality: N/A
+        └── statistics
+
+optimized_plan:
+Join(Right)
+├── build keys: [proven_empty.k (#0)]
+├── probe keys: [estimated_empty.k (#1)]
+├── other filters: []
+├── output columns: [estimated_empty.k (#1), proven_empty.k (#0)]
+├── outer columns: []
+├── used columns: [estimated_empty.k (#1), proven_empty.k (#0)]
+├── cardinality: 0.000
+├── precise cardinality: 0
+├── statistics
+├── Scan
+│   ├── table: default.proven_empty (#0)
+│   ├── filters: []
+│   ├── order by: []
+│   ├── limit: NONE
+│   ├── output columns: [proven_empty.k (#0)]
+│   ├── outer columns: []
+│   ├── used columns: [proven_empty.k (#0)]
+│   ├── cardinality: 0.000
+│   ├── precise cardinality: 0
+│   └── statistics
+└── Scan
+    ├── table: default.estimated_empty (#1)
+    ├── filters: []
+    ├── order by: []
+    ├── limit: NONE
+    ├── output columns: [estimated_empty.k (#1)]
+    ├── outer columns: []
+    ├── used columns: [estimated_empty.k (#1)]
+    ├── cardinality: 0.000
+    ├── precise cardinality: N/A
+    └── statistics
+
+
+=== keep_proven_empty_build_side ===
+description: When the proven-empty input is already the hash-build side, keep the LEFT JOIN orientation.
+sql: SELECT e.k, p.k
+FROM estimated_empty AS e
+LEFT JOIN proven_empty AS p ON e.k = p.k
+raw_plan:
+EvalScalar
+├── scalars: [estimated_empty.k (#0) AS (#0), proven_empty.k (#1) AS (#1)]
+├── output columns: [estimated_empty.k (#0), proven_empty.k (#1)]
+├── outer columns: []
+├── used columns: [estimated_empty.k (#0), proven_empty.k (#1)]
+├── cardinality: 0.000
+├── precise cardinality: N/A
+├── statistics
+└── Join(Left)
+    ├── build keys: [proven_empty.k (#1)]
+    ├── probe keys: [estimated_empty.k (#0)]
+    ├── other filters: []
+    ├── output columns: [estimated_empty.k (#0), proven_empty.k (#1)]
+    ├── outer columns: []
+    ├── used columns: [estimated_empty.k (#0), proven_empty.k (#1)]
+    ├── cardinality: 0.000
+    ├── precise cardinality: N/A
+    ├── statistics
+    ├── Scan
+    │   ├── table: default.proven_empty (#1)
+    │   ├── filters: []
+    │   ├── order by: []
+    │   ├── limit: NONE
+    │   ├── output columns: [proven_empty.k (#1)]
+    │   ├── outer columns: []
+    │   ├── used columns: [proven_empty.k (#1)]
+    │   ├── cardinality: 0.000
+    │   ├── precise cardinality: N/A
+    │   └── statistics
+    └── Scan
+        ├── table: default.estimated_empty (#0)
+        ├── filters: []
+        ├── order by: []
+        ├── limit: NONE
+        ├── output columns: [estimated_empty.k (#0)]
+        ├── outer columns: []
+        ├── used columns: [estimated_empty.k (#0)]
+        ├── cardinality: 0.000
+        ├── precise cardinality: N/A
+        └── statistics
+
+optimized_plan:
+Join(Left)
+├── build keys: [proven_empty.k (#1)]
+├── probe keys: [estimated_empty.k (#0)]
+├── other filters: []
+├── output columns: [estimated_empty.k (#0), proven_empty.k (#1)]
+├── outer columns: []
+├── used columns: [estimated_empty.k (#0), proven_empty.k (#1)]
+├── cardinality: 0.000
+├── precise cardinality: N/A
+├── statistics
+├── Scan
+│   ├── table: default.proven_empty (#1)
+│   ├── filters: []
+│   ├── order by: []
+│   ├── limit: NONE
+│   ├── output columns: [proven_empty.k (#1)]
+│   ├── outer columns: []
+│   ├── used columns: [proven_empty.k (#1)]
+│   ├── cardinality: 0.000
+│   ├── precise cardinality: 0
+│   └── statistics
+└── Scan
+    ├── table: default.estimated_empty (#0)
+    ├── filters: []
+    ├── order by: []
+    ├── limit: NONE
+    ├── output columns: [estimated_empty.k (#0)]
+    ├── outer columns: []
+    ├── used columns: [estimated_empty.k (#0)]
+    ├── cardinality: 0.000
+    ├── precise cardinality: N/A
+    └── statistics
+
+
+=== catalog_all_null_does_not_fold_count ===
+description: Potentially stale catalog all-NULL statistics must not fold an IS NOT NULL count to a constant zero.
+sql: SELECT count(*) FROM stale_all_null WHERE k IS NOT NULL
+raw_plan:
+EvalScalar
+├── scalars: [COUNT(*) (#1) AS (#1)]
+├── output columns: [COUNT(*) (#1)]
+├── outer columns: []
+├── used columns: [COUNT(*) (#1), stale_all_null.k (#0)]
+├── cardinality: 1.000
+├── precise cardinality: 1
+├── statistics
+└── Aggregate(Initial)
+    ├── group items: []
+    ├── aggregate functions: [count() AS (#1)]
+    ├── output columns: [COUNT(*) (#1)]
+    ├── outer columns: []
+    ├── used columns: [COUNT(*) (#1), stale_all_null.k (#0)]
+    ├── cardinality: 1.000
+    ├── precise cardinality: 1
+    ├── statistics
+    └── Filter
+        ├── filters: [is_not_null(stale_all_null.k (#0))]
+        ├── output columns: [stale_all_null.k (#0)]
+        ├── outer columns: []
+        ├── used columns: [stale_all_null.k (#0)]
+        ├── cardinality: 0.000
+        ├── precise cardinality: N/A
+        ├── statistics
+        └── Scan
+            ├── table: default.stale_all_null (#0)
+            ├── filters: []
+            ├── order by: []
+            ├── limit: NONE
+            ├── output columns: [stale_all_null.k (#0)]
+            ├── outer columns: []
+            ├── used columns: [stale_all_null.k (#0)]
+            ├── cardinality: 0.000
+            ├── precise cardinality: N/A
+            └── statistics
+
+optimized_plan:
+Aggregate(Final)
+├── group items: []
+├── aggregate functions: [count() AS (#1)]
+├── output columns: [COUNT(*) (#1)]
+├── outer columns: []
+├── used columns: [COUNT(*) (#1), stale_all_null.k (#0)]
+├── cardinality: 1.000
+├── precise cardinality: 1
+├── statistics
+│   └── stale_all_null.k (#0): { min: 0, max: 5, ndv: 0, null count: 0 }
+└── Aggregate(Partial)
+    ├── group items: []
+    ├── aggregate functions: [count() AS (#1)]
+    ├── output columns: [COUNT(*) (#1)]
+    ├── outer columns: []
+    ├── used columns: [COUNT(*) (#1), stale_all_null.k (#0)]
+    ├── cardinality: 1.000
+    ├── precise cardinality: 1
+    ├── statistics
+    │   └── stale_all_null.k (#0): { min: 0, max: 5, ndv: 0, null count: 0 }
+    └── Scan
+        ├── table: default.stale_all_null (#0)
+        ├── filters: [is_not_null(stale_all_null.k (#0))]
+        ├── order by: []
+        ├── limit: NONE
+        ├── output columns: [stale_all_null.k (#0)]
+        ├── outer columns: []
+        ├── used columns: [stale_all_null.k (#0)]
+        ├── cardinality: 1.600
+        ├── precise cardinality: N/A
+        └── statistics
+            └── stale_all_null.k (#0): { min: 0, max: 5, ndv: 0, null count: 0 }
+
+
+=== stale_residual_range_is_not_proven_false ===
+description: Disjoint column ranges may be stale: a cross-side residual must not prove that an INNER join has no matches.
+sql: SELECT l.k, r.k FROM residual_left l INNER JOIN residual_right r ON l.k > r.k
+raw_plan:
+EvalScalar
+├── scalars: [residual_left.k (#0) AS (#0), residual_right.k (#1) AS (#1)]
+├── output columns: [residual_left.k (#0), residual_right.k (#1)]
+├── outer columns: []
+├── used columns: [residual_left.k (#0), residual_right.k (#1)]
+├── cardinality: 0.000
+├── precise cardinality: N/A
+├── statistics
+└── Join(Inner)
+    ├── build keys: []
+    ├── probe keys: []
+    ├── other filters: [gt(residual_left.k (#0), residual_right.k (#1))]
+    ├── output columns: [residual_left.k (#0), residual_right.k (#1)]
+    ├── outer columns: []
+    ├── used columns: [residual_left.k (#0), residual_right.k (#1)]
+    ├── cardinality: 0.000
+    ├── precise cardinality: N/A
+    ├── statistics
+    ├── Scan
+    │   ├── table: default.residual_right (#1)
+    │   ├── filters: []
+    │   ├── order by: []
+    │   ├── limit: NONE
+    │   ├── output columns: [residual_right.k (#1)]
+    │   ├── outer columns: []
+    │   ├── used columns: [residual_right.k (#1)]
+    │   ├── cardinality: 0.000
+    │   ├── precise cardinality: N/A
+    │   └── statistics
+    └── Scan
+        ├── table: default.residual_left (#0)
+        ├── filters: []
+        ├── order by: []
+        ├── limit: NONE
+        ├── output columns: [residual_left.k (#0)]
+        ├── outer columns: []
+        ├── used columns: [residual_left.k (#0)]
+        ├── cardinality: 0.000
+        ├── precise cardinality: N/A
+        └── statistics
+
+optimized_plan:
+Join(Inner)
+├── build keys: []
+├── probe keys: []
+├── other filters: [gt(residual_left.k (#0), residual_right.k (#1))]
+├── output columns: [residual_left.k (#0), residual_right.k (#1)]
+├── outer columns: []
+├── used columns: [residual_left.k (#0), residual_right.k (#1)]
+├── cardinality: 32.000
+├── precise cardinality: N/A
+├── statistics
+│   ├── residual_left.k (#0): { min: 0, max: 5, ndv: 6, null count: 0 }
+│   └── residual_right.k (#1): { min: 10, max: 15, ndv: 6, null count: 0 }
+├── Scan
+│   ├── table: default.residual_right (#1)
+│   ├── filters: []
+│   ├── order by: []
+│   ├── limit: NONE
+│   ├── output columns: [residual_right.k (#1)]
+│   ├── outer columns: []
+│   ├── used columns: [residual_right.k (#1)]
+│   ├── cardinality: 8.000
+│   ├── precise cardinality: 8
+│   └── statistics
+│       └── residual_right.k (#1): { min: 10, max: 15, ndv: 6, null count: 0 }
+└── Scan
+    ├── table: default.residual_left (#0)
+    ├── filters: []
+    ├── order by: []
+    ├── limit: NONE
+    ├── output columns: [residual_left.k (#0)]
+    ├── outer columns: []
+    ├── used columns: [residual_left.k (#0)]
+    ├── cardinality: 8.000
+    ├── precise cardinality: 8
+    └── statistics
+        └── residual_left.k (#0): { min: 0, max: 5, ndv: 6, null count: 0 }
+
+
+=== stale_residual_range_is_not_proven_true ===
+description: An apparently always-true residual from stale ranges must not count as confirmed matches that eliminate every ANTI join row.
+sql: SELECT l.k FROM residual_left l LEFT ANTI JOIN residual_right r ON l.k < r.k
+raw_plan:
+EvalScalar
+├── scalars: [residual_left.k (#0) AS (#0)]
+├── output columns: [residual_left.k (#0), residual_right.k (#1)]
+├── outer columns: []
+├── used columns: [residual_left.k (#0), residual_right.k (#1)]
+├── cardinality: 0.000
+├── precise cardinality: N/A
+├── statistics
+└── Join(LeftAnti)
+    ├── build keys: []
+    ├── probe keys: []
+    ├── other filters: [lt(residual_left.k (#0), residual_right.k (#1))]
+    ├── output columns: [residual_left.k (#0), residual_right.k (#1)]
+    ├── outer columns: []
+    ├── used columns: [residual_left.k (#0), residual_right.k (#1)]
+    ├── cardinality: 0.000
+    ├── precise cardinality: N/A
+    ├── statistics
+    ├── Scan
+    │   ├── table: default.residual_right (#1)
+    │   ├── filters: []
+    │   ├── order by: []
+    │   ├── limit: NONE
+    │   ├── output columns: [residual_right.k (#1)]
+    │   ├── outer columns: []
+    │   ├── used columns: [residual_right.k (#1)]
+    │   ├── cardinality: 0.000
+    │   ├── precise cardinality: N/A
+    │   └── statistics
+    └── Scan
+        ├── table: default.residual_left (#0)
+        ├── filters: []
+        ├── order by: []
+        ├── limit: NONE
+        ├── output columns: [residual_left.k (#0)]
+        ├── outer columns: []
+        ├── used columns: [residual_left.k (#0)]
+        ├── cardinality: 0.000
+        ├── precise cardinality: N/A
+        └── statistics
+
+optimized_plan:
+Join(LeftAnti)
+├── build keys: []
+├── probe keys: []
+├── other filters: [lt(residual_left.k (#0), residual_right.k (#1))]
+├── output columns: [residual_left.k (#0), residual_right.k (#1)]
+├── outer columns: []
+├── used columns: [residual_left.k (#0), residual_right.k (#1)]
+├── cardinality: 0.800
+├── precise cardinality: N/A
+├── statistics
+│   ├── residual_left.k (#0): { min: 0, max: 5, ndv: 0.786357323129599, null count: 0 }
+│   └── residual_right.k (#1): { min: 10, max: 15, ndv: 0.7999999999999998, null count: 0 }
+├── Scan
+│   ├── table: default.residual_right (#1)
+│   ├── filters: []
+│   ├── order by: []
+│   ├── limit: NONE
+│   ├── output columns: [residual_right.k (#1)]
+│   ├── outer columns: []
+│   ├── used columns: [residual_right.k (#1)]
+│   ├── cardinality: 8.000
+│   ├── precise cardinality: 8
+│   └── statistics
+│       └── residual_right.k (#1): { min: 10, max: 15, ndv: 6, null count: 0 }
+└── Scan
+    ├── table: default.residual_left (#0)
+    ├── filters: []
+    ├── order by: []
+    ├── limit: NONE
+    ├── output columns: [residual_left.k (#0)]
+    ├── outer columns: []
+    ├── used columns: [residual_left.k (#0)]
+    ├── cardinality: 8.000
+    ├── precise cardinality: 8
+    └── statistics
+        └── residual_left.k (#0): { min: 0, max: 5, ndv: 6, null count: 0 }
+
+
+=== residual_modulo_signedness ===
+description: The non-equi Join estimation entry must preserve the modulo safeguards used by ordinary filters.
+sql: SELECT l.k FROM residual_left l LEFT ANTI JOIN residual_right r ON l.k % -2 = r.k
+raw_plan:
+EvalScalar
+├── scalars: [residual_left.k (#0) AS (#0)]
+├── output columns: [residual_left.k (#0), residual_right.k (#1)]
+├── outer columns: []
+├── used columns: [residual_left.k (#0), residual_right.k (#1)]
+├── cardinality: 0.000
+├── precise cardinality: N/A
+├── statistics
+└── Join(LeftAnti)
+    ├── build keys: [residual_right.k (#1)]
+    ├── probe keys: [modulo(residual_left.k (#0), -2)]
+    ├── other filters: []
+    ├── output columns: [residual_left.k (#0), residual_right.k (#1)]
+    ├── outer columns: []
+    ├── used columns: [residual_left.k (#0), residual_right.k (#1)]
+    ├── cardinality: 0.000
+    ├── precise cardinality: N/A
+    ├── statistics
+    ├── Scan
+    │   ├── table: default.residual_right (#1)
+    │   ├── filters: []
+    │   ├── order by: []
+    │   ├── limit: NONE
+    │   ├── output columns: [residual_right.k (#1)]
+    │   ├── outer columns: []
+    │   ├── used columns: [residual_right.k (#1)]
+    │   ├── cardinality: 0.000
+    │   ├── precise cardinality: N/A
+    │   └── statistics
+    └── Scan
+        ├── table: default.residual_left (#0)
+        ├── filters: []
+        ├── order by: []
+        ├── limit: NONE
+        ├── output columns: [residual_left.k (#0)]
+        ├── outer columns: []
+        ├── used columns: [residual_left.k (#0)]
+        ├── cardinality: 0.000
+        ├── precise cardinality: N/A
+        └── statistics
+
+optimized_plan:
+Join(LeftAnti)
+├── build keys: [residual_right.k (#1)]
+├── probe keys: [modulo(residual_left.k (#0), -2)]
+├── other filters: []
+├── output columns: [residual_left.k (#0), residual_right.k (#1)]
+├── outer columns: []
+├── used columns: [residual_left.k (#0), residual_right.k (#1)]
+├── cardinality: 8.000
+├── precise cardinality: N/A
+├── statistics
+│   ├── residual_left.k (#0): { min: 0, max: 5, ndv: 6, null count: 0 }
+│   └── residual_right.k (#1): { min: 10, max: 15, ndv: 6, null count: 0 }
+├── Scan
+│   ├── table: default.residual_right (#1)
+│   ├── filters: []
+│   ├── order by: []
+│   ├── limit: NONE
+│   ├── output columns: [residual_right.k (#1)]
+│   ├── outer columns: []
+│   ├── used columns: [residual_right.k (#1)]
+│   ├── cardinality: 8.000
+│   ├── precise cardinality: 8
+│   └── statistics
+│       └── residual_right.k (#1): { min: 10, max: 15, ndv: 6, null count: 0 }
+└── Scan
+    ├── table: default.residual_left (#0)
+    ├── filters: []
+    ├── order by: []
+    ├── limit: NONE
+    ├── output columns: [residual_left.k (#0)]
+    ├── outer columns: []
+    ├── used columns: [residual_left.k (#0)]
+    ├── cardinality: 8.000
+    ├── precise cardinality: 8
+    └── statistics
+        └── residual_left.k (#0): { min: 0, max: 5, ndv: 6, null count: 0 }
+
+

--- a/src/query/sql/tests/it/optimizer/selectivity.rs
+++ b/src/query/sql/tests/it/optimizer/selectivity.rs
@@ -1515,8 +1515,8 @@ fn test_selectivity_logical_outcomes() -> Result<()> {
 
     write_case_title(
         &mut file,
-        "domain_folded_logical_predicates",
-        "Domain-folded constants should still compose with remaining predicate selectivity.",
+        "stale_range_logical_predicates",
+        "Potentially stale range statistics should remain estimates when composing logical predicates.",
     )?;
     let domain_folded_stats = ColumnStatSet::from_iter([
         (Symbol::new(0), ColumnStat::UInt {

--- a/src/query/sql/tests/it/optimizer/selectivity_comparison.txt
+++ b/src/query/sql/tests/it/optimizer/selectivity_comparison.txt
@@ -2,11 +2,11 @@
 description: Comparison predicates should update estimated rows and column stats consistently.
 expr          : a = 5
 cardinality   : 100
-estimated     : 0
+estimated     : 20
 in stats      :
 0 ColumnStat { min: UInt(10), max: UInt(19), ndv: 10.0, null_count: 0, histogram: None }
 out stats     :
-0 ColumnStat { min: UInt(10), max: UInt(19), ndv: 0.0, null_count: 0, histogram: None }
+0 ColumnStat { min: UInt(5), max: UInt(5), ndv: 1.0, null_count: 0, histogram: None }
 
 expr          : a = 15
 cardinality   : 100
@@ -58,19 +58,19 @@ out stats     :
 
 expr          : a > 19
 cardinality   : 100
-estimated     : 0
+estimated     : 20
 in stats      :
 0 ColumnStat { min: UInt(10), max: UInt(19), ndv: 10.0, null_count: 0, histogram: None }
 out stats     :
-0 ColumnStat { min: UInt(10), max: UInt(19), ndv: 0.0, null_count: 0, histogram: None }
+0 ColumnStat { min: UInt(10), max: UInt(19), ndv: ~8.926258176[..10.0], null_count: 0, histogram: None }
 
 expr          : a > 25
 cardinality   : 100
-estimated     : 0
+estimated     : 20
 in stats      :
 0 ColumnStat { min: UInt(10), max: UInt(19), ndv: 10.0, null_count: 0, histogram: None }
 out stats     :
-0 ColumnStat { min: UInt(10), max: UInt(19), ndv: 0.0, null_count: 0, histogram: None }
+0 ColumnStat { min: UInt(10), max: UInt(19), ndv: ~8.926258176[..10.0], null_count: 0, histogram: None }
 
 expr          : a >= 5
 cardinality   : 100
@@ -106,27 +106,27 @@ out stats     :
 
 expr          : a >= 25
 cardinality   : 100
-estimated     : 0
+estimated     : 20
 in stats      :
 0 ColumnStat { min: UInt(10), max: UInt(19), ndv: 10.0, null_count: 0, histogram: None }
 out stats     :
-0 ColumnStat { min: UInt(10), max: UInt(19), ndv: 0.0, null_count: 0, histogram: None }
+0 ColumnStat { min: UInt(10), max: UInt(19), ndv: ~8.926258176[..10.0], null_count: 0, histogram: None }
 
 expr          : a < 5
 cardinality   : 100
-estimated     : 0
+estimated     : 20
 in stats      :
 0 ColumnStat { min: UInt(10), max: UInt(19), ndv: 10.0, null_count: 0, histogram: None }
 out stats     :
-0 ColumnStat { min: UInt(10), max: UInt(19), ndv: 0.0, null_count: 0, histogram: None }
+0 ColumnStat { min: UInt(10), max: UInt(19), ndv: ~8.926258176[..10.0], null_count: 0, histogram: None }
 
 expr          : a < 10
 cardinality   : 100
-estimated     : 0
+estimated     : 20
 in stats      :
 0 ColumnStat { min: UInt(10), max: UInt(19), ndv: 10.0, null_count: 0, histogram: None }
 out stats     :
-0 ColumnStat { min: UInt(10), max: UInt(19), ndv: 0.0, null_count: 0, histogram: None }
+0 ColumnStat { min: UInt(10), max: UInt(19), ndv: ~8.926258176[..10.0], null_count: 0, histogram: None }
 
 expr          : a < 16
 cardinality   : 100
@@ -154,11 +154,11 @@ out stats     :
 
 expr          : a <= 5
 cardinality   : 100
-estimated     : 0
+estimated     : 20
 in stats      :
 0 ColumnStat { min: UInt(10), max: UInt(19), ndv: 10.0, null_count: 0, histogram: None }
 out stats     :
-0 ColumnStat { min: UInt(10), max: UInt(19), ndv: 0.0, null_count: 0, histogram: None }
+0 ColumnStat { min: UInt(10), max: UInt(19), ndv: ~8.926258176[..10.0], null_count: 0, histogram: None }
 
 expr          : a <= 10
 cardinality   : 100

--- a/src/query/sql/tests/it/optimizer/selectivity_histogram.txt
+++ b/src/query/sql/tests/it/optimizer/selectivity_histogram.txt
@@ -82,11 +82,11 @@ out stats     :
 
 expr          : tail > 737
 cardinality   : 738
-estimated     : 0
+estimated     : 147.6
 in stats      :
 0 ColumnStat { min: UInt(0), max: UInt(737), ndv: 738.0, null_count: 0, histogram: Some(TypedHistogram { accuracy: true, buckets: [TypedHistogramBucket { lower_bound: 0, upper_bound: 737, num_values: 738.0, num_distinct: 738.0 }], avg_spacing: None }) }
 out stats     :
-0 ColumnStat { min: UInt(0), max: UInt(737), ndv: 0.0, null_count: 0, histogram: None }
+0 ColumnStat { min: UInt(0), max: UInt(737), ndv: ~147.59999999999997[..147.6], null_count: 0, histogram: Some(TypedHistogram { accuracy: false, row_scale: 0.2, buckets: [TypedHistogramBucket { lower_bound: 0, upper_bound: 737, num_values: 738.0, num_distinct: 738.0 }], avg_spacing: None }) }
 
 === histogram_multi_step_propagation ===
 description: Partial numeric buckets should keep row-mass alignment and accumulated range constraints visible across AND predicates.

--- a/src/query/sql/tests/it/optimizer/selectivity_logical.txt
+++ b/src/query/sql/tests/it/optimizer/selectivity_logical.txt
@@ -414,19 +414,19 @@ in stats      :
 out stats     :
 0 ColumnStat { min: UInt(0), max: UInt(3), ndv: 1.0, null_count: 0, histogram: None }
 
-=== domain_folded_logical_predicates ===
-description: Domain-folded constants should still compose with remaining predicate selectivity.
+=== stale_range_logical_predicates ===
+description: Potentially stale range statistics should remain estimates when composing logical predicates.
 expr          : or_filters(and_filters(a > 1, c > 2), and_filters(b < 3, d < 4))
 cardinality   : 10
-estimated     : 8
+estimated     : 8.8
 in stats      :
 0 ColumnStat { min: UInt(0), max: UInt(0), ndv: 1.0, null_count: 0, histogram: None }
 1 ColumnStat { min: UInt(0), max: UInt(0), ndv: 1.0, null_count: 0, histogram: None }
 2 ColumnStat { min: UInt(0), max: UInt(4), ndv: 5.0, null_count: 0, histogram: None }
 3 ColumnStat { min: UInt(0), max: UInt(4), ndv: 5.0, null_count: 0, histogram: None }
 out stats     :
-0 ColumnStat { min: UInt(0), max: UInt(0), ndv: ~0.9999998976[..1.0], null_count: 0, histogram: None }
-1 ColumnStat { min: UInt(0), max: UInt(0), ndv: ~0.9999998976[..1.0], null_count: 0, histogram: None }
-2 ColumnStat { min: UInt(0), max: UInt(4), ndv: ~4.8[..5.0], null_count: 0, histogram: None }
-3 ColumnStat { min: UInt(0), max: UInt(4), ndv: ~4.8[..5.0], null_count: 0, histogram: None }
+0 ColumnStat { min: UInt(0), max: UInt(0), ndv: ~0.9999999993808264[..1.0], null_count: 0, histogram: None }
+1 ColumnStat { min: UInt(0), max: UInt(0), ndv: ~0.9999999993808264[..1.0], null_count: 0, histogram: None }
+2 ColumnStat { min: UInt(0), max: UInt(4), ndv: ~4.928[..5.0], null_count: 0, histogram: None }
+3 ColumnStat { min: UInt(0), max: UInt(4), ndv: ~4.928[..5.0], null_count: 0, histogram: None }
 

--- a/src/query/sql/tests/it/optimizer/selectivity_null.txt
+++ b/src/query/sql/tests/it/optimizer/selectivity_null.txt
@@ -2,11 +2,11 @@
 description: Estimated zero selectivity should not be treated as a proven empty result.
 expr          : is_not_null(n)
 cardinality   : 8
-estimated     : 0
+estimated     : 1.6
 in stats      :
 0 ColumnStat { min: UInt(0), max: UInt(5), ndv: 6.0, null_count: ~8.0, histogram: Some(TypedHistogram { accuracy: false, buckets: [TypedHistogramBucket { lower_bound: 0, upper_bound: 5, num_values: 6.0, num_distinct: 6.0 }], avg_spacing: None }) }
 out stats     :
-0 ColumnStat { min: UInt(0), max: UInt(5), ndv: 6.0, null_count: 0, histogram: Some(TypedHistogram { accuracy: false, buckets: [TypedHistogramBucket { lower_bound: 0, upper_bound: 5, num_values: 6.0, num_distinct: 6.0 }], avg_spacing: None }) }
+0 ColumnStat { min: UInt(0), max: UInt(5), ndv: ~1.5999999999999996[..1.6], null_count: 0, histogram: Some(TypedHistogram { accuracy: false, row_scale: 0.26666666666666666, buckets: [TypedHistogramBucket { lower_bound: 0, upper_bound: 5, num_values: 6.0, num_distinct: 6.0 }], avg_spacing: None }) }
 
 expr          : is_not_null(n)
 cardinality   : 0
@@ -18,11 +18,11 @@ out stats     :
 
 expr          : n > 10
 cardinality   : 8
-estimated     : 0
+estimated     : 1.6
 in stats      :
 0 ColumnStat { min: UInt(0), max: UInt(5), ndv: 6.0, null_count: 2, histogram: Some(TypedHistogram { accuracy: true, buckets: [TypedHistogramBucket { lower_bound: 0, upper_bound: 5, num_values: 6.0, num_distinct: 6.0 }], avg_spacing: None }) }
 out stats     :
-0 ColumnStat { min: UInt(0), max: UInt(5), ndv: 0.0, null_count: 0, histogram: None }
+0 ColumnStat { min: UInt(0), max: UInt(5), ndv: ~1.1999999999999997[..1.2000000000000002], null_count: ~0.4, histogram: None }
 
 expr          : n > 1
 cardinality   : exact 0

--- a/src/query/sql/tests/it/optimizer/selectivity_smoke.rs
+++ b/src/query/sql/tests/it/optimizer/selectivity_smoke.rs
@@ -54,6 +54,8 @@ use databend_common_statistics::StatBounds;
 use databend_common_statistics::TypedHistogram;
 use proptest::prelude::*;
 
+const DEFAULT_UNKNOWN_SELECTIVITY: f64 = 0.2;
+
 fn column_binding(name: &str, index: usize, data_type: DataType) -> ColumnBinding {
     ColumnBindingBuilder::new(
         name.to_string(),
@@ -119,6 +121,344 @@ fn zero_cardinality_comparison_selectivity_is_finite() {
 
     assert_eq!(estimated_rows, 0.0);
     assert!(estimated_rows.is_finite());
+    assert!(!estimator.is_proven_empty());
+    assert_eq!(
+        estimator.column_stats()[&Symbol::new(0)].ndv(),
+        NdvEstimate::exact(0.0)
+    );
+}
+
+#[test]
+fn estimated_zero_selectivity_is_not_proven_empty() {
+    let column_stats = ColumnStatSet::from_iter([(Symbol::new(0), ColumnStat::UInt {
+        min: 0,
+        max: 5,
+        ndv: NdvEstimate::exact(6.0),
+        null_count: StatCount::estimate(8.0, 8.0),
+        histogram: None,
+    })]);
+    let expr = function_expr("is_not_null", vec![column_expr(
+        "a",
+        0,
+        DataType::Nullable(Box::new(DataType::Number(NumberDataType::UInt64))),
+    )]);
+
+    let mut estimator = SelectivityEstimator::new(column_stats, StatCardinality::exact(8));
+    let estimated_rows = estimator
+        .apply(&[expr], &FunctionContext::default())
+        .expect("all-null estimate should use the unknown fallback");
+
+    assert_eq!(estimated_rows, 8.0 * DEFAULT_UNKNOWN_SELECTIVITY);
+    assert!(!estimator.is_proven_empty());
+    assert!(estimator.column_stats()[&Symbol::new(0)].ndv().upper > 0.0);
+}
+
+#[test]
+fn exact_all_null_selectivity_is_proven_empty() {
+    let column_stats = ColumnStatSet::from_iter([(Symbol::new(0), ColumnStat::AllNull {
+        null_count: StatCount::exact(8),
+    })]);
+    let expr = function_expr("is_not_null", vec![column_expr(
+        "a",
+        0,
+        DataType::Nullable(Box::new(DataType::Number(NumberDataType::UInt64))),
+    )]);
+
+    let mut estimator = SelectivityEstimator::new(column_stats, StatCardinality::exact(8));
+    let estimated_rows = estimator
+        .apply(&[expr], &FunctionContext::default())
+        .expect("exact all-null input should prove an empty filter");
+
+    assert_eq!(estimated_rows, 0.0);
+    assert!(estimator.is_proven_empty());
+    assert_eq!(
+        estimator.column_stats()[&Symbol::new(0)].ndv(),
+        NdvEstimate::exact(0.0)
+    );
+}
+
+#[test]
+fn constant_filter_truthiness_tracks_proven_empty() {
+    for (scalar, expected_rows, proven_empty) in [
+        (Scalar::Number(NumberScalar::UInt8(1)), 10.0, false),
+        (Scalar::Number(NumberScalar::Int8(-1)), 10.0, false),
+        (Scalar::Number(NumberScalar::UInt8(0)), 0.0, true),
+        (Scalar::Boolean(true), 10.0, false),
+        (Scalar::Boolean(false), 0.0, true),
+        (Scalar::Null, 0.0, true),
+    ] {
+        let mut estimator =
+            SelectivityEstimator::new(ColumnStatSet::new(), StatCardinality::estimate(10.0));
+        let estimated_rows = estimator
+            .apply(&[constant_expr(scalar)], &FunctionContext::default())
+            .expect("constant predicate should estimate");
+
+        assert_eq!(estimated_rows, expected_rows);
+        assert_eq!(estimator.is_proven_empty(), proven_empty);
+    }
+}
+
+#[test]
+fn stale_range_statistics_are_not_proven_empty() {
+    let column_stats = ColumnStatSet::from_iter([(Symbol::new(0), ColumnStat::UInt {
+        min: 0,
+        max: 5,
+        ndv: NdvEstimate::exact(6.0),
+        null_count: StatCount::exact(0),
+        histogram: None,
+    })]);
+    let expr = comparison_expr(
+        "gt",
+        column_expr("a", 0, DataType::Number(NumberDataType::UInt64)),
+        constant_expr(Scalar::Number(NumberScalar::UInt64(10))),
+    );
+
+    let mut estimator = SelectivityEstimator::new(column_stats, StatCardinality::estimate(100.0));
+    let estimated_rows = estimator
+        .apply(&[expr], &FunctionContext::default())
+        .expect("stale range should use an unknown selectivity");
+
+    assert_eq!(estimated_rows, 100.0 * DEFAULT_UNKNOWN_SELECTIVITY);
+    assert!(!estimator.is_proven_empty());
+    assert!(estimator.column_stats()[&Symbol::new(0)].ndv().upper > 0.0);
+}
+
+#[test]
+fn selective_equality_survives_stale_range_in_conjunction() {
+    let range_column = Symbol::new(0);
+    let equality_column = Symbol::new(1);
+    let column_stats = ColumnStatSet::from_iter([
+        (range_column, ColumnStat::UInt {
+            min: 0,
+            max: 5,
+            ndv: NdvEstimate::exact(6.0),
+            null_count: StatCount::exact(0),
+            histogram: None,
+        }),
+        (equality_column, ColumnStat::UInt {
+            min: 0,
+            max: 99,
+            ndv: NdvEstimate::exact(100.0),
+            null_count: StatCount::exact(0),
+            histogram: None,
+        }),
+    ]);
+    let stale_range = comparison_expr(
+        "gt",
+        column_expr("range_value", 0, DataType::Number(NumberDataType::UInt64)),
+        constant_expr(Scalar::Number(NumberScalar::UInt64(10))),
+    );
+    let selective_equality = comparison_expr(
+        "eq",
+        column_expr(
+            "selective_value",
+            1,
+            DataType::Number(NumberDataType::UInt64),
+        ),
+        constant_expr(Scalar::Number(NumberScalar::UInt64(42))),
+    );
+    let mut stale_range_only =
+        SelectivityEstimator::new(column_stats.clone(), StatCardinality::estimate(100.0));
+    let mut conjunction = SelectivityEstimator::new(column_stats, StatCardinality::estimate(100.0));
+
+    let stale_range_rows = stale_range_only
+        .apply(
+            std::slice::from_ref(&stale_range),
+            &FunctionContext::default(),
+        )
+        .expect("stale range should estimate");
+    let conjunction_rows = conjunction
+        .apply(
+            &[stale_range, selective_equality],
+            &FunctionContext::default(),
+        )
+        .expect("conjunction should estimate");
+
+    assert_eq!(stale_range_rows, 100.0 * DEFAULT_UNKNOWN_SELECTIVITY);
+    assert_eq!(conjunction_rows, 1.0);
+    assert!(conjunction_rows < stale_range_rows);
+    assert!(!conjunction.is_proven_empty());
+}
+
+#[test]
+fn unrelated_modulo_does_not_hide_proven_contradiction() {
+    let contradictory_lower = comparison_expr(
+        "gte",
+        column_expr("a", 0, DataType::Number(NumberDataType::UInt64)),
+        constant_expr(Scalar::Number(NumberScalar::UInt64(5))),
+    );
+    let contradictory_upper = comparison_expr(
+        "lt",
+        column_expr("a", 0, DataType::Number(NumberDataType::UInt64)),
+        constant_expr(Scalar::Number(NumberScalar::UInt64(5))),
+    );
+    let modulo = number_modulo_equality_expr(
+        Symbol::new(1),
+        NumberDataType::UInt64,
+        NumberScalar::UInt64(2),
+        NumberDataType::UInt64,
+        NumberScalar::UInt64(0),
+        NumberDataType::UInt64,
+    );
+    let mut estimator =
+        SelectivityEstimator::new(ColumnStatSet::new(), StatCardinality::estimate(100.0));
+
+    let rows = estimator
+        .apply(
+            &[contradictory_lower, contradictory_upper, modulo],
+            &FunctionContext::default(),
+        )
+        .expect("an unrelated modulo predicate must not hide an exact contradiction");
+
+    assert_eq!(rows, 0.0);
+    assert!(estimator.is_proven_empty());
+}
+
+#[test]
+fn erroring_modulo_is_not_removed_by_later_contradiction() {
+    let modulo_by_zero = number_modulo_equality_expr(
+        Symbol::new(1),
+        NumberDataType::UInt64,
+        NumberScalar::UInt64(0),
+        NumberDataType::UInt64,
+        NumberScalar::UInt64(0),
+        NumberDataType::UInt64,
+    );
+    let contradictory_lower = comparison_expr(
+        "gte",
+        column_expr("a", 0, DataType::Number(NumberDataType::UInt64)),
+        constant_expr(Scalar::Number(NumberScalar::UInt64(5))),
+    );
+    let contradictory_upper = comparison_expr(
+        "lt",
+        column_expr("a", 0, DataType::Number(NumberDataType::UInt64)),
+        constant_expr(Scalar::Number(NumberScalar::UInt64(5))),
+    );
+    let mut estimator =
+        SelectivityEstimator::new(ColumnStatSet::new(), StatCardinality::estimate(100.0));
+
+    let rows = estimator
+        .apply(
+            &[modulo_by_zero, contradictory_lower, contradictory_upper],
+            &FunctionContext::default(),
+        )
+        .expect("a later contradiction must not remove an earlier erroring modulo predicate");
+
+    assert!(rows > 0.0);
+    assert!(!estimator.is_proven_empty());
+}
+
+#[test]
+fn modulo_with_negative_divisor_is_not_proven_empty() {
+    let mut estimator = SelectivityEstimator::new(ColumnStatSet::new(), StatCardinality::exact(10));
+    let predicate = int64_modulo_equality_expr(Symbol::new(0), -2, 0);
+
+    assert!(
+        estimator
+            .apply(&[predicate], &FunctionContext::default())
+            .unwrap()
+            > 0.0
+    );
+    assert!(!estimator.is_proven_empty());
+}
+
+#[test]
+fn modulo_large_integer_comparison_does_not_lose_precision() {
+    let mut estimator = SelectivityEstimator::new(ColumnStatSet::new(), StatCardinality::exact(1));
+    let predicate = int64_modulo_equality_expr(Symbol::new(0), i64::MIN, i64::MAX);
+
+    assert!(
+        estimator
+            .apply(&[predicate], &FunctionContext::default())
+            .unwrap()
+            > 0.0
+    );
+    assert!(!estimator.is_proven_empty());
+}
+
+#[test]
+fn modulo_mixed_integer_signedness_is_not_proven_empty() {
+    let mut estimator = SelectivityEstimator::new(ColumnStatSet::new(), StatCardinality::exact(1));
+    let predicate = number_modulo_equality_expr(
+        Symbol::new(0),
+        NumberDataType::UInt64,
+        NumberScalar::Int8(-2),
+        NumberDataType::Int8,
+        NumberScalar::UInt8(255),
+        NumberDataType::UInt8,
+    );
+
+    assert!(
+        estimator
+            .apply(&[predicate], &FunctionContext::default())
+            .unwrap()
+            > 0.0
+    );
+    assert!(!estimator.is_proven_empty());
+}
+
+#[test]
+fn modulo_out_of_range_remainders_are_not_proven_empty() {
+    for (divisor, remainder) in [(-1, -1), (-2, -2), (-2, 2), (2, -2), (2, 2)] {
+        let mut estimator =
+            SelectivityEstimator::new(ColumnStatSet::new(), StatCardinality::exact(10));
+        let predicate = int64_modulo_equality_expr(Symbol::new(0), divisor, remainder);
+
+        assert!(
+            estimator
+                .apply(&[predicate], &FunctionContext::default())
+                .unwrap()
+                > 0.0
+        );
+        assert!(!estimator.is_proven_empty());
+    }
+}
+
+fn int64_modulo_equality_expr(column_index: Symbol, divisor: i64, remainder: i64) -> ScalarExpr {
+    number_modulo_equality_expr(
+        column_index,
+        NumberDataType::Int64,
+        NumberScalar::Int64(divisor),
+        NumberDataType::Int64,
+        NumberScalar::Int64(remainder),
+        NumberDataType::Int64,
+    )
+}
+
+fn number_modulo_equality_expr(
+    column_index: Symbol,
+    column_type: NumberDataType,
+    divisor: NumberScalar,
+    divisor_type: NumberDataType,
+    remainder: NumberScalar,
+    remainder_type: NumberDataType,
+) -> ScalarExpr {
+    let modulo = function_expr("modulo", vec![
+        column_expr(
+            "number",
+            column_index.as_usize(),
+            DataType::Number(column_type),
+        ),
+        ScalarExpr::TypedConstantExpr(
+            ConstantExpr {
+                span: None,
+                value: Scalar::Number(divisor),
+            },
+            DataType::Number(divisor_type),
+        ),
+    ]);
+
+    comparison_expr(
+        "eq",
+        modulo,
+        ScalarExpr::TypedConstantExpr(
+            ConstantExpr {
+                span: None,
+                value: Scalar::Number(remainder),
+            },
+            DataType::Number(remainder_type),
+        ),
+    )
 }
 
 #[test]

--- a/src/query/sql/tests/it/optimizer/selectivity_special_predicate.txt
+++ b/src/query/sql/tests/it/optimizer/selectivity_special_predicate.txt
@@ -12,13 +12,13 @@ out stats     :
 
 expr          : a % 4 = 5
 cardinality   : 100
-estimated     : 0
+estimated     : 20
 in stats      :
 0 ColumnStat { min: UInt(0), max: UInt(9), ndv: 10.0, null_count: 0, histogram: None }
 1 ColumnStat { min: UInt(0), max: UInt(9), ndv: 10.0, null_count: 10, histogram: None }
 out stats     :
-0 ColumnStat { min: UInt(0), max: UInt(9), ndv: 0.0, null_count: 0, histogram: None }
-1 ColumnStat { min: UInt(0), max: UInt(9), ndv: 0.0, null_count: 0, histogram: None }
+0 ColumnStat { min: UInt(0), max: UInt(9), ndv: ~8.926258176[..10.0], null_count: 0, histogram: None }
+1 ColumnStat { min: UInt(0), max: UInt(9), ndv: ~8.657822719999999[..10.0], null_count: ~2.0, histogram: None }
 
 expr          : a % 0 = 0
 cardinality   : 100
@@ -40,11 +40,11 @@ out stats     :
 
 expr          : i % 4 = 5
 cardinality   : 100
-estimated     : 0
+estimated     : 20
 in stats      :
 0 ColumnStat { min: Int(-9), max: Int(9), ndv: 19.0, null_count: 0, histogram: None }
 out stats     :
-0 ColumnStat { min: Int(-9), max: Int(9), ndv: 0.0, null_count: 0, histogram: None }
+0 ColumnStat { min: Int(-9), max: Int(9), ndv: ~13.129151127426473[..19.0], null_count: 0, histogram: None }
 
 expr          : i % -4 = -1
 cardinality   : 100
@@ -56,11 +56,11 @@ out stats     :
 
 expr          : i % -4 = 5
 cardinality   : 100
-estimated     : 0
+estimated     : 20
 in stats      :
 0 ColumnStat { min: Int(-9), max: Int(9), ndv: 19.0, null_count: 0, histogram: None }
 out stats     :
-0 ColumnStat { min: Int(-9), max: Int(9), ndv: 0.0, null_count: 0, histogram: None }
+0 ColumnStat { min: Int(-9), max: Int(9), ndv: ~13.129151127426473[..19.0], null_count: 0, histogram: None }
 
 expr          : i % -1 = 0
 cardinality   : 100
@@ -90,11 +90,11 @@ out stats     :
 
 expr          : s like 'a\_b'
 cardinality   : 100
-estimated     : 0
+estimated     : 12.5
 in stats      :
 0 ColumnStat { min: Bytes([97, 97]), max: Bytes([122, 122]), ndv: 40.0, null_count: 0, histogram: None }
 out stats     :
-0 ColumnStat { min: Bytes([97, 97]), max: Bytes([122, 122]), ndv: 0.0, null_count: 0, histogram: None }
+0 ColumnStat { min: Bytes([97, 97]), max: Bytes([122, 122]), ndv: ~11.352935632512011[..12.5], null_count: 0, histogram: None }
 
 expr          : s like '%%%%'
 cardinality   : 100

--- a/src/query/sql/tests/it/optimizer/selectivity_typed_comparison.txt
+++ b/src/query/sql/tests/it/optimizer/selectivity_typed_comparison.txt
@@ -28,11 +28,11 @@ out stats     :
 description: Constant constraints should apply only when the typed comparison is compatible.
 expr          : d = cast(10 as date)
 cardinality   : 100
-estimated     : 0
+estimated     : 20
 in stats      :
 0 ColumnStat { min: Int(20), max: Int(29), ndv: 10.0, null_count: 0, histogram: None }
 out stats     :
-0 ColumnStat { min: Int(20), max: Int(29), ndv: 0.0, null_count: 0, histogram: None }
+0 ColumnStat { min: Int(10), max: Int(10), ndv: 1.0, null_count: 0, histogram: None }
 
 expr          : d = cast(25 as date)
 cardinality   : 100
@@ -60,11 +60,11 @@ out stats     :
 
 expr          : dec = cast(5.00 as decimal(10, 2))
 cardinality   : 100
-estimated     : 0
+estimated     : 20
 in stats      :
 0 ColumnStat { min: Float(1.0), max: Float(4.0), ndv: 4.0, null_count: 0, histogram: None }
 out stats     :
-0 ColumnStat { min: Float(1.0), max: Float(4.0), ndv: 0.0, null_count: 0, histogram: None }
+0 ColumnStat { min: Float(5.0), max: Float(5.0), ndv: 1.0, null_count: 0, histogram: None }
 
 expr          : dec = cast(2.00 as decimal(10, 2))
 cardinality   : 100
@@ -78,11 +78,11 @@ out stats     :
 description: String equality should use domain and function statistics without assuming unbounded strings are impossible.
 expr          : s = 'a'
 cardinality   : 100
-estimated     : 0
+estimated     : 20
 in stats      :
 0 ColumnStat { min: Bytes([98]), max: Bytes([101]), ndv: 4.0, null_count: 0, histogram: None }
 out stats     :
-0 ColumnStat { min: Bytes([98]), max: Bytes([101]), ndv: 0.0, null_count: 0, histogram: None }
+0 ColumnStat { min: Bytes([97]), max: Bytes([97]), ndv: 1.0, null_count: 0, histogram: None }
 
 expr          : s = 'c'
 cardinality   : 100

--- a/src/query/sql/tests/it/planner.rs
+++ b/src/query/sql/tests/it/planner.rs
@@ -79,6 +79,12 @@ const LITE_REPLAY_CASE_SPECS: &[LiteReplayCaseSpec] = &[
         default_node_num: 2,
     },
     LiteReplayCaseSpec {
+        name: "02_outer_join_stale_statistics",
+        warehouse_distribution: true,
+        optimizer_skip_list: &[],
+        default_node_num: 1,
+    },
+    LiteReplayCaseSpec {
         name: "01_multi_join_avg_case_expression",
         warehouse_distribution: true,
         optimizer_skip_list: &[],

--- a/tests/sqllogictests/suites/base/03_common/03_0005_select_filter.test
+++ b/tests/sqllogictests/suites/base/03_common/03_0005_select_filter.test
@@ -43,6 +43,39 @@ SELECT count() FROM numbers_mt (10) where -1
 ----
 10
 
+query I
+SELECT count(*) FROM numbers(10) WHERE to_int64(number) % -2 = 0
+----
+5
+
+query I
+SELECT count(*)
+FROM numbers(1)
+WHERE (to_int64(number) + 9223372036854775807)
+      % (-9223372036854775807 - 1)
+      = 9223372036854775807
+----
+1
+
+query I
+SELECT count(*)
+FROM numbers(1)
+WHERE (number + 18446744073709551615) % to_int64(-2) = 255
+----
+1
+
+query I
+SELECT count(*)
+FROM numbers(1)
+WHERE (to_int64(number) - 9223372036854775807 - 1) % -1 = -1
+----
+0
+
+statement error Division by zero
+SELECT count(*)
+FROM numbers(1)
+WHERE (to_int64(number) - 9223372036854775807 - 1) % 0 = -1
+
 query II
 SELECT number as c1, (number+1) as c2 FROM numbers_mt (3) where number >1
 ----

--- a/tests/sqllogictests/suites/mode/standalone/explain/bloom_filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/bloom_filter.test
@@ -122,7 +122,7 @@ explain select 1 from bloom_test_t where c2=0;
 EvalScalar
 ├── output columns: [1 (#3)]
 ├── expressions: [1]
-├── estimated rows: 0.00
+├── estimated rows: 1.60
 └── TableScan
     ├── table: default.default.bloom_test_t
     ├── scan id: 0
@@ -133,7 +133,7 @@ EvalScalar
     ├── partitions scanned: 0
     ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 3 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 0 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(bloom_test_t.c2 (#1) = 0)], limit: NONE]
-    └── estimated rows: 0.00
+    └── estimated rows: 1.60
 
 query T
 explain select 1 from bloom_test_t where c2=3;

--- a/tests/sqllogictests/suites/mode/standalone/explain/current_time_selectivity.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/current_time_selectivity.test
@@ -38,16 +38,16 @@ Aggregate(Final)
     ├── group items: []
     ├── aggregate functions: [count() AS (#5)]
     └── Join(Inner)
-        ├── build keys: [customers.segment_id (#3)]
-        ├── probe keys: [segments.segment_id (#4)]
+        ├── build keys: [customers.customer_id (#2)]
+        ├── probe keys: [fact_events.customer_id (#0)]
         ├── other filters: []
         ├── Join(Inner)
-        │   ├── build keys: [fact_events.customer_id (#0)]
-        │   ├── probe keys: [customers.customer_id (#2)]
+        │   ├── build keys: [segments.segment_id (#4)]
+        │   ├── probe keys: [customers.segment_id (#3)]
         │   ├── other filters: []
         │   ├── Scan
-        │   │   ├── table: current_time_selectivity.fact_events (#0)
-        │   │   ├── filters: [gte(fact_events.event_time (#1), subtract_hours(now(), 24))]
+        │   │   ├── table: current_time_selectivity.segments (#2)
+        │   │   ├── filters: []
         │   │   ├── order by: []
         │   │   └── limit: NONE
         │   └── Scan
@@ -56,8 +56,8 @@ Aggregate(Final)
         │       ├── order by: []
         │       └── limit: NONE
         └── Scan
-            ├── table: current_time_selectivity.segments (#2)
-            ├── filters: []
+            ├── table: current_time_selectivity.fact_events (#0)
+            ├── filters: [gte(fact_events.event_time (#1), subtract_hours(now(), 24))]
             ├── order by: []
             └── limit: NONE
 

--- a/tests/sqllogictests/suites/mode/standalone/explain/eliminate_outer_join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/eliminate_outer_join.test
@@ -599,7 +599,7 @@ explain select * from t left join t t1 on t.a = t1.a where t1.a <= 1 or (t.a > 1
 Filter
 ├── output columns: [t.a (#0), t1.a (#1)]
 ├── filters: [t1.a (#1) <= 1 or t.a (#0) > 1 and t.a (#0) < 2]
-├── estimated rows: 2.00
+├── estimated rows: 8.40
 └── HashJoin
     ├── output columns: [t.a (#0), t1.a (#1)]
     ├── join type: LEFT OUTER

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -35,7 +35,7 @@ TableScan
 ├── partitions scanned: 0
 ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
 ├── push downs: [filters: [t1.a (#0) > 0], limit: NONE]
-└── estimated rows: 0.00
+└── estimated rows: 0.20
 
 query T
 explain(verbose) select * from numbers(0)
@@ -71,7 +71,7 @@ explain select * from t1, t2 where (t1.a = t2.a and t1.a > 3) or (t1.a = t2.a an
 Filter
 ├── output columns: [t2.a (#2), t2.b (#3), t1.b (#1), t1.a (#0)]
 ├── filters: [t1.a (#0) > 3 or t2.a (#2) > 5 and t1.a (#0) > 1]
-├── estimated rows: 0.00
+├── estimated rows: 0.04
 └── HashJoin
     ├── output columns: [t2.a (#2), t2.b (#3), t1.b (#1), t1.a (#0)]
     ├── join type: INNER
@@ -81,7 +81,7 @@ Filter
     ├── filters: []
     ├── build join filters:
     │   └── filter id:0, build key:t1.a (#0), probe targets:[t2.a (#2)@scan1], filter type:bloom,inlist,min_max
-    ├── estimated rows: 0.00
+    ├── estimated rows: 0.20
     ├── TableScan(Build)
     │   ├── table: default.default.t1
     │   ├── scan id: 0
@@ -92,7 +92,7 @@ Filter
     │   ├── partitions scanned: 0
     │   ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
     │   ├── push downs: [filters: [t1.a (#0) > 3 or t1.a (#0) > 1], limit: NONE]
-    │   └── estimated rows: 0.00
+    │   └── estimated rows: 0.20
     └── TableScan(Probe)
         ├── table: default.default.t2
         ├── scan id: 1
@@ -350,7 +350,7 @@ explain select * from t1,t2 where (t1.a > 1 and t2.a > 2) or (t1.b < 3 and t2.b 
 Filter
 ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
 ├── filters: [t1.a (#0) > 1 and t2.a (#2) > 2 or t1.b (#1) < 3 and t2.b (#3) < 4]
-├── estimated rows: 4.00
+├── estimated rows: 4.18
 └── HashJoin
     ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
     ├── join type: CROSS
@@ -388,7 +388,7 @@ explain select * from t1,t2 where (t1.a > 1 and t2.a > 2) or (t1.b < 3 and t2.b 
 Filter
 ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
 ├── filters: [t1.a (#0) > 1 and t2.a (#2) > 2 or t1.b (#1) < 3 and t2.b (#3) < 4 or t1.a (#0) = 2]
-├── estimated rows: 4.00
+├── estimated rows: 4.40
 └── HashJoin
     ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
     ├── join type: CROSS
@@ -436,7 +436,7 @@ HashJoin
 ├── probe keys: []
 ├── keys is null equal: []
 ├── filters: [t1.a (#0) > 1 and t2.a (#2) > 2 or t1.b (#1) < 3 and t2.b (#3) < 4 or t3.a (#4) = 2]
-├── estimated rows: 41.00
+├── estimated rows: 44.60
 ├── HashJoin(Build)
 │   ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
 │   ├── join type: CROSS
@@ -489,11 +489,11 @@ HashJoin
 ├── probe keys: []
 ├── keys is null equal: []
 ├── filters: []
-├── estimated rows: 32.00
+├── estimated rows: 33.45
 ├── Filter(Build)
 │   ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
 │   ├── filters: [t1.a (#0) > 1 and t2.a (#2) > 2 or t1.b (#1) < 3 and t2.b (#3) < 4]
-│   ├── estimated rows: 4.00
+│   ├── estimated rows: 4.18
 │   └── HashJoin
 │       ├── output columns: [t2.a (#2), t2.b (#3), t1.a (#0), t1.b (#1)]
 │       ├── join type: CROSS

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain_analyze_partial.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain_analyze_partial.test
@@ -81,13 +81,13 @@ query T
 explain analyze partial select * from t1 join t2 on t1.a = t2.b where t1.a > 10;
 ----
 HashJoin: INNER
-├── estimated rows: 0.00
+├── estimated rows: 2.00
 ├── TableScan
 │   ├── table: default.default.t2
-│   └── estimated rows: 0.00
+│   └── estimated rows: 2.00
 └── TableScan
     ├── table: default.default.t1
-    └── estimated rows: 0.00
+    └── estimated rows: 2.00
 
 
 statement ok

--- a/tests/sqllogictests/suites/mode/standalone/explain/filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/filter.test
@@ -74,7 +74,7 @@ TableScan
 ├── partitions scanned: 0
 ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 2 to 0 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(t1.d (#0) < CAST(t1.a (#1) AS Timestamp NULL))], limit: NONE]
-└── estimated rows: 0.00
+└── estimated rows: 40.00
 
 query T
 explain select * from  t2 where d < a;
@@ -89,7 +89,7 @@ TableScan
 ├── partitions scanned: 0
 ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 2 to 0 cost: <slt:ignore>>]
 ├── push downs: [filters: [t2.d (#0) < CAST(t2.a (#1) AS Timestamp)], limit: NONE]
-└── estimated rows: 0.00
+└── estimated rows: 40.00
 
 query T
 explain select number from numbers(6) where number = 1 or number = 5 or number = 3;

--- a/tests/sqllogictests/suites/mode/standalone/explain/function_context_statistics.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/function_context_statistics.test
@@ -9,8 +9,9 @@ statement ok
 CREATE TABLE function_context_default_filter AS
 SELECT 1643745600000000::TIMESTAMP AS ts FROM numbers(10)
 
-## SelectivityEstimator::apply folds the predicate with the query context.
-## All ten timestamps have local date 2022-02-02 in Asia/Shanghai.
+## The predicate uses the query context, but stored timestamp bounds cannot
+## prove it true. The cast comparison currently uses an unknown estimate;
+## the result check below still verifies the Asia/Shanghai interpretation.
 
 query T
 SETTINGS (timezone = 'Asia/Shanghai')
@@ -26,10 +27,24 @@ Scan
 ├── output columns: [function_context_default_filter.ts (#0)]
 ├── outer columns: []
 ├── used columns: [function_context_default_filter.ts (#0)]
-├── cardinality: 10.000
+├── cardinality: 2.000
 ├── precise cardinality: N/A
 └── statistics
-    └── function_context_default_filter.ts (#0): { min: 1643745600000000, max: 1643745600000000, ndv: 1, null count: 0 }
+    └── function_context_default_filter.ts (#0): { min: 1643745600000000, max: 1643745600000000, ndv: 0.8926258175999999, null count: 0 }
+
+query I
+SETTINGS (timezone = 'Asia/Shanghai')
+SELECT count(*) FROM function_context_default_filter
+WHERE to_date(ts) = DATE '2022-02-02'
+----
+10
+
+query I
+SETTINGS (timezone = 'UTC')
+SELECT count(*) FROM function_context_default_filter
+WHERE to_date(ts) = DATE '2022-02-02'
+----
+0
 
 statement ok
 DROP TABLE function_context_default_filter

--- a/tests/sqllogictests/suites/mode/standalone/explain/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join.test
@@ -101,7 +101,7 @@ HashJoin
 ├── probe keys: []
 ├── keys is null equal: []
 ├── filters: []
-├── estimated rows: 0.00
+├── estimated rows: 1.60
 ├── TableScan(Build)
 │   ├── table: default.default.t
 │   ├── scan id: 0
@@ -112,7 +112,7 @@ HashJoin
 │   ├── partitions scanned: 0
 │   ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [t.number (#0) > 1], limit: NONE]
-│   └── estimated rows: 0.00
+│   └── estimated rows: 0.20
 └── TableScan(Probe)
     ├── table: default.default.t1
     ├── scan id: 1
@@ -176,7 +176,7 @@ HashJoin
 ├── filters: []
 ├── build join filters:
 │   └── filter id:0, build key:t1.number (#1), probe targets:[t2.number (#2)@scan2], filter type:bloom,inlist,min_max
-├── estimated rows: 0.00
+├── estimated rows: 2.00
 ├── HashJoin(Build)
 │   ├── output columns: [t1.number (#1), t.number (#0)]
 │   ├── join type: CROSS
@@ -184,7 +184,7 @@ HashJoin
 │   ├── probe keys: []
 │   ├── keys is null equal: []
 │   ├── filters: []
-│   ├── estimated rows: 0.00
+│   ├── estimated rows: 2.00
 │   ├── TableScan(Build)
 │   │   ├── table: default.default.t
 │   │   ├── scan id: 0
@@ -195,7 +195,7 @@ HashJoin
 │   │   ├── partitions scanned: 0
 │   │   ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
 │   │   ├── push downs: [filters: [t.number (#0) = 1], limit: NONE]
-│   │   └── estimated rows: 0.00
+│   │   └── estimated rows: 0.20
 │   └── TableScan(Probe)
 │       ├── table: default.default.t1
 │       ├── scan id: 1
@@ -1048,7 +1048,7 @@ HashJoin
 ├── probe keys: []
 ├── keys is null equal: []
 ├── filters: [s.a (#1) <= t1.a (#2)]
-├── estimated rows: 0.00
+├── estimated rows: 0.80
 ├── TableScan(Build)
 │   ├── table: default.default.t1
 │   ├── scan id: 1
@@ -1059,7 +1059,7 @@ HashJoin
 │   ├── partitions scanned: 0
 │   ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t1.a (#2) > 100)], limit: NONE]
-│   └── estimated rows: 0.00
+│   └── estimated rows: 0.80
 └── EvalScalar(Probe)
     ├── output columns: [MAX(a) (#1)]
     ├── expressions: [1]

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_inner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_inner.test
@@ -30,7 +30,7 @@ HashJoin
 ├── filters: []
 ├── build join filters:
 │   └── filter id:0, build key:t2.a (#2), probe targets:[t1.a (#0)@scan0], filter type:bloom,inlist,min_max
-├── estimated rows: 0.00
+├── estimated rows: 0.40
 ├── TableScan(Build)
 │   ├── table: default.default.t2
 │   ├── scan id: 1
@@ -41,7 +41,7 @@ HashJoin
 │   ├── partitions scanned: 0
 │   ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t2.a (#2) > 3)], limit: NONE]
-│   └── estimated rows: 0.00
+│   └── estimated rows: 0.60
 └── TableScan(Probe)
     ├── table: default.default.t1
     ├── scan id: 0
@@ -53,7 +53,7 @@ HashJoin
     ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t1.a (#0) > 3)], limit: NONE]
     ├── apply join filters: [#0]
-    └── estimated rows: 0.00
+    └── estimated rows: 0.80
 
 # can propagate (t2.a > 1 or t2.a <= 2)
 query T

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_semi_anti.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_semi_anti.test
@@ -30,7 +30,7 @@ HashJoin
 ├── filters: []
 ├── build join filters:
 │   └── filter id:0, build key:t2.a (#2), probe targets:[t1.a (#0)@scan0], filter type:bloom,inlist,min_max
-├── estimated rows: 0.00
+├── estimated rows: 0.40
 ├── TableScan(Build)
 │   ├── table: default.default.t2
 │   ├── scan id: 1
@@ -41,7 +41,7 @@ HashJoin
 │   ├── partitions scanned: 0
 │   ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t2.a (#2) > 3)], limit: NONE]
-│   └── estimated rows: 0.00
+│   └── estimated rows: 0.60
 └── TableScan(Probe)
     ├── table: default.default.t1
     ├── scan id: 0
@@ -53,7 +53,7 @@ HashJoin
     ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t1.a (#0) > 3)], limit: NONE]
     ├── apply join filters: [#0]
-    └── estimated rows: 0.00
+    └── estimated rows: 0.80
 
 # left anti, can propagate t1.a > 3
 query T
@@ -66,7 +66,7 @@ HashJoin
 ├── probe keys: [t1.a (#0)]
 ├── keys is null equal: [false]
 ├── filters: []
-├── estimated rows: 0.00
+├── estimated rows: 0.40
 ├── TableScan(Build)
 │   ├── table: default.default.t2
 │   ├── scan id: 1
@@ -77,7 +77,7 @@ HashJoin
 │   ├── partitions scanned: 0
 │   ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t2.a (#2) > 3)], limit: NONE]
-│   └── estimated rows: 0.00
+│   └── estimated rows: 0.60
 └── TableScan(Probe)
     ├── table: default.default.t1
     ├── scan id: 0
@@ -88,7 +88,7 @@ HashJoin
     ├── partitions scanned: 0
     ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t1.a (#0) > 3)], limit: NONE]
-    └── estimated rows: 0.00
+    └── estimated rows: 0.80
 
 statement ok
 drop table if exists t1;

--- a/tests/sqllogictests/suites/mode/standalone/explain/range_pruner.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/range_pruner.test
@@ -10,7 +10,7 @@ explain select 1 from range_t where c > 'efg'
 EvalScalar
 ├── output columns: [1 (#2)]
 ├── expressions: [1]
-├── estimated rows: 0.00
+├── estimated rows: 0.40
 └── TableScan
     ├── table: default.default.range_t
     ├── scan id: 0
@@ -21,7 +21,7 @@ EvalScalar
     ├── partitions scanned: 0
     ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(range_t.c (#0) > 'efg')], limit: NONE]
-    └── estimated rows: 0.00
+    └── estimated rows: 0.40
 
 
 query T
@@ -35,7 +35,7 @@ explain select 1 from range_t where i > 20
 EvalScalar
 ├── output columns: [1 (#2)]
 ├── expressions: [1]
-├── estimated rows: 0.00
+├── estimated rows: 0.40
 └── TableScan
     ├── table: default.default.range_t
     ├── scan id: 0
@@ -46,7 +46,7 @@ EvalScalar
     ├── partitions scanned: 0
     ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(range_t.i (#1) > 20)], limit: NONE]
-    └── estimated rows: 0.00
+    └── estimated rows: 0.40
 
 statement ok
 create or replace table range_pruner_trust_loan_daily(contract_no varchar, notify_date int)
@@ -60,7 +60,7 @@ explain select 1 from range_pruner_trust_loan_daily where notify_date = '2024051
 EvalScalar
 ├── output columns: [1 (#2)]
 ├── expressions: [1]
-├── estimated rows: 0.00
+├── estimated rows: 0.20
 └── TableScan
     ├── table: default.default.range_pruner_trust_loan_daily
     ├── scan id: 0
@@ -71,7 +71,7 @@ EvalScalar
     ├── partitions scanned: 0
     ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
     ├── push downs: [filters: [range_pruner_trust_loan_daily.notify_date (#1) = '20240513' and range_pruner_trust_loan_daily.contract_no (#0) = '20240508003088208902099794704998'], limit: NONE]
-    └── estimated rows: 0.00
+    └── estimated rows: 0.20
 
 query T
 explain select number from numbers(10) where number > 5 and try_cast(get(try_parse_json(number::String),'xx') as varchar) < '10' and 1 = 0;

--- a/tests/sqllogictests/suites/mode/standalone/explain/selectivity/filter.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/selectivity/filter.test
@@ -29,7 +29,7 @@ TableScan
 ├── partitions scanned: 0
 ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(t.number (#0) > 737)], limit: NONE]
-└── estimated rows: 0.00
+└── estimated rows: 147.60
 
 query T
 EXPLAIN SELECT * FROM t WHERE number > 700;

--- a/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
@@ -626,7 +626,7 @@ EvalScalar
     │               ├── output columns: []
     │               ├── limit: 1
     │               ├── offset: 0
-    │               ├── estimated rows: 0.00
+    │               ├── estimated rows: 0.80
     │               └── TableScan
     │                   ├── table: default.default.t
     │                   ├── scan id: 1
@@ -637,7 +637,7 @@ EvalScalar
     │                   ├── partitions scanned: 0
     │                   ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
     │                   ├── push downs: [filters: [is_true(t.i (#1) > 10)], limit: 1]
-    │                   └── estimated rows: 0.00
+    │                   └── estimated rows: 0.80
     └── TableScan(Probe)
         ├── table: default.default.t
         ├── scan id: 0
@@ -802,7 +802,7 @@ TableScan
 ├── partitions scanned: 1
 ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(like(t.i (#0), 'data%'))], limit: NONE]
-└── estimated rows: 3.00
+└── estimated rows: 0.38
 
 query T
 select * from t where i like any (SELECT c1 FROM (VALUES ('data%')) words(c1));
@@ -821,7 +821,7 @@ HashJoin
 ├── probe keys: []
 ├── keys is null equal: []
 ├── filters: [like(t.i (#0), CAST(subquery_1 (#1) AS String NULL))]
-├── estimated rows: 3.00
+├── estimated rows: 1.50
 ├── ConstantTableScan(Build)
 │   ├── output columns: [c1 (#1)]
 │   └── column 0: ['data%']
@@ -872,7 +872,7 @@ HashJoin
 ├── probe keys: []
 ├── keys is null equal: []
 ├── filters: [like(t.i (#0), CAST(subquery_1 (#1) AS String NULL), '$')]
-├── estimated rows: 0.38
+├── estimated rows: 1.50
 ├── ConstantTableScan(Build)
 │   ├── output columns: [c1 (#1)]
 │   └── column 0: ['data$%%']

--- a/tests/sqllogictests/suites/mode/standalone/explain/union.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/union.test
@@ -27,7 +27,7 @@ explain select * from v where a > b
 ----
 UnionAll
 ├── output columns: [a (#4), b (#5)]
-├── estimated rows: 0.00
+├── estimated rows: 0.80
 ├── TableScan
 │   ├── table: default.default.t1
 │   ├── scan id: 0
@@ -38,7 +38,7 @@ UnionAll
 │   ├── partitions scanned: 0
 │   ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
 │   ├── push downs: [filters: [is_true(t1.a (#0) > t1.b (#1))], limit: NONE]
-│   └── estimated rows: 0.00
+│   └── estimated rows: 0.40
 └── TableScan
     ├── table: default.default.t2
     ├── scan id: 1
@@ -49,7 +49,7 @@ UnionAll
     ├── partitions scanned: 0
     ├── pruning stats: [segments: <read cost: <slt:ignore>, range pruning: 1 to 0 cost: <slt:ignore>>]
     ├── push downs: [filters: [is_true(t2.a (#2) > t2.b (#3))], limit: NONE]
-    └── estimated rows: 0.00
+    └── estimated rows: 0.40
 
 query T
 explain select * from v where a > 1

--- a/tests/sqllogictests/suites/tpch_iceberg/prune.test
+++ b/tests/sqllogictests/suites/tpch_iceberg/prune.test
@@ -19,11 +19,11 @@ explain select 1 from  ctl.tpch.lineitem where l_orderkey < 1;
 EvalScalar
 ├── output columns: [1 (#16)]
 ├── expressions: [1]
-├── estimated rows: 0.00
+├── estimated rows: 120114.40
 └── Filter
     ├── output columns: []
     ├── filters: [is_true(lineitem.l_orderkey (#0) < 1)]
-    ├── estimated rows: 0.00
+    ├── estimated rows: 120114.40
     └── TableScan
         ├── table: ctl.tpch.lineitem
         ├── scan id: 0
@@ -41,11 +41,11 @@ explain select 1 from  ctl.tpch.lineitem where l_orderkey < 1 or l_commitdate < 
 EvalScalar
 ├── output columns: [1 (#16)]
 ├── expressions: [1]
-├── estimated rows: 0.00
+├── estimated rows: 120114.40
 └── Filter
     ├── output columns: []
     ├── filters: [lineitem.l_orderkey (#0) < 1 or lineitem.l_commitdate (#11) < '1992-01-31']
-    ├── estimated rows: 0.00
+    ├── estimated rows: 120114.40
     └── TableScan
         ├── table: ctl.tpch.lineitem
         ├── scan id: 0
@@ -63,11 +63,11 @@ explain select 1 from  ctl.tpch.lineitem where l_orderkey < 1 and l_commitdate >
 EvalScalar
 ├── output columns: [1 (#16)]
 ├── expressions: [1]
-├── estimated rows: 0.00
+├── estimated rows: 120114.40
 └── Filter
     ├── output columns: []
     ├── filters: [is_true(lineitem.l_orderkey (#0) < 1), is_true(lineitem.l_commitdate (#11) > '1992-01-31')]
-    ├── estimated rows: 0.00
+    ├── estimated rows: 120114.40
     └── TableScan
         ├── table: ctl.tpch.lineitem
         ├── scan id: 0
@@ -85,11 +85,11 @@ explain select 1 from  ctl.tpch.lineitem where l_orderkey > 1 and l_commitdate =
 EvalScalar
 ├── output columns: [1 (#16)]
 ├── expressions: [1]
-├── estimated rows: 0.00
+├── estimated rows: 120114.40
 └── Filter
     ├── output columns: []
     ├── filters: [is_true(lineitem.l_orderkey (#0) > 1), is_true(lineitem.l_commitdate (#11) = '1992-01-22')]
-    ├── estimated rows: 0.00
+    ├── estimated rows: 120114.40
     └── TableScan
         ├── table: ctl.tpch.lineitem
         ├── scan id: 0
@@ -108,11 +108,11 @@ explain select 1 from ctl.tpch.lineitem where l_orderkey < 1 and length(l_commen
 EvalScalar
 ├── output columns: [1 (#16)]
 ├── expressions: [1]
-├── estimated rows: 0.00
+├── estimated rows: 120114.40
 └── Filter
     ├── output columns: []
     ├── filters: [is_true(lineitem.l_orderkey (#0) < 1), is_true(length(lineitem.l_comment (#15)) > 0)]
-    ├── estimated rows: 0.00
+    ├── estimated rows: 120114.40
     └── TableScan
         ├── table: ctl.tpch.lineitem
         ├── scan id: 0


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Keep **zero-row estimates** separate from **proven-empty inputs** so the optimizer can choose a better hash Build side without treating uncertain statistics as facts.

The key case is a LEFT/RIGHT OUTER JOIN whose inputs both estimate to zero: one may be genuinely empty while the other contains many rows. Prefer the uniquely proven-empty input as Build instead of resolving the tie by Join orientation alone.

## Changes

- Track and propagate proven emptiness through Filter, Scan, and Join. Retain column distributions when zero is only an estimate.
- Use type constraints and exact input facts for deterministic folding, not potentially stale distributions. Apply the same distinction to Join residuals.
- Use proven emptiness to break Outer Join zero-estimate ties and enable existing optimizations such as COUNT folding.
- Avoid unsafe modulo domain folding when proving emptiness, preserving integer precision and error behavior.

Some expression estimates become more conservative. No migration or configuration change is required.

## Examples

Tested versions:
- **Before**: baseline [`9a88f1b663`](https://github.com/databendlabs/databend/commit/9a88f1b663), without this PR.
- **After**: PR revision [`da87f3ed46`](https://github.com/databendlabs/databend/commit/da87f3ed46), including this fix.

Both versions were executed. Plan diagrams are abridged; actual input sizes were checked with `count(*)`.

### 1. Break a zero-estimate tie using proven emptiness

After `ANALYZE`, appended data makes two columns' ranges overlap while their histograms remain disjoint. Their self-join returns 2,000 rows but estimates zero in both revisions. An outer Join pairs this result with an empty table.

<details>
<summary>Reproduce: SQL and observed histogram output</summary>

```sql
CREATE DATABASE IF NOT EXISTS simple_build_example;
USE simple_build_example;
SET enable_analyze_histogram = 1;

CREATE OR REPLACE TABLE empty_orders (k BIGINT);
CREATE OR REPLACE TABLE pairs (a BIGINT, b BIGINT);
INSERT INTO pairs SELECT number, number + 1000 FROM numbers(1000);
ANALYZE TABLE pairs;
INSERT INTO pairs SELECT number + 1000, number FROM numbers(1000);
```

Both columns now contain every value in `0..1999`, but the stored histograms still cover disjoint ranges. `SELECT column_name, histogram FROM fuse_statistic('simple_build_example', 'pairs')` shows these first and last buckets (98 intermediate buckets omitted per column):

```text
a:
  [bucket id: 0, min: "0", max: "9", ndv: 10.0, count: 10.0]
  ...
  [bucket id: 99, min: "990", max: "999", ndv: 10.0, count: 10.0]
b:
  [bucket id: 0, min: "1000", max: "1009", ndv: 10.0, count: 10.0]
  ...
  [bucket id: 99, min: "1990", max: "1999", ndv: 10.0, count: 10.0]
```

```sql
SELECT count(*) FROM empty_orders; -- 0
SELECT count(*) FROM pairs l JOIN pairs r ON l.a = r.b; -- 2000

EXPLAIN
SELECT e.k, j.a
FROM empty_orders e
LEFT JOIN (
    SELECT l.a FROM pairs l JOIN pairs r ON l.a = r.b
) j ON e.k = j.a;
```

</details>

| Outer input | Estimated rows | Precise cardinality | Actual rows |
|---|---:|---|---:|
| `empty_orders` | 0 | 0 | 0 |
| `pairs l JOIN pairs r` | 0 | N/A | 2,000 |

```text
Before: LEFT OUTER                 After: RIGHT OUTER
├── Build: self-join (2,000 rows)   ├── Build: empty_orders (0 rows)
└── Probe: empty_orders (0 rows)   └── Probe: self-join (2,000 rows)
```

The inner estimate stays zero. The improvement is selecting the proven-empty Build input while preserving the outer-join semantics.

### 2. Preserve uncertainty in Join residual estimates

The query selects accounts for which no enabled EU rule requires a higher balance.

<details>
<summary>Reproduce: SQL</summary>

```sql
CREATE DATABASE IF NOT EXISTS eligibility_example;
USE eligibility_example;

CREATE OR REPLACE TABLE selected_accounts (id BIGINT);
CREATE OR REPLACE TABLE accounts (id BIGINT, balance BIGINT);
CREATE OR REPLACE TABLE review_rules (
    min_balance BIGINT, region STRING, enabled BOOLEAN
);

INSERT INTO selected_accounts VALUES (42);
INSERT INTO accounts SELECT number, 100 + number FROM numbers(1000);
INSERT INTO review_rules
SELECT 10000 + number,
       if(number % 2 = 0, 'EU', 'US'),
       number % 2 = 1
FROM numbers(1000);

EXPLAIN
SELECT s.id, eligible.id
FROM selected_accounts s
LEFT JOIN (
    SELECT a.id
    FROM accounts a
    WHERE NOT EXISTS (
        SELECT 1 FROM review_rules r
        WHERE r.region = 'EU'
          AND r.enabled
          AND a.balance < r.min_balance
    )
) eligible ON s.id = eligible.id;
```

</details>

The rules contain 500 disabled EU rows and 500 enabled US rows. No rule satisfies both filters, so all 1,000 accounts qualify.

The optimizer rewrites the correlated `NOT EXISTS` as a **LEFT ANTI JOIN**, with `a.balance < r.min_balance` as its residual predicate. Both versions estimate 500 rows for the filtered rules. Before the fix, the optimizer folds the residual to true from column ranges and treats the matches as confirmed, estimating the anti-join result at zero—even though the filtered rule input is actually empty.

This PR keeps those matches uncertain. The anti-join estimator limits estimated, unconfirmed coverage to 90% of the account input, leaving 100 estimated qualifying accounts. The resulting Build choice changes:

| | Before | After |
|---|---|---|
| Estimated qualifying accounts | 0 | 100 |
| Actual qualifying accounts | 1,000 | 1,000 |
| Outer Build input | 1,000-row qualifying result | 1-row selected-account table |
| Outer Join | LEFT OUTER | RIGHT OUTER |

This illustrates the residual-estimation change, not the zero-tie rule above.

### 3. Fold COUNT over a proven-empty Join

When a LEFT JOIN's preserved input is empty, `count(*)` is zero. Before the fix, this exact fact is lost at the Join. Propagating `precise_cardinality = Some(0)` lets the existing `RuleFoldCountAggregate` eliminate the Join, aggregation, and table scans.

```text
Before                             After
AggregateFinal                     EvalScalar: 0
└── AggregatePartial               └── DummyTableScan
    └── HashJoin
        ├── empty table
        └── populated table
```

<details>
<summary>Reproduce: SQL</summary>

```sql
CREATE DATABASE IF NOT EXISTS proven_empty_example;
USE proven_empty_example;

CREATE OR REPLACE TABLE pending_orders (order_id BIGINT NOT NULL);
CREATE OR REPLACE TABLE order_items (order_id BIGINT NOT NULL);
INSERT INTO order_items SELECT number FROM numbers(1000);

EXPLAIN
SELECT count(*)
FROM pending_orders p
LEFT JOIN order_items i ON p.order_id = i.order_id;
```

</details>

## Regression coverage

- [`02_outer_join_stale_statistics`](https://github.com/databendlabs/databend/blob/da87f3ed46990d52376bbfb16c5f252b54a0c515/src/query/sql/test-support/data/cases/basic/02_outer_join_stale_statistics.yaml): injected stale ranges and selective predicates ([physical-plan golden](https://github.com/databendlabs/databend/blob/da87f3ed46990d52376bbfb16c5f252b54a0c515/src/query/sql/test-support/data/results/basic/02_outer_join_stale_statistics_physical.txt)).
- [`outer_join_empty_cardinality`](https://github.com/databendlabs/databend/blob/da87f3ed46990d52376bbfb16c5f252b54a0c515/src/query/sql/tests/it/optimizer/outer_join_empty_cardinality.rs): zero-estimate ties with the proven-empty input on either side, catalog all-NULL statistics, and Join residuals.

## Validation

- Example plan and result checks passed on MySQL and HTTP, including result changes after inserts.
- SQL crate: 132 unit tests and 133 integration tests passed, including lightweight replay.
- Service-side `basic` replay passed, including physical-plan goldens.
- MySQL and HTTP: 32 Filter/modulo checks and 1,966 EXPLAIN checks across 85 files passed per protocol.
- `cargo clippy -p databend-common-sql --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

No performance benchmark was run.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test

## Type of change

- [x] Bug Fix
- [x] Performance Improvement

## AI assistance

- AI usage: A coding agent assisted with the implementation, regression tests, plan validation, and PR description.
- Responsible human: @dantengsky
- [ ] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20220)

<!-- Reviewable:end -->
