### PR TITLE
fix(test): fix parser and stateful test failures

### DIFF
--- a/src/query/ast/tests/it/testdata/stmt-error.txt
+++ b/src/query/ast/tests/it/testdata/stmt-error.txt
@@ -96,7 +96,7 @@ error:
 1 | create table a (c1 decimal(38), c2 int) partition by ();
   | ------                                                ^
   | |                                                     |
-  | |                                                     expecting `<LiteralString>`, '<LiteralCodeString>', '<LiteralInteger>', '<LiteralFloat>', 'TRUE', 'FALSE', or more ...
+  | |                                                     unexpected `)`, expecting <Ident>, <LiteralString>, `IDENTIFIER`, <LiteralCodeString>, <LiteralInteger>, <LiteralFloat>, <MySQLLiteralHex>, <PGLiteralHex>, `TRUE`, `FALSE`, or `NULL`
   | |                                                     while parsing expression
   | while parsing `CREATE [OR REPLACE] TABLE [IF NOT EXISTS] [<database>.]<table> [<source>] [<table_options>]`
 

--- a/tests/suites/1_stateful/02_query/02_0011_explain_analyze_part_info.py
+++ b/tests/suites/1_stateful/02_query/02_0011_explain_analyze_part_info.py
@@ -30,11 +30,9 @@ with NativeClient(name="client1>") as client1:
 
     for sql in prepare_sqls:
         mycursor.execute(sql)
-        res = mycursor.fetchall()
 
     for i in range(10):
         mycursor.execute(f"insert into test_explain_analyze_0011_1 values ({i})")
-        res = mycursor.fetchall()
 
     def explain_output(res):
         cnt = 0


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Update the parser error golden output after the SQL parser error-tracking refactor
- Avoid calling `fetchall()` after DDL and INSERT statements that do not produce result sets
- Fix the affected stateful cluster and standalone CI tests

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation performed:

- `cargo test -p databend-common-ast --test it parser::test_statement_error`
- Python syntax compilation for `02_0011_explain_analyze_part_info.py`
- `cargo fmt --all -- --check`
- `git diff --check`

The full stateful harness was not run locally because it stops existing Databend processes and starts a local test cluster. The same invalid `fetchall()` failure was confirmed in both the cluster and standalone CI jobs.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent investigated the CI logs, identified the root causes, and drafted the parser golden and stateful test fixes
- Responsible human: @dqhl76
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20231)
<!-- Reviewable:end -->
