### PR TITLE
docs: add AI contribution policy and PR guardrail

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,3 +24,16 @@ Briefly describe what this PR aims to solve. Include background context that wil
 - [ ] Refactoring
 - [ ] Performance Improvement
 - [ ] Other (please describe):
+
+## AI assistance
+
+<!--
+See AI_POLICY.md. Agent-opened PRs are welcome; a responsible human on the author side must own the change.
+The responsible human is NOT the reviewer — it is the submitter-side owner who has read the diff,
+can explain each change, and will answer questions during review.
+Write "None" for AI usage if no AI was involved.
+-->
+
+- AI usage: <!-- e.g. "Claude Code drafted the patch; I reviewed and added logic tests" or "None" -->
+- Responsible human: <!-- @github-id — author-side owner: has read every line, can explain each change, answers questions during review, owns follow-up fixes -->
+- [ ] The responsible human has read every line of this diff and can explain each change

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,6 +34,6 @@ can explain each change, and will answer questions during review.
 Write "None" for AI usage if no AI was involved.
 -->
 
-- AI usage: <!-- e.g. "Claude Code drafted the patch; I reviewed and added logic tests" or "None" -->
+- AI usage: <!-- Describe the assistance and affected scope without product/model/provider names, or write "None" -->
 - Responsible human: <!-- @github-id — author-side owner: has read every line, can explain each change, answers questions during review, owns follow-up fixes -->
 - [ ] The responsible human has read every line of this diff and can explain each change

--- a/.github/scripts/check_pr_ai_assistance.js
+++ b/.github/scripts/check_pr_ai_assistance.js
@@ -1,0 +1,47 @@
+module.exports = async ({ context, core }) => {
+  const body = context.payload.pull_request.body || "";
+  // Strip HTML comments so template placeholders don't count as content.
+  const stripped = body.replace(/<!--[\s\S]*?-->/g, "");
+
+  const problems = [];
+  const sectionMatch = stripped.match(
+    /^##\s*AI assistance\s*\n([\s\S]*?)(?=\n##\s|$(?![\s\S]))/im,
+  );
+
+  if (!sectionMatch) {
+    problems.push("the `## AI assistance` section is missing");
+  } else {
+    const section = sectionMatch[1];
+
+    const usage = section.match(/^-[ \t]*AI usage:[ \t]*(\S.*)$/im);
+    if (!usage) {
+      problems.push(
+        "`AI usage:` is not filled in (write `None` if no AI was used)",
+      );
+    }
+
+    const human = section.match(/^-[ \t]*Responsible human:.*@[A-Za-z0-9][A-Za-z0-9-]*/im);
+    if (!human) {
+      problems.push(
+        "`Responsible human:` must name a GitHub user, e.g. `@your-github-id`",
+      );
+    }
+
+    const readBox = section.match(
+      /^-\s*\[x\]\s+The responsible human has read every line/im,
+    );
+    if (!readBox) {
+      problems.push(
+        'the checkbox "The responsible human has read every line of this diff" is not checked',
+      );
+    }
+  }
+
+  if (problems.length > 0) {
+    core.setOutput("ai", "invalid");
+    core.setOutput("problems", problems.map((p) => `- ${p}`).join("\n"));
+    core.setFailed(`AI assistance section incomplete: ${problems.join("; ")}`);
+  } else {
+    core.setOutput("ai", "valid");
+  }
+};

