### PR TITLE
feat(query): derive sort and window statistics

### DIFF
--- a/src/query/sql/src/planner/optimizer/ir/mod.rs
+++ b/src/query/sql/src/planner/optimizer/ir/mod.rs
@@ -52,5 +52,5 @@ pub use stats::MAX_SELECTIVITY;
 pub use stats::SelectivityEstimator;
 pub use stats::TopNSet;
 pub use stats::UniformSampleSet;
-pub(crate) use stats::finite_range_ndv_upper;
 pub(crate) use stats::cap_stat_info_by_rows;
+pub(crate) use stats::finite_range_ndv_upper;

--- a/src/query/sql/src/planner/optimizer/ir/mod.rs
+++ b/src/query/sql/src/planner/optimizer/ir/mod.rs
@@ -53,3 +53,4 @@ pub use stats::SelectivityEstimator;
 pub use stats::TopNSet;
 pub use stats::UniformSampleSet;
 pub(crate) use stats::finite_range_ndv_upper;
+pub(crate) use stats::cap_stat_info_by_rows;

--- a/src/query/sql/src/planner/optimizer/ir/stats/cardinality.rs
+++ b/src/query/sql/src/planner/optimizer/ir/stats/cardinality.rs
@@ -1,0 +1,125 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_statistics::NdvEstimate;
+use databend_common_statistics::StatCount;
+
+use crate::optimizer::ir::StatInfo;
+
+pub(crate) fn cap_stat_info_by_rows(mut stat_info: StatInfo, limit: usize) -> StatInfo {
+    let input_cardinality = stat_info.cardinality;
+    let limit = limit as f64;
+    if limit == 0.0 {
+        stat_info.cardinality = 0.0;
+        stat_info.statistics.precise_cardinality =
+            stat_info.statistics.precise_cardinality.map(|_| 0);
+        stat_info.statistics.column_stats.clear();
+        stat_info.statistics.top_n.clear();
+        stat_info.statistics.count_min_sketch.clear();
+        return stat_info;
+    }
+
+    if input_cardinality <= limit {
+        return stat_info;
+    }
+
+    stat_info.cardinality = limit;
+    stat_info.statistics.precise_cardinality = stat_info
+        .statistics
+        .precise_cardinality
+        .map(|cardinality| cardinality.min(limit as u64));
+
+    for column_stat in stat_info.statistics.column_stats.values_mut() {
+        let ndv_upper = column_stat.ndv.upper.min(limit);
+        column_stat.ndv = match column_stat.ndv.expected {
+            Some(expected) => NdvEstimate::new(expected.min(ndv_upper), ndv_upper),
+            None => NdvEstimate::upper_bound(ndv_upper),
+        };
+
+        column_stat.null_count = if column_stat.null_count == StatCount::exact(0) {
+            StatCount::exact(0)
+        } else {
+            let upper = column_stat.null_count.upper().min(limit);
+            let expected = column_stat.null_count.expected() * limit / input_cardinality;
+            StatCount::estimate(expected.min(upper), upper)
+        };
+        column_stat.histogram = None;
+    }
+
+    stat_info.statistics.top_n.clear();
+    stat_info.statistics.count_min_sketch.clear();
+    stat_info
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use databend_common_statistics::Datum;
+
+    use super::*;
+    use crate::Symbol;
+    use crate::optimizer::ir::ColumnStat;
+    use crate::optimizer::ir::Statistics;
+
+    fn stat_info(cardinality: f64, precise_cardinality: Option<u64>) -> StatInfo {
+        StatInfo {
+            cardinality,
+            statistics: Statistics {
+                precise_cardinality,
+                column_stats: HashMap::from([(Symbol::new(0), ColumnStat {
+                    min: Datum::Int(1),
+                    max: Datum::Int(100),
+                    ndv: NdvEstimate::new(80.0, 90.0),
+                    null_count: StatCount::estimate(20.0, 30.0),
+                    histogram: None,
+                })]),
+                top_n: Default::default(),
+                count_min_sketch: Default::default(),
+            },
+        }
+    }
+
+    #[test]
+    fn test_cap_stat_info_by_zero_rows() {
+        let capped = cap_stat_info_by_rows(stat_info(100.0, Some(100)), 0);
+
+        assert_eq!(capped.cardinality, 0.0);
+        assert_eq!(capped.statistics.precise_cardinality, Some(0));
+        assert!(capped.statistics.column_stats.is_empty());
+    }
+
+    #[test]
+    fn test_cap_stat_info_without_reduction() {
+        let capped = cap_stat_info_by_rows(stat_info(10.0, Some(10)), 20);
+        let column_stat = &capped.statistics.column_stats[&Symbol::new(0)];
+
+        assert_eq!(capped.cardinality, 10.0);
+        assert_eq!(capped.statistics.precise_cardinality, Some(10));
+        assert_eq!(column_stat.ndv, NdvEstimate::new(80.0, 90.0));
+        assert_eq!(column_stat.null_count, StatCount::estimate(20.0, 30.0));
+    }
+
+    #[test]
+    fn test_cap_stat_info_reduces_count_bounds() {
+        let capped = cap_stat_info_by_rows(stat_info(100.0, Some(100)), 10);
+        let column_stat = &capped.statistics.column_stats[&Symbol::new(0)];
+
+        assert_eq!(capped.cardinality, 10.0);
+        assert_eq!(capped.statistics.precise_cardinality, Some(10));
+        assert_eq!(column_stat.ndv, NdvEstimate::exact(10.0));
+        assert_eq!(column_stat.null_count, StatCount::estimate(2.0, 10.0));
+        assert!(column_stat.histogram.is_none());
+    }
+}

