### PR TITLE
refactor(meta): add function get_mv_source_binding_snapshot

### DIFF
--- a/src/meta/api/src/api_impl/materialized_view_api.rs
+++ b/src/meta/api/src/api_impl/materialized_view_api.rs
@@ -47,8 +47,8 @@
 //!
 //! - [`MaterializedViewApi::list_mvs_by_source_table_id`] returns every edge,
 //!   including invalid ones, for management and lifecycle operations.
-//! - [`MaterializedViewApi::list_valid_mvs_by_source_table_id`] filters edges by
-//!   the expected generation obtained with the caller's stable source binding.
+//! - [`MaterializedViewApi::get_mv_source_binding_snapshot`] reads the source
+//!   generation before and after collecting matching edges.
 //!
 //! `CreateMaterializedViewMeta::expected_source_generation` provides the same
 //! fence for CREATE. `create_table` compares it with the current value and uses
@@ -125,6 +125,7 @@
 use databend_common_meta_app::schema::MVDefinition;
 use databend_common_meta_app::schema::MVDefinitionIdent;
 use databend_common_meta_app::schema::MVInfo;
+use databend_common_meta_app::schema::MVSourceBindingVersionIdent;
 use databend_common_meta_app::schema::SourceTableMV;
 use databend_common_meta_app::schema::SourceTableMVIdent;
 use databend_common_meta_app::schema::TableId;
@@ -142,6 +143,15 @@ use log::warn;
 
 use crate::deserialize_struct_get_response;
 use crate::kv_pb_api::KVPbApi;
+
+/// A generation-consistent view of active MV bindings for one source table.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MVSourceBindingSnapshot {
+    /// Source binding generation at which `materialized_views` was collected.
+    pub generation: u64,
+    /// Empty when the generation changed while MV metadata was being collected.
+    pub materialized_views: Vec<MVInfo>,
+}
 
 /// APIs for metadata that belongs exclusively to materialized views.
 #[async_trait::async_trait]
@@ -165,7 +175,7 @@ where
     ///
     /// This unfiltered view is intended for management, SHOW, GC, and refresh
     /// discovery. SELECT optimization and source-table maintenance must use
-    /// [`MaterializedViewApi::list_valid_mvs_by_source_table_id`] instead.
+    /// [`MaterializedViewApi::get_mv_source_binding_snapshot`] instead.
     #[logcall::logcall]
     #[fastrace::trace]
     async fn list_mvs_by_source_table_id(
@@ -176,38 +186,54 @@ where
         list_mvs_by_source_table_id_impl(self, tenant, source_table_id, None).await
     }
 
-    /// List MVs valid for the caller's stable source binding.
+    /// Get MVs valid at a stable source binding generation.
     ///
-    /// ```text
-    /// list SourceTableMVIdent(tenant, source_table_id, *) -> mv_table_ids
-    /// filter relationship.bound_source_generation == expected_source_generation
-    /// mget MVDefinitionIdent(mv_table_id) + TableId(mv_table_id) -> MVInfo
-    /// ```
-    ///
-    /// The result contains both maintenance modes.
-    /// INSERT selects `MVDefinition::sync_creation = true`; scheduled refresh
-    /// selects `false`.
-    /// No collection version is returned. An MV created after the relationship
-    /// list is a new empty table, so the current INSERT does not write it. An MV
-    /// dropped after the list may still receive the current INSERT while its
-    /// dropped `TableMeta` is retained for GC. A definition or `TableMeta`
-    /// missing between the list and mget is omitted with a warning.
+    /// The generation is read before and after collecting MV metadata. If it
+    /// changes during collection, the returned MV list is empty and
+    /// `generation` contains the final observed value. A caller that later
+    /// writes data must still compare this generation when committing.
     #[logcall::logcall]
     #[fastrace::trace]