--- a/.github/scripts/check_pr_ai_assistance.js
+++ b/.github/scripts/check_pr_ai_assistance.js
@@ -1,10 +1,8 @@
 module.exports = async ({ context, core }) => {
   const body = context.payload.pull_request.body || "";
-  // Strip HTML comments so template placeholders don't count as content.
-  const stripped = body.replace(/<!--[\s\S]*?-->/g, "");
 
   const problems = [];
-  const sectionMatch = stripped.match(
+  const sectionMatch = body.match(
     /^##\s*AI assistance\s*\n([\s\S]*?)(?=\n##\s|$(?![\s\S]))/im,
   );
 
@@ -13,15 +11,17 @@ module.exports = async ({ context, core }) => {
   } else {
     const section = sectionMatch[1];
 
-    const usage = section.match(/^-[ \t]*AI usage:[ \t]*(\S.*)$/im);
-    if (!usage) {
+    const usageLine = section.match(/^-[ \t]*AI usage:[ \t]*(.*)$/im);
+    const usage = usageLine?.[1].trim();
+    if (!usage || usage.startsWith("<!--")) {
       problems.push(
         "`AI usage:` is not filled in (write `None` if no AI was used)",
       );
     }
 
-    const human = section.match(/^-[ \t]*Responsible human:.*@[A-Za-z0-9][A-Za-z0-9-]*/im);
-    if (!human) {
+    const humanLine = section.match(/^-[ \t]*Responsible human:[ \t]*(.*)$/im);
+    const human = humanLine?.[1].trim();
+    if (!human || !/^@[A-Za-z0-9][A-Za-z0-9-]*/.test(human)) {
       problems.push(
         "`Responsible human:` must name a GitHub user, e.g. `@your-github-id`",
       );

--- a/.github/scripts/check_pr_ai_assistance.js
+++ b/.github/scripts/check_pr_ai_assistance.js
@@ -1,8 +1,32 @@
+const removeHtmlComments = (input) => {
+  let visible = "";
+  let cursor = 0;
+
+  while (cursor < input.length) {
+    const commentStart = input.indexOf("<!--", cursor);
+    if (commentStart === -1) {
+      visible += input.slice(cursor);
+      break;
+    }
+
+    visible += input.slice(cursor, commentStart);
+    const commentEnd = input.indexOf("-->", commentStart + 4);
+    if (commentEnd === -1) {
+      // GitHub hides an unterminated comment through the end of the body.
+      break;
+    }
+    cursor = commentEnd + 3;
+  }
+
+  return visible;
+};
+
 module.exports = async ({ github, context, core }) => {
   const body = context.payload.pull_request.body || "";
+  const visibleBody = removeHtmlComments(body);
 
   const problems = [];
-  const sectionMatch = body.match(
+  const sectionMatch = visibleBody.match(
     /^##\s*AI assistance\s*\n([\s\S]*?)(?=\n##\s|$(?![\s\S]))/im,
   );
 
@@ -13,7 +37,7 @@ module.exports = async ({ github, context, core }) => {
 
     const usageLine = section.match(/^-[ \t]*AI usage:[ \t]*(.*)$/im);
     const usage = usageLine?.[1].trim();
-    if (!usage || usage.startsWith("<!--")) {
+    if (!usage) {
       problems.push(
         "`AI usage:` is not filled in (write `None` if no AI was used)",
       );

--- a/.github/scripts/check_pr_ai_assistance.js
+++ b/.github/scripts/check_pr_ai_assistance.js
@@ -1,4 +1,4 @@
-module.exports = async ({ context, core }) => {
+module.exports = async ({ github, context, core }) => {
   const body = context.payload.pull_request.body || "";
 
   const problems = [];
@@ -21,10 +21,35 @@ module.exports = async ({ context, core }) => {
 
     const humanLine = section.match(/^-[ \t]*Responsible human:[ \t]*(.*)$/im);
     const human = humanLine?.[1].trim();
-    if (!human || !/^@[A-Za-z0-9][A-Za-z0-9-]*/.test(human)) {
+    const usernameMatch = human?.match(/^@([A-Za-z0-9-]+)$/);
+    const username = usernameMatch?.[1];
+    const usernameIsValid =
+      username &&
+      username.length <= 39 &&
+      !username.startsWith("-") &&
+      !username.endsWith("-") &&
+      !username.includes("--") &&
+      username.toLowerCase() !== "your-github-id";
+
+    if (!usernameIsValid) {
       problems.push(
-        "`Responsible human:` must name a GitHub user, e.g. `@your-github-id`",
+        "`Responsible human:` must name a real GitHub user, e.g. `@octocat`",
       );
+    } else {
+      try {
+        const { data: account } = await github.rest.users.getByUsername({
+          username,
+        });
+        if (account.type !== "User") {
+          problems.push("`Responsible human:` must refer to a human account");
+        }
+      } catch (error) {
+        if (error.status === 404) {
+          problems.push(`Responsible human \`@${username}\` does not exist`);
+        } else {
+          throw error;
+        }
+      }
     }
 
     const readBox = section.match(

--- a/.github/scripts/check_pr_ai_assistance.js
+++ b/.github/scripts/check_pr_ai_assistance.js
@@ -21,9 +21,44 @@ const removeHtmlComments = (input) => {
   return visible;
 };
 
+const removeFencedCodeBlocks = (input) => {
+  const lines = input.split("\n");
+  const visibleLines = [];
+  let fence = null;
+
+  for (const line of lines) {
+    const content = line.replace(/^ {0,3}/, "");
+
+    if (!fence) {
+      const opener = content.match(/^(`{3,}|~{3,})/);
+      if (opener) {
+        fence = { marker: opener[1][0], length: opener[1].length };
+        visibleLines.push("");
+      } else {
+        visibleLines.push(line);
+      }
+      continue;
+    }
+
+    let markerLength = 0;
+    while (content[markerLength] === fence.marker) {
+      markerLength += 1;
+    }
+    if (
+      markerLength >= fence.length &&
+      content.slice(markerLength).trim() === ""
+    ) {
+      fence = null;
+    }
+    visibleLines.push("");
+  }
+
+  return visibleLines.join("\n");
+};
+
 module.exports = async ({ github, context, core }) => {
   const body = context.payload.pull_request.body || "";
-  const visibleBody = removeHtmlComments(body);
+  const visibleBody = removeFencedCodeBlocks(removeHtmlComments(body));
 
   const problems = [];
   const sectionMatch = visibleBody.match(
@@ -60,6 +95,19 @@ module.exports = async ({ github, context, core }) => {
         "`Responsible human:` must name a real GitHub user, e.g. `@octocat`",
       );
     } else {
+      const prAuthor = context.payload.pull_request.user;
+      const authorIsBot =
+        prAuthor.type === "Bot" || prAuthor.login.toLowerCase().endsWith("[bot]");
+
+      if (
+        !authorIsBot &&
+        username.toLowerCase() !== prAuthor.login.toLowerCase()
+      ) {
+        problems.push(
+          `Responsible human must match the PR author \`@${prAuthor.login}\``,
+        );
+      }
+
       try {
         const { data: account } = await github.rest.users.getByUsername({
           username,

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -149,3 +149,46 @@ jobs:
           body: |
             At least one type of change must be checked in the PR description.
             @${{ github.event.pull_request.user.login }} please update it 🙏.
+
+  ai_assistance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check AI assistance section
+        uses: actions/github-script@v9
+        id: check
+        with:
+          script: |
+            const script = require('./.github/scripts/check_pr_ai_assistance.js')
+            await script({ context, core })
+      - name: Delete Comment
+        if: always() && steps.check.outputs.ai == 'valid'
+        uses: everpcpc/comment-on-pr-action@v1
+        with:
+          token: ${{ github.token }}
+          identifier: "pr-assistant-ai-assistance"
+          delete: true
+      - name: Comment on PR
+        if: always() && steps.check.outputs.ai == 'invalid'
+        uses: everpcpc/comment-on-pr-action@v1
+        with:
+          token: ${{ github.token }}
+          identifier: "pr-assistant-ai-assistance"
+          body: |
+            The `## AI assistance` section is incomplete. Review is blocked until it is filled in.
+            @${{ github.event.pull_request.user.login }} please update it 🙏.
+
+            ${{ steps.check.outputs.problems }}
+
+            Required format (see [AI_POLICY.md](https://github.com/databendlabs/databend/blob/main/AI_POLICY.md)):
+
+            ```
+            ## AI assistance
+
+            - AI usage: Claude Code drafted the patch; I reviewed and added logic tests (or "None")
+            - Responsible human: @your-github-id
+            - [x] The responsible human has read every line of this diff and can explain each change
+            ```
+
+            The responsible human is the author-side owner — the person who has read the diff,
+            can explain each change, and will answer questions during review.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -160,7 +160,7 @@ jobs:
         with:
           script: |
             const script = require('./.github/scripts/check_pr_ai_assistance.js')
-            await script({ context, core })
+            await script({ github, context, core })
       - name: Delete Comment
         if: always() && steps.check.outputs.ai == 'valid'
         uses: everpcpc/comment-on-pr-action@v1
@@ -185,8 +185,8 @@ jobs:
             ```
             ## AI assistance
 
-            - AI usage: Claude Code drafted the patch; I reviewed and added logic tests (or "None")
-            - Responsible human: @your-github-id
+            - AI usage: An AI coding agent drafted the patch; I reviewed and added logic tests (or "None")
+            - Responsible human: @actual-github-id
             - [x] The responsible human has read every line of this diff and can explain each change
             ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ This file is the top-level guide for repository-specific working rules. Start by
 
 ## Core Workflow
 - Build context from the codebase first. Databend is a multi-crate Rust workspace, so understand the affected module boundaries before editing.
+- Agents may open PRs directly, but every PR must name a responsible human on the author side who has read the full diff, can explain the changes, and answers review questions. Fill in the "AI assistance" section of the PR template. See [`AI_POLICY.md`](AI_POLICY.md).
 - For code issues inside the repository, default to best-effort root cause analysis. Do not stop at symptom-only fixes when the underlying cause can be found with reasonable investigation.
 - When guidance, lower-level docs, and repository practice conflict or are ambiguous, identify the specific conflict that affects the current decision instead of assuming one source is automatically correct.
 - Validate incrementally. Run the smallest relevant checks early, and scale verification to the parts that will remain in the branch and enter review.
@@ -26,6 +27,7 @@ This file is the top-level guide for repository-specific working rules. Start by
 - A clean full build of the workspace can take about 20 minutes. Prefer the smallest relevant build or test step first, then scale validation up before handoff.
 
 ## Detail Index
+- [`AI_POLICY.md`](AI_POLICY.md) for AI-assisted contribution rules: human accountability, disclosure, and what gets PRs closed.
 - [`agents/repository-structure.md`](agents/repository-structure.md) for workspace layout and where code, tests, tooling, and fixtures live.
 - [`agents/development-commands.md`](agents/development-commands.md) for setup, build, run, test, format, and lint commands.
 - [`agents/coding-style.md`](agents/coding-style.md) for Rust, Python, shell, naming, error handling, and observability conventions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ This file is the top-level guide for repository-specific working rules. Start by
 - A clean full build of the workspace can take about 20 minutes. Prefer the smallest relevant build or test step first, then scale validation up before handoff.
 
 ## Detail Index
-- [`AI_POLICY.md`](AI_POLICY.md) for AI-assisted contribution rules: human accountability, disclosure, and what gets PRs closed.
+- [`AI_POLICY.md`](AI_POLICY.md) for AI-assisted contribution rules: human accountability, declaration, and what gets PRs closed.
 - [`agents/repository-structure.md`](agents/repository-structure.md) for workspace layout and where code, tests, tooling, and fixtures live.
 - [`agents/development-commands.md`](agents/development-commands.md) for setup, build, run, test, format, and lint commands.
 - [`agents/coding-style.md`](agents/coding-style.md) for Rust, Python, shell, naming, error handling, and observability conventions.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -82,34 +82,35 @@ Generated code fails in patterns that hand-written code rarely does. Before requ
 
 Fixing these before review is the author’s job. Finding them in review is a signal the diff was not read.
 
-## Disclosure (recommended)
+## AI declaration (required)
 
-Disclosure is **recommended**, not a merge blocker by default.
+Every PR must complete the `## AI assistance` section. This declaration is a review-entry requirement:
 
-Add a short note in the PR body when AI materially helped with:
+- If AI materially helped with code, tests, docs, or the PR summary, describe the type of assistance and the affected scope
+- If no AI was involved beyond ordinary autocomplete, spell check, or linter suggestions, write `None`
+- Describe the work, not the vendor: do not include product, model, or provider names
 
-- Code generation or substantial edits
-- Tests or docs
-- PR summary text for a complex change
-
-Examples:
+A complete, valid example:
 
 ```md
 ## AI assistance
 
-- Used Claude Code for the initial storage iterator patch; I reworked error paths and added logic tests myself.
-- Used an LLM to draft the PR summary; technical claims were verified against the diff.
+- AI usage: An AI coding agent drafted the storage iterator patch; I reworked the error paths and added logic tests
+- Responsible human: @your-actual-github-id
+- [x] The responsible human has read every line of this diff and can explain each change
 ```
+
+For a PR without material AI assistance:
 
 ```md
 ## AI assistance
 
-IDE autocomplete only. No agent-generated patches.
+- AI usage: None
+- Responsible human: @your-actual-github-id
+- [x] The responsible human has read every line of this diff and can explain each change
 ```
 
-You do **not** need to disclose ordinary autocomplete, spell check, or linter suggestions.
-
-Maintainers may ask for disclosure or a walkthrough when a change is high risk (catalog/meta, storage correctness, transactions, planner semantics, security boundaries). Failure to disclose is not automatic rejection; refusal to take responsibility is.
+The declaration identifies how the change was produced; it does not reduce the responsible human’s obligations. Maintainers may also request a walkthrough for high-risk changes (catalog/meta, storage correctness, transactions, planner semantics, security boundaries).
 
 ## Quality bar for AI-assisted PRs
 
@@ -160,7 +161,7 @@ Review the change, not the tool.
 | --- | --- |
 | `AI_POLICY.md` (this file) | Community rules for AI-assisted contribution and review |
 | `AGENTS.md` + `agents/` | How coding agents should work inside this repository |
-| `.github/PULL_REQUEST_TEMPLATE.md` | PR checklist (CLA, summary, tests, change type) |
+| `.github/PULL_REQUEST_TEMPLATE.md` | PR checklist (CLA, summary, tests, change type, AI declaration) |
 | `.github/CODEOWNERS` | Domain reviewers for merge paths |
 
 If maintainer guidance for a specific PR conflicts with this document, follow the maintainer’s explicit guidance for that PR, then propose an update here if the exception should become policy.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,179 @@
+# Databend AI Policy
+
+Databend welcomes AI-assisted development.
+
+We already ship agent-oriented product features and maintain repository guidance for coding agents (`AGENTS.md`, `agents/`). This policy is about **how humans and AI collaborate on contributions** so maintainers can keep the warehouse correct, reviewable, and safe.
+
+This policy covers contributions to this repository: code, tests, docs, issues, PR descriptions, and review discussion.
+
+## Principles
+
+1. **AI is a normal engineering tool.** Using models, agents, or IDE assistants is allowed and encouraged when it improves quality or speed.
+2. **A human remains accountable.** Whoever opens the PR owns the change: correctness, security, compatibility, tests, and follow-up fixes.
+3. **Understanding is mandatory.** If you cannot explain the change in your own words, it is not ready to submit.
+4. **Reviewer time is scarce.** Low-effort AI output that shifts the real work onto maintainers will usually be closed.
+5. **Database semantics need evidence.** Planner, executor, storage, meta, and SQL behavior changes need tests that can falsify the implementation — not vibes.
+
+## What is allowed
+
+You may use AI to:
+
+- Explore the codebase and form a root-cause hypothesis
+- Draft implementations, refactors, tests, docs, and benchmarks
+- Generate alternative designs for a human to compare
+- Help with formatting, boilerplate, and mechanical edits
+- Assist local review before you open a PR
+
+When working with coding agents in this repository, follow `AGENTS.md` and the linked docs under `agents/`. Prefer the smallest relevant build/test loop, keep diffs reviewable, and treat tests as part of the change.
+
+## What is not allowed
+
+The following will usually result in the issue/PR being closed, possibly without extended discussion:
+
+1. **Ownerless autonomous contribution**
+   - Agents **may** open PRs, update branches, and use `gh` tooling — see `agents/commit-and-pr.md`. What is banned is a PR with no accountable human: every PR must name an author-side person who has read the diff, can explain the changes, will answer review questions, and owns follow-up fixes. This person is not the reviewer — reviewers are assigned separately via CODEOWNERS
+   - Bulk drive-by PRs that show no local validation or understanding of Databend module boundaries
+
+2. **AI-generated conversation as a substitute for thinking**
+   - Pasting model replies as your response to maintainer questions
+   - Long, generic, high-confidence commentary that does not address the concrete code or failure mode
+   - Using AI to argue for a change you cannot defend yourself
+   - Exception: using AI to translate or polish **your own** reasoning (for example, writing in Chinese and posting an AI-assisted English version) is fine and encouraged — the ideas must be yours
+
+3. **Slop submissions**
+   - PRs that do not compile, fail basic lint, or clearly were not read by the author
+   - Fake or tautological tests that only mirror the implementation
+   - Huge unrelated diffs, noisy renames, or “cleanup” mixed into a behavior change without need
+   - Secret redaction failures, license-incompatible pasted code, or unexplained dependency churn
+
+4. **Bypassing collaboration norms**
+   - Skipping issue/RFC discussion for large semantic or architectural changes
+   - Ignoring CLA, PR template, CODEOWNERS review paths, or requested test evidence
+
+## Human accountability requirements
+
+Agent-opened PRs are welcome. Every PR — however it was produced — must have a **responsible human** (the PR author, or the person named in the PR body for bot-authored PRs) who has:
+
+- **Read every line of the final diff.** Unread code does not enter review. If the diff is too large to read, it is too large to submit — split it
+
+and who can:
+
+- State the user-visible or developer-visible problem in plain language
+- Explain why this approach is correct for Databend’s architecture
+- Point to the tests or manual validation that would fail if the fix were wrong
+- Answer review questions without outsourcing the reply to a model transcript
+- Own production risk: compatibility, upgrade/migration, performance, and data safety
+
+If no responsible human engages when maintainers ask, the PR may be closed regardless of code quality.
+
+AI assistance does **not** lower the quality bar. It raises the author’s duty to filter bad output before review.
+
+## Self-review before requesting review
+
+Generated code fails in patterns that hand-written code rarely does. Before requesting review, the responsible human should walk the diff specifically looking for:
+
+- **Hallucinated interfaces**: calls to functions, settings, or SQL behaviors that do not exist in this codebase or behave differently than the model assumed
+- **Plausible-but-wrong edge cases**: NULL handling, overflow, empty input, timezone/precision, non-UTF-8 — verify against actual Databend behavior, not the model’s memory of “how databases work”
+- **Tests that mirror the implementation**: a test that re-derives expected output from the same logic proves nothing; expected values should come from an independent source (MySQL/other engines, a spec, or hand computation)
+- **Silently swallowed errors**: `unwrap_or_default`, broad `match _ =>`, or dropped `Result`s inserted to make code compile
+- **Unnecessary abstraction and dead code**: traits, generics, helpers, and config knobs that no second caller needs; delete them before review
+- **Comments and names that don’t match behavior**: generated comments often describe intent, not what the code does
+- **Divergence from neighboring code**: if the surrounding module solves the same problem differently, follow it or explain why not
+
+Fixing these before review is the author’s job. Finding them in review is a signal the diff was not read.
+
+## Disclosure (recommended)
+
+Disclosure is **recommended**, not a merge blocker by default.
+
+Add a short note in the PR body when AI materially helped with:
+
+- Code generation or substantial edits
+- Tests or docs
+- PR summary text for a complex change
+
+Examples:
+
+```md
+## AI assistance
+
+- Used Claude Code for the initial storage iterator patch; I reworked error paths and added logic tests myself.
+- Used an LLM to draft the PR summary; technical claims were verified against the diff.
+```
+
+```md
+## AI assistance
+
+IDE autocomplete only. No agent-generated patches.
+```
+
+You do **not** need to disclose ordinary autocomplete, spell check, or linter suggestions.
+
+Maintainers may ask for disclosure or a walkthrough when a change is high risk (catalog/meta, storage correctness, transactions, planner semantics, security boundaries). Failure to disclose is not automatic rejection; refusal to take responsibility is.
+
+## Quality bar for AI-assisted PRs
+
+AI-assisted changes must still satisfy normal Databend contribution expectations:
+
+### Scope
+- Prefer small, reviewable PRs over agent-produced megadiffs
+- Split mechanical regeneration from semantic changes
+- Do not mix drive-by refactors into bug fixes
+
+### Evidence
+- Bug fixes: include a regression test whenever practical
+- Planner / executor / storage behavior: add or update logic tests (or the relevant suite) with expected output when deterministic
+- Performance claims: include before/after measurements, not anecdotes
+- “No Test — Explain why” in the PR template requires a real reason, not convenience
+
+### Local validation
+- Run the smallest relevant checks first, then stronger validation before handoff
+- For Rust changes intended to land, do not submit known clippy/format failures
+- If full workspace validation is expensive, say what you ran and what remains uncovered
+
+### Communication
+- Write PR summaries for humans: motivation, behavior change, risks, validation
+- Quote model output only when needed, inside blockquotes, with your own interpretation
+- Keep discussion concrete and tied to files, tests, and failure modes
+
+## Maintainer and reviewer guidance
+
+Review the change, not the tool.
+
+- **At least one human must have read the diff before merge.** Approvals from AI review bots do not count toward this; they are assistants, not reviewers
+- Spend human attention on correctness, data safety, compatibility, performance, and test adequacy
+- Prefer questions that check author understanding over style nits already handled by CI. For high-risk areas, one probing question (“why is this branch safe when the snapshot is stale?”) reveals more than ten nits
+- Read the tests first: verify they can fail, and that expected outputs come from an independent source rather than the implementation itself
+- If a PR looks AI-generated and low-effort, ask for a tighter summary, tests, or a reduced diff; close it if the author cannot engage
+- Domain CODEOWNERS remain the authority for their areas
+- It is fine to use AI to help review, but merge decisions stay with humans
+
+## Security, license, and confidentiality
+
+- You are responsible for ensuring contributed material is license-compatible, whether typed or generated
+- Do not paste proprietary code, private customer data, credentials, or internal secrets into prompts in a way that causes them to land in the repository
+- Treat security-sensitive areas (auth, authorization, multi-tenant isolation, sandbox UDF boundaries) as high scrutiny regardless of how the code was produced
+
+## Relationship to other docs
+
+| Doc | Role |
+| --- | --- |
+| `AI_POLICY.md` (this file) | Community rules for AI-assisted contribution and review |
+| `AGENTS.md` + `agents/` | How coding agents should work inside this repository |
+| `.github/PULL_REQUEST_TEMPLATE.md` | PR checklist (CLA, summary, tests, change type) |
+| `.github/CODEOWNERS` | Domain reviewers for merge paths |
+
+If maintainer guidance for a specific PR conflicts with this document, follow the maintainer’s explicit guidance for that PR, then propose an update here if the exception should become policy.
+
+## Enforcement
+
+- Maintainers may request changes, ask for human clarification, require more tests, or close PRs that violate this policy
+- Repeated low-effort or unattended agent spam may result in blocked contributions
+- Good-faith AI-assisted work that is well explained, tested, and reviewable is welcome
+
+## Short version
+
+Use AI freely.  
+Read every line before you submit.  
+Submit only what you understand, can test, and can defend.  
+Do not waste reviewer time with unattended slop.

--- a/agents/commit-and-pr.md
+++ b/agents/commit-and-pr.md
@@ -67,6 +67,12 @@ Added tests in `02_0063_function_generate_series.test` for:
 
 - [x] New feature (non-breaking change which adds functionality)
 
+## AI assistance
+
+- AI usage: An AI coding agent drafted the implementation; I reviewed the final diff and added logic tests
+- Responsible human: @your-actual-github-id
+- [x] The responsible human has read every line of this diff and can explain each change
+
 <!-- Reviewable:start -->
 
 ---

--- a/agents/commit-and-pr.md
+++ b/agents/commit-and-pr.md
@@ -16,6 +16,8 @@
 - Call out rollout risks such as migrations, config toggles, or backfills.
 - Push the branch to your fork and create the PR into `origin`.
 - You can use `gh` tooling for the PR flow.
+- Agent-opened PRs must fill in the "AI assistance" section of the PR template, including the responsible human (`@github-id`) — the author-side owner who has read the diff and can explain the changes during review. See [`AI_POLICY.md`](../AI_POLICY.md).
+- Before opening or updating a PR, present the full diff to the responsible human for reading. Do not request review on code no human has read.
 
 ## Example PR Description
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Add an AI contribution policy that welcomes agent-opened PRs while requiring an accountable human on the author side.
- Require the responsible human to read the full diff, explain each change, answer review questions, and own follow-up fixes.
- Document AI-specific self-review checks for database code, tests, errors, and unnecessary abstractions.
- Add the policy to agent-visible repository guidance and the PR template.
- Add a PR Assistant check that blocks review when the AI assistance section, responsible human, or human-read confirmation is missing.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Documentation and GitHub workflow policy change. The validation script was exercised locally against missing, default, unchecked, `None`, completed, and non-terminal-section PR bodies; the workflow YAML was parsed successfully.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [x] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: AI assisted with policy research, drafting, review, implementation, and validation; the responsible human reviewed the final diff and requested submission.
- Responsible human: @bohutang
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20225)
<!-- Reviewable:end -->
