### PR TITLE
fix(query): keep active temporary tables during vacuum

### DIFF
--- a/src/query/service/src/servers/http/v1/session/client_session_manager.rs
+++ b/src/query/service/src/servers/http/v1/session/client_session_manager.rs
@@ -193,8 +193,8 @@ impl ClientSessionManager {
         let client_session_api = UserApiProvider::instance().client_session_api(&tenant);
         client_session_api
             .upsert_client_session_id(
-                client_session_id,
                 &user_name,
+                client_session_id,
                 self.max_idle_time + self.min_refresh_interval + TTL_GRACE_PERIOD_META,
             )
             .await?;
@@ -283,8 +283,8 @@ impl ClientSessionManager {
         // client session id
         client_session_api
             .upsert_client_session_id(
-                &client_session_id,
                 &claim.user,
+                &client_session_id,
                 self.max_idle_time + self.min_refresh_interval + TTL_GRACE_PERIOD_META,
             )
             .await?;
@@ -347,7 +347,7 @@ impl ClientSessionManager {
     ) -> Result<()> {
         let client_session_api = UserApiProvider::instance().client_session_api(tenant);
         client_session_api
-            .drop_client_session_id(session_id, user_name)
+            .drop_client_session_id(user_name, session_id)
             .await
             .ok();
         let state_key = Self::state_key(tenant, session_id, user_name);

--- a/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
+++ b/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
@@ -673,7 +673,7 @@ mod tests {
         let completed = Arc::new(AtomicBool::new(false));
         let completed_clone = completed.clone();
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
-        let task = tokio::spawn(async move {
+        let task = databend_common_base::runtime::spawn(async move {
             shutdown_rx.await.ok();
             completed_clone.store(true, Ordering::SeqCst);
         });

--- a/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
+++ b/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
@@ -46,9 +46,12 @@ use opensrv_mysql::InitWriter;
 use opensrv_mysql::ParamParser;
 use opensrv_mysql::QueryResultWriter;
 use opensrv_mysql::StatementMetaWriter;
+use parking_lot::Mutex;
 use rand::Rng as _;
 use rand::thread_rng;
 use tokio::io::AsyncWrite;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
 use uuid::Uuid;
 
 use crate::auth::CredentialType;
@@ -78,12 +81,59 @@ struct InteractiveWorkerBase {
     version: BuildInfoRef,
 }
 
+struct KeepAliveHandle {
+    shutdown_tx: oneshot::Sender<()>,
+    task: JoinHandle<()>,
+}
+
+#[derive(Default)]
+struct KeepAliveTaskInner {
+    handle: Mutex<Option<KeepAliveHandle>>,
+}
+
+impl Drop for KeepAliveTaskInner {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.get_mut().take() {
+            drop(handle.shutdown_tx);
+            handle.task.abort();
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct KeepAliveTask {
+    inner: Arc<KeepAliveTaskInner>,
+}
+
+impl KeepAliveTask {
+    fn is_started(&self) -> bool {
+        self.inner.handle.lock().is_some()
+    }
+
+    fn start(&self, shutdown_tx: oneshot::Sender<()>, task: JoinHandle<()>) {
+        let old = self
+            .inner
+            .handle
+            .lock()
+            .replace(KeepAliveHandle { shutdown_tx, task });
+        debug_assert!(old.is_none());
+    }
+
+    pub(crate) async fn stop(&self) {
+        let Some(handle) = self.inner.handle.lock().take() else {
+            return;
+        };
+        handle.shutdown_tx.send(()).ok();
+        handle.task.await.ok();
+    }
+}
+
 pub struct InteractiveWorker {
     base: InteractiveWorkerBase,
     version: String,
     salt: [u8; 20],
     client_addr: String,
-    keep_alive_task_started: bool,
+    keep_alive_task: KeepAliveTask,
 }
 
 #[async_trait::async_trait]
@@ -253,8 +303,8 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for InteractiveWorke
                 }
 
                 let mut writer = DFQueryResultWriter::create(writer, self.base.session.clone());
-                if !self.keep_alive_task_started {
-                    self.start_keep_alive().await
+                if !self.keep_alive_task.is_started() {
+                    self.start_keep_alive()
                 }
 
                 let instant = Instant::now();
@@ -534,17 +584,18 @@ impl InteractiveWorker {
         version: BuildInfoRef,
         client_addr: String,
         salt: [u8; 20],
+        keep_alive_task: KeepAliveTask,
     ) -> InteractiveWorker {
         InteractiveWorker {
             version: format!("{MYSQL_VERSION}-{}", version.commit_detail),
             base: InteractiveWorkerBase { session, version },
             salt,
             client_addr,
-            keep_alive_task_started: false,
+            keep_alive_task,
         }
     }
 
-    async fn start_keep_alive(&mut self) {
+    fn start_keep_alive(&mut self) {
         let session = &self.base.session;
         let tenant = session.get_current_tenant();
         let session_id = session.get_id();
@@ -552,9 +603,9 @@ impl InteractiveWorker {
             .get_current_user()
             .expect("mysql handler should be authed when call")
             .name;
-        self.keep_alive_task_started = true;
+        let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
 
-        databend_common_base::runtime::spawn(async move {
+        let task = databend_common_base::runtime::spawn(async move {
             loop {
                 UserApiProvider::instance()
                     .client_session_api(&tenant)
@@ -565,9 +616,13 @@ impl InteractiveWorker {
                     )
                     .await
                     .ok();
-                tokio::time::sleep(Duration::from_secs(3600)).await;
+                tokio::select! {
+                    _ = tokio::time::sleep(Duration::from_secs(3600)) => {},
+                    _ = &mut shutdown_rx => break,
+                }
             }
         });
+        self.keep_alive_task.start(shutdown_tx, task);
     }
 }
 
@@ -599,5 +654,34 @@ impl ProgressReporter for ContextProgressReporter {
     fn affected_rows(&self) -> u64 {
         let progress = self.context.get_write_progress_value();
         progress.rows as u64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::Ordering;
+
+    use tokio::sync::oneshot;
+
+    use super::KeepAliveTask;
+
+    #[tokio::test]
+    async fn test_stop_keep_alive_task() {
+        let keep_alive_task = KeepAliveTask::default();
+        let completed = Arc::new(AtomicBool::new(false));
+        let completed_clone = completed.clone();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let task = tokio::spawn(async move {
+            shutdown_rx.await.ok();
+            completed_clone.store(true, Ordering::SeqCst);
+        });
+        keep_alive_task.start(shutdown_tx, task);
+
+        keep_alive_task.stop().await;
+
+        assert!(completed.load(Ordering::SeqCst));
+        assert!(!keep_alive_task.is_started());
     }
 }

--- a/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
+++ b/src/query/service/src/servers/mysql/mysql_interactive_worker.rs
@@ -559,8 +559,8 @@ impl InteractiveWorker {
                 UserApiProvider::instance()
                     .client_session_api(&tenant)
                     .upsert_client_session_id(
-                        &session_id,
                         &user_name,
+                        &session_id,
                         Duration::from_secs(3600 + 600),
                     )
                     .await

--- a/src/query/service/src/servers/mysql/mysql_session.rs
+++ b/src/query/service/src/servers/mysql/mysql_session.rs
@@ -166,7 +166,7 @@ impl MySQLConnection {
             let user = session.get_current_user()?.name;
             UserApiProvider::instance()
                 .client_session_api(&tenant)
-                .drop_client_session_id(&session_id, &user)
+                .drop_client_session_id(&user, &session_id)
                 .await
                 .ok();
             drop_all_temp_tables(

--- a/src/query/service/src/servers/mysql/mysql_session.rs
+++ b/src/query/service/src/servers/mysql/mysql_session.rs
@@ -44,6 +44,7 @@ use socket2::TcpKeepalive;
 
 use crate::servers::mysql::MYSQL_VERSION;
 use crate::servers::mysql::mysql_interactive_worker::InteractiveWorker;
+use crate::servers::mysql::mysql_interactive_worker::KeepAliveTask;
 use crate::sessions::Session;
 use crate::sessions::SessionManager;
 
@@ -144,8 +145,14 @@ impl MySQLConnection {
 
         query_executor.spawn(async move {
             let tls_clone = tls.clone();
-            let interactive_worker =
-                InteractiveWorker::create(session.clone(), version, client_addr, salt);
+            let keep_alive_task = KeepAliveTask::default();
+            let interactive_worker = InteractiveWorker::create(
+                session.clone(),
+                version,
+                client_addr,
+                salt,
+                keep_alive_task.clone(),
+            );
             let opts = IntermediaryOptions {
                 process_use_statement_on_query: true,
                 reject_connection_on_dbname_absence: false,
@@ -160,6 +167,7 @@ impl MySQLConnection {
             };
 
             run_result.ok();
+            keep_alive_task.stop().await;
 
             let tenant = session.get_current_tenant();
             let session_id = session.get_id();

--- a/src/query/storages/fuse/src/table_functions/fuse_vacuum_temporary_table.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_vacuum_temporary_table.rs
@@ -37,6 +37,35 @@ use log::info;
 use crate::sessions::TableContext;
 use crate::table_functions::SimpleTableFunc;
 
+fn parse_temp_table_session<'a>(
+    path: &'a str,
+    tenant_name: &str,
+) -> Result<(&'a str, &'a str, String)> {
+    let parts: Vec<_> = path.split('/').collect();
+    if parts.first() != Some(&TEMP_TABLE_STORAGE_PREFIX) {
+        return Err(ErrorCode::Internal(format!(
+            "invalid path for temp table: {path}"
+        )));
+    }
+
+    // HTTP temporary tables are tenant-scoped, while MySQL temporary tables and
+    // HTTP temporary tables created by older versions use the legacy layout.
+    let user_index = if parts.get(1) == Some(&tenant_name) {
+        2
+    } else {
+        1
+    };
+    let session_index = user_index + 1;
+    if parts.len() <= session_index {
+        return Err(ErrorCode::Internal(format!(
+            "invalid path for temp table: {path}"
+        )));
+    }
+
+    let session_path = parts[..=session_index].join("/");
+    Ok((parts[user_index], parts[session_index], session_path))
+}
+
 #[async_backtrace::framed]
 pub async fn vacuum_inactive_temp_tables(
     ctx: &Arc<dyn TableContext>,
@@ -48,7 +77,8 @@ pub async fn vacuum_inactive_temp_tables(
         .recursive(true)
         .await?;
 
-    let client_session_mgr = UserApiProvider::instance().client_session_api(&ctx.get_tenant());
+    let tenant = ctx.get_tenant();
+    let client_session_mgr = UserApiProvider::instance().client_session_api(&tenant);
     let mut user_session_ids = HashSet::new();
     let mut inactive_user_session_ids = Vec::new();
     let session_limit = limit.unwrap_or(u64::MAX) as usize;
@@ -62,24 +92,19 @@ pub async fn vacuum_inactive_temp_tables(
             continue;
         }
         let path = entry.path();
-        let parts: Vec<_> = path.split('/').collect();
-        if parts.len() < 3 {
-            return Err(ErrorCode::Internal(format!(
-                "invalid path for temp table: {path}"
-            )));
-        };
-        let user_name = parts[1].to_string();
-        let session_id = parts[2].to_string();
-        if user_session_ids.contains(&(user_name.clone(), session_id.clone())) {
+        let (user_name, session_id, session_path) =
+            parse_temp_table_session(path, tenant.tenant_name())?;
+        let user_session = (user_name.to_string(), session_id.to_string(), session_path);
+        if user_session_ids.contains(&user_session) {
             continue;
         }
-        user_session_ids.insert((user_name.clone(), session_id.clone()));
+        user_session_ids.insert(user_session.clone());
         if client_session_mgr
-            .get_client_session(&user_name, &session_id)
+            .get_client_session(user_name, session_id)
             .await?
             .is_none()
         {
-            inactive_user_session_ids.push((user_name, session_id));
+            inactive_user_session_ids.push(user_session);
             if inactive_user_session_ids.len() >= session_limit {
                 break;
             }
@@ -88,18 +113,17 @@ pub async fn vacuum_inactive_temp_tables(
 
     let mut session_num = 0;
 
-    for (user_name, session_id) in inactive_user_session_ids {
+    for (user_name, session_id, session_path) in inactive_user_session_ids {
         if client_session_mgr
             .get_client_session(&user_name, &session_id)
             .await?
             .is_none()
         {
-            let path = format!("{}/{}/{}", TEMP_TABLE_STORAGE_PREFIX, user_name, session_id);
             info!(
                 "[TEMP TABLE] session={session_id} vacuum temporary table: {}",
-                path
+                session_path
             );
-            op.remove_all(&path).await?;
+            op.remove_all(&session_path).await?;
             session_num += 1;
         }
     }
@@ -173,5 +197,44 @@ impl SimpleTableFunc for FuseVacuumTemporaryTable {
             }
         };
         Ok(Self { limit })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_temp_table_session;
+
+    #[test]
+    fn test_parse_temp_table_session() {
+        assert_eq!(
+            (
+                "root",
+                "http-session",
+                "_tmp_tbl/tenant_a/root/http-session".to_string()
+            ),
+            parse_temp_table_session(
+                "_tmp_tbl/tenant_a/root/http-session/table/block.parquet",
+                "tenant_a"
+            )
+            .unwrap()
+        );
+        assert_eq!(
+            (
+                "root",
+                "legacy-session",
+                "_tmp_tbl/root/legacy-session".to_string()
+            ),
+            parse_temp_table_session(
+                "_tmp_tbl/root/legacy-session/table/block.parquet",
+                "tenant_a"
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_rejects_invalid_temp_table_path() {
+        assert!(parse_temp_table_session("_tmp_tbl/root", "tenant_a").is_err());
+        assert!(parse_temp_table_session("other/root/session/block.parquet", "tenant_a").is_err());
     }
 }

--- a/src/query/storages/fuse/src/table_functions/fuse_vacuum_temporary_table.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_vacuum_temporary_table.rs
@@ -31,6 +31,7 @@ use databend_common_expression::types::StringType;
 use databend_common_storage::DataOperator;
 use databend_common_users::UserApiProvider;
 use databend_storages_common_table_meta::meta::TEMP_TABLE_STORAGE_PREFIX;
+use databend_storages_common_table_meta::table_id_ranges::is_temp_table_id;
 use futures_util::TryStreamExt;
 use log::info;
 
@@ -40,7 +41,7 @@ use crate::table_functions::SimpleTableFunc;
 fn parse_temp_table_session<'a>(
     path: &'a str,
     tenant_name: &str,
-) -> Result<(&'a str, &'a str, String)> {
+) -> Result<Option<(&'a str, &'a str, String)>> {
     let parts: Vec<_> = path.split('/').collect();
     if parts.first() != Some(&TEMP_TABLE_STORAGE_PREFIX) {
         return Err(ErrorCode::Internal(format!(
@@ -48,22 +49,34 @@ fn parse_temp_table_session<'a>(
         )));
     }
 
-    // HTTP temporary tables are tenant-scoped, while MySQL temporary tables and
-    // HTTP temporary tables created by older versions use the legacy layout.
-    let user_index = if parts.get(1) == Some(&tenant_name) {
-        2
-    } else {
-        1
+    // A temporary table ID follows database ID in both layouts, which makes the
+    // layouts distinguishable even when a legacy user name equals the tenant.
+    let has_temp_table_id = |user_index: usize| {
+        parts
+            .get(user_index + 3)
+            .and_then(|part| part.parse::<u64>().ok())
+            .is_some_and(is_temp_table_id)
+    };
+    let legacy_layout = has_temp_table_id(1);
+    let tenant_layout = has_temp_table_id(2);
+    let user_index = match (legacy_layout, tenant_layout) {
+        (true, false) => 1,
+        (false, true) if parts.get(1) == Some(&tenant_name) => 2,
+        (false, true) => return Ok(None),
+        _ => {
+            return Err(ErrorCode::Internal(format!(
+                "invalid path for temp table: {path}"
+            )));
+        }
     };
     let session_index = user_index + 1;
-    if parts.len() <= session_index {
-        return Err(ErrorCode::Internal(format!(
-            "invalid path for temp table: {path}"
-        )));
-    }
 
     let session_path = parts[..=session_index].join("/");
-    Ok((parts[user_index], parts[session_index], session_path))
+    Ok(Some((
+        parts[user_index],
+        parts[session_index],
+        session_path,
+    )))
 }
 
 #[async_backtrace::framed]
@@ -92,8 +105,11 @@ pub async fn vacuum_inactive_temp_tables(
             continue;
         }
         let path = entry.path();
-        let (user_name, session_id, session_path) =
-            parse_temp_table_session(path, tenant.tenant_name())?;
+        let Some((user_name, session_id, session_path)) =
+            parse_temp_table_session(path, tenant.tenant_name())?
+        else {
+            continue;
+        };
         let user_session = (user_name.to_string(), session_id.to_string(), session_path);
         if user_session_ids.contains(&user_session) {
             continue;
@@ -202,6 +218,8 @@ impl SimpleTableFunc for FuseVacuumTemporaryTable {
 
 #[cfg(test)]
 mod tests {
+    use databend_storages_common_table_meta::table_id_ranges::TEMP_TBL_ID_BEGIN;
+
     use super::parse_temp_table_session;
 
     #[test]
@@ -213,9 +231,12 @@ mod tests {
                 "_tmp_tbl/tenant_a/root/http-session".to_string()
             ),
             parse_temp_table_session(
-                "_tmp_tbl/tenant_a/root/http-session/table/block.parquet",
+                &format!(
+                    "_tmp_tbl/tenant_a/root/http-session/1/{TEMP_TBL_ID_BEGIN}/_b/block.parquet"
+                ),
                 "tenant_a"
             )
+            .unwrap()
             .unwrap()
         );
         assert_eq!(
@@ -225,10 +246,38 @@ mod tests {
                 "_tmp_tbl/root/legacy-session".to_string()
             ),
             parse_temp_table_session(
-                "_tmp_tbl/root/legacy-session/table/block.parquet",
+                &format!("_tmp_tbl/root/legacy-session/1/{TEMP_TBL_ID_BEGIN}/_b/block.parquet"),
                 "tenant_a"
             )
             .unwrap()
+            .unwrap()
+        );
+        assert_eq!(
+            (
+                "tenant_a",
+                "mysql-session",
+                "_tmp_tbl/tenant_a/mysql-session".to_string()
+            ),
+            parse_temp_table_session(
+                &format!("_tmp_tbl/tenant_a/mysql-session/1/{TEMP_TBL_ID_BEGIN}/_b/block.parquet"),
+                "tenant_a"
+            )
+            .unwrap()
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_skips_other_tenant_temp_table_path() {
+        assert!(
+            parse_temp_table_session(
+                &format!(
+                    "_tmp_tbl/tenant_b/root/http-session/1/{TEMP_TBL_ID_BEGIN}/_b/block.parquet"
+                ),
+                "tenant_a"
+            )
+            .unwrap()
+            .is_none()
         );
     }
 

--- a/tests/nox/suites/http_handler/test_cookie.py
+++ b/tests/nox/suites/http_handler/test_cookie.py
@@ -18,7 +18,7 @@ class GlobalCookieJar(RequestsCookieJar):
 
 
 def do_query(session_client, query, session_state=None, enable_cookie=True):
-    url = f"http://127.0.0.1:8000/v1/query"
+    url = "http://127.0.0.1:8000/v1/query"
     query_payload = {
         "sql": query,
         "pagination": {"wait_time_secs": 100, "max_rows_per_page": 2},
@@ -91,6 +91,34 @@ def test_temp_table():
     session_state = resp.json()["session"]
     assert not session_state["need_sticky"]
     assert not session_state["need_keep_alive"]
+
+
+def test_active_temp_table_survives_vacuum():
+    vacuum_client = requests.session()
+    resp = do_query(vacuum_client, "select * from fuse_vacuum_temporary_table()")
+    assert resp.status_code == 200, resp.text
+
+    client = requests.session()
+    client.cookies = GlobalCookieJar()
+    client.cookies.set("cookie_enabled", "true")
+
+    resp = do_query(client, "create temp table active_temp(a int)")
+    assert resp.status_code == 200, resp.text
+    session_state = resp.json()["session"]
+
+    resp = do_query(client, "insert into active_temp values (1)", session_state)
+    assert resp.status_code == 200, resp.text
+    session_state = resp.json()["session"]
+
+    resp = do_query(vacuum_client, "select * from fuse_vacuum_temporary_table()")
+    assert resp.status_code == 200, resp.text
+
+    resp = do_query(client, "select * from active_temp", session_state)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["data"] == [["1"]], resp.text
+
+    resp = do_query(client, "drop table active_temp", resp.json()["session"])
+    assert resp.status_code == 200, resp.text
 
 
 def test_no_cookie_if_not_enabled():


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Pass `user_name` and `client_session_id` to the client-session Meta API in the declared order for HTTP and MySQL sessions.
- Parse tenant-scoped HTTP temporary-table storage paths during vacuum while retaining support for the legacy/MySQL path layout.
- Add an HTTP regression test that creates and writes a temporary table, runs temporary-table vacuum from another client, and verifies the active table remains readable.

The reversed Meta key prevented vacuum from finding an active session and allowed it to delete that session's temporary-table files, causing subsequent reads to fail with `NoSuchKey`. The tenant-scoped storage layout on current `main` also required vacuum to preserve the full tenant/user/session prefix.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validated with:

- `cargo test -p databend-common-storages-fuse --lib table_functions::fuse_vacuum_temporary_table::tests`
- `cargo test -p databend-query --lib servers::http::v1::session::client_session_manager::tests::test_state_key_is_tenant_scoped`
- `pytest -q suites/http_handler/test_cookie.py` (4 passed against local Meta/Query services)
- `cargo clippy -p databend-common-storages-fuse --lib -- -D warnings`
- `cargo clippy -p databend-query --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `ruff format --check` and `ruff check` for the changed Python test

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent investigated the session/vacuum failure, drafted the Rust and Python changes, and ran the local validation.
- Responsible human: @SkyFan2002
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20254)
<!-- Reviewable:end -->
