### PR TITLE
refactor(query): infer equality for singleton domains

### DIFF
--- a/src/query/expression/src/property.rs
+++ b/src/query/expression/src/property.rs
@@ -680,6 +680,8 @@ impl<T: Ord> SimpleDomainCmp for SimpleDomain<T> {
     fn domain_eq(&self, other: &Self) -> FunctionDomain<BooleanType> {
         if self.min > other.max || self.max < other.min {
             FunctionDomain::Domain(ALL_FALSE_DOMAIN)
+        } else if self.min == self.max && other.min == other.max && self.min == other.min {
+            FunctionDomain::Domain(ALL_TRUE_DOMAIN)
         } else {
             FunctionDomain::Full
         }
@@ -688,6 +690,8 @@ impl<T: Ord> SimpleDomainCmp for SimpleDomain<T> {
     fn domain_noteq(&self, other: &Self) -> FunctionDomain<BooleanType> {
         if self.min > other.max || self.max < other.min {
             FunctionDomain::Domain(ALL_TRUE_DOMAIN)
+        } else if self.min == self.max && other.min == other.max && self.min == other.min {
+            FunctionDomain::Domain(ALL_FALSE_DOMAIN)
         } else {
             FunctionDomain::Full
         }
@@ -804,4 +808,64 @@ pub fn unify_string(
             max: rhs.max.clone().unwrap_or_else(|| max.clone()),
         },
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_domain_equality_for_singletons() {
+        let singleton = SimpleDomain { min: 7, max: 7 };
+
+        assert_eq!(
+            singleton.domain_eq(&singleton),
+            FunctionDomain::Domain(ALL_TRUE_DOMAIN)
+        );
+        assert_eq!(
+            singleton.domain_noteq(&singleton),
+            FunctionDomain::Domain(ALL_FALSE_DOMAIN)
+        );
+    }
+
+    #[test]
+    fn test_domain_equality_keeps_existing_range_results() {
+        let lhs = SimpleDomain { min: 1, max: 3 };
+        let overlapping = SimpleDomain { min: 2, max: 4 };
+        let disjoint = SimpleDomain { min: 5, max: 7 };
+
+        assert_eq!(lhs.domain_eq(&overlapping), FunctionDomain::Full);
+        assert_eq!(lhs.domain_noteq(&overlapping), FunctionDomain::Full);
+        assert_eq!(
+            lhs.domain_eq(&disjoint),
+            FunctionDomain::Domain(ALL_FALSE_DOMAIN)
+        );
+        assert_eq!(
+            lhs.domain_noteq(&disjoint),
+            FunctionDomain::Domain(ALL_TRUE_DOMAIN)
+        );
+    }
+
+    #[test]
+    fn test_string_domain_equality_for_singletons_and_unbounded_ranges() {
+        let singleton = StringDomain {
+            min: "databend".to_string(),
+            max: Some("databend".to_string()),
+        };
+        let unbounded = StringDomain {
+            min: "".to_string(),
+            max: None,
+        };
+
+        assert_eq!(
+            singleton.domain_eq(&singleton),
+            FunctionDomain::Domain(ALL_TRUE_DOMAIN)
+        );
+        assert_eq!(
+            singleton.domain_noteq(&singleton),
+            FunctionDomain::Domain(ALL_FALSE_DOMAIN)
+        );
+        assert_eq!(unbounded.domain_eq(&unbounded), FunctionDomain::Full);
+        assert_eq!(unbounded.domain_noteq(&unbounded), FunctionDomain::Full);
+    }
 }

--- a/src/query/functions/tests/it/scalars/comparison.rs
+++ b/src/query/functions/tests/it/scalars/comparison.rs
@@ -27,6 +27,7 @@ fn test_comparison() {
 
     test_eq(file);
     test_noteq(file);
+    test_singleton_domain_equality(file);
     test_lt(file);
     test_lte(file);
     test_gt(file);
@@ -34,6 +35,29 @@ fn test_comparison() {
     test_like(file);
     test_regexp(file);
     test_decimal(file);
+}
+
+fn test_singleton_domain_equality(file: &mut impl Write) {
+    let numeric = [
+        ("lhs", UInt8Type::from_data(vec![7u8, 7])),
+        ("rhs", UInt8Type::from_data(vec![7u8, 7])),
+    ];
+    run_ast(file, "lhs = rhs", &numeric);
+    run_ast(file, "lhs != rhs", &numeric);
+
+    let strings = [
+        ("lhs", StringType::from_data(vec!["databend", "databend"])),
+        ("rhs", StringType::from_data(vec!["databend", "databend"])),
+    ];
+    run_ast(file, "lhs = rhs", &strings);
+    run_ast(file, "lhs != rhs", &strings);
+
+    let nullable = [
+        ("lhs", Int64Type::from_opt_data(vec![Some(7), None])),
+        ("rhs", Int64Type::from_opt_data(vec![Some(7), None])),
+    ];
+    run_ast(file, "lhs = rhs", &nullable);
+    run_ast(file, "lhs != rhs", &nullable);
 }
 
 fn test_eq(file: &mut impl Write) {

--- a/src/query/functions/tests/it/scalars/testdata/comparison.txt
+++ b/src/query/functions/tests/it/scalars/testdata/comparison.txt
@@ -598,6 +598,142 @@ output domain  : {NULL}
 output         : NULL
 
 
+ast            : lhs = rhs
+raw expr       : eq(lhs::UInt8, rhs::UInt8)
+checked expr   : eq<UInt8, UInt8>(lhs, rhs)
+optimized expr : true
+evaluation:
++--------+---------+---------+---------+
+|        | lhs     | rhs     | Output  |
++--------+---------+---------+---------+
+| Type   | UInt8   | UInt8   | Boolean |
+| Domain | {7..=7} | {7..=7} | {TRUE}  |
+| Row 0  | 7       | 7       | true    |
+| Row 1  | 7       | 7       | true    |
++--------+---------+---------+---------+
+evaluation (internal):
++--------+-----------------------+
+| Column | Data                  |
++--------+-----------------------+
+| lhs    | Column(UInt8([7, 7])) |
+| rhs    | Column(UInt8([7, 7])) |
+| Output | Boolean([0b______11]) |
++--------+-----------------------+
+
+
+ast            : lhs != rhs
+raw expr       : noteq(lhs::UInt8, rhs::UInt8)
+checked expr   : noteq<UInt8, UInt8>(lhs, rhs)
+optimized expr : false
+evaluation:
++--------+---------+---------+---------+
+|        | lhs     | rhs     | Output  |
++--------+---------+---------+---------+
+| Type   | UInt8   | UInt8   | Boolean |
+| Domain | {7..=7} | {7..=7} | {FALSE} |
+| Row 0  | 7       | 7       | false   |
+| Row 1  | 7       | 7       | false   |
++--------+---------+---------+---------+
+evaluation (internal):
++--------+-----------------------+
+| Column | Data                  |
++--------+-----------------------+
+| lhs    | Column(UInt8([7, 7])) |
+| rhs    | Column(UInt8([7, 7])) |
+| Output | Boolean([0b______00]) |
++--------+-----------------------+
+
+
+ast            : lhs = rhs
+raw expr       : eq(lhs::String, rhs::String)
+checked expr   : eq<String, String>(lhs, rhs)
+optimized expr : true
+evaluation:
++--------+---------------------------+---------------------------+---------+
+|        | lhs                       | rhs                       | Output  |
++--------+---------------------------+---------------------------+---------+
+| Type   | String                    | String                    | Boolean |
+| Domain | {"databend"..="databend"} | {"databend"..="databend"} | {TRUE}  |
+| Row 0  | 'databend'                | 'databend'                | true    |
+| Row 1  | 'databend'                | 'databend'                | true    |
++--------+---------------------------+---------------------------+---------+
+evaluation (internal):
++--------+------------------------------------------+
+| Column | Data                                     |
++--------+------------------------------------------+
+| lhs    | Column(StringColumn[databend, databend]) |
+| rhs    | Column(StringColumn[databend, databend]) |
+| Output | Boolean([0b______11])                    |
++--------+------------------------------------------+
+
+
+ast            : lhs != rhs
+raw expr       : noteq(lhs::String, rhs::String)
+checked expr   : noteq<String, String>(lhs, rhs)
+optimized expr : false
+evaluation:
++--------+---------------------------+---------------------------+---------+
+|        | lhs                       | rhs                       | Output  |
++--------+---------------------------+---------------------------+---------+
+| Type   | String                    | String                    | Boolean |
+| Domain | {"databend"..="databend"} | {"databend"..="databend"} | {FALSE} |
+| Row 0  | 'databend'                | 'databend'                | false   |
+| Row 1  | 'databend'                | 'databend'                | false   |
++--------+---------------------------+---------------------------+---------+
+evaluation (internal):
++--------+------------------------------------------+
+| Column | Data                                     |
++--------+------------------------------------------+
+| lhs    | Column(StringColumn[databend, databend]) |
+| rhs    | Column(StringColumn[databend, databend]) |
+| Output | Boolean([0b______00])                    |
++--------+------------------------------------------+
+
+
+ast            : lhs = rhs
+raw expr       : eq(lhs::Int64 NULL, rhs::Int64 NULL)
+checked expr   : eq<Int64 NULL, Int64 NULL>(lhs, rhs)
+evaluation:
++--------+------------------+------------------+-----------------+
+|        | lhs              | rhs              | Output          |
++--------+------------------+------------------+-----------------+
+| Type   | Int64 NULL       | Int64 NULL       | Boolean NULL    |
+| Domain | {7..=7} ∪ {NULL} | {7..=7} ∪ {NULL} | {TRUE} ∪ {NULL} |
+| Row 0  | 7                | 7                | true            |
+| Row 1  | NULL             | NULL             | NULL            |
++--------+------------------+------------------+-----------------+
+evaluation (internal):
++--------+--------------------------------------------------------------------------+
+| Column | Data                                                                     |
++--------+--------------------------------------------------------------------------+
+| lhs    | Column(NullableColumn { column: Int64([7, 0]), validity: [0b______01] }) |
+| rhs    | Column(NullableColumn { column: Int64([7, 0]), validity: [0b______01] }) |
+| Output | NullableColumn { column: Boolean([0b______11]), validity: [0b______01] } |
++--------+--------------------------------------------------------------------------+
+
+
+ast            : lhs != rhs
+raw expr       : noteq(lhs::Int64 NULL, rhs::Int64 NULL)
+checked expr   : noteq<Int64 NULL, Int64 NULL>(lhs, rhs)
+evaluation:
++--------+------------------+------------------+------------------+
+|        | lhs              | rhs              | Output           |
++--------+------------------+------------------+------------------+
+| Type   | Int64 NULL       | Int64 NULL       | Boolean NULL     |
+| Domain | {7..=7} ∪ {NULL} | {7..=7} ∪ {NULL} | {FALSE} ∪ {NULL} |
+| Row 0  | 7                | 7                | false            |
+| Row 1  | NULL             | NULL             | NULL             |
++--------+------------------+------------------+------------------+
+evaluation (internal):
++--------+--------------------------------------------------------------------------+
+| Column | Data                                                                     |
++--------+--------------------------------------------------------------------------+
+| lhs    | Column(NullableColumn { column: Int64([7, 0]), validity: [0b______01] }) |
+| rhs    | Column(NullableColumn { column: Int64([7, 0]), validity: [0b______01] }) |
+| Output | NullableColumn { column: Boolean([0b______00]), validity: [0b______01] } |
++--------+--------------------------------------------------------------------------+
+
+
 ast            : '1'<'2'
 raw expr       : lt('1', '2')
 checked expr   : lt<String, String>("1", "2")
@@ -1626,17 +1762,18 @@ output         : false
 ast            : lhs like 'a%'
 raw expr       : like(lhs::String, 'a%')
 checked expr   : like<String, String>(lhs, "a%")
+optimized expr : true
 evaluation:
-+--------+-----------------+---------------+
-|        | lhs             | Output        |
-+--------+-----------------+---------------+
-| Type   | String          | Boolean       |
-| Domain | {"abc"..="abf"} | {FALSE, TRUE} |
-| Row 0  | 'abc'           | true          |
-| Row 1  | 'abd'           | true          |
-| Row 2  | 'abe'           | true          |
-| Row 3  | 'abf'           | true          |
-+--------+-----------------+---------------+
++--------+-----------------+---------+
+|        | lhs             | Output  |
++--------+-----------------+---------+
+| Type   | String          | Boolean |
+| Domain | {"abc"..="abf"} | {TRUE}  |
+| Row 0  | 'abc'           | true    |
+| Row 1  | 'abd'           | true    |
+| Row 2  | 'abe'           | true    |
+| Row 3  | 'abf'           | true    |
++--------+-----------------+---------+
 evaluation (internal):
 +--------+------------------------------------------+
 | Column | Data                                     |
@@ -1673,17 +1810,18 @@ evaluation (internal):
 ast            : lhs like 'ab%'
 raw expr       : like(lhs::String, 'ab%')
 checked expr   : like<String, String>(lhs, "ab%")
+optimized expr : true
 evaluation:
-+--------+-----------------+---------------+
-|        | lhs             | Output        |
-+--------+-----------------+---------------+
-| Type   | String          | Boolean       |
-| Domain | {"abc"..="abf"} | {FALSE, TRUE} |
-| Row 0  | 'abc'           | true          |
-| Row 1  | 'abd'           | true          |
-| Row 2  | 'abe'           | true          |
-| Row 3  | 'abf'           | true          |
-+--------+-----------------+---------------+
++--------+-----------------+---------+
+|        | lhs             | Output  |
++--------+-----------------+---------+
+| Type   | String          | Boolean |
+| Domain | {"abc"..="abf"} | {TRUE}  |
+| Row 0  | 'abc'           | true    |
+| Row 1  | 'abd'           | true    |
+| Row 2  | 'abe'           | true    |
+| Row 3  | 'abf'           | true    |
++--------+-----------------+---------+
 evaluation (internal):
 +--------+------------------------------------------+
 | Column | Data                                     |

--- a/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/subquery.test
@@ -802,7 +802,7 @@ TableScan
 ├── partitions scanned: 1
 ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 ├── push downs: [filters: [is_true(like(t.i (#0), 'data%'))], limit: NONE]
-└── estimated rows: 0.38
+└── estimated rows: 3.00
 
 query T
 select * from t where i like any (SELECT c1 FROM (VALUES ('data%')) words(c1));


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Infer all-true equality and all-false inequality for identical singleton domains.
- Preserve the existing exact results for disjoint domains and conservative results for overlapping non-singleton domains.
- Add numeric, string, nullable, overlapping, disjoint, and unbounded-domain regression coverage.
- Allow dependent domain reasoning, such as fixed-prefix LIKE checks, to fold when the derived prefix range is a singleton.

Closes #20217.

## Implementation

The generic SimpleDomain comparison now recognizes the case where both inputs have equal minimum and maximum values. String domains reuse the same logic after normalization. Nullable comparison continues to wrap the precise non-null result with the possible NULL result.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent investigated the domain contracts, drafted the implementation and regression tests, ran local validation, and prepared this PR description.
- Responsible human: @KKould
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20250)
<!-- Reviewable:end -->