--- a/src/query/sql/src/planner/optimizer/ir/stats/mod.rs
+++ b/src/query/sql/src/planner/optimizer/ir/stats/mod.rs
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod cardinality;
 mod column_stat;
 mod constraint;
 mod join;
 mod selectivity;
 
+pub(crate) use cardinality::cap_stat_info_by_rows;
 pub use column_stat::*;
 use databend_common_statistics::Datum;
 pub use databend_common_statistics::UniformSampleSet;

--- a/src/query/sql/src/planner/plans/sort.rs
+++ b/src/query/sql/src/planner/plans/sort.rs
@@ -26,6 +26,7 @@ use crate::optimizer::ir::RelExpr;
 use crate::optimizer::ir::RelationalProperty;
 use crate::optimizer::ir::RequiredProperty;
 use crate::optimizer::ir::StatInfo;
+use crate::optimizer::ir::cap_stat_info_by_rows;
 use crate::plans::Operator;
 use crate::plans::RelOp;
 
@@ -188,6 +189,13 @@ impl Operator for Sort {
     }
 
     fn derive_stats(&self, rel_expr: &RelExpr) -> Result<Arc<StatInfo>> {
-        rel_expr.derive_cardinality_child(0)
+        let input = rel_expr.derive_cardinality_child(0)?;
+        let Some(limit) = self.limit else {
+            return Ok(input);
+        };
+        Ok(Arc::new(cap_stat_info_by_rows(
+            input.as_ref().clone(),
+            limit,
+        )))
     }
 }

--- a/src/query/sql/src/planner/plans/window.rs
+++ b/src/query/sql/src/planner/plans/window.rs
@@ -20,9 +20,16 @@ use databend_common_ast::Span;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_expression::ConstantFolder;
+use databend_common_expression::FunctionContext;
 use databend_common_expression::Scalar;
+use databend_common_expression::stat_distribution::NdvEstimate;
+use databend_common_expression::stat_distribution::StatCardinality;
+use databend_common_expression::stat_distribution::StatCount;
 use databend_common_expression::types::DataType;
 use databend_common_expression::types::NumberDataType;
+use databend_common_functions::BUILTIN_FUNCTIONS;
+use databend_common_statistics::Datum;
 use educe::Educe;
 use enum_as_inner::EnumAsInner;
 use serde::Deserialize;
@@ -34,11 +41,14 @@ use crate::ColumnSet;
 use crate::ScalarExpr;
 use crate::Symbol;
 use crate::binder::WindowOrderByInfo;
+use crate::optimizer::ir::ColumnStat;
 use crate::optimizer::ir::Distribution;
 use crate::optimizer::ir::RelExpr;
 use crate::optimizer::ir::RelationalProperty;
 use crate::optimizer::ir::RequiredProperty;
 use crate::optimizer::ir::StatInfo;
+use crate::optimizer::ir::cap_stat_info_by_rows;
+use crate::plans::EvalScalar;
 use crate::plans::LagLeadFunction;
 use crate::plans::NtileFunction;
 use crate::plans::Operator;
@@ -178,6 +188,264 @@ impl Window {
         }
         Ok(col_set)
     }