-    async fn list_valid_mvs_by_source_table_id(
+    async fn get_mv_source_binding_snapshot(
         &self,
         tenant: &Tenant,
         source_table_id: u64,
-        expected_source_generation: u64,
-    ) -> Result<Vec<MVInfo>, MetaError> {
-        list_mvs_by_source_table_id_impl(
+    ) -> Result<MVSourceBindingSnapshot, MetaError> {
+        let generation_before = get_mv_source_generation(self, tenant, source_table_id).await?;
+        let mut materialized_views = list_mvs_by_source_table_id_impl(
             self,
             tenant,
             source_table_id,
-            Some(expected_source_generation),
+            Some(generation_before),
         )
-        .await
+        .await?;
+        let generation_after = get_mv_source_generation(self, tenant, source_table_id).await?;
+
+        if generation_before != generation_after {
+            materialized_views.clear();
+        }
+
+        Ok(MVSourceBindingSnapshot {
+            generation: generation_after,
+            materialized_views,
+        })
     }
+}
+
+async fn get_mv_source_generation<KV>(
+    kv_api: &KV,
+    tenant: &Tenant,
+    source_table_id: u64,
+) -> Result<u64, MetaError>
+where
+    KV: kvapi::KVApi<Error = MetaError> + ?Sized,
+{
+    let generation_ident = MVSourceBindingVersionIdent::new(tenant, source_table_id);
+    Ok(kv_api
+        .get_pb(&generation_ident)
+        .await?
+        .map(|record| record.data.current_source_generation)
+        .unwrap_or(0))
 }
 
 async fn list_mvs_by_source_table_id_impl<KV>(

--- a/src/meta/schema-api-test-suite/src/schema_api_test_suite.rs
+++ b/src/meta/schema-api-test-suite/src/schema_api_test_suite.rs
@@ -1765,11 +1765,11 @@ impl SchemaApiTestSuite {
                     .await
                     .is_err()
             );
-            assert!(
-                mt.list_valid_mvs_by_source_table_id(&tenant, missing_source_id, 0)
-                    .await?
-                    .is_empty()
-            );
+            let snapshot = mt
+                .get_mv_source_binding_snapshot(&tenant, missing_source_id)
+                .await?;
+            assert_eq!(snapshot.generation, 0);
+            assert!(snapshot.materialized_views.is_empty());
             assert!(
                 mt.get_pb(&MVSourceBindingVersionIdent::new(
                     &tenant,
@@ -1798,13 +1798,10 @@ impl SchemaApiTestSuite {
                     .is_err()
             );
             assert!(
-                mt.list_valid_mvs_by_source_table_id(
-                    &tenant,
-                    source_table_id,
-                    initial_source_binding_generation,
-                )
-                .await?
-                .is_empty()
+                mt.get_mv_source_binding_snapshot(&tenant, source_table_id)
+                    .await?
+                    .materialized_views
+                    .is_empty()
             );
             assert!(
                 mt.get_pb(&MVSourceBindingVersionIdent::new(&tenant, source_table_id))
@@ -1851,6 +1848,18 @@ impl SchemaApiTestSuite {
             created
         };
         let mv_id = created.table_id;
+        let snapshot = mt
+            .get_mv_source_binding_snapshot(&tenant, source_table_id)
+            .await?;
+        assert_eq!(snapshot.generation, initial_source_binding_generation);
+        assert_eq!(
+            snapshot
+                .materialized_views
+                .iter()
+                .map(|mv| mv.mv_id)
+                .collect::<Vec<_>>(),
+            vec![mv_id]
+        );
 
         // MV membership changes do not advance the source binding version.
         {
@@ -1886,16 +1895,16 @@ impl SchemaApiTestSuite {
                 db_name: db_name.clone(),
             })
             .await?;
+            let snapshot = mt
+                .get_mv_source_binding_snapshot(&tenant, source_table_id)
+                .await?;
+            assert_eq!(snapshot.generation, source_binding_generation);
             assert_eq!(
-                mt.list_valid_mvs_by_source_table_id(
-                    &tenant,
-                    source_table_id,
-                    source_binding_generation,
-                )
-                .await?
-                .iter()
-                .map(|mv| mv.mv_id)
-                .collect::<Vec<_>>(),
+                snapshot
+                    .materialized_views
+                    .iter()
+                    .map(|mv| mv.mv_id)
+                    .collect::<Vec<_>>(),
                 vec![mv_id]
             );
 
@@ -1918,11 +1927,11 @@ impl SchemaApiTestSuite {
                 .await
                 .is_err()
             );
-            assert!(
-                mt.list_valid_mvs_by_source_table_id(&tenant, source_table_id, next_generation,)
-                    .await?
-                    .is_empty()
-            );
+            let snapshot = mt
+                .get_mv_source_binding_snapshot(&tenant, source_table_id)
+                .await?;
+            assert_eq!(snapshot.generation, next_generation);
+            assert!(snapshot.materialized_views.is_empty());
             assert_eq!(
                 mt.list_mvs_by_source_table_id(&tenant, source_table_id)
                     .await?
@@ -1946,11 +1955,7 @@ impl SchemaApiTestSuite {
             );
 
             let mvs = mt
-                .list_valid_mvs_by_source_table_id(
-                    &tenant,
-                    source_table_id,
-                    initial_source_binding_generation,
-                )
+                .list_mvs_by_source_table_id(&tenant, source_table_id)
                 .await?;
             let [mv] = mvs.as_slice() else {
                 panic!("one complete MV must be returned");
@@ -1984,13 +1989,11 @@ impl SchemaApiTestSuite {
                     .is_none()
             );
 
-            let mvs = mt
-                .list_valid_mvs_by_source_table_id(
-                    &tenant,
-                    source_table_id,
-                    source_binding_generation,
-                )
+            let snapshot = mt
+                .get_mv_source_binding_snapshot(&tenant, source_table_id)
                 .await?;
+            assert_eq!(snapshot.generation, source_binding_generation);
+            let mvs = snapshot.materialized_views;
             let [mv] = mvs.as_slice() else {
                 panic!("the replacement MV must be returned");
             };
@@ -2030,13 +2033,11 @@ impl SchemaApiTestSuite {
                     .is_none()
             );
 
-            let mvs = mt
-                .list_valid_mvs_by_source_table_id(
-                    &tenant,
-                    replacement_source_table_id,
-                    source_binding_generation,
-                )
+            let snapshot = mt
+                .get_mv_source_binding_snapshot(&tenant, replacement_source_table_id)
                 .await?;
+            assert_eq!(snapshot.generation, source_binding_generation);
+            let mvs = snapshot.materialized_views;
             let [mv] = mvs.as_slice() else {
                 panic!("the new-source replacement MV must be returned");
             };
@@ -2118,16 +2119,16 @@ impl SchemaApiTestSuite {
                 name_ident: TableNameIdent::new(&tenant, &db_name, replacement_source_name),
             })
             .await?;
+            let snapshot = mt
+                .get_mv_source_binding_snapshot(&tenant, replacement_source_table_id)
+                .await?;
+            assert_eq!(snapshot.generation, source_binding_generation);
             assert_eq!(
-                mt.list_valid_mvs_by_source_table_id(
-                    &tenant,
-                    replacement_source_table_id,
-                    source_binding_generation,
-                )
-                .await?
-                .iter()
-                .map(|mv| mv.mv_id)
-                .collect::<Vec<_>>(),
+                snapshot
+                    .materialized_views
+                    .iter()
+                    .map(|mv| mv.mv_id)
+                    .collect::<Vec<_>>(),
                 vec![new_source_replacement.table_id]
             );
 


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Replace the caller-supplied generation filter with get_mv_source_binding_snapshot. The API reads the source generation before and after collecting matching MV metadata, clears the result if the generation changes, and returns the final generation for downstream commit fencing.

Migrate the materialized-view lifecycle tests to validate missing sources, active and invalid bindings, replacements, and source drop/undrop through the snapshot API.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

<!--
See AI_POLICY.md. Agent-opened PRs are welcome; a responsible human on the author side must own the change.
The responsible human is NOT the reviewer — it is the submitter-side owner who has read the diff,
can explain each change, and will answer questions during review.
Write "None" for AI usage if no AI was involved.
-->

- AI usage: An AI coding agent assisted with extracting the MV source binding snapshot API and migrating its lifecycle tests.
- Responsible human: @TCeason 
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20245)
<!-- Reviewable:end -->
