### PR TITLE
ci(compat): rework compat_fuse runner with shared-data case groups

### DIFF
--- a/.github/actions/test_compat_fuse/action.yml
+++ b/.github/actions/test_compat_fuse/action.yml
@@ -1,5 +1,5 @@
-name: "Test fuse-table format in an old query is compatible with new query"
-description: "Download old binaries and current binaries, write data with old query, read data with new query"
+name: "Test fuse-table format compatibility across query versions"
+description: "Run ordered compatibility cases across old and current queries"
 runs:
   using: "composite"
   steps:
@@ -11,7 +11,7 @@ runs:
     - name: Test compatibility
       shell: bash
       run: |
-        pip install pyyaml -q
+        pip install 'PyYAML==6.0.3' -q
         python3 ./tests/compat_fuse/test_compat_fuse.py --run-all
     - name: Upload failure
       if: failure()

--- a/tests/compat_fuse/test_cases.yaml
+++ b/tests/compat_fuse/test_cases.yaml
@@ -1,10 +1,12 @@
 # Fuse table compatibility test matrix.
 #
-# Each entry tests write-then-read across query versions:
+# Each object tests write-then-read across query versions:
 #   writer  — the query version that writes data
 #   reader  — the query version that reads data ("current" = latest build)
 #   meta    — meta-service versions to run in order; used to upgrade on-disk meta data
 #   suite   — sqllogictest sub-directory under tests/compat_fuse/compat-logictest/
+# A top-level array groups complete objects that run in order while sharing the
+# same Meta and Fuse files. Processes still stop between writer/Meta/reader steps.
 #
 # To add a new test case, append an entry to the appropriate section below.
 # To bump a version, edit the version string in place.

--- a/tests/compat_fuse/test_compat_fuse.py
+++ b/tests/compat_fuse/test_compat_fuse.py
@@ -19,20 +19,33 @@ import urllib.request
 from pathlib import Path
 
 
-def load_test_cases(path: Path) -> list[dict]:
-    """Load test cases from a YAML file."""
+def load_test_cases(path: Path) -> list[dict | list[dict]]:
+    """Load standalone cases and shared-data case groups from YAML."""
     import yaml
 
     with open(path) as f:
         cases = yaml.safe_load(f)
-    # Ensure all values in meta lists are strings (yaml may parse "1.2.527" as float)
-    for case in cases:
-        case["meta"] = [str(v) for v in case["meta"]]
-        if "writer" in case:
+
+    # YAML may parse unquoted versions such as 1.2.527 as numbers.
+    required_fields = {"writer", "reader", "meta", "suite"}
+    for index, entry in enumerate(cases):
+        if not isinstance(entry, (dict, list)):
+            raise ValueError(f"Case entry {index + 1} must be an object or array")
+        group = entry if isinstance(entry, list) else [entry]
+        if not group:
+            raise ValueError(f"Shared-data group {index + 1} must not be empty")
+        for case in group:
+            if not isinstance(case, dict) or not required_fields.issubset(case):
+                raise ValueError(
+                    f"Case entry {index + 1} requires fields {sorted(required_fields)}"
+                )
+            if not isinstance(case["meta"], list) or not case["meta"]:
+                raise ValueError(
+                    f"Case entry {index + 1} requires a non-empty meta list"
+                )
             case["writer"] = str(case["writer"])
-        if "reader" in case:
             case["reader"] = str(case["reader"])
-        if "suite" in case:
+            case["meta"] = [str(v) for v in case["meta"]]
             case["suite"] = str(case["suite"])
     return cases
 