+
+    fn derive_output_stat(&self, stat_info: &StatInfo) -> Result<Option<ColumnStat>> {
+        if stat_info.cardinality == 0.0 {
+            return Ok(None);
+        }
+
+        match &self.function {
+            WindowFuncType::RowNumber => Ok(Some(self.derive_row_number_stat(stat_info))),
+            WindowFuncType::Rank | WindowFuncType::DenseRank => {
+                Ok(Some(self.derive_rank_stat(stat_info)))
+            }
+            WindowFuncType::Ntile(ntile) => Ok(Some(self.derive_ntile_stat(stat_info, ntile.n))),
+            WindowFuncType::LagLead(lag_lead) => self.derive_lag_lead_stat(stat_info, lag_lead),
+            _ => Ok(None),
+        }
+    }
+
+    fn derive_row_number_stat(&self, stat_info: &StatInfo) -> ColumnStat {
+        let upper = self.ranking_upper(stat_info);
+        let partitions = self.estimated_partition_count(stat_info);
+        let expected = (stat_info.cardinality / partitions)
+            .ceil()
+            .clamp(1.0, upper as f64);
+        ColumnStat {
+            min: Datum::UInt(1),
+            max: Datum::UInt(upper),
+            ndv: NdvEstimate::new(expected, upper as f64),
+            null_count: StatCount::exact(0),
+            histogram: None,
+        }
+    }
+
+    fn derive_rank_stat(&self, stat_info: &StatInfo) -> ColumnStat {
+        let upper = self.ranking_upper(stat_info);
+        ColumnStat {
+            min: Datum::UInt(1),
+            max: Datum::UInt(upper),
+            ndv: NdvEstimate::upper_bound(upper as f64),
+            null_count: StatCount::exact(0),
+            histogram: None,
+        }
+    }
+
+    fn derive_ntile_stat(&self, stat_info: &StatInfo, buckets: u64) -> ColumnStat {
+        let upper = buckets.min(cardinality_upper(stat_info.cardinality)).max(1);
+        ColumnStat {
+            min: Datum::UInt(1),
+            max: Datum::UInt(upper),
+            ndv: NdvEstimate::upper_bound(upper as f64),
+            null_count: StatCount::exact(0),
+            histogram: None,
+        }
+    }
+
+    fn derive_lag_lead_stat(
+        &self,
+        stat_info: &StatInfo,
+        lag_lead: &LagLeadFunction,
+    ) -> Result<Option<ColumnStat>> {
+        let cardinality = stat_cardinality(stat_info);
+        let Some(mut output) =
+            self.derive_scalar_stat(lag_lead.arg.as_ref(), stat_info, cardinality)?
+        else {
+            return Ok(None);
+        };
+
+        if lag_lead.offset == 0 {
+            return Ok(Some(output));
+        }
+
+        let boundary_rows = (self.estimated_partition_count(stat_info) * lag_lead.offset as f64)
+            .min(stat_info.cardinality);
+        let source_rows = (stat_info.cardinality - boundary_rows).max(0.0);
+        let argument_may_be_null = output.null_count.upper() > 0.0;
+        let argument_null_rate = output.null_count.expected() / stat_info.cardinality;
+        let expected_nulls_from_argument = argument_null_rate * source_rows;
+
+        let (expected_null_count, default_may_be_null) = if let Some(default) = &lag_lead.default {
+            match self.derive_default_stat(default.as_ref(), stat_info, cardinality)? {
+                Some(FoldedConstantStat::Value(default_stat)) => {
+                    let default_may_be_null = default_stat.null_count.upper() > 0.0;
+                    let default_null_rate =
+                        default_stat.null_count.expected() / stat_info.cardinality;
+                    output = merge_column_stats(output, default_stat, stat_info.cardinality)?;
+                    (
+                        expected_nulls_from_argument + default_null_rate * boundary_rows,
+                        default_may_be_null,
+                    )
+                }
+                Some(FoldedConstantStat::Null) => {
+                    (expected_nulls_from_argument + boundary_rows, true)
+                }
+                None => return Ok(None),
+            }
+        } else {
+            (expected_nulls_from_argument + boundary_rows, true)
+        };
+
+        let nullable = argument_may_be_null || default_may_be_null;
+        output.null_count = if nullable {
+            StatCount::estimate(
+                expected_null_count.min(stat_info.cardinality),
+                stat_info.cardinality,
+            )
+        } else {
+            StatCount::exact(0)
+        };
+        output.ndv = output.ndv.reduce(stat_info.cardinality);
+        output.histogram = None;
+        Ok(Some(output))
+    }
+
+    fn derive_scalar_stat(
+        &self,
+        scalar: &ScalarExpr,
+        stat_info: &StatInfo,
+        cardinality: StatCardinality,
+    ) -> Result<Option<ColumnStat>> {
+        if let Some(stat) =
+            EvalScalar::derive_item_stat(scalar, &stat_info.statistics, cardinality)?
+        {
+            return Ok(Some(stat));
+        }
+
+        let source = self.scalar_source(scalar);
+        if let Some(stat) =
+            EvalScalar::derive_item_stat(source, &stat_info.statistics, cardinality)?
+        {
+            return Ok(Some(stat));
+        }
+
+        Ok(match fold_constant_stat(source)? {
+            Some(FoldedConstantStat::Value(stat)) => Some(stat),
+            Some(FoldedConstantStat::Null) | None => None,
+        })
+    }
+
+    fn derive_default_stat(
+        &self,
+        scalar: &ScalarExpr,
+        stat_info: &StatInfo,
+        cardinality: StatCardinality,
+    ) -> Result<Option<FoldedConstantStat>> {
+        if let Some(stat) =
+            EvalScalar::derive_item_stat(scalar, &stat_info.statistics, cardinality)?
+        {
+            return Ok(Some(FoldedConstantStat::Value(stat)));
+        }
+
+        let source = self.scalar_source(scalar);
+        if let Some(stat) =
+            EvalScalar::derive_item_stat(source, &stat_info.statistics, cardinality)?
+        {
+            return Ok(Some(FoldedConstantStat::Value(stat)));
+        }
+
+        fold_constant_stat(source)
+    }
+
+    fn scalar_source<'a>(&'a self, scalar: &'a ScalarExpr) -> &'a ScalarExpr {
+        let ScalarExpr::BoundColumnRef(column) = scalar else {
+            return scalar;
+        };
+
+        self.arguments
+            .iter()
+            .find(|item| item.index == column.column.index)
+            .map(|item| &item.scalar)
+            .unwrap_or(scalar)
+    }
+
+    fn ranking_upper(&self, stat_info: &StatInfo) -> u64 {
+        self.top
+            .map(|top| top as u64)
+            .unwrap_or_else(|| cardinality_upper(stat_info.cardinality))
+            .min(cardinality_upper(stat_info.cardinality))
+            .max(1)
+    }
+
+    fn estimated_partition_count(&self, stat_info: &StatInfo) -> f64 {
+        if self.partition_by.is_empty() {
+            return 1.0;
+        }
+
+        let cardinality_upper = stat_info.cardinality.max(1.0);
+
+        self.partition_by
+            .iter()
+            .try_fold(1.0, |partitions, item| {
+                let ndv = stat_info
+                    .statistics
+                    .column_stats
+                    .get(&item.index)?
+                    .ndv
+                    .expected?;
+                Some((partitions * ndv.max(1.0)).min(cardinality_upper))
+            })
+            .unwrap_or(1.0)
+            .clamp(1.0, cardinality_upper)
+    }
+}
+
+fn cardinality_upper(cardinality: f64) -> u64 {
+    cardinality.ceil().max(1.0) as u64
+}
+
+enum FoldedConstantStat {
+    Null,
+    Value(ColumnStat),
+}
+
+fn fold_constant_stat(expr: &ScalarExpr) -> Result<Option<FoldedConstantStat>> {
+    let expr = expr.as_expr()?;
+    let (expr, _) = ConstantFolder::fold(&expr, &FunctionContext::default(), &BUILTIN_FUNCTIONS);
+    let Ok(constant) = expr.into_constant() else {
+        return Ok(None);
+    };
+    if constant.scalar == Scalar::Null {
+        return Ok(Some(FoldedConstantStat::Null));
+    }
+    Ok(constant
+        .scalar
+        .to_datum()
+        .map(ColumnStat::from_const)
+        .map(FoldedConstantStat::Value))
+}
+
+fn stat_cardinality(stat_info: &StatInfo) -> StatCardinality {
+    stat_info
+        .statistics
+        .precise_cardinality
+        .map(StatCardinality::exact)
+        .unwrap_or_else(|| StatCardinality::estimate(stat_info.cardinality))
+}
+
+fn merge_column_stats(left: ColumnStat, right: ColumnStat, cardinality: f64) -> Result<ColumnStat> {
+    let min = if left.min.compare(&right.min)?.is_lt() {
+        left.min
+    } else {
+        right.min
+    };
+    let max = if left.max.compare(&right.max)?.is_gt() {
+        left.max
+    } else {
+        right.max
+    };
+    let ndv_upper = (left.ndv.upper + right.ndv.upper).min(cardinality);
+    let ndv = match (left.ndv.expected, right.ndv.expected) {
+        (Some(left), Some(right)) => NdvEstimate::new((left + right).min(ndv_upper), ndv_upper),
+        _ => NdvEstimate::upper_bound(ndv_upper),
+    };
+    Ok(ColumnStat {
+        min,
+        max,
+        ndv,
+        null_count: StatCount::exact(0),
+        histogram: None,
+    })
 }
 
 impl Operator for WindowGroup {
@@ -253,7 +521,22 @@ impl Operator for WindowGroup {
     }
 
     fn derive_stats(&self, rel_expr: &RelExpr) -> Result<Arc<StatInfo>> {
-        rel_expr.derive_cardinality_child(0)
+        let input = rel_expr.derive_cardinality_child(0)?;
+        let mut stat_info = input.as_ref().clone();
+        let cardinality = stat_cardinality(&stat_info);
+        for item in &self.scalar_items {
+            if let Some(stat) =
+                EvalScalar::derive_item_stat(&item.scalar, &stat_info.statistics, cardinality)?
+            {
+                stat_info.statistics.column_stats.insert(item.index, stat);
+            }
+        }
+        for window in &self.windows {
+            if let Some(stat) = window.derive_output_stat(&stat_info)? {
+                stat_info.statistics.column_stats.insert(window.index, stat);
+            }
+        }
+        Ok(Arc::new(stat_info))
     }
 }
 
