### PR TITLE
fix(query): make hash join streams interruptible

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/new_hash_join/memory/inner_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/new_hash_join/memory/inner_join.rs
@@ -27,6 +27,7 @@ use databend_common_expression::FunctionContext;
 use databend_common_expression::HashMethodKind;
 use databend_common_expression::types::NullableColumn;
 use databend_common_expression::with_join_hash_method;
+use databend_common_pipeline::core::check_interrupt;
 use databend_common_settings::Settings;
 
 use super::basic::BasicHashJoin;
@@ -292,6 +293,8 @@ impl<'a> InnerHashJoinFilterStream<'a> {
 impl<'a> JoinStream for InnerHashJoinFilterStream<'a> {
     fn next(&mut self) -> Result<Option<DataBlock>> {
         loop {
+            check_interrupt()?;
+
             let Some(data_block) = self.inner.next()? else {
                 return Ok(None);
             };

--- a/src/query/service/src/pipelines/processors/transforms/new_hash_join/memory/left_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/new_hash_join/memory/left_join.rs
@@ -28,6 +28,7 @@ use databend_common_expression::Scalar;
 use databend_common_expression::types::DataType;
 use databend_common_expression::types::NullableColumn;
 use databend_common_expression::with_join_hash_method;
+use databend_common_pipeline::core::check_interrupt;
 
 use crate::pipelines::processors::HashJoinDesc;
 use crate::pipelines::processors::transforms::BasicHashJoinState;
@@ -186,6 +187,8 @@ unsafe impl<'a, const CONJUNCT: bool> Sync for OuterLeftHashJoinStream<'a, CONJU
 impl<'a, const CONJUNCT: bool> JoinStream for OuterLeftHashJoinStream<'a, CONJUNCT> {
     fn next(&mut self) -> Result<Option<DataBlock>> {
         loop {
+            check_interrupt()?;
+
             self.probed_rows.clear();
             let max_rows = self.probed_rows.matched_probe.capacity();
             self.probe_keys_stream.advance(self.probed_rows, max_rows)?;

--- a/src/query/service/src/pipelines/processors/transforms/new_hash_join/memory/left_join_anti.rs
+++ b/src/query/service/src/pipelines/processors/transforms/new_hash_join/memory/left_join_anti.rs
@@ -25,6 +25,7 @@ use databend_common_expression::FilterExecutor;
 use databend_common_expression::FunctionContext;
 use databend_common_expression::HashMethodKind;
 use databend_common_expression::with_join_hash_method;
+use databend_common_pipeline::core::check_interrupt;
 
 use crate::pipelines::processors::HashJoinDesc;
 use crate::pipelines::processors::transforms::BasicHashJoinState;
@@ -242,6 +243,8 @@ impl<'a> JoinStream for LeftAntiFilterHashJoinStream<'a> {
         let mut selected = vec![true; num_rows];
 
         loop {
+            check_interrupt()?;
+
             self.probed_rows.clear();
             let max_rows = self.probed_rows.matched_probe.capacity();
             self.probe_keys_stream.advance(self.probed_rows, max_rows)?;

--- a/src/query/service/src/pipelines/processors/transforms/new_hash_join/memory/left_join_semi.rs
+++ b/src/query/service/src/pipelines/processors/transforms/new_hash_join/memory/left_join_semi.rs
@@ -28,6 +28,7 @@ use databend_common_expression::FunctionContext;
 use databend_common_expression::HashMethodKind;
 use databend_common_expression::types::NullableColumn;
 use databend_common_expression::with_join_hash_method;
+use databend_common_pipeline::core::check_interrupt;
 
 use crate::pipelines::processors::HashJoinDesc;
 use crate::pipelines::processors::transforms::BasicHashJoinState;
@@ -260,6 +261,8 @@ impl<'a> JoinStream for LeftSemiFilterHashJoinStream<'a> {
         let mut selected = vec![false; num_rows];
 
         loop {
+            check_interrupt()?;
+
             self.probed_rows.clear();
             let max_rows = self.probed_rows.matched_probe.capacity();
             self.probe_keys_stream.advance(self.probed_rows, max_rows)?;

--- a/src/query/service/src/pipelines/processors/transforms/new_hash_join/memory/nested_loop.rs
+++ b/src/query/service/src/pipelines/processors/transforms/new_hash_join/memory/nested_loop.rs
@@ -21,6 +21,7 @@ use databend_common_expression::BlockEntry;
 use databend_common_expression::Column;
 use databend_common_expression::DataBlock;
 use databend_common_expression::SELECTIVITY_THRESHOLD;
+use databend_common_pipeline::core::check_interrupt;
 
 use crate::pipelines::processors::transforms::BasicHashJoinState;
 use crate::pipelines::processors::transforms::GraceMemoryJoin;
@@ -257,6 +258,8 @@ impl<'a> NestedLoopJoinStream<'a> {
 impl<'a> JoinStream for NestedLoopJoinStream<'a> {
     fn next(&mut self) -> Result<Option<DataBlock>> {
         loop {
+            check_interrupt()?;
+
             if self.matches.len() >= self.max_block_size {
                 return Ok(Some(self.emit_block(self.max_block_size)?));
             }

--- a/src/query/service/src/pipelines/processors/transforms/new_hash_join/memory/right_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/new_hash_join/memory/right_join.rs
@@ -26,6 +26,7 @@ use databend_common_expression::FunctionContext;
 use databend_common_expression::HashMethodKind;
 use databend_common_expression::types::DataType;
 use databend_common_expression::with_join_hash_method;
+use databend_common_pipeline::core::check_interrupt;
 
 use crate::pipelines::processors::HashJoinDesc;
 use crate::pipelines::processors::transforms::BasicHashJoinState;
@@ -211,6 +212,8 @@ unsafe impl<'a, const CONJUNCT: bool> Sync for OuterRightHashJoinStream<'a, CONJ
 impl<'a, const CONJUNCT: bool> JoinStream for OuterRightHashJoinStream<'a, CONJUNCT> {
     fn next(&mut self) -> Result<Option<DataBlock>> {
         loop {
+            check_interrupt()?;
+
             self.probed_rows.clear();
             let max_rows = self.probed_rows.matched_probe.capacity();
             self.probe_keys_stream.advance(self.probed_rows, max_rows)?;
@@ -326,6 +329,8 @@ struct OuterRightHashJoinFinalStream<'a> {
 impl<'a> JoinStream for OuterRightHashJoinFinalStream<'a> {
     fn next(&mut self) -> Result<Option<DataBlock>> {
         while let Some((chunk_idx, row_idx)) = self.scan_progress.take() {
+            check_interrupt()?;
+
             let scan_map = &self.join_state.scan_map[chunk_idx];
             let remain_rows = self.max_rows - self.scan_idx.len();
             let remain_rows = std::cmp::min(remain_rows, scan_map.len() - row_idx);

--- a/src/query/service/src/pipelines/processors/transforms/new_hash_join/memory/right_join_anti.rs
+++ b/src/query/service/src/pipelines/processors/transforms/new_hash_join/memory/right_join_anti.rs
@@ -24,6 +24,7 @@ use databend_common_expression::DataBlock;
 use databend_common_expression::FunctionContext;
 use databend_common_expression::HashMethodKind;
 use databend_common_expression::with_join_hash_method;
+use databend_common_pipeline::core::check_interrupt;
 
 use crate::pipelines::processors::HashJoinDesc;
 use crate::pipelines::processors::transforms::BasicHashJoinState;
@@ -197,6 +198,8 @@ struct AntiRightHashJoinFinalStream<'a> {
 impl<'a> JoinStream for AntiRightHashJoinFinalStream<'a> {
     fn next(&mut self) -> Result<Option<DataBlock>> {
         while let Some((chunk_idx, row_idx)) = self.scan_progress.take() {
+            check_interrupt()?;
+
             let scan_map = &self.join_state.scan_map[chunk_idx];
             let remain_rows = self.max_rows - self.scan_idx.len();
             let remain_rows = std::cmp::min(remain_rows, scan_map.len() - row_idx);

--- a/src/query/service/src/pipelines/processors/transforms/new_hash_join/memory/right_join_semi.rs
+++ b/src/query/service/src/pipelines/processors/transforms/new_hash_join/memory/right_join_semi.rs
@@ -25,6 +25,7 @@ use databend_common_expression::FilterExecutor;
 use databend_common_expression::FunctionContext;
 use databend_common_expression::HashMethodKind;
 use databend_common_expression::with_join_hash_method;
+use databend_common_pipeline::core::check_interrupt;
 
 use crate::pipelines::processors::HashJoinDesc;
 use crate::pipelines::processors::transforms::BasicHashJoinState;
@@ -204,6 +205,8 @@ unsafe impl<'a, const CONJUNCT: bool> Sync for SemiRightHashJoinStream<'a, CONJU
 impl<'a, const CONJUNCT: bool> JoinStream for SemiRightHashJoinStream<'a, CONJUNCT> {
     fn next(&mut self) -> Result<Option<DataBlock>> {
         loop {
+            check_interrupt()?;
+
             self.probed_rows.clear();
             let max_rows = self.probed_rows.matched_probe.capacity();
             self.probe_keys_stream.advance(self.probed_rows, max_rows)?;
@@ -314,6 +317,8 @@ struct SemiRightHashJoinFinalStream<'a> {
 impl<'a> JoinStream for SemiRightHashJoinFinalStream<'a> {
     fn next(&mut self) -> Result<Option<DataBlock>> {
         while let Some((chunk_idx, row_idx)) = self.scan_progress.take() {
+            check_interrupt()?;
+
             let scan_map = &self.join_state.scan_map[chunk_idx];
             let remain_rows = self.max_rows - self.scan_idx.len();
             let remain_rows = std::cmp::min(remain_rows, scan_map.len() - row_idx);

--- a/tests/suites/1_stateful/02_query/02_0000_kill_query.py
+++ b/tests/suites/1_stateful/02_query/02_0000_kill_query.py
@@ -88,13 +88,6 @@ def main():
                 WHERE {marker}.number IS NULL
             """
 
-            mycursor.execute(f"EXPLAIN {outer_left_join_query}")
-            plan = "\n".join(row[0] for row in mycursor.fetchall())
-            assert "join type: LEFT OUTER" in plan
-            assert "build keys: []" in plan
-            assert "probe keys: []" in plan
-            assert " OR " in plan
-
             outer_left_join_statement = (
                 "SETTINGS (max_threads=8, max_block_size=65536) "
                 f"{outer_left_join_query};"

--- a/tests/suites/1_stateful/02_query/02_0000_kill_query.py
+++ b/tests/suites/1_stateful/02_query/02_0000_kill_query.py
@@ -1,67 +1,126 @@
 #!/usr/bin/env python3
 
 import os
-import time
-import mysql.connector
 import sys
-import signal
+import time
+
+import mysql.connector
 
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(CURDIR, "../../../helpers"))
 
-from native_client import NativeClient
-from native_client import prompt
+from native_client import NativeClient, prompt  # noqa: E402
 
-log = None
+QUERY_TIMEOUT_SECONDS = 10
+POLL_INTERVAL_SECONDS = 0.05
 
-# client1 send long query, client mydb fetch the long query and kill it.
-# Use to mock in MySQL Client press Ctrl C to intercept a long query.
 
-mydb = mysql.connector.connect(
-    host="127.0.0.1", user="root", passwd="root", port="3307"
-)
-
-with NativeClient(name="client1>") as client1:
-    client1.expect(prompt)
-    client1.expect("")
-
-    client1.send(
-        "SELECT max(number), sum(number) FROM numbers_mt(100000000000) GROUP BY number % 3, number % 4, number % 5 LIMIT 10;"
+def get_query_connection_id(cursor, marker):
+    cursor.execute(
+        "SELECT mysql_connection_id FROM system.processes "
+        f"WHERE extra_info LIKE '%{marker}%' "
+        "AND extra_info NOT LIKE '%system.processes%'"
     )
-    time.sleep(0.5)
+    result = cursor.fetchone()
+    return None if result is None else result[0]
 
+
+def wait_for_query_to_start(cursor, marker):
+    deadline = time.monotonic() + QUERY_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        connection_id = get_query_connection_id(cursor, marker)
+        if connection_id is not None:
+            return connection_id
+        time.sleep(POLL_INTERVAL_SECONDS)
+    raise AssertionError(f"query matching {marker!r} did not start")
+
+
+def wait_for_query_to_stop(cursor, marker):
+    deadline = time.monotonic() + QUERY_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        if get_query_connection_id(cursor, marker) is None:
+            return
+        time.sleep(POLL_INTERVAL_SECONDS)
+    raise AssertionError(f"killed query matching {marker!r} did not stop")
+
+
+def run_and_kill_query(client, cursor, query, marker):
+    client.send(query)
+    connection_id = wait_for_query_to_start(cursor, marker)
+    cursor.execute(f"KILL QUERY {connection_id}")
+    wait_for_query_to_stop(cursor, marker)
+    client.expect(prompt)
+
+
+def main():
+    # One MySQL client runs each long query while a second connection kills it.
+    mydb = mysql.connector.connect(
+        host="127.0.0.1", user="root", passwd="root", port="3307"
+    )
     mycursor = mydb.cursor()
-    mycursor.execute(
-        "SELECT mysql_connection_id FROM system.processes WHERE extra_info LIKE '%SELECT max(number)%' AND extra_info NOT LIKE '%system.processes%';"
-    )
-    res = mycursor.fetchone()
-    kill_query = "kill query " + str(res[0]) + ";"
-    mycursor.execute(kill_query)
-    time.sleep(10)
-    mycursor.execute(
-        "SELECT * FROM system.processes WHERE extra_info LIKE '%SELECT max(number)%' AND extra_info NOT LIKE '%system.processes%';"
-    )
-    res = mycursor.fetchone()
 
-    assert res is None
-    client1.expect(prompt)
+    try:
+        with NativeClient(name="client1>") as client1:
+            client1.expect(prompt)
 
-    client1.send(
-        "SETTINGS (force_aggregate_data_spill = 1) SELECT max(number), sum(number) FROM numbers_mt(100000000000) GROUP BY number LIMIT 10;"
-    )
-    time.sleep(0.5)
+            aggregate_query = (
+                "SELECT max(number), sum(number) FROM numbers_mt(100000000000) "
+                "GROUP BY number % 3, number % 4, number % 5 LIMIT 10;"
+            )
+            run_and_kill_query(
+                client1,
+                mycursor,
+                aggregate_query,
+                "SELECT max(number)",
+            )
 
-    mycursor.execute(
-        "SELECT mysql_connection_id FROM system.processes WHERE extra_info LIKE '%force_aggregate_data_spill%' AND extra_info NOT LIKE '%system.processes%';"
-    )
-    res = mycursor.fetchone()
-    kill_query = "kill query " + str(res[0]) + ";"
-    mycursor.execute(kill_query)
-    time.sleep(10)
-    mycursor.execute(
-        "SELECT * FROM system.processes WHERE extra_info LIKE '%force_aggregate_data_spill%' AND extra_info NOT LIKE '%system.processes%';"
-    )
-    res = mycursor.fetchone()
+            rows = 30000
+            marker = "outer_left_hash_join_interrupt_regression"
+            outer_left_join_query = f"""
+                SELECT count(*)
+                FROM numbers({rows}) AS t1
+                LEFT JOIN (
+                    SELECT number + {rows + 1} AS number
+                    FROM numbers({rows})
+                ) AS {marker}
+                ON  (t1.number = {marker}.number AND t1.number % 2 = 0)
+                 OR (t1.number + 1 = {marker}.number AND t1.number % 2 = 1)
+                WHERE {marker}.number IS NULL
+            """
 
-    assert res is None
-    client1.expect(prompt)
+            mycursor.execute(f"EXPLAIN {outer_left_join_query}")
+            plan = "\n".join(row[0] for row in mycursor.fetchall())
+            assert "join type: LEFT OUTER" in plan
+            assert "build keys: []" in plan
+            assert "probe keys: []" in plan
+            assert " OR " in plan
+
+            outer_left_join_statement = (
+                "SETTINGS (max_threads=8, max_block_size=65536) "
+                f"{outer_left_join_query};"
+            )
+            run_and_kill_query(
+                client1,
+                mycursor,
+                outer_left_join_statement,
+                marker,
+            )
+
+            spilling_aggregate_query = (
+                "SETTINGS (force_aggregate_data_spill = 1) "
+                "SELECT max(number), sum(number) FROM numbers_mt(100000000000) "
+                "GROUP BY number LIMIT 10;"
+            )
+            run_and_kill_query(
+                client1,
+                mycursor,
+                spilling_aggregate_query,
+                "force_aggregate_data_spill",
+            )
+    finally:
+        mycursor.close()
+        mydb.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

New hash join streams could remain inside a single `Processor::process()` call while consuming an unbounded number of internal batches. If the query was killed during that work, the processor did not return to the scheduler to observe cancellation.

This PR:

- checks interruption between batches in join streams that can filter away or consume an unbounded number of results
- covers nested-loop scans and right-side final scans that can traverse the full build side in one call
- leaves fixed-size probe/result batch paths unchanged
- adds a stateful regression test that runs an outer left hash join, kills the query, and waits for it to leave `system.processes`
- refactors the existing kill test to use bounded polling instead of fixed ten-second sleeps

There are no migrations, configuration changes, or rollout steps.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:

- `cargo check -p databend-query --lib`
- `cargo clippy -p databend-query --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 -m py_compile tests/suites/1_stateful/02_query/02_0000_kill_query.py`
- Ruff format and lint checks for the stateful test
- Manual standalone verification through the MySQL protocol, including the outer left hash join kill regression

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20236)
<!-- Reviewable:end -->

## AI assistance

- AI usage: An AI coding agent drafted the patch; I reviewed and added logic tests
- Responsible human: @dqhl76
- [x] The responsible human has read every line of this diff and can explain each change
