### PR TITLE
refactor(query): defer expression collection and cloning

### DIFF
--- a/src/query/service/src/physical_plans/physical_add_stream_column.rs
+++ b/src/query/service/src/physical_plans/physical_add_stream_column.rs
@@ -136,7 +136,7 @@ impl AddStreamColumn {
     ) -> Result<PhysicalPlan> {
         let input_schema = input.output_schema()?;
         let num_fields = input_schema.fields().len();
-        let column_entries = metadata.read().columns_by_table_index(table_index);
+        let metadata = metadata.read();
 
         let stream_columns = [
             StreamColumn::new(ORIGIN_VERSION_COL_NAME, StreamColumnType::OriginVersion),
@@ -151,7 +151,7 @@ impl AddStreamColumn {
         let mut exprs = Vec::with_capacity(stream_columns.len());
         for stream_column in stream_columns.iter() {
             let column_index =
-                Binder::find_column_index(&column_entries, stream_column.column_name())?;
+                Binder::find_column_index(&metadata, table_index, stream_column.column_name())?;
             let schema_index = input_schema.index_of(&column_index.to_string()).unwrap();
 
             let origin_stream_column_scalar_expr = ScalarExpr::BoundColumnRef(BoundColumnRef {

--- a/src/query/service/src/physical_plans/physical_table_scan.rs
+++ b/src/query/service/src/physical_plans/physical_table_scan.rs
@@ -307,7 +307,6 @@ impl PhysicalPlanBuilder {
                 let read_guard = self.metadata.read();
                 let virtual_column_id_set = read_guard
                     .virtual_columns_by_table_index(scan.table_index)
-                    .iter()
                     .map(|column| column.index())
                     .collect::<HashSet<_>>();
                 for required_column_id in required_column_ids {

--- a/src/query/sql/src/planner/binder/aggregate.rs
+++ b/src/query/sql/src/planner/binder/aggregate.rs
@@ -29,6 +29,7 @@ use databend_common_expression::types::NumberScalar;
 use indexmap::Equivalent;
 use itertools::Itertools;
 
+use super::Any;
 use super::ExprContext;
 use super::Finder;
 use super::GROUPING_ID_COLUMN_NAME;
@@ -157,13 +158,25 @@ enum ExpandedGroup {
     GroupingSets(Vec<Vec<GroupItem>>),
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
+enum AggregateCall {
+    Aggregate(ScalarItem),
+    Udaf(ScalarItem),
+}
+
+impl AggregateCall {
+    fn item(&self) -> &ScalarItem {
+        match self {
+            AggregateCall::Aggregate(item) | AggregateCall::Udaf(item) => item,
+        }
+    }
+}
+
 #[derive(Default, Clone, PartialEq, Eq, Debug)]
 pub struct AggregateInfo {
-    /// Builtin aggregation functions.
-    aggregate_functions: Vec<ScalarItem>,
-
-    /// User-defined aggregation functions.
-    udaf_calls: Vec<ScalarItem>,
+    /// Aggregate calls in ascending column index order.
+    /// Column indices are allocated monotonically, so registration order preserves this ordering.
+    aggregate_calls: Vec<AggregateCall>,
 
     /// Arguments of aggregation functions
     aggregate_arguments: Vec<ScalarItem>,
@@ -261,15 +274,23 @@ impl AggregateInfo {
 
     pub fn lookup_aggregate_function(&self, aggregate: &AggregateFunction) -> Option<&ScalarItem> {
         let scalar = ScalarExpr::AggregateFunction(aggregate.clone());
-        self.aggregate_functions
+        self.aggregate_calls
             .iter()
+            .filter_map(|call| match call {
+                AggregateCall::Aggregate(item) => Some(item),
+                AggregateCall::Udaf(_) => None,
+            })
             .find(|item| item.scalar.equivalent(&scalar))
     }
 
     pub fn lookup_udaf_call(&self, udaf: &UDAFCall) -> Option<&ScalarItem> {
         let scalar = ScalarExpr::UDAFCall(udaf.clone());
-        self.udaf_calls
+        self.aggregate_calls
             .iter()
+            .filter_map(|call| match call {
+                AggregateCall::Aggregate(_) => None,
+                AggregateCall::Udaf(item) => Some(item),
+            })
             .find(|item| item.scalar.equivalent(&scalar))
     }
 
@@ -303,21 +324,25 @@ impl AggregateInfo {
     }
 
     pub fn has_aggregate_calls(&self) -> bool {
-        !self.aggregate_functions.is_empty() || !self.udaf_calls.is_empty()
+        !self.aggregate_calls.is_empty()
+    }
+
+    pub fn aggregate_calls(&self) -> impl Iterator<Item = &ScalarItem> {
+        self.aggregate_calls.iter().map(AggregateCall::item)
     }
 
     pub fn has_aggregate_call_index(&self, index: Symbol) -> bool {
-        self.aggregate_functions
-            .iter()
-            .chain(self.udaf_calls.iter())
-            .any(|item| item.index == index)
+        self.aggregate_calls().any(|item| item.index == index)
     }
 
-    pub fn aggregate_calls_for_plan(&self) -> Vec<ScalarItem> {
-        let mut items = self.aggregate_functions.clone();
-        items.extend(self.udaf_calls.iter().cloned());
-        items.sort_by_key(|item| item.index);
-        items
+    fn push_aggregate_call(&mut self, call: AggregateCall) {
+        debug_assert!(
+            self.aggregate_calls
+                .last()
+                .is_none_or(|last| last.item().index < call.item().index),
+            "aggregate calls must be registered in column index order"
+        );
+        self.aggregate_calls.push(call);
     }
 
     fn lookup_existing_aggregate_function_column(
@@ -407,10 +432,10 @@ impl AggregateInfo {
             *aggregate.return_type.clone(),
         );
 
-        self.aggregate_functions.push(ScalarItem {
+        self.push_aggregate_call(AggregateCall::Aggregate(ScalarItem {
             scalar: replaced_agg.into(),
             index,
-        });
+        }));
 
         Ok(build_replaced_aggregate_column(
             &aggregate.display_name,
@@ -446,10 +471,10 @@ impl AggregateInfo {
             .write()
             .add_derived_column(udaf.display_name.clone(), *udaf.return_type.clone());
 
-        self.udaf_calls.push(ScalarItem {
+        self.push_aggregate_call(AggregateCall::Udaf(ScalarItem {
             scalar: replaced_udaf.into(),
             index,
-        });
+        }));
 
         Ok(build_replaced_aggregate_column(
             &udaf.display_name,
@@ -775,9 +800,9 @@ impl AggregateRewriter<'_> {
 
     pub fn check_no_aggregate_calls(expr: &ScalarExpr, error_message: &str) -> Result<()> {
         let f = |scalar: &ScalarExpr| scalar.is_aggregate();
-        let mut finder = Finder::new(&f);
-        finder.visit(expr)?;
-        if !finder.scalars().is_empty() {
+        let mut any = Any::new(&f);
+        any.visit(expr)?;
+        if any.result() {
             return Err(ErrorCode::Internal(error_message.to_string()));
         }
 
@@ -1104,7 +1129,7 @@ impl Binder {
         let aggregate_plan = Aggregate {
             mode: AggregateMode::Initial,
             group_items: agg_info.group_items.clone(),
-            aggregate_functions: agg_info.aggregate_calls_for_plan(),
+            aggregate_functions: agg_info.aggregate_calls().cloned().collect(),
             from_distinct: false,
             rank_limit: None,
 
@@ -1206,11 +1231,12 @@ impl Binder {
         // from the context, we can detect the failure and fallback to resolving with `available_aliases`.
 
         let f = |scalar: &ScalarExpr| scalar.is_aggregate();
+        let mut any = Any::new(&f);
         let mut groups = Vec::new();
         for (idx, select_item) in select_list.items.iter().enumerate() {
-            let mut finder = Finder::new(&f);
-            finder.visit(&select_item.scalar)?;
-            if finder.scalars().is_empty() {
+            any.reset();
+            any.visit(&select_item.scalar)?;
+            if !any.result() {
                 groups.push(Expr::Literal {
                     span: None,
                     value: Literal::UInt64(idx as u64 + 1),
@@ -1352,8 +1378,7 @@ impl Binder {
         for item in bind_context.aggregate_info.group_items.iter() {
             let mut finder = Finder::new(&f);
             finder.visit(&item.scalar)?;
-            if !finder.scalars().is_empty() {
-                let scalar = finder.scalars().first().unwrap();
+            if let Some(scalar) = finder.scalars().first().copied() {
                 let display_name = match scalar {
                     ScalarExpr::AggregateFunction(agg) => agg.display_name.clone(),
                     ScalarExpr::UDAFCall(udaf) => udaf.display_name.clone(),
@@ -1537,10 +1562,10 @@ mod tests {
         };
 
         let mut agg_info = AggregateInfo::default();
-        agg_info.aggregate_functions.push(ScalarItem {
+        agg_info.push_aggregate_call(AggregateCall::Aggregate(ScalarItem {
             scalar: replaced.clone().into(),
             index: Symbol::new(42),
-        });
+        }));
 
         assert!(agg_info.lookup_aggregate_function(&original).is_none());
         assert_eq!(
@@ -1567,10 +1592,10 @@ mod tests {
         };
 
         let mut agg_info = AggregateInfo::default();
-        agg_info.udaf_calls.push(ScalarItem {
+        agg_info.push_aggregate_call(AggregateCall::Udaf(ScalarItem {
             scalar: replaced.clone().into(),
             index: Symbol::new(84),
-        });
+        }));
 
         assert!(agg_info.lookup_udaf_call(&original).is_none());
         assert_eq!(
@@ -1593,10 +1618,10 @@ mod tests {
         };
 
         let mut agg_info = AggregateInfo::default();
-        agg_info.aggregate_functions.push(ScalarItem {
+        agg_info.push_aggregate_call(AggregateCall::Aggregate(ScalarItem {
             scalar: replaced.clone().into(),
             index: Symbol::new(42),
-        });
+        }));
 
         let mut expr: ScalarExpr = replaced.into();
         AggregateRewriter::rewrite_existing_expr(

--- a/src/query/sql/src/planner/binder/aggregate.rs
+++ b/src/query/sql/src/planner/binder/aggregate.rs
@@ -943,7 +943,7 @@ impl Binder {
         &mut self,
         bind_context: &mut BindContext,
         select_list: &SelectList<'_>,
-        group_by_aliases: &ClauseAliasBindings,
+        group_by_aliases: &ClauseAliasBindings<'_>,
         group_by: &GroupBy,
     ) -> Result<()> {
         let original_context = bind_context.replace_expr_context(ExprContext::GroupClaue);
@@ -1149,7 +1149,7 @@ impl Binder {
         bind_context: &mut BindContext,
         select_list: &SelectList<'_>,
         sets: &[Vec<GroupItem>],
-        group_by_aliases: &ClauseAliasBindings,
+        group_by_aliases: &ClauseAliasBindings<'_>,
     ) -> Result<()> {
         let mut grouping_sets = Vec::with_capacity(sets.len());
         for set in sets {
@@ -1251,14 +1251,14 @@ impl Binder {
         bind_context: &mut BindContext,
         select_list: &SelectList<'_>,
         group_by: &[GroupItem],
-        group_by_aliases: &ClauseAliasBindings,
+        group_by_aliases: &ClauseAliasBindings<'_>,
         collect_grouping_sets: bool,
         grouping_sets: &mut Vec<Vec<ScalarExpr>>,
     ) -> Result<()> {
         if collect_grouping_sets {
             grouping_sets.push(Vec::with_capacity(group_by.len()));
         }
-        let mut group_by_aliases = group_by_aliases.clone();
+        let mut group_by_aliases = group_by_aliases.group_item_state();
         for item in group_by.iter() {
             let expr = &item.expr;
             // If expr is a number literal, then this is a index group item.
@@ -1301,7 +1301,7 @@ impl Binder {
                     self.ctx.clone(),
                     &self.name_resolution_ctx,
                     self.metadata.clone(),
-                    preferred_aliases.unwrap_or(&[]),
+                    preferred_aliases,
                     fallback_aliases,
                     false,
                 )?;
@@ -1323,13 +1323,11 @@ impl Binder {
                 grouping_sets.last_mut().unwrap().push(scalar_expr.clone());
             }
 
-            let group_item_index = if let Some(index) = bind_context
+            let group_item_exists = bind_context
                 .aggregate_info
                 .group_items_map
-                .get(&scalar_expr)
-            {
-                *index
-            } else {
+                .contains_key(&scalar_expr);
+            if !group_item_exists {
                 let group_item_name = format!("{:#}", expr);
                 let index = if let ScalarExpr::BoundColumnRef(BoundColumnRef {
                     column: ColumnBinding { index, .. },
@@ -1351,13 +1349,9 @@ impl Binder {
                     scalar_expr,
                     bind_context.aggregate_info.group_items.len() - 1,
                 );
-                bind_context.aggregate_info.group_items.len() - 1
-            };
-            if let Some(alias) = group_alias {
-                let group_item_scalar = bind_context.aggregate_info.group_items[group_item_index]
-                    .scalar
-                    .clone();
-                group_by_aliases.register_group_item_alias(alias, group_item_scalar);
+            }
+            if let Some(alias_index) = group_alias {
+                group_by_aliases.register_group_item_alias(alias_index);
             }
         }
 

--- a/src/query/sql/src/planner/binder/bind_context.rs
+++ b/src/query/sql/src/planner/binder/bind_context.rs
@@ -64,6 +64,39 @@ use crate::normalize_identifier;
 use crate::optimizer::ir::SExpr;
 use crate::plans::ScalarExpr;
 
+#[derive(Clone, Copy)]
+pub struct AliasLookup<'a> {
+    aliases: &'a [(String, ScalarExpr)],
+    indices: Option<&'a [usize]>,
+}
+
+impl<'a> AliasLookup<'a> {
+    pub fn all(aliases: &'a [(String, ScalarExpr)]) -> Self {
+        Self {
+            aliases,
+            indices: None,
+        }
+    }
+
+    pub fn indexed(aliases: &'a [(String, ScalarExpr)], indices: &'a [usize]) -> Self {
+        Self {
+            aliases,
+            indices: Some(indices),
+        }
+    }
+
+    fn len(self) -> usize {
+        self.indices.map_or(self.aliases.len(), <[usize]>::len)
+    }
+
+    fn iter(self) -> impl Iterator<Item = &'a (String, ScalarExpr)> {
+        (0..self.len()).map(move |index| {
+            let index = self.indices.map_or(index, |indices| indices[index]);
+            &self.aliases[index]
+        })
+    }
+}
+
 /// Context of current expression, this is used to check if
 /// the expression is valid in current context.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, EnumAsInner)]
@@ -425,7 +458,7 @@ impl BindContext {
         database: Option<&str>,
         table: Option<&str>,
         column: &Identifier,
-        available_aliases: &[(String, ScalarExpr)],
+        available_aliases: AliasLookup<'_>,
         name_resolution_ctx: &NameResolutionContext,
     ) -> Result<NameResolutionResult> {
         let result = self.resolve_name_candidates(
@@ -443,8 +476,8 @@ impl BindContext {
         database: Option<&str>,
         table: Option<&str>,
         column: &Identifier,
-        available_aliases: &[(String, ScalarExpr)],
-        fallback_aliases: Option<&[(String, ScalarExpr)]>,
+        available_aliases: AliasLookup<'_>,
+        fallback_aliases: Option<AliasLookup<'_>>,
         name_resolution_ctx: &NameResolutionContext,
     ) -> Result<NameResolutionResult> {
         let mut result = self.resolve_name_candidates(
@@ -474,7 +507,7 @@ impl BindContext {
         database: Option<&str>,
         table: Option<&str>,
         column: &Identifier,
-        available_aliases: &[(String, ScalarExpr)],
+        available_aliases: AliasLookup<'_>,
         name_resolution_ctx: &NameResolutionContext,
     ) -> Result<NameResolutionCandidates> {
         let name = &column.name;
@@ -501,7 +534,7 @@ impl BindContext {
                 &mut result,
             );
         } else if self.expr_context.prefer_resolve_alias() {
-            for (alias, scalar) in available_aliases {
+            for (alias, scalar) in available_aliases.iter() {
                 if database.is_none() && table.is_none() && name == alias {
                     result.push(NameResolutionResult::Alias {
                         alias: alias.clone(),
@@ -529,7 +562,7 @@ impl BindContext {
             );
 
             if result.is_empty() {
-                for (alias, scalar) in available_aliases {
+                for (alias, scalar) in available_aliases.iter() {
                     if database.is_none() && table.is_none() && name == alias {
                         result.push(NameResolutionResult::Alias {
                             alias: alias.clone(),
@@ -974,18 +1007,16 @@ impl BindContext {
                         let next_virtual_column_id = virtual_schema
                             .map(|virtual_schema| virtual_schema.next_column_id)
                             .unwrap_or(VIRTUAL_COLUMN_ID_START);
-                        let exists_virtual_columns =
-                            metadata.virtual_columns_by_table_index(table_index);
-                        let mut max_column_id = next_virtual_column_id.saturating_sub(1);
-                        for exists_virtual_column in exists_virtual_columns {
-                            if let ColumnEntry::VirtualColumn(VirtualColumn { column_id, .. }) =
-                                exists_virtual_column
-                            {
-                                if column_id > max_column_id {
-                                    max_column_id = column_id;
+                        let max_column_id = metadata
+                            .virtual_columns_by_table_index(table_index)
+                            .filter_map(|column| match column {
+                                ColumnEntry::VirtualColumn(VirtualColumn { column_id, .. }) => {
+                                    Some(*column_id)
                                 }
-                            }
-                        }
+                                _ => None,
+                            })
+                            .max()
+                            .unwrap_or_else(|| next_virtual_column_id.saturating_sub(1));
                         if max_column_id >= next_virtual_column_id {
                             max_column_id + 1
                         } else {

--- a/src/query/sql/src/planner/binder/bind_context.rs
+++ b/src/query/sql/src/planner/binder/bind_context.rs
@@ -44,7 +44,6 @@ use databend_common_expression::infer_schema_type;
 use databend_common_meta_app::principal::UserDefinedFunction;
 use enum_as_inner::EnumAsInner;
 use indexmap::IndexMap;
-use itertools::Itertools;
 use jsonb::keypath::OwnedKeyPaths;
 use parking_lot::RwLock;
 
@@ -124,6 +123,26 @@ pub enum NameResolutionResult {
     Column(ColumnBinding),
     InternalColumn(InternalColumnBinding),
     Alias { alias: String, scalar: ScalarExpr },
+}
+
+#[derive(Default)]
+struct NameResolutionCandidates {
+    first: Option<NameResolutionResult>,
+    ambiguous: bool,
+}
+
+impl NameResolutionCandidates {
+    fn push(&mut self, candidate: NameResolutionResult) {
+        match &self.first {
+            Some(first) if first != &candidate => self.ambiguous = true,
+            Some(_) => {}
+            None => self.first = Some(candidate),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.first.is_none()
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
@@ -457,7 +476,7 @@ impl BindContext {
         column: &Identifier,
         available_aliases: &[(String, ScalarExpr)],
         name_resolution_ctx: &NameResolutionContext,
-    ) -> Result<Vec<NameResolutionResult>> {
+    ) -> Result<NameResolutionCandidates> {
         let name = &column.name;
         let column_case_sensitive = name_resolution_ctx.is_case_sensitive(column);
         if name_resolution_ctx.deny_column_reference {
@@ -471,9 +490,8 @@ impl BindContext {
             return Err(err.set_span(column.span));
         }
 
-        let mut result = vec![];
+        let mut result = NameResolutionCandidates::default();
         // Lookup parent context to resolve outer reference.
-        let mut alias_match_count = 0;
         if !self.expr_context.allow_resolve_alias() {
             self.search_bound_columns_recursively(
                 database,
@@ -489,12 +507,10 @@ impl BindContext {
                         alias: alias.clone(),
                         scalar: scalar.clone(),
                     });
-
-                    alias_match_count += 1;
                 }
             }
 
-            if alias_match_count == 0 {
+            if result.is_empty() {
                 self.search_bound_columns_recursively(
                     database,
                     table,
@@ -529,17 +545,19 @@ impl BindContext {
 
     fn finish_resolve_name(
         column: &Identifier,
-        mut result: Vec<NameResolutionResult>,
+        result: NameResolutionCandidates,
     ) -> Result<NameResolutionResult> {
         let name = &column.name;
-        if result.len() > 1 && !result.iter().all_equal() {
+        if result.ambiguous {
             return Err(ErrorCode::SemanticError(format!(
                 "column {name} reference or alias is ambiguous, please use another alias name",
             ))
             .set_span(column.span));
         }
 
-        if result.is_empty() {
+        if let Some(result) = result.first {
+            Ok(result)
+        } else {
             let err = if column.is_quoted() {
                 ErrorCode::SemanticError(format!(
                     "column {name} doesn't exist, do you mean '{name}'?"
@@ -548,8 +566,6 @@ impl BindContext {
                 ErrorCode::SemanticError(format!("column {name} doesn't exist"))
             };
             Err(err.set_span(column.span))
-        } else {
-            Ok(result.remove(0))
         }
     }
 
@@ -584,13 +600,13 @@ impl BindContext {
 
     // Search bound column recursively from the parent context.
     // If current context found results, it'll stop searching.
-    pub fn search_bound_columns_recursively(
+    fn search_bound_columns_recursively(
         &self,
         database: Option<&str>,
         table: Option<&str>,
         column: &Identifier,
         column_case_sensitive: bool,
-        result: &mut Vec<NameResolutionResult>,
+        result: &mut NameResolutionCandidates,
     ) {
         let mut bind_context: &BindContext = self;
         loop {
@@ -621,7 +637,7 @@ impl BindContext {
         table: Option<&str>,
         column: &Identifier,
         column_case_sensitive: bool,
-        result: &mut Vec<NameResolutionResult>,
+        result: &mut NameResolutionCandidates,
     ) {
         for column_binding in bind_context.columns.iter() {
             if let Some(lower) = &column_binding.column_name_lower {

--- a/src/query/sql/src/planner/binder/bind_mutation/bind.rs
+++ b/src/query/sql/src/planner/binder/bind_mutation/bind.rs
@@ -31,7 +31,8 @@ use databend_common_expression::types::DataType;
 use databend_common_pipeline::core::SharedLockGuard;
 
 use crate::BindContext;
-use crate::ColumnEntry;
+use crate::IndexType;
+use crate::Metadata;
 use crate::ScalarBinder;
 use crate::ScalarExpr;
 use crate::Symbol;
@@ -194,28 +195,31 @@ impl Binder {
             table_name.clone()
         };
 
-        let target_column_entries = self
-            .metadata
-            .read()
-            .columns_by_table_index(target_table_index);
-
         let mut matched_evaluators = Vec::with_capacity(matched_clauses.len());
         let mut unmatched_evaluators = Vec::with_capacity(unmatched_clauses.len());
         let mut field_index_map = HashMap::<usize, String>::new();
-        if self.has_update(&matched_clauses) {
-            // If exists update clause, we need to read all columns of target table.
-            for (idx, field) in table.schema_with_stream().fields().iter().enumerate() {
-                let column_index = Self::find_column_index(&target_column_entries, field.name())?;
-                field_index_map.insert(idx, column_index.to_string());
-            }
-        }
-
-        if table.change_tracking_enabled() && mutation_strategy != MutationStrategy::NotMatchedOnly
         {
-            for stream_column in table.stream_columns() {
-                let column_index =
-                    Self::find_column_index(&target_column_entries, stream_column.column_name())?;
-                required_columns.insert(column_index);
+            let metadata = self.metadata.read();
+            if self.has_update(&matched_clauses) {
+                // If exists update clause, we need to read all columns of target table.
+                for (idx, field) in table.schema_with_stream().fields().iter().enumerate() {
+                    let column_index =
+                        Self::find_column_index(&metadata, target_table_index, field.name())?;
+                    field_index_map.insert(idx, column_index.to_string());
+                }
+            }
+
+            if table.change_tracking_enabled()
+                && mutation_strategy != MutationStrategy::NotMatchedOnly
+            {
+                for stream_column in table.stream_columns() {
+                    let column_index = Self::find_column_index(
+                        &metadata,
+                        target_table_index,
+                        stream_column.column_name(),
+                    )?;
+                    required_columns.insert(column_index);
+                }
             }
         }
 
@@ -495,8 +499,12 @@ impl Binder {
         }
     }
 
-    pub fn find_column_index(column_entries: &Vec<ColumnEntry>, col_name: &str) -> Result<Symbol> {
-        for column_entry in column_entries {
+    pub fn find_column_index(
+        metadata: &Metadata,
+        table_index: IndexType,
+        col_name: &str,
+    ) -> Result<Symbol> {
+        for column_entry in metadata.columns_by_table_index(table_index) {
             if col_name == column_entry.name() {
                 return Ok(column_entry.index());
             }
@@ -521,7 +529,6 @@ fn insert_only(mutation: &crate::plans::Mutation) -> bool {
     let metadata = mutation.metadata.read();
     let target_table_columns: HashSet<Symbol> = metadata
         .columns_by_table_index(mutation.target_table_index)
-        .iter()
         .map(|column| column.index())
         .collect();
 

--- a/src/query/sql/src/planner/binder/bind_mutation/mutation_expression.rs
+++ b/src/query/sql/src/planner/binder/bind_mutation/mutation_expression.rs
@@ -36,8 +36,8 @@ use crate::ColumnSet;
 use crate::ScalarBinder;
 use crate::ScalarExpr;
 use crate::Visibility;
+use crate::binder::Any;
 use crate::binder::Binder;
-use crate::binder::Finder;
 use crate::binder::InternalColumnBinding;
 use crate::binder::MutationStrategy;
 use crate::binder::MutationType;
@@ -610,9 +610,9 @@ impl Binder {
             ) || scalar.is_aggregate()
         };
 
-        let mut finder = Finder::new(&f);
-        finder.visit(scalar)?;
-        Ok(finder.scalars().is_empty())
+        let mut any = Any::new(&f);
+        any.visit(scalar)?;
+        Ok(!any.result())
     }
 }
 

--- a/src/query/sql/src/planner/binder/bind_mutation/mutation_expression.rs
+++ b/src/query/sql/src/planner/binder/bind_mutation/mutation_expression.rs
@@ -41,7 +41,7 @@ use crate::binder::Binder;
 use crate::binder::InternalColumnBinding;
 use crate::binder::MutationStrategy;
 use crate::binder::MutationType;
-use crate::binder::split_conjunctions;
+use crate::binder::into_conjunctions;
 use crate::binder::util::TableIdentifier;
 use crate::optimizer::OptimizerContext;
 use crate::optimizer::ir::SExpr;
@@ -572,7 +572,7 @@ impl Binder {
             } else {
                 MutationStrategy::MatchedOnly
             };
-            let predicates = split_conjunctions(&scalar);
+            let predicates = into_conjunctions(scalar).collect();
             Ok((strategy, predicates))
         } else {
             Ok((MutationStrategy::Direct, vec![]))

--- a/src/query/sql/src/planner/binder/bind_table_reference/bind_join.rs
+++ b/src/query/sql/src/planner/binder/bind_table_reference/bind_join.rs
@@ -380,7 +380,7 @@ impl Binder {
 
         let mut other_condition_columns = ColumnSet::new();
         for predicate in other_conditions.iter() {
-            other_condition_columns.extend(predicate.used_columns());
+            predicate.collect_used_columns(&mut other_condition_columns);
         }
 
         self.push_down_other_conditions(
@@ -449,13 +449,13 @@ impl Binder {
             };
         let mut join_condition_columns = ColumnSet::new();
         for predicate in left_conditions.iter() {
-            join_condition_columns.extend(predicate.used_columns());
+            predicate.collect_used_columns(&mut join_condition_columns);
         }
         for predicate in right_conditions.iter() {
-            join_condition_columns.extend(predicate.used_columns());
+            predicate.collect_used_columns(&mut join_condition_columns);
         }
         for predicate in non_equi_conditions.iter() {
-            join_condition_columns.extend(predicate.used_columns());
+            predicate.collect_used_columns(&mut join_condition_columns);
         }
         join_condition_columns.extend(other_condition_columns);
         if !join_condition_columns.is_empty() {

--- a/src/query/sql/src/planner/binder/bind_table_reference/bind_join.rs
+++ b/src/query/sql/src/planner/binder/bind_table_reference/bind_join.rs
@@ -29,7 +29,7 @@ use crate::BindContext;
 use crate::ColumnBinding;
 use crate::ColumnSet;
 use crate::MetadataRef;
-use crate::binder::Finder;
+use crate::binder::Any;
 use crate::binder::JoinPredicate;
 use crate::binder::Visibility;
 use crate::binder::reject_grouping_functions;
@@ -784,9 +784,9 @@ impl<'a> JoinConditionResolver<'a> {
             )
         };
         for scalar in scalars {
-            let mut finder = Finder::new(&f);
-            finder.visit(scalar)?;
-            if !finder.scalars().is_empty() {
+            let mut any = Any::new(&f);
+            any.visit(scalar)?;
+            if any.result() {
                 return Err(ErrorCode::SemanticError(
                     "Join condition can't contain aggregate or window functions".to_string(),
                 )

--- a/src/query/sql/src/planner/binder/binder.rs
+++ b/src/query/sql/src/planner/binder/binder.rs
@@ -47,7 +47,7 @@ use databend_common_meta_app::principal::StageFileFormatType;
 use databend_storages_common_table_meta::table::is_stream_name;
 use log::warn;
 
-use super::Finder;
+use super::Any;
 use crate::BindContext;
 use crate::ColumnBinding;
 use crate::MetadataRef;
@@ -1077,9 +1077,9 @@ impl Binder {
                     | ScalarExpr::AsyncFunctionCall(_)
             ) || scalar.is_aggregate()
         };
-        let mut finder = Finder::new(&f);
-        finder.visit(scalar)?;
-        Ok(finder.scalars().is_empty())
+        let mut any = Any::new(&f);
+        any.visit(scalar)?;
+        Ok(!any.result())
     }
 
     pub(crate) fn check_allowed_scalar_expr_with_subquery_for_copy_table(
@@ -1098,9 +1098,9 @@ impl Binder {
                 .unwrap_or(true),
             _ => false,
         };
-        let mut finder = Finder::new(&f);
-        finder.visit(scalar)?;
-        Ok(finder.scalars().is_empty())
+        let mut any = Any::new(&f);
+        any.visit(scalar)?;
+        Ok(!any.result())
     }
 
     pub(crate) fn add_bound_columns_into_expr(

--- a/src/query/sql/src/planner/binder/expr_values.rs
+++ b/src/query/sql/src/planner/binder/expr_values.rs
@@ -41,28 +41,32 @@ use crate::plans::walk_expr_mut;
 
 pub(crate) struct ExprValuesRewriter {
     ctx: Arc<dyn TableContext>,
-    scalars: Vec<ScalarExpr>,
+    invalid: bool,
 }
 
 impl ExprValuesRewriter {
     pub fn new(ctx: Arc<dyn TableContext>) -> Self {
         Self {
             ctx,
-            scalars: vec![],
+            invalid: false,
         }
     }
 
-    pub fn reset_scalars(&mut self) {
-        self.scalars.clear();
+    pub fn reset(&mut self) {
+        self.invalid = false;
     }
 
-    pub fn scalars(&self) -> &[ScalarExpr] {
-        &self.scalars
+    pub fn is_invalid(&self) -> bool {
+        self.invalid
     }
 }
 
 impl<'a> VisitorMut<'a> for ExprValuesRewriter {
     fn visit(&mut self, expr: &'a mut ScalarExpr) -> Result<()> {
+        if self.invalid {
+            return Ok(());
+        }
+
         match &expr {
             ScalarExpr::AsyncFunctionCall(async_func) => {
                 let tenant = self.ctx.get_tenant();
@@ -96,7 +100,7 @@ impl<'a> VisitorMut<'a> for ExprValuesRewriter {
                     .map(|property| property.kind == FunctionKind::SRF)
                     .unwrap_or(false)
                 {
-                    self.scalars.push(expr.clone());
+                    self.invalid = true;
                     return Ok(());
                 }
             }
@@ -105,7 +109,7 @@ impl<'a> VisitorMut<'a> for ExprValuesRewriter {
             | ScalarExpr::SubqueryExpr(_)
             | ScalarExpr::UDFCall(_)
             | ScalarExpr::UDAFCall(_) => {
-                self.scalars.push(expr.clone());
+                self.invalid = true;
                 return Ok(());
             }
             ScalarExpr::BoundColumnRef(_)
@@ -158,10 +162,10 @@ impl BindContext {
 
             let (mut scalar, data_type) = scalar_binder.bind(expr)?;
 
-            rewriter.reset_scalars();
+            rewriter.reset();
             rewriter.visit(&mut scalar)?;
 
-            if !rewriter.scalars().is_empty() {
+            if rewriter.is_invalid() {
                 return Err(ErrorCode::SemanticError(
                     "Aggregate, external udf and window functions are not allowed in value expressions"
                         .to_string(),

--- a/src/query/sql/src/planner/binder/having.rs
+++ b/src/query/sql/src/planner/binder/having.rs
@@ -23,7 +23,7 @@ use crate::BindContext;
 use crate::Binder;
 use crate::binder::ExprContext;
 use crate::binder::aggregate::AggregateRewriter;
-use crate::binder::split_conjunctions;
+use crate::binder::into_conjunctions;
 use crate::optimizer::ir::SExpr;
 use crate::planner::semantic::GroupingChecker;
 use crate::plans::Filter;
@@ -83,7 +83,7 @@ impl Binder {
             having
         };
 
-        let predicates = split_conjunctions(&scalar);
+        let predicates = into_conjunctions(scalar).collect();
 
         let filter = Filter { predicates };
 

--- a/src/query/sql/src/planner/binder/having.rs
+++ b/src/query/sql/src/planner/binder/having.rs
@@ -18,7 +18,7 @@ use databend_common_ast::ast::Expr;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 
-use super::Finder;
+use super::Any;
 use crate::BindContext;
 use crate::Binder;
 use crate::binder::ExprContext;
@@ -28,7 +28,7 @@ use crate::optimizer::ir::SExpr;
 use crate::planner::semantic::GroupingChecker;
 use crate::plans::Filter;
 use crate::plans::ScalarExpr;
-use crate::plans::Visitor;
+use crate::plans::Visitor as _;
 use crate::plans::VisitorMut as _;
 
 impl Binder {
@@ -57,9 +57,9 @@ impl Binder {
         bind_context.expr_context = ExprContext::HavingClause;
 
         let f = |scalar: &ScalarExpr| matches!(scalar, ScalarExpr::WindowFunction(_));
-        let mut finder = Finder::new(&f);
-        finder.visit(&having)?;
-        if !finder.scalars().is_empty() {
+        let mut any = Any::new(&f);
+        any.visit(&having)?;
+        if any.result() {
             return Err(ErrorCode::SemanticError(
                 "Having clause can't contain window functions".to_string(),
             )

--- a/src/query/sql/src/planner/binder/project_set.rs
+++ b/src/query/sql/src/planner/binder/project_set.rs
@@ -95,10 +95,9 @@ impl DeferredAggregateRewriter<'_> {
     fn find_registered_aggregate_scalar(&self, index: crate::Symbol) -> Option<ScalarExpr> {
         self.bind_context
             .aggregate_info
-            .aggregate_calls_for_plan()
-            .into_iter()
+            .aggregate_calls()
             .find(|item| item.index == index)
-            .map(|item| item.scalar)
+            .map(|item| item.scalar.clone())
     }
 }
 

--- a/src/query/sql/src/planner/binder/qualify.rs
+++ b/src/query/sql/src/planner/binder/qualify.rs
@@ -23,7 +23,7 @@ use crate::Binder;
 use crate::binder::ExprContext;
 use crate::binder::ScalarBinder;
 use crate::binder::aggregate::AggregateRewriter;
-use crate::binder::split_conjunctions;
+use crate::binder::into_conjunctions;
 use crate::binder::window::WindowRewriter;
 use crate::binder::window::find_replaced_window_function;
 use crate::optimizer::ir::SExpr;
@@ -90,7 +90,7 @@ impl Binder {
             qualify
         };
 
-        let predicates = split_conjunctions(&scalar);
+        let predicates = into_conjunctions(scalar).collect();
 
         let filter = Filter { predicates };
 

--- a/src/query/sql/src/planner/binder/scalar_common.rs
+++ b/src/query/sql/src/planner/binder/scalar_common.rs
@@ -161,24 +161,45 @@ pub fn reject_grouping_functions<'a>(
     Ok(())
 }
 
-pub fn split_conjunctions(scalar: &ScalarExpr) -> Vec<ScalarExpr> {
-    let mut predicates = Vec::new();
+#[inline]
+fn conjunctions_with<T>(
+    scalar: T,
+    mut expand: impl FnMut(T, &mut Vec<T>) -> Option<T>,
+) -> impl Iterator<Item = T> {
     let mut stack = vec![scalar];
 
-    while let Some(scalar) = stack.pop() {
-        match scalar {
-            ScalarExpr::FunctionCall(func)
-                if matches!(func.func_name.as_str(), "and" | "and_filters") =>
-            {
-                stack.extend(func.arguments.iter().rev());
-            }
-            _ => {
-                predicates.push(scalar.clone());
+    std::iter::from_fn(move || {
+        loop {
+            let scalar = stack.pop()?;
+            if let Some(scalar) = expand(scalar, &mut stack) {
+                return Some(scalar);
             }
         }
-    }
+    })
+}
 
-    predicates
+fn is_conjunction(func: &FunctionCall) -> bool {
+    matches!(func.func_name.as_str(), "and" | "and_filters")
+}
+
+pub fn conjunctions(scalar: &ScalarExpr) -> impl Iterator<Item = &ScalarExpr> {
+    conjunctions_with(scalar, |scalar, stack| match scalar {
+        ScalarExpr::FunctionCall(func) if is_conjunction(func) => {
+            stack.extend(func.arguments.iter().rev());
+            None
+        }
+        _ => Some(scalar),
+    })
+}
+
+pub fn into_conjunctions(scalar: ScalarExpr) -> impl Iterator<Item = ScalarExpr> {
+    conjunctions_with(scalar, |scalar, stack| match scalar {
+        ScalarExpr::FunctionCall(func) if is_conjunction(&func) => {
+            stack.extend(func.arguments.into_iter().rev());
+            None
+        }
+        _ => Some(scalar),
+    })
 }
 
 #[cfg(test)]
@@ -202,18 +223,17 @@ mod tests {
     }
 
     #[test]
-    fn test_split_conjunctions_handles_deep_and_chain() {
+    fn test_conjunctions_handles_deep_and_chain() {
         let mut expr = bool_constant(true);
         for _ in 0..1024 {
             expr = and(expr, bool_constant(true));
         }
 
-        let predicates = split_conjunctions(&expr);
-        assert_eq!(predicates.len(), 1025);
+        assert_eq!(conjunctions(&expr).count(), 1025);
     }
 
     #[test]
-    fn test_split_conjunctions_handles_and_filters() {
+    fn test_conjunctions_handles_and_filters() {
         let expr = ScalarExpr::FunctionCall(FunctionCall {
             span: None,
             func_name: "and_filters".to_string(),
@@ -225,8 +245,8 @@ mod tests {
             ],
         });
 
-        let predicates = split_conjunctions(&expr);
-        assert_eq!(predicates.len(), 4);
+        assert_eq!(conjunctions(&expr).count(), 4);
+        assert_eq!(into_conjunctions(expr).count(), 4);
     }
 
     #[test]

--- a/src/query/sql/src/planner/binder/scalar_common.rs
+++ b/src/query/sql/src/planner/binder/scalar_common.rs
@@ -20,6 +20,7 @@ use databend_common_exception::Result;
 use databend_common_expression::Scalar;
 use databend_common_expression::types::DataType;
 
+use crate::ColumnSet;
 use crate::optimizer::ir::RelationalProperty;
 use crate::plans::BoundColumnRef;
 use crate::plans::CastExpr;
@@ -290,7 +291,11 @@ pub fn split_equivalent_predicate(scalar: &ScalarExpr) -> Option<(ScalarExpr, Sc
 }
 
 pub fn satisfied_by(scalar: &ScalarExpr, prop: &RelationalProperty) -> bool {
-    scalar.used_columns().is_subset(&prop.output_columns) && !scalar.used_columns().is_empty()
+    satisfied_by_columns(&scalar.used_columns(), prop)
+}
+
+fn satisfied_by_columns(columns: &ColumnSet, prop: &RelationalProperty) -> bool {
+    !columns.is_empty() && columns.is_subset(&prop.output_columns)
 }
 
 /// Helper to determine join condition type from a scalar expression.
@@ -339,15 +344,16 @@ impl<'a> JoinPredicate<'a> {
         left_prop: &RelationalProperty,
         right_prop: &RelationalProperty,
     ) -> Self {
-        if scalar.used_columns().is_empty() {
+        let used_columns = scalar.used_columns();
+        if used_columns.is_empty() {
             return Self::ALL(scalar);
         }
 
-        if satisfied_by(scalar, left_prop) {
+        if satisfied_by_columns(&used_columns, left_prop) {
             return Self::Left(scalar);
         }
 
-        if satisfied_by(scalar, right_prop) {
+        if satisfied_by_columns(&used_columns, right_prop) {
             return Self::Right(scalar);
         }
 
@@ -357,9 +363,10 @@ impl<'a> JoinPredicate<'a> {
                 let mut right_exprs = Vec::new();
 
                 for expr in func.arguments.iter() {
-                    if satisfied_by(expr, left_prop) {
+                    let used_columns = expr.used_columns();
+                    if satisfied_by_columns(&used_columns, left_prop) {
                         left_exprs.push(expr.clone());
-                    } else if satisfied_by(expr, right_prop) {
+                    } else if satisfied_by_columns(&used_columns, right_prop) {
                         right_exprs.push(expr.clone());
                     } else {
                         return Self::Other(scalar);
@@ -383,8 +390,12 @@ impl<'a> JoinPredicate<'a> {
                 let is_equal_op = func.func_name.as_str() == "eq";
                 let left = &func.arguments[0];
                 let right = &func.arguments[1];
+                let left_used_columns = left.used_columns();
+                let right_used_columns = right.used_columns();
 
-                if satisfied_by(left, left_prop) && satisfied_by(right, right_prop) {
+                if satisfied_by_columns(&left_used_columns, left_prop)
+                    && satisfied_by_columns(&right_used_columns, right_prop)
+                {
                     return Self::Both {
                         left: Box::new(Cow::Borrowed(left)),
                         right: Box::new(Cow::Borrowed(right)),
@@ -392,7 +403,9 @@ impl<'a> JoinPredicate<'a> {
                     };
                 }
 
-                if satisfied_by(right, left_prop) && satisfied_by(left, right_prop) {
+                if satisfied_by_columns(&right_used_columns, left_prop)
+                    && satisfied_by_columns(&left_used_columns, right_prop)
+                {
                     return Self::Both {
                         left: Box::new(Cow::Borrowed(right)),
                         right: Box::new(Cow::Borrowed(left)),

--- a/src/query/sql/src/planner/binder/scalar_common.rs
+++ b/src/query/sql/src/planner/binder/scalar_common.rs
@@ -33,12 +33,12 @@ use crate::plans::walk_expr;
 pub const GROUPING_FUNC_NAME: &str = "grouping";
 pub const GROUPING_ID_COLUMN_NAME: &str = "_grouping_id";
 
-// Visitor that find Expressions that match a particular predicate
+// Visitor that collects references to expressions that match a predicate.
 pub struct Finder<'a, F>
 where F: Fn(&ScalarExpr) -> bool
 {
     find_fn: &'a F,
-    scalars: Vec<ScalarExpr>,
+    scalars: Vec<&'a ScalarExpr>,
 }
 
 impl<'a, F> Finder<'a, F>
@@ -51,7 +51,7 @@ where F: Fn(&ScalarExpr) -> bool
         }
     }
 
-    pub fn scalars(&self) -> &[ScalarExpr] {
+    pub fn scalars(&self) -> &[&'a ScalarExpr] {
         &self.scalars
     }
 
@@ -69,10 +69,51 @@ where F: Fn(&ScalarExpr) -> bool
 {
     fn visit(&mut self, expr: &'a ScalarExpr) -> Result<()> {
         if (self.find_fn)(expr) {
-            if !(self.scalars.contains(expr)) {
-                self.scalars.push((*expr).clone())
-            }
+            self.scalars.push(expr);
             // stop recursing down this expr once we find a match
+        } else {
+            walk_expr(self, expr)?;
+        }
+        Ok(())
+    }
+}
+
+/// Visitor that checks whether any expression matches a predicate.
+pub struct Any<'a, F>
+where F: Fn(&ScalarExpr) -> bool
+{
+    find_fn: &'a F,
+    result: bool,
+}
+
+impl<'a, F> Any<'a, F>
+where F: Fn(&ScalarExpr) -> bool
+{
+    pub fn new(find_fn: &'a F) -> Self {
+        Self {
+            find_fn,
+            result: false,
+        }
+    }
+
+    pub fn result(&self) -> bool {
+        self.result
+    }
+
+    pub fn reset(&mut self) {
+        self.result = false;
+    }
+}
+
+impl<'a, F> Visitor<'a> for Any<'_, F>
+where F: Fn(&ScalarExpr) -> bool
+{
+    fn visit(&mut self, expr: &'a ScalarExpr) -> Result<()> {
+        if self.result {
+            return Ok(());
+        }
+        if (self.find_fn)(expr) {
+            self.result = true;
         } else {
             walk_expr(self, expr)?;
         }
@@ -109,9 +150,9 @@ pub fn reject_grouping_functions<'a>(
     clause_name: &str,
 ) -> Result<()> {
     for scalar in scalars {
-        let mut grouping_finder = Finder::new(&is_grouping_function);
-        grouping_finder.visit(scalar)?;
-        if let Some(ScalarExpr::FunctionCall(func)) = grouping_finder.scalars().first() {
+        let mut finder = Finder::new(&is_grouping_function);
+        finder.visit(scalar)?;
+        if let Some(ScalarExpr::FunctionCall(func)) = finder.scalars().first().copied() {
             return Err(grouping_clause_error(func, clause_name));
         }
     }
@@ -185,6 +226,57 @@ mod tests {
 
         let predicates = split_conjunctions(&expr);
         assert_eq!(predicates.len(), 4);
+    }
+
+    #[test]
+    fn test_finder_borrows_matches() {
+        let expr = and(
+            bool_constant(false),
+            and(bool_constant(false), bool_constant(true)),
+        );
+        let ScalarExpr::FunctionCall(function) = &expr else {
+            unreachable!();
+        };
+        let expected = &function.arguments[0];
+
+        let predicate = |scalar: &ScalarExpr| {
+            matches!(
+                scalar,
+                ScalarExpr::ConstantExpr(ConstantExpr {
+                    value: Scalar::Boolean(false),
+                    ..
+                })
+            )
+        };
+        let mut finder = Finder::new(&predicate);
+        finder.visit(&expr).unwrap();
+        let found = finder.scalars()[0];
+
+        assert!(std::ptr::eq(found, expected));
+    }
+
+    #[test]
+    fn test_any_stops_after_first_match() {
+        let expr = and(
+            bool_constant(false),
+            and(bool_constant(false), bool_constant(true)),
+        );
+        let visits = std::cell::Cell::new(0);
+        let predicate = |scalar: &ScalarExpr| {
+            visits.set(visits.get() + 1);
+            matches!(
+                scalar,
+                ScalarExpr::ConstantExpr(ConstantExpr {
+                    value: Scalar::Boolean(false),
+                    ..
+                })
+            )
+        };
+        let mut any = Any::new(&predicate);
+        any.visit(&expr).unwrap();
+
+        assert!(any.result());
+        assert_eq!(visits.get(), 2);
     }
 }
 

--- a/src/query/sql/src/planner/binder/select.rs
+++ b/src/query/sql/src/planner/binder/select.rs
@@ -33,6 +33,7 @@ use databend_common_expression::type_check::common_super_type;
 use databend_common_expression::types::DataType;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 
+use super::Any;
 use super::Finder;
 use super::aggregate_prepass::AggregateExprInfo;
 use super::reject_grouping_functions;
@@ -218,11 +219,12 @@ impl GroupByAliasPolicy {
             return Self::FallbackOnly;
         }
 
-        let mut finder = Finder::new(&|expr| {
+        let predicate = |expr: &ScalarExpr| {
             expr.is_aggregate() || matches!(expr, ScalarExpr::WindowFunction(_))
-        });
-        finder.visit(&item.scalar).unwrap();
-        if finder.scalars().is_empty() {
+        };
+        let mut any = Any::new(&predicate);
+        any.visit(&item.scalar).unwrap();
+        if !any.result() {
             Self::Preferred
         } else {
             Self::FallbackOnly
@@ -457,9 +459,9 @@ impl Binder {
                     scalar.is_aggregate() || matches!(scalar, ScalarExpr::WindowFunction(_))
                 };
 
-                let mut finder = Finder::new(&f);
-                finder.visit(&scalar)?;
-                if !finder.scalars().is_empty() {
+                let mut any = Any::new(&f);
+                any.visit(&scalar)?;
+                if any.result() {
                     return Err(ErrorCode::SemanticError(
                         "Where clause can't contain aggregate or window functions".to_string(),
                     )

--- a/src/query/sql/src/planner/binder/select.rs
+++ b/src/query/sql/src/planner/binder/select.rs
@@ -43,12 +43,13 @@ use crate::ColumnSet;
 use crate::NameResolutionContext;
 use crate::Symbol;
 use crate::Visibility;
+use crate::binder::AliasLookup;
 use crate::binder::ColumnBindingBuilder;
 use crate::binder::ExprContext;
 use crate::binder::INTERNAL_COLUMN_FACTORY;
 use crate::binder::bind_table_reference::JoinConditions;
 use crate::binder::project::SelectInfo;
-use crate::binder::scalar_common::split_conjunctions;
+use crate::binder::scalar_common::conjunctions;
 use crate::optimizer::ir::SExpr;
 use crate::planner::binder::BindContext;
 use crate::planner::binder::Binder;
@@ -67,20 +68,41 @@ pub struct SelectList<'a> {
     pub items: Vec<SelectItem<'a>>,
 }
 
-#[derive(Debug, Default, Clone)]
-pub(crate) struct ClauseAliasBindings {
-    preferred: Vec<(String, ScalarExpr)>,
-    available: Vec<(String, ScalarExpr)>,
-    prior_group_aliases: Vec<(String, ScalarExpr)>,
+#[derive(Debug)]
+pub(crate) struct ClauseAliasBindings<'a> {
+    aliases: &'a [(String, ScalarExpr)],
+    preferred: Vec<usize>,
+    available: Vec<usize>,
     group_by_column_first: bool,
 }
 
-pub(crate) type ClauseAliasLookup<'a> = (
-    Option<&'a [(String, ScalarExpr)]>,
-    Option<&'a [(String, ScalarExpr)]>,
-);
+pub(crate) type ClauseAliasLookup<'a> = (AliasLookup<'a>, Option<AliasLookup<'a>>);
 
-impl ClauseAliasBindings {
+pub(crate) struct GroupItemAliasState<'a> {
+    aliases: &'a [(String, ScalarExpr)],
+    preferred: &'a [usize],
+    available: &'a [usize],
+    prior_group_aliases: Vec<usize>,
+    group_by_column_first: bool,
+}
+
+impl ClauseAliasBindings<'_> {
+    pub(crate) fn group_item_state(&self) -> GroupItemAliasState<'_> {
+        GroupItemAliasState {
+            aliases: self.aliases,
+            preferred: &self.preferred,
+            available: &self.available,
+            prior_group_aliases: Vec::new(),
+            group_by_column_first: self.group_by_column_first,
+        }
+    }
+}
+
+impl GroupItemAliasState<'_> {
+    fn lookup<'a>(&'a self, indices: &'a [usize]) -> AliasLookup<'a> {
+        AliasLookup::indexed(self.aliases, indices)
+    }
+
     pub(crate) fn group_item_aliases(
         &self,
         expr: &Expr,
@@ -101,14 +123,10 @@ impl ClauseAliasBindings {
             let fallback_aliases = if disable_select_alias_fallback || self.available.is_empty() {
                 None
             } else {
-                Some(self.available.as_slice())
+                Some(self.lookup(self.available))
             };
 
-            return (
-                (!self.prior_group_aliases.is_empty())
-                    .then_some(self.prior_group_aliases.as_slice()),
-                fallback_aliases,
-            );
+            return (self.lookup(&self.prior_group_aliases), fallback_aliases);
         }
 
         // With `enable_group_by_column_first`, the first binding pass should
@@ -120,41 +138,32 @@ impl ClauseAliasBindings {
         // must not shadow the underlying column `x` inside GROUP BY sets.
         if self.group_by_column_first || disable_select_alias_fallback {
             return (
-                None,
-                (!self.available.is_empty()).then_some(self.available.as_slice()),
+                self.lookup(&[]),
+                (!self.available.is_empty()).then(|| self.lookup(self.available)),
             );
         }
 
-        let preferred = (!self.preferred.is_empty()).then_some(self.preferred.as_slice());
         let fallback =
-            (self.preferred.len() != self.available.len()).then_some(self.available.as_slice());
+            (self.preferred.len() != self.available.len()).then(|| self.lookup(self.available));
 
-        (preferred, fallback)
+        (self.lookup(self.preferred), fallback)
     }
 
     pub(crate) fn matched_group_item_alias(
         &self,
         expr: &Expr,
         scalar_expr: &ScalarExpr,
-    ) -> Option<String> {
+    ) -> Option<usize> {
         let column_name = Self::simple_unqualified_column_name(expr)?;
-        self.available
-            .iter()
-            .find(|(alias, scalar)| {
-                alias.eq_ignore_ascii_case(column_name) && scalar == scalar_expr
-            })
-            .map(|(alias, _)| alias.clone())
+        self.available.iter().copied().find(|index| {
+            let (alias, scalar) = &self.aliases[*index];
+            alias.eq_ignore_ascii_case(column_name) && scalar == scalar_expr
+        })
     }
 
-    pub(crate) fn register_group_item_alias(&mut self, alias: String, scalar: ScalarExpr) {
-        if !self
-            .prior_group_aliases
-            .iter()
-            .any(|(existing_alias, existing_scalar)| {
-                existing_alias.eq_ignore_ascii_case(&alias) && existing_scalar == &scalar
-            })
-        {
-            self.prior_group_aliases.push((alias, scalar));
+    pub(crate) fn register_group_item_alias(&mut self, alias_index: usize) {
+        if !self.prior_group_aliases.contains(&alias_index) {
+            self.prior_group_aliases.push(alias_index);
         }
     }
 
@@ -266,21 +275,22 @@ impl SelectAliasCatalog {
         &self.aliases
     }
 
-    pub(crate) fn group_by_bindings(&self, group_by_column_first: bool) -> ClauseAliasBindings {
+    pub(crate) fn group_by_bindings(&self, group_by_column_first: bool) -> ClauseAliasBindings<'_> {
         let mut bindings = ClauseAliasBindings {
+            aliases: &self.aliases,
+            preferred: Vec::new(),
+            available: Vec::new(),
             group_by_column_first,
-            ..Default::default()
         };
         for item in &self.items {
             if !item.explicit_expr_alias {
                 continue;
             }
 
-            let entry = self.aliases[item.alias_index].clone();
             if item.group_by_policy == GroupByAliasPolicy::Preferred {
-                bindings.preferred.push(entry.clone());
+                bindings.preferred.push(item.alias_index);
             }
-            bindings.available.push(entry);
+            bindings.available.push(item.alias_index);
         }
         bindings
     }
@@ -471,7 +481,7 @@ impl Binder {
                 reject_grouping_functions(Some(&scalar), "Where clause")?;
 
                 let filter_plan = Filter {
-                    predicates: split_conjunctions(&scalar),
+                    predicates: conjunctions(&scalar).cloned().collect(),
                 };
                 let new_expr = SExpr::create_unary(Arc::new(filter_plan.into()), Arc::new(child));
 

--- a/src/query/sql/src/planner/binder/select.rs
+++ b/src/query/sql/src/planner/binder/select.rs
@@ -907,7 +907,7 @@ impl Binder {
                 finder.reset_finder();
                 finder.visit(&s.scalar)?;
                 for scalar in finder.scalars() {
-                    non_lazy_cols.extend(scalar.used_columns())
+                    scalar.collect_used_columns(&mut non_lazy_cols);
                 }
             }
             metadata.add_non_lazy_columns(non_lazy_cols);
@@ -956,7 +956,7 @@ impl Binder {
             if let ScalarExpr::WindowFunction(_) = &s.scalar {
                 continue;
             } else {
-                select_cols.extend(s.scalar.used_columns())
+                s.scalar.collect_used_columns(&mut select_cols);
             }
         }
 

--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -81,7 +81,7 @@ use crate::binder::ColumnBindingBuilder;
 use crate::binder::CteInfo;
 use crate::binder::ExprContext;
 use crate::binder::Visibility;
-use crate::binder::split_conjunctions;
+use crate::binder::conjunctions;
 use crate::binder::table_args::execute_subquery_for_scalar;
 use crate::optimizer::ir::SExpr;
 use crate::planner::semantic::TypeChecker;
@@ -381,7 +381,6 @@ impl Binder {
 
         let table = self.metadata.read().table(table_index).clone();
         let table_name = table.name();
-        let columns = self.metadata.read().columns_by_table_index(table_index);
         let scan_id = self.metadata.write().next_scan_id();
         log::info!(
             "RUNTIME-FILTER: bind_base_table scan_id: {},table_entry: {:?}",
@@ -389,64 +388,69 @@ impl Binder {
             table
         );
         let mut base_column_scan_id = HashMap::new();
-        for column in columns.iter() {
-            match column {
-                ColumnEntry::BaseTableColumn(BaseTableColumn {
-                    column_name,
-                    column_index,
-                    path_indices,
-                    data_type,
-                    table_index,
-                    column_position,
-                    virtual_expr,
-                    ..
-                }) => {
-                    let column_binding = ColumnBindingBuilder::new(
-                        column_name.clone(),
-                        *column_index,
-                        Box::new(DataType::from(data_type)),
-                        if path_indices.is_some() || is_stream_column(column_name) {
-                            Visibility::InVisible
-                        } else {
-                            Visibility::Visible
-                        },
-                    )
-                    .table_name(Some(table_name.to_string()))
-                    .database_name(Some(database_name.to_string()))
-                    .table_index(Some(*table_index))
-                    .column_position(*column_position)
-                    .virtual_expr(virtual_expr.clone())
-                    .case_sensitive(case_sensitive)
-                    .build();
-                    bind_context.add_column_binding(column_binding);
-                    base_column_scan_id.insert(*column_index, scan_id);
-                }
-                ColumnEntry::VirtualColumn(VirtualColumn {
-                    table_index,
-                    column_index,
-                    column_name,
-                    data_type,
-                    ..
-                }) => {
-                    let column_binding = ColumnBindingBuilder::new(
-                        column_name.clone(),
-                        *column_index,
-                        Box::new(DataType::from(data_type)),
-                        Visibility::InVisible,
-                    )
-                    .table_name(Some(table_name.to_string()))
-                    .database_name(Some(database_name.to_string()))
-                    .table_index(Some(*table_index))
-                    .build();
-                    bind_context.add_column_binding(column_binding);
-                    base_column_scan_id.insert(*column_index, scan_id);
-                }
-                other => {
-                    return Err(ErrorCode::Internal(format!(
-                        "Invalid column entry '{:?}' encountered while binding the base table '{}'. Ensure that the table definition and column references are correct.",
-                        other.name(),
-                        table_name
-                    )));
+        let mut scan_columns = Vec::new();
+        {
+            let metadata = self.metadata.read();
+            for column in metadata.columns_by_table_index(table_index) {
+                scan_columns.push(column.index());
+                match column {
+                    ColumnEntry::BaseTableColumn(BaseTableColumn {
+                        column_name,
+                        column_index,
+                        path_indices,
+                        data_type,
+                        table_index,
+                        column_position,
+                        virtual_expr,
+                        ..
+                    }) => {
+                        let column_binding = ColumnBindingBuilder::new(
+                            column_name.clone(),
+                            *column_index,
+                            Box::new(DataType::from(data_type)),
+                            if path_indices.is_some() || is_stream_column(column_name) {
+                                Visibility::InVisible
+                            } else {
+                                Visibility::Visible
+                            },
+                        )
+                        .table_name(Some(table_name.to_string()))
+                        .database_name(Some(database_name.to_string()))
+                        .table_index(Some(*table_index))
+                        .column_position(*column_position)
+                        .virtual_expr(virtual_expr.clone())
+                        .case_sensitive(case_sensitive)
+                        .build();
+                        bind_context.add_column_binding(column_binding);
+                        base_column_scan_id.insert(*column_index, scan_id);
+                    }
+                    ColumnEntry::VirtualColumn(VirtualColumn {
+                        table_index,
+                        column_index,
+                        column_name,
+                        data_type,
+                        ..
+                    }) => {
+                        let column_binding = ColumnBindingBuilder::new(
+                            column_name.clone(),
+                            *column_index,
+                            Box::new(DataType::from(data_type)),
+                            Visibility::InVisible,
+                        )
+                        .table_name(Some(table_name.to_string()))
+                        .database_name(Some(database_name.to_string()))
+                        .table_index(Some(*table_index))
+                        .build();
+                        bind_context.add_column_binding(column_binding);
+                        base_column_scan_id.insert(*column_index, scan_id);
+                    }
+                    other => {
+                        return Err(ErrorCode::Internal(format!(
+                            "Invalid column entry '{:?}' encountered while binding the base table '{}'. Ensure that the table definition and column references are correct.",
+                            other.name(),
+                            table_name
+                        )));
+                    }
                 }
             }
         }
@@ -457,7 +461,7 @@ impl Binder {
         let scan_s_expr = SExpr::create_leaf(Arc::new(
             Scan {
                 table_index,
-                columns: columns.into_iter().map(|col| col.index()).collect(),
+                columns: scan_columns.into_iter().collect(),
                 change_type,
                 sample: sample.clone(),
                 scan_id,
@@ -597,7 +601,7 @@ impl Binder {
         );
         let (scalar, _) = scalar_binder.bind(expr)?;
 
-        let secure_predicates = split_conjunctions(&scalar);
+        let secure_predicates = conjunctions(&scalar).cloned().collect();
 
         // Write secure predicates directly into the Scan node.
         let new_expr =

--- a/src/query/sql/src/planner/expression/expression_parser.rs
+++ b/src/query/sql/src/planner/expression/expression_parser.rs
@@ -73,41 +73,43 @@ pub fn bind_table(table_meta: Arc<dyn Table>) -> Result<(BindContext, MetadataRe
         None,
     );
 
-    let columns = metadata.read().columns_by_table_index(table_index);
-    let table = metadata.read().table(table_index).clone();
-    for column in columns.iter() {
-        let column_binding = match column {
-            ColumnEntry::BaseTableColumn(BaseTableColumn {
-                column_index,
-                column_name,
-                data_type,
-                path_indices,
-                virtual_expr,
-                ..
-            }) => {
-                let visibility = if path_indices.is_some() {
-                    Visibility::InVisible
-                } else {
-                    Visibility::Visible
-                };
-                ColumnBindingBuilder::new(
-                    column_name.clone(),
-                    *column_index,
-                    Box::new(data_type.into()),
-                    visibility,
-                )
-                .database_name(Some("default".to_string()))
-                .table_name(Some(table.name().to_string()))
-                .table_index(Some(table.index()))
-                .virtual_expr(virtual_expr.clone())
-                .build()
-            }
-            _ => {
-                return Err(ErrorCode::Internal("Invalid column entry"));
-            }
-        };
+    {
+        let metadata = metadata.read();
+        let table = metadata.table(table_index);
+        for column in metadata.columns_by_table_index(table_index) {
+            let column_binding = match column {
+                ColumnEntry::BaseTableColumn(BaseTableColumn {
+                    column_index,
+                    column_name,
+                    data_type,
+                    path_indices,
+                    virtual_expr,
+                    ..
+                }) => {
+                    let visibility = if path_indices.is_some() {
+                        Visibility::InVisible
+                    } else {
+                        Visibility::Visible
+                    };
+                    ColumnBindingBuilder::new(
+                        column_name.clone(),
+                        *column_index,
+                        Box::new(data_type.into()),
+                        visibility,
+                    )
+                    .database_name(Some("default".to_string()))
+                    .table_name(Some(table.name().to_string()))
+                    .table_index(Some(table.index()))
+                    .virtual_expr(virtual_expr.clone())
+                    .build()
+                }
+                _ => {
+                    return Err(ErrorCode::Internal("Invalid column entry"));
+                }
+            };
 
-        bind_context.add_column_binding(column_binding);
+            bind_context.add_column_binding(column_binding);
+        }
     }
     Ok((bind_context, metadata))
 }

--- a/src/query/sql/src/planner/metadata/metadata.rs
+++ b/src/query/sql/src/planner/metadata/metadata.rs
@@ -234,36 +234,20 @@ impl Metadata {
         materialized_cte_id
     }
 
-    pub fn columns_by_table_index(&self, index: IndexType) -> Vec<ColumnEntry> {
+    pub fn columns_by_table_index(&self, index: IndexType) -> impl Iterator<Item = &ColumnEntry> {
         self.columns
             .iter()
-            .filter(|column| match column {
-                ColumnEntry::BaseTableColumn(BaseTableColumn { table_index, .. }) => {
-                    index == *table_index
-                }
-                ColumnEntry::InternalColumn(TableInternalColumn { table_index, .. }) => {
-                    index == *table_index
-                }
-                ColumnEntry::VirtualColumn(VirtualColumn { table_index, .. }) => {
-                    index == *table_index
-                }
-                _ => false,
-            })
-            .cloned()
-            .collect()
+            .filter(move |column| column.table_index() == Some(index))
     }
 
-    pub fn virtual_columns_by_table_index(&self, index: IndexType) -> Vec<ColumnEntry> {
-        self.columns
-            .iter()
-            .filter(|column| match column {
-                ColumnEntry::VirtualColumn(VirtualColumn { table_index, .. }) => {
-                    index == *table_index
-                }
-                _ => false,
-            })
-            .cloned()
-            .collect()
+    pub fn virtual_columns_by_table_index(
+        &self,
+        index: IndexType,
+    ) -> impl Iterator<Item = &ColumnEntry> {
+        self.columns.iter().filter(move |column| match column {
+            ColumnEntry::VirtualColumn(VirtualColumn { table_index, .. }) => index == *table_index,
+            _ => false,
+        })
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/src/query/sql/src/planner/optimizer/optimizers/cse/analyze.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/cse/analyze.rs
@@ -230,7 +230,6 @@ mod tests {
     fn scan_expr(metadata: &Metadata, table_index: usize) -> SExpr {
         let columns = metadata
             .columns_by_table_index(table_index)
-            .into_iter()
             .map(|column| column.index())
             .collect();
         SExpr::create_leaf(Arc::new(RelOperator::Scan(Scan {

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/filter/normalize_disjunctive_filter.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/filter/normalize_disjunctive_filter.rs
@@ -16,7 +16,7 @@ use databend_common_exception::Result;
 use databend_common_expression::Scalar;
 use itertools::Itertools;
 
-use crate::binder::split_conjunctions;
+use crate::binder::into_conjunctions;
 use crate::plans::ConstantExpr;
 use crate::plans::FunctionCall;
 use crate::plans::ScalarExpr;
@@ -41,9 +41,9 @@ impl NormalizeDisjunctiveFilterOptimizer {
             let rewritten_predicate_scalar = rewrite_predicate_ors(predicate_scalar);
             rewritten_predicates.push(normalize_predicate_scalar(rewritten_predicate_scalar));
         }
-        let mut split_predicates: Vec<ScalarExpr> = Vec::with_capacity(rewritten_predicates.len());
-        for predicate in rewritten_predicates.iter() {
-            split_predicates.extend_from_slice(&split_conjunctions(predicate));
+        let mut split_predicates = Vec::with_capacity(rewritten_predicates.len());
+        for predicate in rewritten_predicates {
+            split_predicates.extend(into_conjunctions(predicate));
         }
         Ok(split_predicates)
     }

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/filter/pull_up_filter.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/filter/pull_up_filter.rs
@@ -18,7 +18,8 @@ use databend_common_exception::Result;
 
 use crate::MetadataRef;
 use crate::ScalarExpr;
-use crate::binder::split_conjunctions;
+use crate::binder::conjunctions;
+use crate::binder::into_conjunctions;
 use crate::optimizer::Optimizer;
 use crate::optimizer::OptimizerContext;
 use crate::optimizer::ir::SExpr;
@@ -86,7 +87,7 @@ impl PullUpFilterOptimizer {
     fn pull_up_filter(&mut self, s_expr: &SExpr, filter: &Filter) -> Result<SExpr> {
         let child = self.pull_up(s_expr.child(0)?)?;
         for predicate in filter.predicates.iter() {
-            self.predicates.extend(split_conjunctions(predicate));
+            self.predicates.extend(conjunctions(predicate).cloned());
         }
         Ok(child)
     }
@@ -109,36 +110,32 @@ impl PullUpFilterOptimizer {
         let mut right = right_pull_up.pull_up(s_expr.child(1)?)?;
         if left_need_pull_up {
             for predicate in left_pull_up.predicates {
-                self.predicates.extend(split_conjunctions(&predicate));
+                self.predicates.extend(into_conjunctions(predicate));
             }
         } else {
             left = left_pull_up.finish(left)?;
         }
         if right_need_pull_up {
             for predicate in right_pull_up.predicates {
-                self.predicates.extend(split_conjunctions(&predicate));
+                self.predicates.extend(into_conjunctions(predicate));
             }
         } else {
             right = right_pull_up.finish(right)?;
         }
         let mut join = join.clone();
         if left_need_pull_up && right_need_pull_up {
-            for condition in join.equi_conditions.iter() {
-                let left_condition = condition.left.clone();
-                let right_condition = condition.right.clone();
+            for condition in std::mem::take(&mut join.equi_conditions) {
                 let predicate = ScalarExpr::FunctionCall(FunctionCall {
                     span: None,
                     func_name: "eq".to_string(),
                     params: vec![],
-                    arguments: vec![left_condition, right_condition],
+                    arguments: vec![condition.left, condition.right],
                 });
                 self.predicates.push(predicate);
             }
-            for predicate in join.non_equi_conditions.iter() {
-                self.predicates.extend(split_conjunctions(predicate));
+            for predicate in std::mem::take(&mut join.non_equi_conditions) {
+                self.predicates.extend(into_conjunctions(predicate));
             }
-            join.equi_conditions.clear();
-            join.non_equi_conditions.clear();
             join.join_type = JoinType::Cross;
         }
         let s_expr = s_expr.replace_plan(Arc::new(RelOperator::Join(join)));

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/agg_index/query_rewrite.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/agg_index/query_rewrite.rs
@@ -33,6 +33,7 @@ use log::info;
 use crate::ColumnBinding;
 use crate::ColumnEntry;
 use crate::IndexType;
+use crate::Metadata;
 use crate::ScalarExpr;
 use crate::Symbol;
 use crate::Visibility;
@@ -51,7 +52,7 @@ use crate::plans::SortItem;
 pub fn try_rewrite(
     table_index: IndexType,
     table_name: &str,
-    base_columns: &[ColumnEntry],
+    metadata: &Metadata,
     s_expr: &SExpr,
     index_plans: &[(u64, String, SExpr)],
 ) -> Result<Option<SExpr>> {
@@ -59,11 +60,21 @@ pub fn try_rewrite(
         return Ok(None);
     }
 
-    let query_info = QueryInfo::new(table_index, table_name, base_columns, s_expr)?;
+    let query_info = QueryInfo::new(
+        table_index,
+        table_name,
+        metadata.columns_by_table_index(table_index),
+        s_expr,
+    )?;
     let agg_index_rewriter = AggIndexRewriter::new(query_info);
 
     for (index_id, sql, view_s_expr) in index_plans.iter() {
-        let view_info = ViewInfo::new(table_index, table_name, base_columns, view_s_expr)?;
+        let view_info = ViewInfo::new(
+            table_index,
+            table_name,
+            metadata.columns_by_table_index(table_index),
+            view_s_expr,
+        )?;
         if let Some(result) =
             agg_index_rewriter.try_rewrite_index(s_expr, *index_id, sql, &view_info)?
         {
@@ -86,10 +97,10 @@ struct QueryInfo {
 }
 
 impl QueryInfo {
-    fn new(
+    fn new<'a>(
         table_index: IndexType,
         table_name: &str,
-        base_columns: &[ColumnEntry],
+        base_columns: impl IntoIterator<Item = &'a ColumnEntry>,
         s_expr: &SExpr,
     ) -> Result<QueryInfo> {
         if let RelOperator::EvalScalar(eval) = s_expr.plan() {
@@ -361,10 +372,10 @@ struct ViewInfo {
 }
 
 impl ViewInfo {
-    fn new(
+    fn new<'a>(
         table_index: IndexType,
         table_name: &str,
-        base_columns: &[ColumnEntry],
+        base_columns: impl IntoIterator<Item = &'a ColumnEntry>,
         s_expr: &SExpr,
     ) -> Result<ViewInfo> {
         let query_info = QueryInfo::new(table_index, table_name, base_columns, s_expr)?;

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/rule_try_apply_agg_index.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/rule_try_apply_agg_index.rs
@@ -165,11 +165,10 @@ impl Rule for RuleTryApplyAggIndex {
             return Ok(());
         }
 
-        let base_columns = metadata.columns_by_table_index(table_index);
         let table_name = metadata.table(table_index).name();
 
         if let Some(mut result) =
-            agg_index::try_rewrite(table_index, table_name, &base_columns, s_expr, index_plans)?
+            agg_index::try_rewrite(table_index, table_name, &metadata, s_expr, index_plans)?
         {
             result.set_applied_rule(&self.id);
             state.add_result(result);

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_eliminate_filter.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_eliminate_filter.rs
@@ -61,18 +61,13 @@ impl Rule for RuleEliminateFilter {
     }
 
     fn apply(&self, s_expr: &SExpr, state: &mut TransformResult) -> Result<()> {
-        let eval_scalar: Filter = s_expr.plan().clone().try_into()?;
-        // First, de-duplication predicates.
-        let origin_predicates = eval_scalar.predicates.clone();
-        let predicates = origin_predicates
-            .clone()
-            .into_iter()
-            .unique()
-            .collect::<Vec<ScalarExpr>>();
+        let RelOperator::Filter(filter) = s_expr.plan() else {
+            unreachable!("RuleEliminateFilter must match a Filter")
+        };
 
         // Rewrite false filter to be empty scan
-        if predicates.iter().any(is_falsy) {
-            let output_columns = eval_scalar
+        if filter.predicates.iter().any(is_falsy) {
+            let output_columns = filter
                 .derive_relational_prop(&RelExpr::with_s_expr(s_expr))?
                 .output_columns
                 .clone();
@@ -92,8 +87,10 @@ impl Rule for RuleEliminateFilter {
 
         // Delete identically equal predicate
         // After constant fold is ready, we can delete the following code
-        let predicates = predicates
-            .into_iter()
+        let predicates = filter
+            .predicates
+            .iter()
+            .unique()
             .filter(|predicate| match predicate {
                 ScalarExpr::FunctionCall(func) if func.func_name == "eq" => {
                     if let (
@@ -131,16 +128,14 @@ impl Rule for RuleEliminateFilter {
                 }
                 predicate => !is_true(predicate),
             })
-            .collect::<Vec<ScalarExpr>>();
+            .collect::<Vec<_>>();
 
         if predicates.is_empty() {
             state.add_result(s_expr.unary_child().clone());
-        } else if origin_predicates.len() != predicates.len() {
-            state.add_result(
-                s_expr
-                    .unary_child_arc()
-                    .ref_build_unary(Filter { predicates }),
-            );
+        } else if filter.predicates.len() != predicates.len() {
+            state.add_result(s_expr.unary_child_arc().ref_build_unary(Filter {
+                predicates: predicates.into_iter().cloned().collect(),
+            }));
         }
         Ok(())
     }

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_filter_nulls.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_filter_nulls.rs
@@ -26,7 +26,6 @@ use crate::optimizer::optimizers::rule::RuleID;
 use crate::optimizer::optimizers::rule::TransformResult;
 use crate::plans::Filter;
 use crate::plans::FunctionCall;
-use crate::plans::Join;
 use crate::plans::JoinType;
 use crate::plans::RelOp;
 use crate::plans::RelOperator;
@@ -99,7 +98,7 @@ impl Rule for RuleFilterNulls {
             state.add_result(s_expr.clone());
             return Ok(());
         }
-        let join: Join = s_expr.plan().clone().try_into()?;
+        let join = s_expr.plan().as_join().unwrap();
         if !matches!(
             join.join_type,
             JoinType::Inner | JoinType::LeftSemi | JoinType::RightSemi
@@ -108,11 +107,11 @@ impl Rule for RuleFilterNulls {
             state.add_result(s_expr.clone());
             return Ok(());
         }
-        let mut left_child = s_expr.child(0)?.clone();
-        let mut right_child = s_expr.child(1)?.clone();
+        let left_child = s_expr.child(0)?;
+        let right_child = s_expr.child(1)?;
 
-        let left_stat = RelExpr::with_s_expr(&left_child).derive_cardinality()?;
-        let right_stat = RelExpr::with_s_expr(&right_child).derive_cardinality()?;
+        let left_stat = RelExpr::with_s_expr(left_child).derive_cardinality()?;
+        let right_stat = RelExpr::with_s_expr(right_child).derive_cardinality()?;
         let mut left_null_predicates = vec![];
         let mut right_null_predicates = vec![];
         for join_key in join.equi_conditions.iter() {
@@ -122,7 +121,7 @@ impl Rule for RuleFilterNulls {
 
             let left_key = &join_key.left;
             let right_key = &join_key.right;
-            if single_plan(&left_child) {
+            if single_plan(left_child) {
                 if let Some(filter) = Self::should_filter_nulls(
                     left_key,
                     &left_stat.statistics,
@@ -131,7 +130,7 @@ impl Rule for RuleFilterNulls {
                     left_null_predicates.push(filter);
                 }
             }
-            if single_plan(&right_child) {
+            if single_plan(right_child) {
                 if let Some(filter) = Self::should_filter_nulls(
                     right_key,
                     &right_stat.statistics,
@@ -141,25 +140,29 @@ impl Rule for RuleFilterNulls {
                 }
             }
         }
-        if !left_null_predicates.is_empty() {
+        let left_child = if !left_null_predicates.is_empty() {
             let left_null_filter = Filter {
                 predicates: left_null_predicates,
             };
-            left_child = SExpr::create_unary(
+            SExpr::create_unary(
                 Arc::new(RelOperator::Filter(left_null_filter)),
                 Arc::new(left_child.clone()),
-            );
-        }
+            )
+        } else {
+            left_child.clone()
+        };
 
-        if !right_null_predicates.is_empty() {
+        let right_child = if !right_null_predicates.is_empty() {
             let right_null_filter = Filter {
                 predicates: right_null_predicates,
             };
-            right_child = SExpr::create_unary(
+            SExpr::create_unary(
                 Arc::new(RelOperator::Filter(right_null_filter)),
                 Arc::new(right_child.clone()),
-            );
-        }
+            )
+        } else {
+            right_child.clone()
+        };
 
         let mut res = s_expr.replace_children(vec![Arc::new(left_child), Arc::new(right_child)]);
         res.set_applied_rule(&self.id());

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/sort_rules/rule_eliminate_sort.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/sort_rules/rule_eliminate_sort.rs
@@ -21,7 +21,6 @@ use crate::optimizer::optimizers::rule::Rule;
 use crate::optimizer::optimizers::rule::RuleID;
 use crate::optimizer::optimizers::rule::TransformResult;
 use crate::plans::RelOp;
-use crate::plans::Sort;
 
 pub struct RuleEliminateSort {
     id: RuleID,
@@ -49,7 +48,7 @@ impl Rule for RuleEliminateSort {
     }
 
     fn apply(&self, s_expr: &SExpr, state: &mut TransformResult) -> Result<()> {
-        let sort: Sort = s_expr.plan().clone().try_into()?;
+        let sort = s_expr.plan().as_sort().unwrap();
         let input = s_expr.child(0)?;
 
         if sort.limit.is_some() {
@@ -67,7 +66,13 @@ impl Rule for RuleEliminateSort {
                 // avg(number) over (partition by number % 3 order by number + 1)
                 // from numbers(50);
                 if partition == &window.partition_by
-                    && (ordering == &sort.items || sort.sort_items_exclude_partition().is_empty())
+                    && (ordering == &sort.items
+                        || sort.items.iter().all(|item| {
+                            window
+                                .partition_by
+                                .iter()
+                                .any(|partition| partition.index == item.index)
+                        }))
                 {
                     state.add_result(input.clone());
                     return Ok(());

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/union_rules/rule_eliminate_union.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/union_rules/rule_eliminate_union.rs
@@ -29,7 +29,6 @@ use crate::plans::ConstantTableScan;
 use crate::plans::Operator;
 use crate::plans::RelOp;
 use crate::plans::RelOperator;
-use crate::plans::UnionAll;
 
 pub struct RuleEliminateUnion {
     id: RuleID,
@@ -84,7 +83,7 @@ impl Rule for RuleEliminateUnion {
     }
 
     fn apply(&self, s_expr: &SExpr, state: &mut TransformResult) -> Result<()> {
-        let union: UnionAll = s_expr.plan().clone().try_into()?;
+        let union = s_expr.plan().as_union_all().unwrap();
 
         // Need to check that union's output indexes are the same as left child's output indexes
         // currently this is always !false now, so the following codes are not necessary

--- a/src/query/sql/src/planner/optimizer/statistics/collect_statistics.rs
+++ b/src/query/sql/src/planner/optimizer/statistics/collect_statistics.rs
@@ -63,6 +63,12 @@ pub struct StatisticsTraceCollector {
     trace: Arc<Mutex<Option<serde_json::Value>>>,
 }
 
+struct StatisticsColumn {
+    index: Symbol,
+    id: ColumnId,
+    name: String,
+}
+
 impl StatisticsTraceCollector {
     pub fn take(self) -> Option<serde_json::Value> {
         self.trace.lock().unwrap().take()
@@ -135,10 +141,24 @@ impl CollectStatisticsOptimizer {
             RelOperator::Scan(scan) => {
                 let (table_entry, columns) = {
                     let metadata = self.metadata.read();
-                    (
-                        metadata.table(scan.table_index).clone(),
-                        metadata.columns_by_table_index(scan.table_index),
-                    )
+                    let columns = metadata
+                        .columns_by_table_index(scan.table_index)
+                        .filter_map(|column| match column {
+                            ColumnEntry::BaseTableColumn(BaseTableColumn {
+                                column_index,
+                                column_id,
+                                column_name,
+                                virtual_expr: None,
+                                ..
+                            }) => Some(StatisticsColumn {
+                                index: *column_index,
+                                id: *column_id,
+                                name: column_name.clone(),
+                            }),
+                            _ => None,
+                        })
+                        .collect::<Vec<_>>();
+                    (metadata.table(scan.table_index).clone(), columns)
                 };
                 let table = table_entry.table();
 
@@ -154,34 +174,21 @@ impl CollectStatisticsOptimizer {
                 let mut top_n = HashMap::new();
                 let mut count_min_sketch = HashMap::new();
                 let collect_frequency_stats = scan.change_type.is_none();
-                for column in columns.iter() {
-                    if let ColumnEntry::BaseTableColumn(BaseTableColumn {
-                        column_index,
-                        column_id,
-                        virtual_expr,
-                        ..
-                    }) = column
+                for column in &columns {
+                    let col_stat = column_statistics_provider.column_statistics(column.id);
+                    column_stats.insert(column.index, col_stat.cloned());
+                    let histogram = column_statistics_provider.histogram(column.id);
+                    histograms.insert(column.index, histogram);
+                    if collect_frequency_stats
+                        && let Some(column_top_n) = column_statistics_provider.top_n(column.id)
                     {
-                        if virtual_expr.is_none() {
-                            let col_stat = column_statistics_provider
-                                .column_statistics(*column_id as ColumnId);
-                            column_stats.insert(*column_index, col_stat.cloned());
-                            let histogram =
-                                column_statistics_provider.histogram(*column_id as ColumnId);
-                            histograms.insert(*column_index, histogram);
-                            if collect_frequency_stats
-                                && let Some(column_top_n) =
-                                    column_statistics_provider.top_n(*column_id as ColumnId)
-                            {
-                                top_n.insert(*column_index, column_top_n);
-                            }
-                            if collect_frequency_stats
-                                && let Some(column_count_min_sketch) = column_statistics_provider
-                                    .count_min_sketch(*column_id as ColumnId)
-                            {
-                                count_min_sketch.insert(*column_index, column_count_min_sketch);
-                            }
-                        }
+                        top_n.insert(column.index, column_top_n);
+                    }
+                    if collect_frequency_stats
+                        && let Some(column_count_min_sketch) =
+                            column_statistics_provider.count_min_sketch(column.id)
+                    {
+                        count_min_sketch.insert(column.index, column_count_min_sketch);
                     }
                 }
 
@@ -478,7 +485,7 @@ impl TraceCollector {
         &mut self,
         scan: &Scan,
         table_entry: &TableEntry,
-        columns: &[ColumnEntry],
+        columns: &[StatisticsColumn],
         table_fields: &[TableField],
         table_stats: &Option<TableStatistics>,
         column_stats: &HashMap<Symbol, Option<BasicColumnStatistics>>,
@@ -494,22 +501,12 @@ impl TraceCollector {
             });
 
         for column in columns {
-            let ColumnEntry::BaseTableColumn(BaseTableColumn {
-                column_index,
-                column_name,
-                virtual_expr: None,
-                ..
-            }) = column
-            else {
-                continue;
-            };
-
-            let column_stat = column_stats.get(column_index).and_then(Option::as_ref);
-            let histogram = histograms.get(column_index).and_then(Option::as_ref);
+            let column_stat = column_stats.get(&column.index).and_then(Option::as_ref);
+            let histogram = histograms.get(&column.index).and_then(Option::as_ref);
             let entry = self
                 .column_stats
                 .0
-                .entry((scan.table_index, column_name.clone()))
+                .entry((scan.table_index, column.name.clone()))
                 .or_insert_with(|| ColumnStatisticsEntry {
                     statistics: None,
                     histogram: None,

--- a/src/query/sql/src/planner/plans/aggregate.rs
+++ b/src/query/sql/src/planner/plans/aggregate.rs
@@ -128,22 +128,22 @@ impl Aggregate {
 
     pub fn used_columns(&self) -> Result<ColumnSet> {
         let mut used_columns = ColumnSet::new();
-        for group_item in self.group_items.iter() {
+        for group_item in &self.group_items {
             used_columns.insert(group_item.index);
-            used_columns.extend(group_item.scalar.used_columns())
+            group_item.scalar.collect_used_columns(&mut used_columns);
         }
-        for agg in self.aggregate_functions.iter() {
+        for agg in &self.aggregate_functions {
             used_columns.insert(agg.index);
-            used_columns.extend(agg.scalar.used_columns())
+            agg.scalar.collect_used_columns(&mut used_columns);
         }
         Ok(used_columns)
     }
 
     pub fn group_columns(&self) -> Result<ColumnSet> {
         let mut col_set = ColumnSet::new();
-        for group_item in self.group_items.iter() {
+        for group_item in &self.group_items {
             col_set.insert(group_item.index);
-            col_set.extend(group_item.scalar.used_columns())
+            group_item.scalar.collect_used_columns(&mut col_set);
         }
         Ok(col_set)
     }

--- a/src/query/sql/src/planner/plans/async_function.rs
+++ b/src/query/sql/src/planner/plans/async_function.rs
@@ -36,9 +36,9 @@ pub struct AsyncFunction {
 impl AsyncFunction {
     pub fn used_columns(&self) -> Result<ColumnSet> {
         let mut used_columns = ColumnSet::new();
-        for item in self.items.iter() {
+        for item in &self.items {
             used_columns.insert(item.index);
-            used_columns.extend(item.scalar.used_columns());
+            item.scalar.collect_used_columns(&mut used_columns);
         }
         Ok(used_columns)
     }
@@ -64,19 +64,14 @@ impl Operator for AsyncFunction {
 
         // Derive outer columns
         let mut outer_columns = input_prop.outer_columns.clone();
-        for item in self.items.iter() {
-            let used_columns = item.scalar.used_columns();
-            let outer = used_columns
-                .difference(&output_columns)
-                .cloned()
-                .collect::<ColumnSet>();
-            outer_columns = outer_columns.union(&outer).cloned().collect();
+        for item in &self.items {
+            item.scalar.collect_used_columns(&mut outer_columns);
         }
-        outer_columns = outer_columns.difference(&output_columns).cloned().collect();
+        outer_columns.retain(|column| !output_columns.contains(column));
 
         // Derive used columns
         let mut used_columns = self.used_columns()?;
-        used_columns.extend(input_prop.used_columns.clone());
+        used_columns.extend(input_prop.used_columns.iter().copied());
 
         // Derive orderings
         let orderings = input_prop.orderings.clone();

--- a/src/query/sql/src/planner/plans/eval_scalar.rs
+++ b/src/query/sql/src/planner/plans/eval_scalar.rs
@@ -80,9 +80,9 @@ impl ScalarItem {
 impl EvalScalar {
     pub fn used_columns(&self) -> Result<ColumnSet> {
         let mut used_columns = ColumnSet::new();
-        for item in self.items.iter() {
+        for item in &self.items {
             used_columns.insert(item.index);
-            used_columns.extend(item.scalar.used_columns());
+            item.scalar.collect_used_columns(&mut used_columns);
         }
         Ok(used_columns)
     }
@@ -167,15 +167,14 @@ impl Operator for EvalScalar {
             .difference(&input_prop.output_columns)
             .cloned()
             .collect::<ColumnSet>();
-        for item in self.items.iter() {
-            let used_columns = item.scalar.used_columns();
-            let outer = used_columns.difference(&input_prop.output_columns).cloned();
-            outer_columns.extend(outer);
+        for item in &self.items {
+            item.scalar.collect_used_columns(&mut outer_columns);
         }
+        outer_columns.retain(|column| !input_prop.output_columns.contains(column));
 
         // Derive used columns
         let mut used_columns = self.used_columns()?;
-        used_columns.extend(input_prop.used_columns.clone());
+        used_columns.extend(input_prop.used_columns.iter().copied());
 
         // Derive orderings
         let orderings = input_prop.orderings.clone();

--- a/src/query/sql/src/planner/plans/expression_scan.rs
+++ b/src/query/sql/src/planner/plans/expression_scan.rs
@@ -45,7 +45,7 @@ impl ExpressionScan {
         let mut columns = ColumnSet::new();
         for row in self.values.iter() {
             for value in row {
-                columns.extend(value.used_columns());
+                value.collect_used_columns(&mut columns);
             }
         }
         Ok(columns)

--- a/src/query/sql/src/planner/plans/filter.rs
+++ b/src/query/sql/src/planner/plans/filter.rs
@@ -35,11 +35,11 @@ pub struct Filter {
 
 impl Filter {
     pub fn used_columns(&self) -> Result<ColumnSet> {
-        Ok(self
-            .predicates
-            .iter()
-            .map(|scalar| scalar.used_columns())
-            .fold(ColumnSet::new(), |acc, x| acc.union(&x).cloned().collect()))
+        let mut used_columns = ColumnSet::new();
+        for predicate in &self.predicates {
+            predicate.collect_used_columns(&mut used_columns);
+        }
+        Ok(used_columns)
     }
 }
 
@@ -58,19 +58,14 @@ impl Operator for Filter {
 
         // Derive outer columns
         let mut outer_columns = input_prop.outer_columns.clone();
-        for scalar in self.predicates.iter() {
-            let used_columns = scalar.used_columns();
-            let outer = used_columns
-                .difference(&output_columns)
-                .cloned()
-                .collect::<ColumnSet>();
-            outer_columns = outer_columns.union(&outer).cloned().collect();
+        for scalar in &self.predicates {
+            scalar.collect_used_columns(&mut outer_columns);
         }
-        outer_columns = outer_columns.difference(&output_columns).cloned().collect();
+        outer_columns.retain(|column| !output_columns.contains(column));
 
         // Derive used columns
         let mut used_columns = self.used_columns()?;
-        used_columns.extend(input_prop.used_columns.clone());
+        used_columns.extend(input_prop.used_columns.iter().copied());
 
         // Derive orderings
         let orderings = input_prop.orderings.clone();

--- a/src/query/sql/src/planner/plans/join.rs
+++ b/src/query/sql/src/planner/plans/join.rs
@@ -533,21 +533,12 @@ impl JoinSideColumnStats {
 impl Join {
     pub fn used_columns(&self) -> Result<ColumnSet> {
         let mut used_columns = ColumnSet::new();
-        for condition in self.equi_conditions.iter() {
-            used_columns = used_columns
-                .union(&condition.left.used_columns())
-                .cloned()
-                .collect();
-            used_columns = used_columns
-                .union(&condition.right.used_columns())
-                .cloned()
-                .collect();
+        for condition in &self.equi_conditions {
+            condition.left.collect_used_columns(&mut used_columns);
+            condition.right.collect_used_columns(&mut used_columns);
         }
-        for condition in self.non_equi_conditions.iter() {
-            used_columns = used_columns
-                .union(&condition.used_columns())
-                .cloned()
-                .collect();
+        for condition in &self.non_equi_conditions {
+            condition.collect_used_columns(&mut used_columns);
         }
         Ok(used_columns)
     }
@@ -780,34 +771,22 @@ impl Operator for Join {
         if let Some(mark_index) = self.marker_index {
             output_columns.insert(mark_index);
         }
-        output_columns = output_columns
-            .union(&right_prop.output_columns)
-            .cloned()
-            .collect();
+        output_columns.extend(right_prop.output_columns.iter().copied());
 
         // Derive outer columns
         let mut outer_columns = left_prop.outer_columns.clone();
-        outer_columns = outer_columns
-            .union(&right_prop.outer_columns)
-            .cloned()
-            .collect();
+        outer_columns.extend(right_prop.outer_columns.iter().copied());
 
-        for condition in self.equi_conditions.iter() {
-            let left_used_columns = condition.left.used_columns();
-            let right_used_columns = condition.right.used_columns();
-            let used_columns: ColumnSet = left_used_columns
-                .union(&right_used_columns)
-                .cloned()
-                .collect();
-            let outer = used_columns.difference(&output_columns).cloned().collect();
-            outer_columns = outer_columns.union(&outer).cloned().collect();
+        for condition in &self.equi_conditions {
+            condition.left.collect_used_columns(&mut outer_columns);
+            condition.right.collect_used_columns(&mut outer_columns);
         }
-        outer_columns = outer_columns.difference(&output_columns).cloned().collect();
+        outer_columns.retain(|column| !output_columns.contains(column));
 
         // Derive used columns
         let mut used_columns = self.used_columns()?;
-        used_columns.extend(left_prop.used_columns.clone());
-        used_columns.extend(right_prop.used_columns.clone());
+        used_columns.extend(left_prop.used_columns.iter().copied());
+        used_columns.extend(right_prop.used_columns.iter().copied());
 
         Ok(Arc::new(RelationalProperty {
             output_columns,

--- a/src/query/sql/src/planner/plans/mutation_source.rs
+++ b/src/query/sql/src/planner/plans/mutation_source.rs
@@ -137,10 +137,11 @@ impl MutationSource {
     }
 
     pub fn refresh_read_partition_columns(&mut self) {
-        self.read_partition_columns = self
-            .all_predicates()
-            .flat_map(|predicate| predicate.used_columns())
-            .collect();
+        let mut read_partition_columns = ColumnSet::new();
+        for predicate in self.all_predicates() {
+            predicate.collect_used_columns(&mut read_partition_columns);
+        }
+        self.read_partition_columns = read_partition_columns;
     }
 
     /// Return all predicates (secure + user) as an owned Vec.

--- a/src/query/sql/src/planner/plans/project_set.rs
+++ b/src/query/sql/src/planner/plans/project_set.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use databend_common_exception::Result;
 
+use crate::ColumnSet;
 use crate::ScalarExpr;
 use crate::optimizer::ir::RelExpr;
 use crate::optimizer::ir::RelationalProperty;
@@ -56,7 +57,7 @@ impl Operator for ProjectSet {
         &self,
         rel_expr: &RelExpr,
     ) -> databend_common_exception::Result<Arc<RelationalProperty>> {
-        let child_prop = rel_expr.derive_relational_prop_child(0)?.as_ref().clone();
+        let child_prop = rel_expr.derive_relational_prop_child(0)?;
 
         // Derive output columns
         let mut output_columns = child_prop.output_columns.clone();
@@ -66,20 +67,19 @@ impl Operator for ProjectSet {
 
         // Derive used columns
         let mut used_columns = child_prop.used_columns.clone();
+        let mut srf_used_columns = ColumnSet::new();
         for srf in &self.srfs {
-            used_columns.extend(srf.scalar.used_columns());
+            srf.scalar.collect_used_columns(&mut srf_used_columns);
         }
+        used_columns.extend(srf_used_columns.iter().copied());
 
         // Derive outer columns
         let mut outer_columns = child_prop.outer_columns.clone();
-        for srf in &self.srfs {
-            outer_columns.extend(
-                srf.scalar
-                    .used_columns()
-                    .difference(&child_prop.output_columns)
-                    .cloned(),
-            );
-        }
+        outer_columns.extend(
+            srf_used_columns
+                .difference(&child_prop.output_columns)
+                .copied(),
+        );
 
         Ok(Arc::new(RelationalProperty {
             output_columns,

--- a/src/query/sql/src/planner/plans/scalar_expr.rs
+++ b/src/query/sql/src/planner/plans/scalar_expr.rs
@@ -164,20 +164,27 @@ impl ScalarExpr {
     }
 
     pub fn used_columns(&self) -> ColumnSet {
-        struct UsedColumnsVisitor {
-            columns: ColumnSet,
+        let mut columns = ColumnSet::new();
+        self.collect_used_columns(&mut columns);
+        columns
+    }
+
+    pub fn collect_used_columns<C>(&self, columns: &mut C)
+    where C: Extend<Symbol> {
+        struct UsedColumnsVisitor<'a, C> {
+            columns: &'a mut C,
         }
 
-        impl<'a> Visitor<'a> for UsedColumnsVisitor {
+        impl<'a, C> Visitor<'a> for UsedColumnsVisitor<'_, C>
+        where C: Extend<Symbol>
+        {
             fn visit_bound_column_ref(&mut self, col: &'a BoundColumnRef) -> Result<()> {
-                self.columns.insert(col.column.index);
+                self.columns.extend(std::iter::once(col.column.index));
                 Ok(())
             }
 
             fn visit_subquery(&mut self, subquery: &'a SubqueryExpr) -> Result<()> {
-                for idx in subquery.outer_columns.iter() {
-                    self.columns.insert(*idx);
-                }
+                self.columns.extend(subquery.outer_columns.iter().copied());
                 if let Some(child_expr) = subquery.child_expr.as_ref() {
                     self.visit(child_expr)?;
                 }
@@ -185,11 +192,8 @@ impl ScalarExpr {
             }
         }
 
-        let mut visitor = UsedColumnsVisitor {
-            columns: ColumnSet::new(),
-        };
+        let mut visitor = UsedColumnsVisitor { columns };
         visitor.visit(self).unwrap();
-        visitor.columns
     }
 
     pub fn is_deterministic(&self) -> bool {

--- a/src/query/sql/src/planner/plans/scan.rs
+++ b/src/query/sql/src/planner/plans/scan.rs
@@ -78,11 +78,11 @@ pub struct AggIndexInfo {
 impl AggIndexInfo {
     pub fn used_columns(&self) -> ColumnSet {
         let mut used_columns = ColumnSet::new();
-        for item in self.selection.iter() {
-            used_columns.extend(item.scalar.used_columns());
+        for item in &self.selection {
+            item.scalar.collect_used_columns(&mut used_columns);
         }
-        for pred in self.predicates.iter() {
-            used_columns.extend(pred.used_columns());
+        for pred in &self.predicates {
+            pred.collect_used_columns(&mut used_columns);
         }
         used_columns
     }
@@ -223,13 +223,13 @@ impl Scan {
     pub(crate) fn used_columns(&self) -> ColumnSet {
         let mut used_columns = ColumnSet::new();
         if let Some(preds) = &self.push_down_predicates {
-            for pred in preds.iter() {
-                used_columns.extend(pred.used_columns());
+            for pred in preds {
+                pred.collect_used_columns(&mut used_columns);
             }
         }
         if let Some(preds) = &self.secure_predicates {
-            for pred in preds.iter() {
-                used_columns.extend(pred.used_columns());
+            for pred in preds {
+                pred.collect_used_columns(&mut used_columns);
             }
         }
         if let Some(prewhere) = &self.prewhere {

--- a/src/query/sql/src/planner/plans/sort.rs
+++ b/src/query/sql/src/planner/plans/sort.rs
@@ -49,20 +49,6 @@ impl Sort {
         self.items.iter().map(|item| item.index).collect()
     }
 
-    pub fn sort_items_exclude_partition(&self) -> Vec<SortItem> {
-        self.items
-            .iter()
-            .filter(|item| match &self.window_partition {
-                Some(window) => !window
-                    .partition_by
-                    .iter()
-                    .any(|partition| partition.index == item.index),
-                None => true,
-            })
-            .cloned()
-            .collect()
-    }
-
     pub fn replace_column(&mut self, old: Symbol, new: Symbol) {
         for item in &mut self.items {
             if item.index == old {

--- a/src/query/sql/src/planner/plans/udaf.rs
+++ b/src/query/sql/src/planner/plans/udaf.rs
@@ -36,9 +36,9 @@ pub struct Udaf {
 impl Udaf {
     pub fn used_columns(&self) -> Result<ColumnSet> {
         let mut used_columns = ColumnSet::new();
-        for item in self.items.iter() {
+        for item in &self.items {
             used_columns.insert(item.index);
-            used_columns.extend(item.scalar.used_columns());
+            item.scalar.collect_used_columns(&mut used_columns);
         }
         Ok(used_columns)
     }
@@ -60,19 +60,14 @@ impl Operator for Udaf {
 
         // Derive outer columns
         let mut outer_columns = input_prop.outer_columns.clone();
-        for item in self.items.iter() {
-            let used_columns = item.scalar.used_columns();
-            let outer = used_columns
-                .difference(&output_columns)
-                .cloned()
-                .collect::<ColumnSet>();
-            outer_columns = outer_columns.union(&outer).cloned().collect();
+        for item in &self.items {
+            item.scalar.collect_used_columns(&mut outer_columns);
         }
-        outer_columns = outer_columns.difference(&output_columns).cloned().collect();
+        outer_columns.retain(|column| !output_columns.contains(column));
 
         // Derive used columns
         let mut used_columns = self.used_columns()?;
-        used_columns.extend(input_prop.used_columns.clone());
+        used_columns.extend(input_prop.used_columns.iter().copied());
 
         // Derive orderings
         let orderings = input_prop.orderings.clone();

--- a/src/query/sql/src/planner/plans/udf.rs
+++ b/src/query/sql/src/planner/plans/udf.rs
@@ -37,9 +37,9 @@ pub struct Udf {
 impl Udf {
     pub fn used_columns(&self) -> Result<ColumnSet> {
         let mut used_columns = ColumnSet::new();
-        for item in self.items.iter() {
+        for item in &self.items {
             used_columns.insert(item.index);
-            used_columns.extend(item.scalar.used_columns());
+            item.scalar.collect_used_columns(&mut used_columns);
         }
         Ok(used_columns)
     }
@@ -65,19 +65,14 @@ impl Operator for Udf {
 
         // Derive outer columns
         let mut outer_columns = input_prop.outer_columns.clone();
-        for item in self.items.iter() {
-            let used_columns = item.scalar.used_columns();
-            let outer = used_columns
-                .difference(&output_columns)
-                .cloned()
-                .collect::<ColumnSet>();
-            outer_columns = outer_columns.union(&outer).cloned().collect();
+        for item in &self.items {
+            item.scalar.collect_used_columns(&mut outer_columns);
         }
-        outer_columns = outer_columns.difference(&output_columns).cloned().collect();
+        outer_columns.retain(|column| !output_columns.contains(column));
 
         // Derive used columns
         let mut used_columns = self.used_columns()?;
-        used_columns.extend(input_prop.used_columns.clone());
+        used_columns.extend(input_prop.used_columns.iter().copied());
 
         // Derive orderings
         let orderings = input_prop.orderings.clone();

--- a/src/query/sql/src/planner/plans/window.rs
+++ b/src/query/sql/src/planner/plans/window.rs
@@ -81,11 +81,11 @@ impl WindowGroup {
 
         for item in &self.scalar_items {
             used_columns.insert(item.index);
-            used_columns.extend(item.scalar.used_columns());
+            item.scalar.collect_used_columns(&mut used_columns);
         }
 
         for window in &self.windows {
-            used_columns.extend(window.used_columns()?);
+            window.collect_used_columns(&mut used_columns)?;
         }
 
         Ok(used_columns)
@@ -127,21 +127,34 @@ impl WindowGroup {
 impl Window {
     pub fn used_columns(&self) -> Result<ColumnSet> {
         let mut used_columns = ColumnSet::new();
-
-        used_columns.insert(self.index);
-        used_columns.extend(self.function.used_columns());
-        used_columns.extend(self.arguments_columns()?);
-        used_columns.extend(self.partition_by_columns()?);
-        used_columns.extend(self.order_by_columns()?);
-
+        self.collect_used_columns(&mut used_columns)?;
         Ok(used_columns)
+    }
+
+    pub fn collect_used_columns(&self, used_columns: &mut ColumnSet) -> Result<()> {
+        used_columns.insert(self.index);
+        self.function.collect_used_columns(used_columns);
+        for arg in &self.arguments {
+            used_columns.insert(arg.index);
+            arg.scalar.collect_used_columns(used_columns);
+        }
+        for part in &self.partition_by {
+            used_columns.insert(part.index);
+            part.scalar.collect_used_columns(used_columns);
+        }
+        for sort in &self.order_by {
+            used_columns.insert(sort.order_by_item.index);
+            sort.order_by_item.scalar.collect_used_columns(used_columns);
+        }
+
+        Ok(())
     }
 
     pub fn arguments_columns(&self) -> Result<ColumnSet> {
         let mut col_set = ColumnSet::new();
         for arg in self.arguments.iter() {
             col_set.insert(arg.index);
-            col_set.extend(arg.scalar.used_columns())
+            arg.scalar.collect_used_columns(&mut col_set);
         }
         Ok(col_set)
     }
@@ -152,7 +165,7 @@ impl Window {
         let mut col_set = ColumnSet::new();
         for part in self.partition_by.iter() {
             col_set.insert(part.index);
-            col_set.extend(part.scalar.used_columns())
+            part.scalar.collect_used_columns(&mut col_set);
         }
         Ok(col_set)
     }
@@ -161,7 +174,7 @@ impl Window {
         let mut col_set = ColumnSet::new();
         for sort in self.order_by.iter() {
             col_set.insert(sort.order_by_item.index);
-            col_set.extend(sort.order_by_item.scalar.used_columns())
+            sort.order_by_item.scalar.collect_used_columns(&mut col_set);
         }
         Ok(col_set)
     }
@@ -408,21 +421,26 @@ impl WindowFuncType {
     }
 
     pub fn used_columns(&self) -> ColumnSet {
+        let mut used_columns = ColumnSet::new();
+        self.collect_used_columns(&mut used_columns);
+        used_columns
+    }
+
+    pub fn collect_used_columns(&self, used_columns: &mut ColumnSet) {
         match self {
             WindowFuncType::Aggregate(agg) => {
-                agg.exprs().flat_map(|expr| expr.used_columns()).collect()
+                for expr in agg.exprs() {
+                    expr.collect_used_columns(used_columns);
+                }
             }
-            WindowFuncType::LagLead(func) => match &func.default {
-                None => func.arg.used_columns(),
-                Some(d) => func
-                    .arg
-                    .used_columns()
-                    .union(&d.used_columns())
-                    .cloned()
-                    .collect(),
-            },
-            WindowFuncType::NthValue(func) => func.arg.used_columns(),
-            _ => ColumnSet::new(),
+            WindowFuncType::LagLead(func) => {
+                func.arg.collect_used_columns(used_columns);
+                if let Some(default) = &func.default {
+                    default.collect_used_columns(used_columns);
+                }
+            }
+            WindowFuncType::NthValue(func) => func.arg.collect_used_columns(used_columns),
+            _ => {}
         }
     }
 

--- a/src/query/sql/src/planner/semantic/type_check.rs
+++ b/src/query/sql/src/planner/semantic/type_check.rs
@@ -47,10 +47,10 @@ use tokio::runtime::Handle;
 use super::name_resolution::NameResolutionContext;
 use crate::BindContext;
 use crate::MetadataRef;
+use crate::binder::AliasLookup;
 use crate::optimizer::ir::SExpr;
 use crate::planner::expression::UdfValidationConfig;
 use crate::plans::DictGetFunctionArgument;
-use crate::plans::ScalarExpr;
 
 const DEFAULT_DECIMAL_PRECISION: i64 = 38;
 const DEFAULT_DECIMAL_SCALE: i64 = 0;
@@ -429,8 +429,8 @@ pub struct TypeChecker<'a, A> {
     name_resolution_ctx: &'a NameResolutionContext,
     metadata: MetadataRef,
 
-    aliases: &'a [(String, ScalarExpr)],
-    fallback_aliases: Option<&'a [(String, ScalarExpr)]>,
+    aliases: AliasLookup<'a>,
+    fallback_aliases: Option<AliasLookup<'a>>,
 
     // true if current expr is inside an aggregate function.
     // This is used to check if there is nested aggregate function.

--- a/src/query/sql/src/planner/semantic/type_check/adapter.rs
+++ b/src/query/sql/src/planner/semantic/type_check/adapter.rs
@@ -62,6 +62,7 @@ use crate::BindContext;
 use crate::DefaultExprBinder;
 use crate::MetadataRef;
 use crate::NameResolutionContext;
+use crate::binder::AliasLookup;
 use crate::binder::StagePathAccess;
 use crate::binder::StageResolver;
 use crate::plans::DictGetFunctionArgument;
@@ -463,8 +464,8 @@ impl<'a> TypeChecker<'a, FullTypeCheckAdapter> {
         ctx: Arc<dyn TableContext>,
         name_resolution_ctx: &'a NameResolutionContext,
         metadata: MetadataRef,
-        aliases: &'a [(String, ScalarExpr)],
-        fallback_aliases: Option<&'a [(String, ScalarExpr)]>,
+        aliases: AliasLookup<'a>,
+        fallback_aliases: Option<AliasLookup<'a>>,
         forbid_udf: bool,
     ) -> Result<Self> {
         Self::try_create_with_adapter_and_alias_fallback(

--- a/src/query/sql/src/planner/semantic/type_check/resolve.rs
+++ b/src/query/sql/src/planner/semantic/type_check/resolve.rs
@@ -35,6 +35,7 @@ use super::rewrite_function;
 use crate::BindContext;
 use crate::MetadataRef;
 use crate::NameResolutionContext;
+use crate::binder::AliasLookup;
 use crate::plans::ConstantExpr;
 use crate::plans::ScalarExpr;
 
@@ -53,7 +54,7 @@ where A: TypeCheckAdapter
             adapter,
             name_resolution_ctx,
             metadata,
-            aliases,
+            AliasLookup::all(aliases),
             None,
         )
     }
@@ -63,8 +64,8 @@ where A: TypeCheckAdapter
         adapter: A,
         name_resolution_ctx: &'a NameResolutionContext,
         metadata: MetadataRef,
-        aliases: &'a [(String, ScalarExpr)],
-        fallback_aliases: Option<&'a [(String, ScalarExpr)]>,
+        aliases: AliasLookup<'a>,
+        fallback_aliases: Option<AliasLookup<'a>>,
     ) -> Result<Self> {
         let func_ctx = adapter.function_context()?;
         let dialect = adapter.settings().get_sql_dialect()?;

--- a/src/query/sql/test-support/src/optimizer/mod.rs
+++ b/src/query/sql/test-support/src/optimizer/mod.rs
@@ -507,7 +507,7 @@ impl StatsApplier<'_> {
     ) -> HashMap<Symbol, Option<BasicColumnStatistics>> {
         let mut result = HashMap::new();
 
-        for column in metadata.columns_by_table_index(table_index).iter() {
+        for column in metadata.columns_by_table_index(table_index) {
             if let ColumnEntry::BaseTableColumn(BaseTableColumn {
                 column_index,
                 column_name,
@@ -543,7 +543,7 @@ impl StatsApplier<'_> {
     ) -> Result<HashMap<Symbol, Option<Histogram>>> {
         let mut result = HashMap::new();
 
-        for column in metadata.columns_by_table_index(table_index).iter() {
+        for column in metadata.columns_by_table_index(table_index) {
             if let ColumnEntry::BaseTableColumn(BaseTableColumn {
                 column_index,
                 column_name,

--- a/src/query/sql/tests/it/semantic/type_check/variant.rs
+++ b/src/query/sql/tests/it/semantic/type_check/variant.rs
@@ -182,14 +182,14 @@ fn virtual_column_bind_context(metadata: Arc<RwLock<Metadata>>) -> Result<BindCo
         bind_context.add_column_binding(
             ColumnBindingBuilder::new(
                 column_name.clone(),
-                column_index,
-                Box::new(DataType::from(&data_type)),
+                *column_index,
+                Box::new(DataType::from(data_type)),
                 Visibility::Visible,
             )
             .table_name(Some("t2".to_string()))
             .database_name(Some("default".to_string()))
             .table_index(Some(table_index))
-            .column_position(column_position)
+            .column_position(*column_position)
             .build(),
         );
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Refactor expression handling in the Binder, Planner, metadata, and optimizer rules to avoid eager collection and deep cloning where borrowed or consuming traversal is sufficient.

The changes include:

- add borrowed expression search and short-circuit predicate visitors
- provide borrowed and consuming conjunction iterators
- iterate aggregate and project-set expressions without cloning until plan construction
- simplify invalid-expression tracking to boolean state
- resolve aliases through catalog indexes and borrowed views
- reuse cached predicate column sets and collect used columns directly
- expose borrowed metadata column iteration and keep statistics snapshots consistent
- inspect optimizer plans by reference before cloning replacement inputs

This is a behavior-preserving refactor focused on expression-processing allocation and code clarity.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validated with:

- `cargo check -p databend-common-sql --lib`
- `cargo check -p databend-query`
- `cargo clippy -p databend-common-sql --lib -- -D warnings`
- SQL crate unit tests and targeted Binder, optimizer, statistics, mutation, and alias-resolution tests

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: Assisted with identifying eager expression cloning and collection patterns, implementing the Binder and Planner refactors, and running targeted validation.
- Responsible human: @KKould
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20253)
<!-- Reviewable:end -->