@@ -112,7 +125,8 @@ def git_partial_clone(
     subprocess.run(
         [
             "git",
-            "-c", "advice.detachedHead=false",
+            "-c",
+            "advice.detachedHead=false",
             "clone",
             "-b",
             branch,
@@ -209,7 +223,7 @@ class TestContext:
         return proc
 
     def start_query(self, ver: str) -> subprocess.Popen:
-        """Start databend-query, track process, wait for port 3307."""
+        """Start databend-query and wait for its MySQL and HTTP ports."""
         query_path = self.bin_path(ver, "query")
         config_path = self.query_config_path(ver)
         stdout_file = str(self.data_dir / f"query-nohup-{ver}.out")
@@ -234,6 +248,7 @@ class TestContext:
 
         try:
             wait_tcp_port(3307, 20)
+            wait_tcp_port(8000, 20)
         except TimeoutError:
             proc.terminate()
             proc.wait()
@@ -244,11 +259,50 @@ class TestContext:
 
         return proc
 
+    def stop_query(self, proc: subprocess.Popen) -> None:
+        """Stop one query process while leaving the shared meta process running."""
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+        if proc in self.processes:
+            self.processes.remove(proc)
+        time.sleep(1)
+
+    def install_enterprise_license(self) -> None:
+        """Install the CI license on the active query, when provided."""
+        license_key = os.environ.get("QUERY_DATABEND_ENTERPRISE_LICENSE")
+        if not license_key:
+            return
+
+        print(" === Install enterprise license")
+        sql = f"SET GLOBAL enterprise_license = '{license_key}'"
+        subprocess.run(
+            [
+                "bendsql",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                "8000",
+                "--user",
+                "root",
+                f"--query={sql}",
+                "--output",
+                "null",
+            ],
+            check=True,
+        )
+
     def run_sqllogictests(self, run_file: str) -> None:
-        """Run sqllogictests for the given test file."""
+        """Run one sqllogictest file against the active query."""
         print(f" === Run test: {run_file}")
 
-        sqllogictests = str(self.bins_dir / "current" / "bin" / "databend-sqllogictests")
+        sqllogictests = str(
+            self.bins_dir / "current" / "bin" / "databend-sqllogictests"
+        )
         subprocess.run(
             [
                 sqllogictests,
@@ -266,16 +320,17 @@ class TestContext:
         """Try to print binary version info; suppress noise from old binaries."""
         result = subprocess.run(
             [bin_path] + args,
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         if result.returncode == 0:
             for line in result.stdout.strip().splitlines():
                 if line.startswith("version:"):
                     print(f"        {line}")
                     return
-            print(f"        (no version line in output)")
+            print("        (no version line in output)")
         else:
-            print(f"        (--cmd ver not supported by this build)")
+            print("        (--cmd ver not supported by this build)")
 
     def clean_data_dir(self) -> None:
         """Remove and recreate the .databend data directory."""
@@ -284,45 +339,57 @@ class TestContext:
             shutil.rmtree(self.data_dir)
         self.data_dir.mkdir(parents=True, exist_ok=True)
 
-    def run_test(self) -> None:
-        """Run the full write -> meta-upgrade -> read compatibility test."""
-        self.cleanup()
-        self.clean_data_dir()
+    def check_versions(self, query_versions: list[str]) -> None:
+        """Print all binaries used by a compatibility scenario."""
+        print(" === Checking binary versions before test ...")
+        for ver in self.meta_versions:
+            print(f" === checking metasrv {ver}")
+            self._print_bin_version(
+                self.bin_path(ver, "meta"), ["--single", "--cmd", "ver"]
+            )
 
-        try:
-            # Verify downloaded binaries by printing their versions
-            print(" === Checking binary versions before test ...")
+        checked = set()
+        for ver in query_versions:
+            if ver in checked:
+                continue
+            checked.add(ver)
+            print(f" === checking query {ver}")
+            self._print_bin_version(self.bin_path(ver, "query"), ["--cmd", "ver"])
+        print(" === All binaries OK")
 
-            for ver in self.meta_versions:
-                print(f" === checking metasrv {ver}")
-                self._print_bin_version(self.bin_path(ver, "meta"), ["--single", "--cmd", "ver"])
-
-            print(f" === checking writer query {self.writer_ver}")
-            self._print_bin_version(self.bin_path(self.writer_ver, "query"), ["--cmd", "ver"])
-
-            print(f" === checking reader query {self.reader_ver}")
-            self._print_bin_version(self.bin_path(self.reader_ver, "query"), ["--cmd", "ver"])
-
-            print(" === All binaries OK")
-
-            # Phase 1: Write
-            print(" === Phase 1: Write data with writer version")
-            self.start_metasrv(self.meta_versions[0])
-            self.start_query(self.writer_ver)
-            self.run_sqllogictests("fuse_compat_write.test")
+    def upgrade_meta(self) -> None:
+        """Start each declared meta version once to upgrade its on-disk state."""
+        print(" === Upgrade meta on-disk data")
+        for ver in self.meta_versions:
+            self.start_metasrv(ver)
+            time.sleep(3)
             self.cleanup()
 
-            # Phase 2: Meta upgrade
-            print(" === Phase 2: Upgrade meta on-disk data")
-            for ver in self.meta_versions:
-                self.start_metasrv(ver)
-                time.sleep(3)
-                self.cleanup()
+    def run_test(self, clean_data: bool = True, install_license: bool = False) -> None:
+        """Run one complete writer -> meta chain -> reader compatibility case."""
+        self.cleanup()
+        if clean_data:
+            self.clean_data_dir()
 
-            # Phase 3: Read
+        try:
+            self.check_versions([self.writer_ver, self.reader_ver])
+
+            print(" === Phase 1: Write data with writer version")
+            self.start_metasrv(self.meta_versions[0])
+            query = self.start_query(self.writer_ver)
+            if install_license:
+                self.install_enterprise_license()
+            self.run_sqllogictests("fuse_compat_write.test")
+            self.stop_query(query)
+            self.cleanup()
+
+            self.upgrade_meta()
+
             print(" === Phase 3: Read data with reader version")
             self.start_metasrv(self.meta_versions[-1])
             self.start_query(self.reader_ver)
+            if install_license:
+                self.install_enterprise_license()
             self.run_sqllogictests("fuse_compat_read.test")
         finally:
             self.cleanup()
@@ -414,21 +481,58 @@ def setup_env() -> None:
     Path(".databend").mkdir(parents=True, exist_ok=True)
 
 
-def download_and_run_case(
-    writer: str, reader: str, meta: list[str], suite: str,
-) -> None:
-    """Download binaries/configs and run one compatibility test case."""
-    download_query_config(writer)
-    download_query_config(reader)
+def download_case_artifacts(case: dict) -> None:
+    """Download all binaries and configs required by one case."""
+    download_query_config(case["writer"])
+    download_query_config(case["reader"])
 
-    for meta_ver in meta:
+    for meta_ver in case["meta"]:
         download_binary(meta_ver)
 
-    download_binary(writer)
-    download_binary(reader)
+    download_binary(case["writer"])
+    download_binary(case["reader"])
+
+
+def download_and_run_case(
+    writer: str,
+    reader: str,
+    meta: list[str],
+    suite: str,
+) -> None:
+    """Download and run one standalone compatibility test case."""
+    case = {"writer": writer, "reader": reader, "meta": meta, "suite": suite}
+    download_case_artifacts(case)
 
     ctx = TestContext(writer, reader, meta, suite)
     ctx.run_test()
+
+
+def download_and_run_group(group: list[dict]) -> None:
+    """Run complete compatibility cases in order while preserving data."""
+    query_versions = []
+    meta_versions = []
+    for case in group:
+        for version in (case["writer"], case["reader"]):
+            if version not in query_versions:
+                query_versions.append(version)
+        for version in case["meta"]:
+            if version not in meta_versions:
+                meta_versions.append(version)
+
+    for version in query_versions:
+        download_query_config(version)
+        download_binary(version)
+    for version in meta_versions:
+        download_binary(version)
+
+    for index, case in enumerate(group):
+        print(
+            f" === Shared-data case {index + 1}/{len(group)}: "
+            f"writer={case['writer']} reader={case['reader']} "
+            f"meta={case['meta']} suite={case['suite']}"
+        )
+        ctx = TestContext(case["writer"], case["reader"], case["meta"], case["suite"])
+        ctx.run_test(clean_data=index == 0, install_license=True)
 
 
 def main():
@@ -473,17 +577,29 @@ def main():
         cases = load_test_cases(yaml_path)
         print(f" === Loaded {len(cases)} test cases from {yaml_path}")
 
-        for i, case in enumerate(cases):
-            writer = case["writer"]
-            reader = case["reader"]
-            meta = case["meta"]
-            suite = case["suite"]
-            print(f" === [{i+1}/{len(cases)}] writer={writer} reader={reader} meta={meta} suite={suite}")
+        for i, entry in enumerate(cases):
+            group = entry if isinstance(entry, list) else [entry]
+            descriptions = []
+            for case in group:
+                descriptions.append(
+                    f"writer={case['writer']} reader={case['reader']} "
+                    f"meta={case['meta']} suite={case['suite']}"
+                )
+            kind = "shared-data group" if isinstance(entry, list) else "case"
+            print(f" === [{i + 1}/{len(cases)}] {kind}: " + " -> ".join(descriptions))
 
             if args.dry_run:
                 continue
 
-            download_and_run_case(writer, reader, meta, suite)
+            if isinstance(entry, list):
+                download_and_run_group(entry)
+            else:
+                download_and_run_case(
+                    entry["writer"],
+                    entry["reader"],
+                    entry["meta"],
+                    entry["suite"],
+                )
 
         if args.dry_run:
             print(" === Dry run complete, no tests executed.")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Rework the `compat_fuse` test runner so a single YAML matrix can express both
standalone write-then-read cases and ordered case groups that share the same
Meta and Fuse on-disk data. Shared-data groups are the prerequisite for
rolling-upgrade compatibility suites (old/current versions alternating over
one data lifecycle) that follow-up storage PRs will add.

No test cases are added or removed: the 10 existing cases still run as
standalone entries, and a `--dry-run` mode prints the resolved plan.

## Changes

- `test_cases.yaml` may now contain a top-level array entry: the enclosed
  complete cases run in order while preserving `.databend` data between them
  (processes still stop between writer/meta/reader steps). Object entries
  behave exactly as before.
- Validate all cases up front (required fields, non-empty meta list) instead
  of failing midway through a multi-hour run.
- Split `run_test` into reusable phases (`check_versions`, `upgrade_meta`,
  `stop_query`) and wait for the query HTTP port in addition to the MySQL
  port.
- Add optional enterprise-license installation via `bendsql`, driven by the
  `QUERY_DATABEND_ENTERPRISE_LICENSE` env var; it is a no-op when the variable
  is absent. Grouped suites added by follow-up PRs rely on it.
- Add `--run-all --dry-run` to print the case plan without executing.
- CI action: pin `PyYAML==6.0.3` for reproducible runs.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _CI-infrastructure change; validated by running the framework itself_

- `python3 tests/compat_fuse/test_compat_fuse.py --run-all --dry-run`
  resolves all 10 existing cases.
- Ad-hoc checks for the new loader: mixed group/standalone YAML parses,
  missing-field and empty-group entries are rejected with clear errors.
- `ruff check` / `ruff format --check` / `yamllint` pass on the touched files.
- The `test_compat_fuse` CI job on this PR exercises the full run path.

## Type of change

- [x] Other (please describe): CI / test-infrastructure rework

## AI assistance

- AI usage: An AI coding agent split this change out of a larger feature
  branch and drafted the commit/PR text; the framework rewrite originates
  from the feature branch.
- Responsible human: @zhang2014
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20242)
<!-- Reviewable:end -->