@@ -338,7 +621,15 @@ impl Operator for Window {
     }
 
     fn derive_stats(&self, rel_expr: &RelExpr) -> Result<Arc<StatInfo>> {
-        rel_expr.derive_cardinality_child(0)
+        let input = rel_expr.derive_cardinality_child(0)?;
+        let mut stat_info = input.as_ref().clone();
+        if let Some(stat) = self.derive_output_stat(&stat_info)? {
+            stat_info.statistics.column_stats.insert(self.index, stat);
+        }
+        if let Some(limit) = self.limit {
+            stat_info = cap_stat_info_by_rows(stat_info, limit);
+        }
+        Ok(Arc::new(stat_info))
     }
 }
 

--- a/src/query/sql/tests/it/optimizer/mod.rs
+++ b/src/query/sql/tests/it/optimizer/mod.rs
@@ -29,6 +29,7 @@ mod outer_join_to_anti;
 mod push_down_filter_project_set;
 mod selectivity;
 mod selectivity_smoke;
+mod stat_derivation;
 mod union_all;
 
 fn table_statistics(rows: u64) -> TableStatistics {

--- a/src/query/sql/tests/it/optimizer/stat_derivation.rs
+++ b/src/query/sql/tests/it/optimizer/stat_derivation.rs
@@ -1,0 +1,236 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::io::Write;
+
+use databend_common_catalog::BasicColumnStatistics;
+use databend_common_catalog::TableStatistics;
+use databend_common_exception::ErrorCode;
+use databend_common_exception::Result;
+use databend_common_sql::ColumnEntry;
+use databend_common_sql::Metadata;
+use databend_common_sql::Symbol;
+use databend_common_sql::optimizer::CollectStatisticsOptimizer;
+use databend_common_sql::optimizer::Optimizer;
+use databend_common_sql::optimizer::OptimizerContext;
+use databend_common_sql::optimizer::ir::RelExpr;
+use databend_common_sql::optimizer::ir::SExpr;
+use databend_common_sql::optimizer::ir::StatInfo;
+use databend_common_sql::optimizer::optimizers::recursive::RecursiveRuleOptimizer;
+use databend_common_sql::optimizer::optimizers::rule::RuleID;
+use databend_common_sql::plans::Operator;
+use databend_common_sql::plans::Plan;
+use databend_common_sql::plans::RelOp;
+use databend_common_statistics::Datum;
+
+use crate::framework::LiteTableContext;
+use crate::framework::golden::open_golden_file;
+use crate::framework::golden::write_case_title;
+
+struct StatsCase {
+    name: &'static str,
+    description: &'static str,
+    sql: &'static str,
+    operator: RelOp,
+}
+
+fn table_statistics(rows: u64) -> TableStatistics {
+    TableStatistics {
+        num_rows: Some(rows),
+        data_size: Some(rows.saturating_mul(16)),
+        data_size_compressed: None,
+        index_size: None,
+        bloom_index_size: None,
+        ngram_index_size: None,
+        inverted_index_size: None,
+        vector_index_size: None,
+        virtual_column_size: None,
+        number_of_blocks: Some(1),
+        number_of_segments: Some(1),
+    }
+}
+
+fn column_statistics() -> HashMap<String, BasicColumnStatistics> {
+    HashMap::from([
+        ("k".to_string(), BasicColumnStatistics {
+            min: Some(Datum::Int(1)),
+            max: Some(Datum::Int(100)),
+            ndv: Some(100),
+            null_count: 10,
+            in_memory_size: 800,
+        }),
+        ("p".to_string(), BasicColumnStatistics {
+            min: Some(Datum::Int(1)),
+            max: Some(Datum::Int(5)),
+            ndv: Some(5),
+            null_count: 0,
+            in_memory_size: 800,
+        }),
+    ])
+}
+
+fn find_operator(expr: &SExpr, operator: RelOp) -> Option<&SExpr> {
+    if expr.plan().rel_op() == operator {
+        return Some(expr);
+    }
+    expr.children()
+        .find_map(|child| find_operator(child, operator.clone()))
+}
+
+fn column_label(metadata: &Metadata, column: Symbol) -> String {
+    let id = column.as_usize();
+    match metadata.column(column) {
+        ColumnEntry::BaseTableColumn(column) => {
+            let table = metadata.table(column.table_index);
+            format!("{}.{} (#{id})", table.name(), column.column_name)
+        }
+        entry => format!("{} (#{id})", entry.name()),
+    }
+}
+
+fn write_stats(file: &mut impl Write, metadata: &Metadata, stats: &StatInfo) -> Result<()> {
+    writeln!(file, "cardinality: {:.3}", stats.cardinality)?;
+    writeln!(
+        file,
+        "precise_cardinality: {:?}",
+        stats.statistics.precise_cardinality
+    )?;
+
+    let mut column_stats = stats.statistics.column_stats.iter().collect::<Vec<_>>();
+    column_stats.sort_by_key(|(column, _)| **column);
+    for (column, stat) in column_stats {
+        writeln!(
+            file,
+            "column_stat: {} min={}, max={}, ndv={:?}, null_count={:?}, histogram={}",
+            column_label(metadata, *column),
+            stat.min,
+            stat.max,
+            stat.ndv,
+            stat.null_count,
+            if stat.histogram.is_some() {
+                "some"
+            } else {
+                "none"
+            }
+        )?;
+    }
+    Ok(())
+}
+
+async fn write_case(file: &mut impl Write, case: &StatsCase) -> Result<()> {
+    let ctx = LiteTableContext::create().await?;
+    ctx.register_table_sql_with_stats(
+        "CREATE TABLE t(k BIGINT NULL, p BIGINT NOT NULL)",
+        Some(table_statistics(100)),
+        column_statistics(),
+        HashMap::new(),
+    )
+    .await?;
+
+    let raw_plan = ctx.bind_sql(case.sql).await?;
+    let (s_expr, metadata) = if case.operator == RelOp::Sort {
+        let Plan::Query {
+            s_expr, metadata, ..
+        } = raw_plan
+        else {
+            return Err(ErrorCode::Internal("expected query plan"));
+        };
+        let opt_ctx = OptimizerContext::new(ctx, metadata.clone());
+        let mut collector = CollectStatisticsOptimizer::new(opt_ctx.clone());
+        let s_expr = collector.optimize(&s_expr).await?;
+        let s_expr = RecursiveRuleOptimizer::new(opt_ctx, &[RuleID::PushDownLimitSort])
+            .optimize_sync(&s_expr)?;
+        (s_expr, metadata)
+    } else {
+        let Plan::Query {
+            s_expr, metadata, ..
+        } = ctx.optimize_plan(raw_plan).await?
+        else {
+            return Err(ErrorCode::Internal("expected optimized query plan"));
+        };
+        (*s_expr, metadata)
+    };
+    let target = find_operator(&s_expr, case.operator.clone()).ok_or_else(|| {
+        ErrorCode::Internal(format!("cannot find {:?} in optimized plan", case.operator))
+    })?;
+    let stats = RelExpr::with_s_expr(target).derive_cardinality()?;
+
+    write_case_title(file, case.name, case.description)?;
+    writeln!(file, "sql: {}", case.sql)?;
+    writeln!(file, "operator: {:?}", case.operator)?;
+    write_stats(file, &metadata.read(), &stats)?;
+    writeln!(file)?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_sort_and_window_statistics_golden() -> Result<()> {
+    let mut file = open_golden_file("optimizer", "stat_derivation.txt")?;
+    let cases = [
+        StatsCase {
+            name: "sort_top_n_caps_statistics",
+            description: "Top-N sort caps row-count statistics without discarding value bounds.",
+            sql: "SELECT k FROM t ORDER BY k LIMIT 10",
+            operator: RelOp::Sort,
+        },
+        StatsCase {
+            name: "row_number_statistics",
+            description: "ROW_NUMBER derives a non-null positive integer range.",
+            sql: "SELECT ROW_NUMBER() OVER (PARTITION BY p ORDER BY k) AS w FROM t",
+            operator: RelOp::Window,
+        },
+        StatsCase {
+            name: "rank_statistics",
+            description: "RANK derives a non-null range bounded by the input cardinality.",
+            sql: "SELECT RANK() OVER (PARTITION BY p ORDER BY k) AS w FROM t",
+            operator: RelOp::Window,
+        },
+        StatsCase {
+            name: "dense_rank_statistics",
+            description: "DENSE_RANK derives a non-null range bounded by the input cardinality.",
+            sql: "SELECT DENSE_RANK() OVER (PARTITION BY p ORDER BY k) AS w FROM t",
+            operator: RelOp::Window,
+        },
+        StatsCase {
+            name: "ntile_statistics",
+            description: "NTILE derives a non-null range bounded by its bucket count.",
+            sql: "SELECT NTILE(4) OVER (PARTITION BY p ORDER BY k) AS w FROM t",
+            operator: RelOp::Window,
+        },
+        StatsCase {
+            name: "lag_statistics",
+            description: "LAG inherits its argument bounds and accounts for boundary NULLs.",
+            sql: "SELECT LAG(k) OVER (PARTITION BY p ORDER BY k) AS w FROM t",
+            operator: RelOp::Window,
+        },
+        StatsCase {
+            name: "lead_default_statistics",
+            description: "LEAD merges a derived default value into its argument bounds.",
+            sql: "SELECT LEAD(k, 1, 200) OVER (PARTITION BY p ORDER BY k) AS w FROM t",
+            operator: RelOp::Window,
+        },
+        StatsCase {
+            name: "window_group_statistics",
+            description: "WindowGroup derives statistics for every supported output column.",
+            sql: "SELECT ROW_NUMBER() OVER (PARTITION BY p ORDER BY k), NTILE(4) OVER (PARTITION BY p ORDER BY k), LAG(k) OVER (PARTITION BY p ORDER BY k) FROM t",
+            operator: RelOp::WindowGroup,
+        },
+    ];
+
+    for case in &cases {
+        write_case(&mut file, case).await?;
+    }
+    Ok(())
+}

--- a/src/query/sql/tests/it/optimizer/stat_derivation.txt
+++ b/src/query/sql/tests/it/optimizer/stat_derivation.txt
@@ -1,0 +1,81 @@
+=== sort_top_n_caps_statistics ===
+description: Top-N sort caps row-count statistics without discarding value bounds.
+sql: SELECT k FROM t ORDER BY k LIMIT 10
+operator: Sort
+cardinality: 10.000
+precise_cardinality: Some(10)
+column_stat: t.k (#0) min=1, max=100, ndv=10.0, null_count=~1.0[..10.0], histogram=none
+column_stat: t.p (#1) min=1, max=5, ndv=5.0, null_count=0, histogram=none
+
+=== row_number_statistics ===
+description: ROW_NUMBER derives a non-null positive integer range.
+sql: SELECT ROW_NUMBER() OVER (PARTITION BY p ORDER BY k) AS w FROM t
+operator: Window
+cardinality: 100.000
+precise_cardinality: Some(100)
+column_stat: t.k (#0) min=1, max=100, ndv=100.0, null_count=10, histogram=none
+column_stat: t.p (#1) min=1, max=5, ndv=5.0, null_count=0, histogram=some
+column_stat: ROW_NUMBER() OVER (PARTITION BY p ORDER BY k) (#2) min=1, max=100, ndv=~20.0[..100.0], null_count=0, histogram=none
+
+=== rank_statistics ===
+description: RANK derives a non-null range bounded by the input cardinality.
+sql: SELECT RANK() OVER (PARTITION BY p ORDER BY k) AS w FROM t
+operator: Window
+cardinality: 100.000
+precise_cardinality: Some(100)
+column_stat: t.k (#0) min=1, max=100, ndv=100.0, null_count=10, histogram=none
+column_stat: t.p (#1) min=1, max=5, ndv=5.0, null_count=0, histogram=some
+column_stat: RANK() OVER (PARTITION BY p ORDER BY k) (#2) min=1, max=100, ndv=?[..100.0], null_count=0, histogram=none
+
+=== dense_rank_statistics ===
+description: DENSE_RANK derives a non-null range bounded by the input cardinality.
+sql: SELECT DENSE_RANK() OVER (PARTITION BY p ORDER BY k) AS w FROM t
+operator: Window
+cardinality: 100.000
+precise_cardinality: Some(100)
+column_stat: t.k (#0) min=1, max=100, ndv=100.0, null_count=10, histogram=none
+column_stat: t.p (#1) min=1, max=5, ndv=5.0, null_count=0, histogram=some
+column_stat: DENSE_RANK() OVER (PARTITION BY p ORDER BY k) (#2) min=1, max=100, ndv=?[..100.0], null_count=0, histogram=none
+
+=== ntile_statistics ===
+description: NTILE derives a non-null range bounded by its bucket count.
+sql: SELECT NTILE(4) OVER (PARTITION BY p ORDER BY k) AS w FROM t
+operator: Window
+cardinality: 100.000
+precise_cardinality: Some(100)
+column_stat: t.k (#0) min=1, max=100, ndv=100.0, null_count=10, histogram=none
+column_stat: t.p (#1) min=1, max=5, ndv=5.0, null_count=0, histogram=some
+column_stat: NTILE(4) OVER (PARTITION BY p ORDER BY k) (#2) min=1, max=4, ndv=?[..4.0], null_count=0, histogram=none
+
+=== lag_statistics ===
+description: LAG inherits its argument bounds and accounts for boundary NULLs.
+sql: SELECT LAG(k) OVER (PARTITION BY p ORDER BY k) AS w FROM t
+operator: Window
+cardinality: 100.000
+precise_cardinality: Some(100)
+column_stat: t.k (#0) min=1, max=100, ndv=100.0, null_count=10, histogram=none
+column_stat: t.p (#1) min=1, max=5, ndv=5.0, null_count=0, histogram=some
+column_stat: LAG(k) OVER (PARTITION BY p ORDER BY k) (#2) min=1, max=100, ndv=100.0, null_count=~14.5[..100.0], histogram=none
+
+=== lead_default_statistics ===
+description: LEAD merges a derived default value into its argument bounds.
+sql: SELECT LEAD(k, 1, 200) OVER (PARTITION BY p ORDER BY k) AS w FROM t
+operator: Window
+cardinality: 100.000
+precise_cardinality: Some(100)
+column_stat: t.k (#0) min=1, max=100, ndv=100.0, null_count=10, histogram=none
+column_stat: t.p (#1) min=1, max=5, ndv=5.0, null_count=0, histogram=some
+column_stat: LEAD(k, 1, 200) OVER (PARTITION BY p ORDER BY k) (#3) min=1, max=200, ndv=100.0, null_count=~9.5[..100.0], histogram=none
+
+=== window_group_statistics ===
+description: WindowGroup derives statistics for every supported output column.
+sql: SELECT ROW_NUMBER() OVER (PARTITION BY p ORDER BY k), NTILE(4) OVER (PARTITION BY p ORDER BY k), LAG(k) OVER (PARTITION BY p ORDER BY k) FROM t
+operator: WindowGroup
+cardinality: 100.000
+precise_cardinality: Some(100)
+column_stat: t.k (#0) min=1, max=100, ndv=100.0, null_count=10, histogram=none
+column_stat: t.p (#1) min=1, max=5, ndv=5.0, null_count=0, histogram=some
+column_stat: ROW_NUMBER() OVER (PARTITION BY p ORDER BY k) (#2) min=1, max=100, ndv=~20.0[..100.0], null_count=0, histogram=none
+column_stat: NTILE(4) OVER (PARTITION BY p ORDER BY k) (#3) min=1, max=4, ndv=?[..4.0], null_count=0, histogram=none
+column_stat: LAG(k) OVER (PARTITION BY p ORDER BY k) (#4) min=1, max=100, ndv=100.0, null_count=~14.5[..100.0], histogram=none
+

--- a/src/query/sql/tests/it/optimizer/stat_derivation.txt
+++ b/src/query/sql/tests/it/optimizer/stat_derivation.txt
@@ -65,6 +65,7 @@ cardinality: 100.000
 precise_cardinality: Some(100)
 column_stat: t.k (#0) min=1, max=100, ndv=100.0, null_count=10, histogram=none
 column_stat: t.p (#1) min=1, max=5, ndv=5.0, null_count=0, histogram=some
+column_stat: lead_default_value (#2) min=200, max=200, ndv=1.0, null_count=0, histogram=none
 column_stat: LEAD(k, 1, 200) OVER (PARTITION BY p ORDER BY k) (#3) min=1, max=200, ndv=100.0, null_count=~9.5[..100.0], histogram=none
 
 === window_group_statistics ===

--- a/tests/sqllogictests/suites/mode/standalone/explain/window.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/window.test
@@ -1049,15 +1049,15 @@ AggregateFinal
 ├── output columns: [count() (#4), numbers.number (#0)]
 ├── group by: [number]
 ├── aggregate functions: [count()]
-├── estimated rows: 166.67
+├── estimated rows: 1.00
 └── AggregatePartial
     ├── group by: [number]
     ├── aggregate functions: [count()]
-    ├── estimated rows: 166.67
+    ├── estimated rows: 1.00
     └── Filter
         ├── output columns: [numbers.number (#0)]
         ├── filters: [numbers.number (#0) = 3, row_number() OVER (PARTITION BY id ORDER BY number DESC) (#3) = 1]
-        ├── estimated rows: 500.00
+        ├── estimated rows: 1.00
         └── Window
             ├── output columns: [numbers.number (#0), row_number_part_0 (#2), row_number() OVER (PARTITION BY id ORDER BY number DESC) (#3)]
             ├── aggregate function: [row_number]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- derive `Sort` statistics while respecting pushed-down Top-N row limits
- derive output column statistics for `ROW_NUMBER`, `RANK`, `DENSE_RANK`, `NTILE`, `LAG`, and `LEAD`
- propagate derived statistics through `WindowGroup`, including bound window arguments and defaults
- conservatively cap NDV/null-count bounds and discard distribution structures that are invalid after biased row limiting

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Commands run:

- `cargo test -p databend-common-sql --test it optimizer::stat_derivation::test_sort_and_window_statistics_golden -- --exact`
- `cargo test -p databend-common-sql optimizer::ir::stats::cardinality::tests --lib`
- `cargo check -p databend-common-sql --tests`
- `cargo fmt --all -- --check`
- `cargo clippy -p databend-common-sql --tests -- -D warnings`

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: Investigated planner statistics behavior, implemented the scoped Rust changes and regression tests, and ran validation.
- Responsible human: @sundy-li
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20248)
<!-- Reviewable:end -->
