### PR TITLE
feat(query): support Latin-1 binary input format

### DIFF
--- a/src/query/functions/src/scalars/binary.rs
+++ b/src/query/functions/src/scalars/binary.rs
@@ -172,12 +172,16 @@ pub fn register(registry: &mut FunctionRegistry) {
             match format.to_ascii_lowercase().as_str() {
                 "hex" => eval_unhex(val, ctx),
                 "base64" => eval_from_base64(val, ctx),
+                "latin1" | "latin-1" | "iso-8859-1" => eval_latin1_bytes(val, ctx),
                 "utf-8" => match val {
                     Value::Scalar(val) => Value::Scalar(val.as_bytes().to_vec()),
                     Value::Column(col) => Value::Column(col.into()),
                 },
                 _ => {
-                    ctx.set_error(0, "The format option only supports hex, base64, and utf-8");
+                    ctx.set_error(
+                        0,
+                        "The format option only supports hex, base64, latin1, and utf-8",
+                    );
                     Value::Scalar(Vec::new())
                 }
             }
@@ -206,6 +210,7 @@ pub fn register(registry: &mut FunctionRegistry) {
             match format.to_ascii_lowercase().as_str() {
                 "hex" => error_to_null(eval_unhex)(val, ctx),
                 "base64" => error_to_null(eval_from_base64)(val, ctx),
+                "latin1" | "latin-1" | "iso-8859-1" => error_to_null(eval_latin1_bytes)(val, ctx),
                 "utf-8" => match val {
                     Value::Scalar(val) => Value::Scalar(Some(val.as_bytes().to_vec())),
                     Value::Column(col) => {
@@ -345,6 +350,26 @@ fn eval_utf8_bytes_nullable(val: Value<StringType>) -> Value<NullableType<Binary
             Value::Column(NullableColumn::new_unchecked(col.into(), validity))
         }
     }
+}
+
+fn eval_latin1_bytes(val: Value<StringType>, ctx: &mut EvalContext) -> Value<BinaryType> {
+    vectorize_string_to_binary(
+        |col| col.total_bytes_len(),
+        |val, output, ctx| {
+            for ch in val.chars() {
+                let code_point = u32::from(ch);
+                if code_point > u32::from(u8::MAX) {
+                    ctx.set_error(
+                        output.len(),
+                        format!("character U+{code_point:04X} cannot be encoded as latin1"),
+                    );
+                    break;
+                }
+                output.data.push(code_point as u8);
+            }
+            output.commit_row();
+        },
+    )(val, ctx)
 }
 
 fn eval_unhex(val: Value<StringType>, ctx: &mut EvalContext) -> Value<BinaryType> {

--- a/src/query/functions/tests/it/scalars/binary.rs
+++ b/src/query/functions/tests/it/scalars/binary.rs
@@ -110,6 +110,29 @@ fn test_to_jsonb_binary(file: &mut impl Write) {
 fn test_to_binary(file: &mut impl Write, is_try: bool) {
     let prefix = if is_try { "TRY_" } else { "" };
 
+    run_ast(
+        file,
+        format!("to_hex({prefix}to_binary(char(0, 65, 127, 128, 255), 'latin1'))"),
+        &[],
+    );
+    run_ast(
+        file,
+        format!("to_hex({prefix}to_binary(char(128, 255), 'latin-1'))"),
+        &[],
+    );
+    run_ast(
+        file,
+        format!("to_hex({prefix}to_binary(char(128, 255), 'iso-8859-1'))"),
+        &[],
+    );
+    run_ast(file, format!("{prefix}to_binary(char(256), 'latin1')"), &[]);
+    run_ast(file, format!("to_hex({prefix}to_binary(s, 'latin1'))"), &[
+        (
+            "s",
+            StringType::from_data(vec!["\u{80}\u{ff}", "\u{100}", "plain"]),
+        ),
+    ]);
+
     run_ast(file, format!("{prefix}to_binary(to_bitmap('1,2,3'))"), &[]);
     run_ast(
         file,

--- a/src/query/functions/tests/it/scalars/testdata/binary.txt
+++ b/src/query/functions/tests/it/scalars/testdata/binary.txt
@@ -248,6 +248,49 @@ evaluation (internal):
 +--------+--------------------------------------------------------+
 
 
+ast            : to_hex(to_binary(char(0, 65, 127, 128, 255), 'latin1'))
+raw expr       : to_hex(to_binary(char(0, 65, 127, 128, 255), 'latin1'))
+checked expr   : to_hex<Binary>(to_binary<String, String>(char<Int64, Int64, Int64, Int64, Int64>(CAST<UInt8>(0_u8 AS Int64), CAST<UInt8>(65_u8 AS Int64), CAST<UInt8>(127_u8 AS Int64), CAST<UInt8>(128_u8 AS Int64), CAST<UInt8>(255_u8 AS Int64)), "latin1"))
+optimized expr : "00417f80ff"
+output type    : String
+output domain  : {"00417f80ff"..="00417f80ff"}
+output         : '00417f80ff'
+
+
+ast            : to_hex(to_binary(char(128, 255), 'latin-1'))
+raw expr       : to_hex(to_binary(char(128, 255), 'latin-1'))
+checked expr   : to_hex<Binary>(to_binary<String, String>(char<Int64, Int64>(CAST<UInt8>(128_u8 AS Int64), CAST<UInt8>(255_u8 AS Int64)), "latin-1"))
+optimized expr : "80ff"
+output type    : String
+output domain  : {"80ff"..="80ff"}
+output         : '80ff'
+
+
+ast            : to_hex(to_binary(char(128, 255), 'iso-8859-1'))
+raw expr       : to_hex(to_binary(char(128, 255), 'iso-8859-1'))
+checked expr   : to_hex<Binary>(to_binary<String, String>(char<Int64, Int64>(CAST<UInt8>(128_u8 AS Int64), CAST<UInt8>(255_u8 AS Int64)), "iso-8859-1"))
+optimized expr : "80ff"
+output type    : String
+output domain  : {"80ff"..="80ff"}
+output         : '80ff'
+
+
+error: 
+  --> SQL:1:1
+  |
+1 | to_binary(char(256), 'latin1')
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ character U+0100 cannot be encoded as latin1 while evaluating function `to_binary('Ā', 'latin1')` in expr `to_binary(char(CAST(256 AS Int64)), 'latin1')`
+
+
+
+error: 
+  --> SQL:1:8
+  |
+1 | to_hex(to_binary(s, 'latin1'))
+  |        ^^^^^^^^^^^^^^^^^^^^^^ character U+0100 cannot be encoded as latin1 while evaluating function `to_binary('Ā', 'latin1')` in expr `to_binary(s, 'latin1')`, during run expr: `to_hex(to_binary(s, 'latin1'))`
+
+
+
 ast            : to_binary(to_bitmap('1,2,3'))
 raw expr       : to_binary(to_bitmap('1,2,3'))
 checked expr   : CAST<Bitmap>(CAST<String>("1,2,3" AS Bitmap) AS Binary)
@@ -379,6 +422,64 @@ evaluation (internal):
 | s      | Column(StringColumn[616263, 646566, 6461746162656e64]) |
 | Output | StringColumn[abc, def, databend]                       |
 +--------+--------------------------------------------------------+
+
+
+ast            : to_hex(TRY_to_binary(char(0, 65, 127, 128, 255), 'latin1'))
+raw expr       : to_hex(TRY_to_binary(char(0, 65, 127, 128, 255), 'latin1'))
+checked expr   : to_hex<Binary NULL>(try_to_binary<String, String>(char<Int64, Int64, Int64, Int64, Int64>(CAST<UInt8>(0_u8 AS Int64), CAST<UInt8>(65_u8 AS Int64), CAST<UInt8>(127_u8 AS Int64), CAST<UInt8>(128_u8 AS Int64), CAST<UInt8>(255_u8 AS Int64)), "latin1"))
+optimized expr : "00417f80ff"
+output type    : String NULL
+output domain  : {"00417f80ff"..="00417f80ff"}
+output         : '00417f80ff'
+
+
+ast            : to_hex(TRY_to_binary(char(128, 255), 'latin-1'))
+raw expr       : to_hex(TRY_to_binary(char(128, 255), 'latin-1'))
+checked expr   : to_hex<Binary NULL>(try_to_binary<String, String>(char<Int64, Int64>(CAST<UInt8>(128_u8 AS Int64), CAST<UInt8>(255_u8 AS Int64)), "latin-1"))
+optimized expr : "80ff"
+output type    : String NULL
+output domain  : {"80ff"..="80ff"}
+output         : '80ff'
+
+
+ast            : to_hex(TRY_to_binary(char(128, 255), 'iso-8859-1'))
+raw expr       : to_hex(TRY_to_binary(char(128, 255), 'iso-8859-1'))
+checked expr   : to_hex<Binary NULL>(try_to_binary<String, String>(char<Int64, Int64>(CAST<UInt8>(128_u8 AS Int64), CAST<UInt8>(255_u8 AS Int64)), "iso-8859-1"))
+optimized expr : "80ff"
+output type    : String NULL
+output domain  : {"80ff"..="80ff"}
+output         : '80ff'
+
+
+ast            : TRY_to_binary(char(256), 'latin1')
+raw expr       : TRY_to_binary(char(256), 'latin1')
+checked expr   : try_to_binary<String, String>(char<Int64>(CAST<UInt16>(256_u16 AS Int64)), "latin1")
+optimized expr : NULL
+output type    : Binary NULL
+output domain  : {NULL}
+output         : NULL
+
+
+ast            : to_hex(TRY_to_binary(s, 'latin1'))
+raw expr       : to_hex(TRY_to_binary(s::String, 'latin1'))
+checked expr   : to_hex<Binary NULL>(try_to_binary<String, String>(s, "latin1"))
+evaluation:
++--------+-----------------+-----------------+
+|        | s               | Output          |
++--------+-----------------+-----------------+
+| Type   | String          | String NULL     |
+| Domain | {"plain"..="Ā"} | {""..} ∪ {NULL} |
+| Row 0  | 'ÿ'            | '80ff'          |
+| Row 1  | 'Ā'             | NULL            |
+| Row 2  | 'plain'         | '706c61696e'    |
++--------+-----------------+-----------------+
+evaluation (internal):
++--------+-------------------------------------------------------------------------------------+
+| Column | Data                                                                                |
++--------+-------------------------------------------------------------------------------------+
+| s      | Column(StringColumn[ÿ, Ā, plain])                                                  |
+| Output | NullableColumn { column: StringColumn[80ff, , 706c61696e], validity: [0b_____101] } |
++--------+-------------------------------------------------------------------------------------+
 
 
 ast            : TRY_to_binary(to_bitmap('1,2,3'))

--- a/tests/sqllogictests/suites/base/03_common/03_0041_insert_into_binary.test
+++ b/tests/sqllogictests/suites/base/03_common/03_0041_insert_into_binary.test
@@ -27,6 +27,31 @@ SELECT id, v FROM t1 order by id
 6 616161
 7 616161
 
+query T
+SELECT to_hex(to_binary(char(0, 65, 127, 128, 255), 'latin1'))
+----
+00417f80ff
+
+query T
+SELECT to_hex(to_binary(as_string(get(parse_json('{"v":"\u0000A\u007f\u0080\u00ff"}'), 'v')), 'latin1'))
+----
+00417f80ff
+
+query T
+SELECT to_hex(try_to_binary(char(128, 255), 'latin-1'))
+----
+80ff
+
+query T
+SELECT to_hex(try_to_binary(char(128, 255), 'iso-8859-1'))
+----
+80ff
+
+query ?
+SELECT try_to_binary(char(256), 'latin1')
+----
+NULL
+
 statement ok
 ALTER TABLE t1 MODIFY COLUMN v string
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

TiCDC Canal-JSON intentionally represents binary column bytes as ISO-8859-1 code points in a JSON string. Converting the decoded string as UTF-8 changes bytes above `0x7f`; for example, `0x80` becomes `c280` and `0xff` becomes `c3bf`.

This PR adds `latin1`, `latin-1`, and `iso-8859-1` formats to `TO_BINARY` and `TRY_TO_BINARY` so consumers can restore the original bytes without changing the Canal-JSON pipeline.

```sql
SELECT TO_HEX(
  TO_BINARY(
    AS_STRING(GET(PARSE_JSON('{"v":"\u0000A\u007f\u0080\u00ff"}'), 'v')),
    'latin1'
  )
);
-- 00417f80ff
```

TiCDC documents this encoding for binary columns and implements it with an ISO-8859-1 decoder:

- https://github.com/pingcap/docs/blob/ceff62e44f9e1c6552d6478bf162bc92aa2d1189/ticdc/ticdc-canal-json.md#L262-L299
- https://github.com/pingcap/tiflow/blob/4880637e6cd6daa67cf0e2f4810f1120ad90e58a/pkg/sink/codec/canal/canal_entry.go#L80-L117

## Implementation

- Encode each Unicode code point in `U+0000..U+00FF` as its corresponding single byte.
- Make `TO_BINARY` reject code points above `U+00FF` instead of truncating them.
- Make `TRY_TO_BINARY` return `NULL` for unrepresentable input.
- Preserve the existing nullable and vectorized function behavior.

The change is backward compatible: existing `hex`, `base64`, and `utf-8` formats are unchanged.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation performed on `origin/main` at `b6a88c6930`:

- `cargo fmt --check -- src/query/functions/src/scalars/binary.rs src/query/functions/tests/it/scalars/binary.rs`
- `cargo test -p databend-common-functions --test it test_binary -- --nocapture`
- `cargo clippy -p databend-common-functions --lib --tests -- -D warnings`
- `cargo build --bin databend-query --bin databend-sqllogictests`
- `databend-sqllogictests` for `03_0041_insert_into_binary.test` with both MySQL and HTTP handlers (20 assertions per handler)

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent researched the TiCDC/Canal encoding contract, implemented the scalar function and regression tests, and drafted this PR description.
- Responsible human: @dbsid
- [ ] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20238)
<!-- Reviewable:end -->
