### PR TITLE
fix(query): inherit function properties through aliases

### DIFF
--- a/src/query/expression/src/function.rs
+++ b/src/query/expression/src/function.rs
@@ -338,11 +338,20 @@ impl FunctionRegistry {
 
     pub fn get_property(&self, func_name: &str) -> Option<FunctionProperty> {
         let func_name = func_name.to_lowercase();
-        if self.contains(&func_name) {
-            Some(self.properties.get(&func_name).cloned().unwrap_or_default())
-        } else {
-            None
+        if !self.contains(&func_name) {
+            return None;
         }
+
+        // Properties are stored under canonical function names, and aliases point directly to
+        // their canonical functions.
+        let canonical_name = self.aliases.get(&func_name).unwrap_or(&func_name);
+
+        Some(
+            self.properties
+                .get(canonical_name)
+                .cloned()
+                .unwrap_or_default(),
+        )
     }
 
     pub fn register_function(&mut self, func: Function) {

--- a/src/query/sql/src/planner/semantic/materialized_view_rewriter.rs
+++ b/src/query/sql/src/planner/semantic/materialized_view_rewriter.rs
@@ -757,6 +757,30 @@ mod tests {
     }
 
     #[test]
+    fn test_materialized_view_checker_rejects_non_deterministic_functions() -> Result<()> {
+        // Non-deterministic functions (and their aliases) must not appear in an MV definition,
+        // because refresh would recompute different values than the original query. Aliases such
+        // as current_timestamp/current_date resolve to canonical functions whose properties mark
+        // them non-deterministic, so they must be rejected just like the canonical names.
+        for sql in [
+            "SELECT amount, now() AS t FROM t WHERE amount > 0",
+            "SELECT amount, current_timestamp AS t FROM t WHERE amount > 0",
+            "SELECT amount, current_timestamp() AS t FROM t WHERE amount > 0",
+            "SELECT amount, today() AS d FROM t WHERE amount > 0",
+            "SELECT amount, current_date AS d FROM t WHERE amount > 0",
+            "SELECT amount, current_date() AS d FROM t WHERE amount > 0",
+            "SELECT amount, rand() AS r FROM t WHERE amount > 0",
+            "SELECT amount, uuid() AS u FROM t WHERE amount > 0",
+            "SELECT amount FROM t WHERE created_at > now()",
+            "SELECT amount FROM t WHERE created_at > current_timestamp",
+        ] {
+            let checker = check_query(sql)?;
+            assert!(!checker.is_supported(), "should reject: {sql}");
+        }
+        Ok(())
+    }
+
+    #[test]
     fn test_rewrite_non_aggregate_query() -> Result<()> {
         let (query, rewriter) =
             rewrite("SELECT amount AS value, category FROM t WHERE amount > 0")?;


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Function properties are stored under canonical names. Previously, get_property() recognized an alias as a registered function but looked up metadata by the alias itself, causing aliases such as current_timestamp, current_date, and uuid to fall back to deterministic defaults.
    
After validating the input name, resolve its direct alias before reading canonical metadata. This adds one O(1) map lookup during binding or planning and does not affect row evaluation, ScalarExpr names, existing SQL plans, or EXPLAIN output.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: None
- Responsible human: @TCeason
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20255)
<!-- Reviewable:end -->
