### PR TITLE
fix(query): prevent temporary CTAS staging leaks

### DIFF
--- a/src/query/service/src/interpreters/interpreter_table_create.rs
+++ b/src/query/service/src/interpreters/interpreter_table_create.rs
@@ -55,6 +55,8 @@ use databend_common_users::UserApiProvider;
 use databend_enterprise_attach_table::get_attach_table_handler;
 use databend_meta_client::types::MatchSeq;
 use databend_storages_common_cache::LoadParams;
+use databend_storages_common_session::TempTblMgrRef;
+use databend_storages_common_session::abort_staged_temp_table;
 use databend_storages_common_table_meta::meta::TableSnapshot;
 use databend_storages_common_table_meta::meta::Versioned;
 use databend_storages_common_table_meta::table::OPT_KEY_COMMENT;
@@ -98,7 +100,6 @@ use crate::servers::http::v1::ClientSessionManager;
 use crate::sessions::QueryContext;
 use crate::sessions::TableContextAuthorization;
 use crate::sessions::TableContextLicense;
-use crate::sessions::TableContextSession;
 use crate::sessions::TableContextSettings;
 use crate::sessions::TableContextTableAccess;
 use crate::sql::plans::Insert;
@@ -116,6 +117,22 @@ impl CreateTableInterpreter {
     pub fn try_create(ctx: Arc<QueryContext>, plan: CreateTablePlan) -> Result<Self> {
         Ok(CreateTableInterpreter { ctx, plan })
     }
+}
+
+async fn cleanup_staged_temp_table(
+    mgr: TempTblMgrRef,
+    table_id: u64,
+    temp_prefix: &str,
+) -> Result<()> {
+    if let Err(e) = abort_staged_temp_table(mgr.clone(), table_id, temp_prefix).await {
+        log::warn!(
+            "Failed to clean up staged temporary table id {}: {:?}",
+            table_id,
+            e
+        );
+    }
+    ClientSessionManager::instance().remove_temp_tbl_mgr(temp_prefix.to_string(), &mgr);
+    Ok(())
 }
 
 #[async_trait::async_trait]
@@ -205,15 +222,26 @@ impl CreateTableInterpreter {
         req.as_dropped = true;
         req.table_meta.drop_on = Some(Utc::now());
         let table_meta = req.table_meta.clone();
-        let reply = catalog.create_table(req.clone()).await?;
+        // The prefix is moved into the pipeline's 'static finish hook, while the request itself can
+        // be consumed by the catalog.
+        let temp_prefix = req.table_meta.options.get(OPT_KEY_TEMP_PREFIX).cloned();
+        let reply = catalog.create_table(req).await?;
         if !reply.new_table && self.plan.create_option != CreateOption::CreateOrReplace {
             return Ok(PipelineBuildResult::create());
         }
-        if let Some(prefix) = req.table_meta.options.get(OPT_KEY_TEMP_PREFIX).cloned() {
-            self.register_temp_table(prefix).await?;
+        let table_id = reply.table_id;
+        if let Some(prefix) = temp_prefix.as_deref()
+            && let Err(e) = self.register_temp_table(prefix).await
+        {
+            cleanup_staged_temp_table(
+                self.ctx.get_current_session().temp_tbl_mgr(),
+                table_id,
+                prefix,
+            )
+            .await?;
+            return Err(e);
         }
 
-        let table_id = reply.table_id;
         let prev_table_id = reply.prev_table_id;
         let orphan_table_name = reply.orphan_table_name.clone();
         let table_id_seq = reply
@@ -221,7 +249,7 @@ impl CreateTableInterpreter {
             .expect("internal error: table_id_seq must have been set. CTAS(replace) of table");
         let db_id = reply.db_id;
 
-        if !req.table_meta.options.contains_key(OPT_KEY_TEMP_PREFIX) {
+        if temp_prefix.is_none() {
             self.process_ownership(&tenant, reply).await?;
         }
 
@@ -253,9 +281,24 @@ impl CreateTableInterpreter {
             table_info: Some(table_info),
         };
 
-        let mut pipeline = InsertInterpreter::try_create(self.ctx.clone(), insert_plan)?
-            .execute2()
-            .await?;
+        let pipeline_result = match InsertInterpreter::try_create(self.ctx.clone(), insert_plan) {
+            Ok(interpreter) => interpreter.execute2().await,
+            Err(e) => Err(e),
+        };
+        let mut pipeline = match pipeline_result {
+            Ok(pipeline) => pipeline,
+            Err(e) => {
+                if let Some(prefix) = &temp_prefix {
+                    cleanup_staged_temp_table(
+                        self.ctx.get_current_session().temp_tbl_mgr(),
+                        table_id,
+                        prefix,
+                    )
+                    .await?;
+                }
+                return Err(e);
+            }
+        };
 
         let db_name = self.plan.database.clone();
         let table_name = self.plan.table.clone();
@@ -276,11 +319,11 @@ impl CreateTableInterpreter {
         //
         // If the un-drop fails, data inserted and the table will be invisible, and available for vacuum.
 
-        let ctx = self.ctx.clone();
+        let temp_cleanup =
+            temp_prefix.map(|prefix| (self.ctx.get_current_session().temp_tbl_mgr(), prefix));
         pipeline
             .main_pipeline
             .lift_on_finished(move |info: &ExecutionInfo| {
-                info!("{:?}", ctx.session_state()?.temp_tbl_mgr);
                 let qualified_table_name = format!("{}.{}", db_name, table_name);
 
                 if info.res.is_ok() {
@@ -307,11 +350,22 @@ impl CreateTableInterpreter {
                         info!("create {} as select failed. {:?}", qualified_table_name, e);
                         e
                     })?;
-                    info!("{:?}", ctx.session_state()?.temp_tbl_mgr);
                 }
 
                 Ok(())
             });
+
+        if let Some((temp_tbl_mgr, temp_prefix)) = temp_cleanup {
+            pipeline
+                .main_pipeline
+                .set_on_finished(always_callback(move |_: &ExecutionInfo| {
+                    GlobalIORuntime::instance().block_on(cleanup_staged_temp_table(
+                        temp_tbl_mgr,
+                        table_id,
+                        &temp_prefix,
+                    ))
+                }));
+        }
 
         Ok(pipeline)
     }
@@ -387,7 +441,7 @@ impl CreateTableInterpreter {
         }
 
         let reply = catalog.create_table(req.clone()).await?;
-        if let Some(prefix) = req.table_meta.options.get(OPT_KEY_TEMP_PREFIX).cloned() {
+        if let Some(prefix) = req.table_meta.options.get(OPT_KEY_TEMP_PREFIX) {
             self.register_temp_table(prefix).await?;
         }
 
@@ -560,11 +614,12 @@ impl CreateTableInterpreter {
             .await
     }
 
-    async fn register_temp_table(&self, prefix: String) -> Result<()> {
+    async fn register_temp_table(&self, prefix: &str) -> Result<()> {
         let session = self.ctx.get_current_session();
         if let Some(id) = session.get_client_session_id() {
             let client_session_manager = ClientSessionManager::instance();
-            client_session_manager.add_temp_tbl_mgr(prefix, session.temp_tbl_mgr().clone());
+            client_session_manager
+                .add_temp_tbl_mgr(prefix.to_string(), session.temp_tbl_mgr().clone());
             client_session_manager
                 .refresh_session_handle(
                     self.ctx.get_tenant(),

--- a/src/query/service/src/interpreters/interpreter_table_create.rs
+++ b/src/query/service/src/interpreters/interpreter_table_create.rs
@@ -319,8 +319,6 @@ impl CreateTableInterpreter {
         //
         // If the un-drop fails, data inserted and the table will be invisible, and available for vacuum.
 
-        let temp_cleanup =
-            temp_prefix.map(|prefix| (self.ctx.get_current_session().temp_tbl_mgr(), prefix));
         pipeline
             .main_pipeline
             .lift_on_finished(move |info: &ExecutionInfo| {
@@ -355,10 +353,18 @@ impl CreateTableInterpreter {
                 Ok(())
             });
 
-        if let Some((temp_tbl_mgr, temp_prefix)) = temp_cleanup {
+        if let Some(temp_prefix) = temp_prefix {
+            let temp_tbl_mgr = self.ctx.get_current_session().temp_tbl_mgr();
             pipeline
                 .main_pipeline
-                .set_on_finished(always_callback(move |_: &ExecutionInfo| {
+                .set_on_finished(always_callback(move |info: &ExecutionInfo| {
+                    // Abort only the staged table created by this CTAS. A successfully committed
+                    // table has already been moved out of staged_tables, but avoid cleanup entirely
+                    // on success so this hook never handles unrelated temporary tables.
+                    if info.res.is_ok() {
+                        return Ok(());
+                    }
+
                     GlobalIORuntime::instance().block_on(cleanup_staged_temp_table(
                         temp_tbl_mgr,
                         table_id,

--- a/src/query/service/tests/it/sessions/mod.rs
+++ b/src/query/service/tests/it/sessions/mod.rs
@@ -16,3 +16,4 @@ mod queue_mgr;
 mod session;
 mod session_context;
 mod session_setting;
+mod temp_table;

--- a/src/query/service/tests/it/sessions/session.rs
+++ b/src/query/service/tests/it/sessions/session.rs
@@ -14,9 +14,11 @@
 
 use databend_common_catalog::session_type::SessionType;
 use databend_common_meta_app::tenant::Tenant;
+use databend_common_version::BUILD_INFO;
 use databend_query::sessions::SessionManager;
 use databend_query::test_kits::ConfigBuilder;
 use databend_query::test_kits::TestFixture;
+use databend_query::test_kits::execute_command;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_session() -> anyhow::Result<()> {
@@ -84,6 +86,30 @@ async fn test_local_session_can_override_tenant() -> anyhow::Result<()> {
     session.set_current_tenant(Tenant::new_literal("tenant2"))?;
     let actual = session.get_current_tenant();
     assert_eq!(actual.tenant_name(), "tenant2");
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_failed_temp_ctas_cleans_staged_table() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup().await?;
+    let session = fixture.new_session_with_type(SessionType::MySQL).await?;
+    let ctx = session.create_query_context(&BUILD_INFO).await?;
+
+    for _ in 0..2 {
+        let err = execute_command(
+            ctx.clone(),
+            "CREATE TEMP TABLE t AS SELECT number / 0 FROM numbers(1)",
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code(), 1006);
+    }
+
+    let temp_tbl_mgr = session.temp_tbl_mgr();
+    let tables = temp_tbl_mgr.lock().list_tables()?;
+    assert!(tables.is_empty());
+    assert!(temp_tbl_mgr.lock().is_empty());
 
     Ok(())
 }

--- a/src/query/service/tests/it/sessions/temp_table.rs
+++ b/src/query/service/tests/it/sessions/temp_table.rs
@@ -1,0 +1,112 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use databend_common_exception::ErrorCode;
+use databend_common_meta_app::schema::CreateOption;
+use databend_common_meta_app::schema::CreateTableReq;
+use databend_common_meta_app::schema::TableMeta;
+use databend_common_meta_app::schema::TableNameIdent;
+use databend_common_meta_app::tenant::Tenant;
+use databend_storages_common_session::TempTblMgr;
+use databend_storages_common_session::abort_staged_temp_table;
+use databend_storages_common_table_meta::table::OPT_KEY_DATABASE_ID;
+use parking_lot::Mutex;
+
+fn create_table_req(
+    table_name: &str,
+    engine: &str,
+    create_option: CreateOption,
+    as_dropped: bool,
+) -> CreateTableReq {
+    let mut table_meta = TableMeta {
+        engine: engine.to_string(),
+        ..Default::default()
+    };
+    table_meta
+        .options
+        .insert(OPT_KEY_DATABASE_ID.to_string(), "1".to_string());
+
+    CreateTableReq {
+        create_option,
+        catalog_name: None,
+        name_ident: TableNameIdent {
+            tenant: Tenant::new_literal("tenant"),
+            db_name: "db".to_string(),
+            table_name: table_name.to_string(),
+        },
+        table_meta,
+        as_dropped,
+        materialized_view: None,
+        table_properties: None,
+        table_partition: None,
+    }
+}
+
+#[tokio::test]
+async fn test_aborted_ctas_does_not_leave_a_temporary_table() {
+    let mut mgr = TempTblMgr::default();
+    let staged = mgr
+        .create_table(
+            create_table_req("t", "MEMORY", CreateOption::Create, true),
+            "session".to_string(),
+        )
+        .unwrap();
+    let mgr = Arc::new(Mutex::new(mgr));
+
+    {
+        let guard = mgr.lock();
+        assert!(!guard.is_temp_table("db", "t"));
+        assert!(guard.list_tables().unwrap().is_empty());
+        assert!(!guard.is_empty());
+    }
+
+    abort_staged_temp_table(mgr.clone(), staged.table_id, "session")
+        .await
+        .unwrap();
+    // Cleanup is idempotent.
+    abort_staged_temp_table(mgr.clone(), staged.table_id, "session")
+        .await
+        .unwrap();
+    assert!(mgr.lock().is_empty());
+}
+
+#[tokio::test]
+async fn test_abort_preserves_staged_table_when_cleanup_fails() {
+    let mut mgr = TempTblMgr::default();
+    let staged = mgr
+        .create_table(
+            create_table_req("t", "FUSE", CreateOption::Create, true),
+            "session".to_string(),
+        )
+        .unwrap();
+    mgr.staged_tables
+        .get_mut(&staged.table_id)
+        .unwrap()
+        .meta
+        .options
+        .remove(OPT_KEY_DATABASE_ID);
+    let mgr = Arc::new(Mutex::new(mgr));
+
+    let err = abort_staged_temp_table(mgr.clone(), staged.table_id, "session")
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), ErrorCode::INTERNAL);
+
+    let guard = mgr.lock();
+    assert!(guard.staged_tables.contains_key(&staged.table_id));
+    assert!(guard.list_tables().unwrap().is_empty());
+    assert!(!guard.is_empty());
+}

--- a/src/query/service/tests/it/sessions/temp_table.rs
+++ b/src/query/service/tests/it/sessions/temp_table.rs
@@ -19,6 +19,7 @@ use databend_common_meta_app::schema::CreateOption;
 use databend_common_meta_app::schema::CreateTableReq;
 use databend_common_meta_app::schema::TableMeta;
 use databend_common_meta_app::schema::TableNameIdent;
+use databend_common_meta_app::schema::UpdateTempTableReq;
 use databend_common_meta_app::tenant::Tenant;
 use databend_storages_common_session::TempTblMgr;
 use databend_storages_common_session::abort_staged_temp_table;
@@ -56,31 +57,58 @@ fn create_table_req(
 }
 
 #[tokio::test]
-async fn test_aborted_ctas_does_not_leave_a_temporary_table() {
+async fn test_abort_only_removes_requested_staged_temporary_table() {
     let mut mgr = TempTblMgr::default();
-    let staged = mgr
+    let visible = mgr
         .create_table(
-            create_table_req("t", "MEMORY", CreateOption::Create, true),
+            create_table_req("visible", "MEMORY", CreateOption::Create, false),
+            "session".to_string(),
+        )
+        .unwrap();
+    let aborted = mgr
+        .create_table(
+            create_table_req("aborted", "MEMORY", CreateOption::Create, true),
+            "session".to_string(),
+        )
+        .unwrap();
+    let preserved = mgr
+        .create_table(
+            create_table_req("preserved", "MEMORY", CreateOption::Create, true),
             "session".to_string(),
         )
         .unwrap();
     let mgr = Arc::new(Mutex::new(mgr));
 
-    {
-        let guard = mgr.lock();
-        assert!(!guard.is_temp_table("db", "t"));
-        assert!(guard.list_tables().unwrap().is_empty());
-        assert!(!guard.is_empty());
-    }
-
-    abort_staged_temp_table(mgr.clone(), staged.table_id, "session")
+    abort_staged_temp_table(mgr.clone(), aborted.table_id, "session")
         .await
         .unwrap();
     // Cleanup is idempotent.
-    abort_staged_temp_table(mgr.clone(), staged.table_id, "session")
+    abort_staged_temp_table(mgr.clone(), aborted.table_id, "session")
         .await
         .unwrap();
-    assert!(mgr.lock().is_empty());
+
+    let guard = mgr.lock();
+    assert!(
+        guard
+            .get_table_meta_by_id(aborted.table_id)
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        guard
+            .get_table_meta_by_id(preserved.table_id)
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        guard
+            .get_table_meta_by_id(visible.table_id)
+            .unwrap()
+            .is_some()
+    );
+    assert!(guard.is_temp_table("db", "visible"));
+    assert_eq!(guard.list_tables().unwrap().len(), 1);
+    assert!(!guard.is_empty());
 }
 
 #[tokio::test]
@@ -92,12 +120,18 @@ async fn test_abort_preserves_staged_table_when_cleanup_fails() {
             "session".to_string(),
         )
         .unwrap();
-    mgr.staged_tables
-        .get_mut(&staged.table_id)
+    let mut table_meta = mgr
+        .get_table_meta_by_id(staged.table_id)
         .unwrap()
-        .meta
-        .options
-        .remove(OPT_KEY_DATABASE_ID);
+        .unwrap()
+        .data;
+    table_meta.options.remove(OPT_KEY_DATABASE_ID);
+    mgr.update_multi_table_meta(vec![UpdateTempTableReq {
+        table_id: staged.table_id,
+        desc: "db.t".to_string(),
+        new_table_meta: table_meta,
+        copied_files: Default::default(),
+    }]);
     let mgr = Arc::new(Mutex::new(mgr));
 
     let err = abort_staged_temp_table(mgr.clone(), staged.table_id, "session")
@@ -106,7 +140,12 @@ async fn test_abort_preserves_staged_table_when_cleanup_fails() {
     assert_eq!(err.code(), ErrorCode::INTERNAL);
 
     let guard = mgr.lock();
-    assert!(guard.staged_tables.contains_key(&staged.table_id));
+    assert!(
+        guard
+            .get_table_meta_by_id(staged.table_id)
+            .unwrap()
+            .is_some()
+    );
     assert!(guard.list_tables().unwrap().is_empty());
     assert!(!guard.is_empty());
 }

--- a/src/query/storages/common/session/src/lib.rs
+++ b/src/query/storages/common/session/src/lib.rs
@@ -21,6 +21,6 @@ pub use transaction::TxnManagerRef;
 pub use transaction::TxnState;
 mod session_state;
 pub use session_state::SessionState;
-#[allow(unused_imports)]
+pub use temp_table::abort_staged_temp_table;
 pub use temp_table::drop_all_temp_tables;
 pub use temp_table::drop_table_by_id;

--- a/src/query/storages/common/session/src/temp_table.rs
+++ b/src/query/storages/common/session/src/temp_table.rs
@@ -64,7 +64,7 @@ pub struct TempTblMgr {
     next_id: u64,
 
     // Atomic CTAS tables that have not been published yet.
-    pub staged_tables: HashMap<u64, TempTable>,
+    staged_tables: HashMap<u64, TempTable>,
 }
 
 impl Default for TempTblMgr {

--- a/src/query/storages/common/session/src/temp_table.rs
+++ b/src/query/storages/common/session/src/temp_table.rs
@@ -61,9 +61,21 @@ pub struct TempTblMgr {
     // User-visible temporary tables.
     name_to_id: HashMap<String, u64>,
     id_to_table: HashMap<u64, TempTable>,
-    // Atomic CTAS tables that have not been published yet.
-    staged_tables: HashMap<u64, TempTable>,
     next_id: u64,
+
+    // Atomic CTAS tables that have not been published yet.
+    pub staged_tables: HashMap<u64, TempTable>,
+}
+
+impl Default for TempTblMgr {
+    fn default() -> Self {
+        TempTblMgr {
+            name_to_id: HashMap::new(),
+            id_to_table: HashMap::new(),
+            staged_tables: HashMap::new(),
+            next_id: TEMP_TBL_ID_BEGIN,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -80,12 +92,7 @@ impl TempTblMgr {
     }
 
     pub fn init() -> Arc<Mutex<Self>> {
-        Arc::new(Mutex::new(TempTblMgr {
-            name_to_id: HashMap::new(),
-            id_to_table: HashMap::new(),
-            staged_tables: HashMap::new(),
-            next_id: TEMP_TBL_ID_BEGIN,
-        }))
+        Arc::new(Mutex::new(Self::default()))
     }
 
     fn inc_next_id(&mut self) {
@@ -95,7 +102,7 @@ impl TempTblMgr {
         }
     }
 
-    pub fn is_empty(&mut self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.id_to_table.is_empty() && self.staged_tables.is_empty()
     }
 
@@ -112,9 +119,7 @@ impl TempTblMgr {
             ..
         } = req;
         let Some(db_id) = table_meta.options.get(OPT_KEY_DATABASE_ID) else {
-            return Err(ErrorCode::Internal(format!(
-                "Database id not set in table options"
-            )));
+            return Err(ErrorCode::Internal("Database id not set in table options"));
         };
         let db_id = db_id.parse::<u64>()?;
 
@@ -408,19 +413,15 @@ fn get_table_operator_for_drop_operation(table_meta: &TableMeta) -> Result<Opera
     }
 }
 
-pub async fn abort_staged_temp_table(
-    mgr: TempTblMgrRef,
+async fn cleanup_temp_table_data(
     table_id: u64,
+    table_meta: &TableMeta,
     temp_prefix: &str,
 ) -> Result<()> {
-    let Some(table) = mgr.lock().abort_staged_table(table_id) else {
-        return Ok(());
-    };
-
-    match table.meta.engine.as_str() {
+    match table_meta.engine.as_str() {
         "FUSE" => {
-            let dir = parse_storage_prefix(&table.meta.options, table_id)?;
-            let op = get_table_operator_for_drop_operation(&table.meta)?;
+            let dir = parse_storage_prefix(&table_meta.options, table_id)?;
+            let op = get_table_operator_for_drop_operation(table_meta)?;
             op.remove_all(&dir).await?;
         }
         "MEMORY" => {
@@ -432,7 +433,25 @@ pub async fn abort_staged_temp_table(
         }
         _ => {}
     }
+    Ok(())
+}
 
+pub async fn abort_staged_temp_table(
+    mgr: TempTblMgrRef,
+    table_id: u64,
+    temp_prefix: &str,
+) -> Result<()> {
+    let Some(table_meta) = mgr
+        .lock()
+        .staged_tables
+        .get(&table_id)
+        .map(|table| table.meta.clone())
+    else {
+        return Ok(());
+    };
+
+    cleanup_temp_table_data(table_id, &table_meta, temp_prefix).await?;
+    mgr.lock().abort_staged_table(table_id);
     Ok(())
 }
 
@@ -598,15 +617,6 @@ mod tests {
 
     use super::*;
 
-    fn new_temp_table_mgr() -> TempTblMgr {
-        TempTblMgr {
-            name_to_id: HashMap::new(),
-            id_to_table: HashMap::new(),
-            staged_tables: HashMap::new(),
-            next_id: TEMP_TBL_ID_BEGIN,
-        }
-    }
-
     fn table_name_ident(table_name: &str) -> TableNameIdent {
         TableNameIdent {
             tenant: Tenant::new_literal("tenant"),
@@ -662,7 +672,7 @@ mod tests {
 
     #[test]
     fn test_ctas_commit_preserves_temporary_tables_when_visible_table_changed() {
-        let mut mgr = new_temp_table_mgr();
+        let mut mgr = TempTblMgr::default();
         let table_name = "t";
         let desc = TempTblMgr::temp_table_desc("db", table_name);
 
@@ -727,7 +737,7 @@ mod tests {
 
     #[test]
     fn test_ctas_commit_publishes_its_own_temporary_table() {
-        let mut mgr = new_temp_table_mgr();
+        let mut mgr = TempTblMgr::default();
         let table_name = "t";
         let desc = TempTblMgr::temp_table_desc("db", table_name);
 
@@ -811,27 +821,8 @@ mod tests {
     }
 
     #[test]
-    fn test_aborted_ctas_does_not_leave_a_temporary_table() {
-        let mut mgr = new_temp_table_mgr();
-        let staged = mgr
-            .create_table(
-                create_table_req("t", "FUSE", CreateOption::Create, true),
-                "session".to_string(),
-            )
-            .unwrap();
-
-        assert!(!mgr.is_temp_table("db", "t"));
-        assert!(mgr.list_tables().unwrap().is_empty());
-        assert!(!mgr.is_empty());
-
-        assert!(mgr.abort_staged_table(staged.table_id).is_some());
-        assert!(mgr.abort_staged_table(staged.table_id).is_none());
-        assert!(mgr.is_empty());
-    }
-
-    #[test]
     fn test_ctas_internal_prefix_is_available_to_users() {
-        let mut mgr = new_temp_table_mgr();
+        let mut mgr = TempTblMgr::default();
         let internal_like_name = "__tmp_orphan@user";
 
         let created = mgr

--- a/src/query/storages/common/session/src/temp_table.rs
+++ b/src/query/storages/common/session/src/temp_table.rs
@@ -56,14 +56,13 @@ use log::info;
 use opendal::Operator;
 use parking_lot::Mutex;
 
-// Staged CTAS replacements share name_to_id with user-created temporary tables, so reserve a
-// namespace that users cannot enter through CREATE or RENAME.
-const TEMP_ORPHAN_TABLE_PREFIX: &str = "__tmp_orphan@";
-
 #[derive(Debug, Clone)]
 pub struct TempTblMgr {
+    // User-visible temporary tables.
     name_to_id: HashMap<String, u64>,
     id_to_table: HashMap<u64, TempTable>,
+    // Atomic CTAS tables that have not been published yet.
+    staged_tables: HashMap<u64, TempTable>,
     next_id: u64,
 }
 
@@ -80,23 +79,11 @@ impl TempTblMgr {
         format!("'{}'.'{}'", db_name, table_name)
     }
 
-    fn is_orphan_table_name(table_name: &str) -> bool {
-        table_name.starts_with(TEMP_ORPHAN_TABLE_PREFIX)
-    }
-
-    fn ensure_user_table_name(table_name: &str) -> Result<()> {
-        if Self::is_orphan_table_name(table_name) {
-            return Err(ErrorCode::BadArguments(format!(
-                "Temporary table names starting with '{TEMP_ORPHAN_TABLE_PREFIX}' are reserved"
-            )));
-        }
-        Ok(())
-    }
-
     pub fn init() -> Arc<Mutex<Self>> {
         Arc::new(Mutex::new(TempTblMgr {
             name_to_id: HashMap::new(),
             id_to_table: HashMap::new(),
+            staged_tables: HashMap::new(),
             next_id: TEMP_TBL_ID_BEGIN,
         }))
     }
@@ -109,7 +96,7 @@ impl TempTblMgr {
     }
 
     pub fn is_empty(&mut self) -> bool {
-        self.id_to_table.is_empty()
+        self.id_to_table.is_empty() && self.staged_tables.is_empty()
     }
 
     pub fn create_table(
@@ -124,7 +111,6 @@ impl TempTblMgr {
             as_dropped,
             ..
         } = req;
-        Self::ensure_user_table_name(&name_ident.table_name)?;
         let Some(db_id) = table_meta.options.get(OPT_KEY_DATABASE_ID) else {
             return Err(ErrorCode::Internal(format!(
                 "Database id not set in table options"
@@ -136,9 +122,6 @@ impl TempTblMgr {
         let existing_id = self.name_to_id.get(&desc).copied();
         let engine = table_meta.engine.to_string();
         let table_id = self.next_id;
-        // Keep a two-phase CTAS replacement hidden under its unique temporary table ID until
-        // commit_table_meta publishes it under the requested name.
-        let orphan_table_name = as_dropped.then(|| format!("{TEMP_ORPHAN_TABLE_PREFIX}{table_id}"));
         let new_table = match (existing_id, create_option) {
             (Some(_), CreateOption::Create) => {
                 return Err(ErrorCode::TableAlreadyExists(format!(
@@ -162,20 +145,21 @@ impl TempTblMgr {
                     .map_err(|e| ErrorCode::from(AppError::from(e)))?;
                 }
 
-                let desc = orphan_table_name
-                    .as_ref()
-                    .map(|o| Self::temp_table_desc(&name_ident.db_name, o))
-                    .unwrap_or(desc);
-                let old_id = self.name_to_id.insert(desc.clone(), table_id);
-                if let Some(old_id) = old_id {
-                    self.id_to_table.remove(&old_id);
-                }
-                self.id_to_table.insert(table_id, TempTable {
+                let table = TempTable {
                     db_name: name_ident.db_name,
-                    table_name: orphan_table_name.clone().unwrap_or(name_ident.table_name),
+                    table_name: name_ident.table_name,
                     meta: table_meta,
                     copied_files: BTreeMap::new(),
-                });
+                };
+                if as_dropped {
+                    self.staged_tables.insert(table_id, table);
+                } else {
+                    let old_id = self.name_to_id.insert(desc.clone(), table_id);
+                    if let Some(old_id) = old_id {
+                        self.id_to_table.remove(&old_id);
+                    }
+                    self.id_to_table.insert(table_id, table);
+                }
                 self.inc_next_id();
                 info!(
                     "[TEMP TABLE] session={prefix} created {} table {desc}, id = {db_id}.{table_id}.",
@@ -193,26 +177,18 @@ impl TempTblMgr {
             // The commit guard must compare against the visible table observed during prepare.
             // Direct, single-phase creates do not need this value.
             prev_table_id: as_dropped.then_some(existing_id).flatten(),
-            orphan_table_name,
+            // Persistent tables use an orphan name in meta-service. Temporary CTAS tables are
+            // staged by ID in this manager and do not need an internal name.
+            orphan_table_name: None,
         })
     }
 
     pub fn commit_table_meta(&mut self, req: &CommitTableMetaReq) -> Result<CommitTableMetaReply> {
-        let orphan_desc = Self::temp_table_desc(
-            &req.name_ident.db_name,
-            req.orphan_table_name.as_ref().unwrap(),
-        );
         let desc = Self::temp_table_desc(&req.name_ident.db_name, &req.name_ident.table_name);
-        // Validate the staged mapping before mutating it: concurrent CTAS requests may have the
-        // same visible target, but each commit must publish only its own replacement.
-        let orphan_id = self
-            .name_to_id
-            .get(&orphan_desc)
-            .copied()
-            .ok_or_else(|| ErrorCode::UnknownTable(orphan_desc.clone()))?;
-        if orphan_id != req.table_id {
-            return Err(ErrorCode::TableVersionMismatched(format!(
-                "Temporary table {desc} replacement changed while CTAS was running"
+        if !self.staged_tables.contains_key(&req.table_id) {
+            return Err(ErrorCode::UnknownTable(format!(
+                "Staged temporary table id {} not found",
+                req.table_id
             )));
         }
 
@@ -224,16 +200,21 @@ impl TempTblMgr {
             )));
         }
 
-        // Both publication guards passed, so removing the orphan mapping is now safe.
-        self.name_to_id.remove(&orphan_desc);
-        if let Some(old_id) = self.name_to_id.insert(desc, orphan_id) {
-            self.id_to_table.remove(&old_id);
-        }
-        let table = self.id_to_table.get_mut(&orphan_id).unwrap();
+        let mut table = self.staged_tables.remove(&req.table_id).unwrap();
         table.db_name = req.name_ident.db_name.clone();
         table.table_name = req.name_ident.table_name.clone();
+        if let Some(old_id) = self.name_to_id.insert(desc, req.table_id) {
+            self.id_to_table.remove(&old_id);
+        }
+        self.id_to_table.insert(req.table_id, table);
 
         Ok(CommitTableMetaReply {})
+    }
+
+    /// Discard a CTAS table that has not been published. This is idempotent and cannot remove a
+    /// visible temporary table.
+    fn abort_staged_table(&mut self, table_id: u64) -> Option<TempTable> {
+        self.staged_tables.remove(&table_id)
     }
 
     pub fn rename_table(&mut self, req: &RenameTableReq) -> Result<Option<RenameTableReply>> {
@@ -244,18 +225,9 @@ impl TempTblMgr {
             new_table_name,
         } = req;
         let desc = Self::temp_table_desc(&name_ident.db_name, &name_ident.table_name);
-        if Self::is_orphan_table_name(&name_ident.table_name) {
-            // Reject access to an active staged replacement. Only names not owned by this manager
-            // may fall through to the underlying catalog.
-            if self.name_to_id.contains_key(&desc) {
-                Self::ensure_user_table_name(&name_ident.table_name)?;
-            }
-            return Ok(None);
-        }
         // Keep the source mapping intact until all destination checks pass.
         match self.name_to_id.get(&desc).copied() {
             Some(id) => {
-                Self::ensure_user_table_name(new_table_name)?;
                 let new_desc = Self::temp_table_desc(new_db_name, new_table_name);
                 // A no-op rename finds the source itself and is not a destination collision.
                 if new_desc != desc && self.name_to_id.contains_key(&new_desc) {
@@ -279,15 +251,26 @@ impl TempTblMgr {
         Err(ErrorCode::Unimplemented("Cannot swap tmp table"))
     }
 
-    pub fn get_table_meta_by_id(&self, id: u64) -> Result<Option<SeqV<TableMeta>>> {
-        Ok(self
-            .id_to_table
+    fn table_by_id(&self, id: u64) -> Option<&TempTable> {
+        self.id_to_table
             .get(&id)
-            .map(|t| SeqV::new(0, t.meta.clone())))
+            .or_else(|| self.staged_tables.get(&id))
+    }
+
+    fn table_by_id_mut(&mut self, id: u64) -> Option<&mut TempTable> {
+        if self.id_to_table.contains_key(&id) {
+            self.id_to_table.get_mut(&id)
+        } else {
+            self.staged_tables.get_mut(&id)
+        }
+    }
+
+    pub fn get_table_meta_by_id(&self, id: u64) -> Result<Option<SeqV<TableMeta>>> {
+        Ok(self.table_by_id(id).map(|t| SeqV::new(0, t.meta.clone())))
     }
 
     pub fn get_table_name_by_id(&self, id: u64) -> Option<String> {
-        self.id_to_table.get(&id).map(|t| t.table_name.clone())
+        self.table_by_id(id).map(|t| t.table_name.clone())
     }
 
     pub fn is_temp_table(&self, database_name: &str, table_name: &str) -> bool {
@@ -338,7 +321,7 @@ impl TempTblMgr {
                 copied_files,
                 ..
             } = r;
-            let table = self.id_to_table.get_mut(&table_id).unwrap();
+            let table = self.table_by_id_mut(table_id).unwrap();
             table.meta = new_table_meta;
             table.copied_files.extend(copied_files);
         }
@@ -351,7 +334,7 @@ impl TempTblMgr {
         let UpsertTableOptionReq {
             table_id, options, ..
         } = req;
-        let table = self.id_to_table.get_mut(&table_id);
+        let table = self.table_by_id_mut(table_id);
         let Some(table) = table else {
             return Err(ErrorCode::UnknownTable(format!(
                 "Temporary table id {} not found",
@@ -369,7 +352,7 @@ impl TempTblMgr {
     }
 
     pub fn truncate_table(&mut self, id: u64) -> Result<TruncateTableReply> {
-        let table = self.id_to_table.get_mut(&id);
+        let table = self.table_by_id_mut(id);
         let Some(table) = table else {
             return Err(ErrorCode::UnknownTable(format!(
                 "Temporary table id {} not found",
@@ -384,7 +367,7 @@ impl TempTblMgr {
         &self,
         req: GetTableCopiedFileReq,
     ) -> Result<GetTableCopiedFileReply> {
-        let Some(table) = self.id_to_table.get(&req.table_id) else {
+        let Some(table) = self.table_by_id(req.table_id) else {
             return Err(ErrorCode::UnknownTable(format!(
                 "Temporary table id {} not found",
                 req.table_id
@@ -400,7 +383,7 @@ impl TempTblMgr {
     }
 
     pub fn list_table_copied_file_info(&self, table_id: u64) -> Result<ListTableCopiedFileReply> {
-        let Some(table) = self.id_to_table.get(&table_id) else {
+        let Some(table) = self.table_by_id(table_id) else {
             return Err(ErrorCode::UnknownTable(format!(
                 "Temporary table id {} not found",
                 table_id
@@ -423,6 +406,34 @@ fn get_table_operator_for_drop_operation(table_meta: &TableMeta) -> Result<Opera
         // Use the default operator
         Ok(DataOperator::instance().operator())
     }
+}
+
+pub async fn abort_staged_temp_table(
+    mgr: TempTblMgrRef,
+    table_id: u64,
+    temp_prefix: &str,
+) -> Result<()> {
+    let Some(table) = mgr.lock().abort_staged_table(table_id) else {
+        return Ok(());
+    };
+
+    match table.meta.engine.as_str() {
+        "FUSE" => {
+            let dir = parse_storage_prefix(&table.meta.options, table_id)?;
+            let op = get_table_operator_for_drop_operation(&table.meta)?;
+            op.remove_all(&dir).await?;
+        }
+        "MEMORY" => {
+            let key = InMemoryDataKey {
+                temp_prefix: Some(temp_prefix.to_string()),
+                table_id,
+            };
+            IN_MEMORY_DATA.write().remove(&key);
+        }
+        _ => {}
+    }
+
+    Ok(())
 }
 
 pub async fn drop_table_by_id(
@@ -507,7 +518,7 @@ pub async fn drop_all_temp_tables(
         let mut guard = mgr.lock();
         let mut fuse_table_data = Vec::new(); // (dir, table_meta)
         let mut mem_tbl_ids = Vec::new();
-        for (id, table) in &guard.id_to_table {
+        for (id, table) in guard.id_to_table.iter().chain(&guard.staged_tables) {
             let engine = table.meta.engine.as_str();
             if engine == "FUSE" {
                 // Parse the storage prefix to get the directory path for each table
@@ -527,6 +538,7 @@ pub async fn drop_all_temp_tables(
             }
         }
         guard.id_to_table.clear();
+        guard.staged_tables.clear();
         guard.name_to_id.clear();
         (fuse_table_data, mem_tbl_ids)
     };
@@ -590,6 +602,7 @@ mod tests {
         TempTblMgr {
             name_to_id: HashMap::new(),
             id_to_table: HashMap::new(),
+            staged_tables: HashMap::new(),
             next_id: TEMP_TBL_ID_BEGIN,
         }
     }
@@ -666,6 +679,12 @@ mod tests {
             )
             .unwrap();
         assert_eq!(replacement.prev_table_id, Some(visible.table_id));
+        assert!(
+            !mgr.name_to_id
+                .values()
+                .any(|id| *id == replacement.table_id)
+        );
+        assert!(mgr.staged_tables.contains_key(&replacement.table_id));
 
         mgr.name_to_id.remove(&desc);
         mgr.id_to_table.remove(&visible.table_id);
@@ -676,11 +695,9 @@ mod tests {
             )
             .unwrap();
 
-        let orphan_desc =
-            TempTblMgr::temp_table_desc("db", replacement.orphan_table_name.as_ref().unwrap());
         let current_meta = mgr.id_to_table.get(&current.table_id).unwrap().meta.clone();
         let replacement_meta = mgr
-            .id_to_table
+            .staged_tables
             .get(&replacement.table_id)
             .unwrap()
             .meta
@@ -699,15 +716,11 @@ mod tests {
 
         assert_eq!(mgr.name_to_id.get(&desc), Some(&current.table_id));
         assert_eq!(
-            mgr.name_to_id.get(&orphan_desc),
-            Some(&replacement.table_id)
-        );
-        assert_eq!(
             mgr.id_to_table.get(&current.table_id).unwrap().meta,
             current_meta
         );
         assert_eq!(
-            mgr.id_to_table.get(&replacement.table_id).unwrap().meta,
+            mgr.staged_tables.get(&replacement.table_id).unwrap().meta,
             replacement_meta
         );
     }
@@ -739,57 +752,43 @@ mod tests {
 
         assert_eq!(first.prev_table_id, Some(visible.table_id));
         assert_eq!(second.prev_table_id, Some(visible.table_id));
-        assert_ne!(first.orphan_table_name, second.orphan_table_name);
-        let first_orphan_desc =
-            TempTblMgr::temp_table_desc("db", first.orphan_table_name.as_ref().unwrap());
-        let second_orphan_desc =
-            TempTblMgr::temp_table_desc("db", second.orphan_table_name.as_ref().unwrap());
-        assert_eq!(
-            mgr.name_to_id.get(&first_orphan_desc),
-            Some(&first.table_id)
-        );
-        assert_eq!(
-            mgr.name_to_id.get(&second_orphan_desc),
-            Some(&second.table_id)
-        );
+        assert_eq!(first.orphan_table_name, None);
+        assert_eq!(second.orphan_table_name, None);
+        assert_eq!(mgr.name_to_id.len(), 1);
+        assert_eq!(mgr.id_to_table.len(), 1);
+        assert_eq!(mgr.list_tables().unwrap().len(), 1);
+        assert!(mgr.staged_tables.contains_key(&first.table_id));
+        assert!(mgr.staged_tables.contains_key(&second.table_id));
 
         let name_to_id_before = mgr.name_to_id.clone();
-        let table_meta_before: HashMap<_, _> = mgr
-            .id_to_table
+        let staged_before: HashMap<_, _> = mgr
+            .staged_tables
             .iter()
             .map(|(id, table)| (*id, table.meta.clone()))
             .collect();
-        let mut mismatched_req = commit_table_req(table_name, &first);
-        mismatched_req.table_id = second.table_id;
-        let err = mgr.commit_table_meta(&mismatched_req).unwrap_err();
-        let expected = ErrorCode::TableVersionMismatched(format!(
-            "Temporary table {desc} replacement changed while CTAS was running"
-        ));
-        assert_eq!(
-            (err.code(), err.message()),
-            (expected.code(), expected.message())
-        );
+        let mut unknown_req = commit_table_req(table_name, &first);
+        unknown_req.table_id = first.table_id + 100;
+        let err = mgr.commit_table_meta(&unknown_req).unwrap_err();
+        assert_eq!(err.code(), ErrorCode::UNKNOWN_TABLE);
         assert_eq!(mgr.name_to_id, name_to_id_before);
         assert_eq!(
-            mgr.id_to_table
+            mgr.staged_tables
                 .iter()
                 .map(|(id, table)| (*id, table.meta.clone()))
                 .collect::<HashMap<_, _>>(),
-            table_meta_before
+            staged_before
         );
 
         mgr.commit_table_meta(&commit_table_req(table_name, &first))
             .unwrap();
 
         assert_eq!(mgr.name_to_id.get(&desc), Some(&first.table_id));
-        assert!(!mgr.name_to_id.contains_key(&first_orphan_desc));
-        assert_eq!(
-            mgr.name_to_id.get(&second_orphan_desc),
-            Some(&second.table_id)
-        );
         assert!(!mgr.id_to_table.contains_key(&visible.table_id));
         assert!(mgr.id_to_table.contains_key(&first.table_id));
-        assert!(mgr.id_to_table.contains_key(&second.table_id));
+        assert!(!mgr.id_to_table.contains_key(&second.table_id));
+        assert!(!mgr.staged_tables.contains_key(&first.table_id));
+        assert!(mgr.staged_tables.contains_key(&second.table_id));
+        assert_eq!(mgr.list_tables().unwrap().len(), 1);
 
         let err = mgr
             .commit_table_meta(&commit_table_req(table_name, &second))
@@ -802,94 +801,60 @@ mod tests {
             (expected.code(), expected.message())
         );
         assert_eq!(mgr.name_to_id.get(&desc), Some(&first.table_id));
-        assert_eq!(
-            mgr.name_to_id.get(&second_orphan_desc),
-            Some(&second.table_id)
-        );
         assert!(mgr.id_to_table.contains_key(&first.table_id));
-        assert!(mgr.id_to_table.contains_key(&second.table_id));
+        assert!(mgr.staged_tables.contains_key(&second.table_id));
+
+        assert!(mgr.abort_staged_table(second.table_id).is_some());
+        assert!(mgr.abort_staged_table(second.table_id).is_none());
+        assert_eq!(mgr.name_to_id.get(&desc), Some(&first.table_id));
+        assert!(mgr.id_to_table.contains_key(&first.table_id));
     }
 
     #[test]
-    fn test_ctas_orphan_prefix_is_reserved() {
+    fn test_aborted_ctas_does_not_leave_a_temporary_table() {
         let mut mgr = new_temp_table_mgr();
-        let reserved_name = format!("{TEMP_ORPHAN_TABLE_PREFIX}user");
-
-        let err = mgr
+        let staged = mgr
             .create_table(
-                create_table_req(&reserved_name, "MEMORY", CreateOption::Create, false),
-                "session".to_string(),
-            )
-            .unwrap_err();
-        let expected = ErrorCode::BadArguments(format!(
-            "Temporary table names starting with '{TEMP_ORPHAN_TABLE_PREFIX}' are reserved"
-        ));
-        assert_eq!(
-            (err.code(), err.message()),
-            (expected.code(), expected.message())
-        );
-
-        let visible = mgr
-            .create_table(
-                create_table_req("t", "MEMORY", CreateOption::Create, false),
+                create_table_req("t", "FUSE", CreateOption::Create, true),
                 "session".to_string(),
             )
             .unwrap();
+
+        assert!(!mgr.is_temp_table("db", "t"));
+        assert!(mgr.list_tables().unwrap().is_empty());
+        assert!(!mgr.is_empty());
+
+        assert!(mgr.abort_staged_table(staged.table_id).is_some());
+        assert!(mgr.abort_staged_table(staged.table_id).is_none());
+        assert!(mgr.is_empty());
+    }
+
+    #[test]
+    fn test_ctas_internal_prefix_is_available_to_users() {
+        let mut mgr = new_temp_table_mgr();
+        let internal_like_name = "__tmp_orphan@user";
+
+        let created = mgr
+            .create_table(
+                create_table_req(internal_like_name, "MEMORY", CreateOption::Create, false),
+                "session".to_string(),
+            )
+            .unwrap();
+        assert_eq!(
+            mgr.name_to_id
+                .get(&TempTblMgr::temp_table_desc("db", internal_like_name)),
+            Some(&created.table_id)
+        );
+
         assert!(
-            mgr.rename_table(&rename_table_req("t", "t"))
+            mgr.rename_table(&rename_table_req(internal_like_name, "renamed"))
                 .unwrap()
                 .is_some()
         );
-        let err = mgr
-            .rename_table(&rename_table_req("t", &reserved_name))
-            .unwrap_err();
         assert_eq!(
-            (err.code(), err.message()),
-            (expected.code(), expected.message())
-        );
-        assert_eq!(
-            mgr.name_to_id.get(&TempTblMgr::temp_table_desc("db", "t")),
-            Some(&visible.table_id)
-        );
-
-        // Names not owned by the temporary manager must fall through to the inner catalog.
-        assert!(
-            mgr.rename_table(&rename_table_req("persistent", &reserved_name))
-                .unwrap()
-                .is_none()
-        );
-        assert!(
-            mgr.rename_table(&rename_table_req(&reserved_name, "persistent"))
-                .unwrap()
-                .is_none()
-        );
-
-        let replacement = mgr
-            .create_table(
-                create_table_req("t", "MEMORY", CreateOption::CreateOrReplace, true),
-                "session".to_string(),
-            )
-            .unwrap();
-        let orphan_table_name = replacement.orphan_table_name.as_ref().unwrap();
-        let orphan_desc = TempTblMgr::temp_table_desc("db", orphan_table_name);
-        assert_eq!(
-            replacement.orphan_table_name.as_deref(),
-            Some(format!("{TEMP_ORPHAN_TABLE_PREFIX}{}", replacement.table_id).as_str())
-        );
-        assert_eq!(
-            mgr.name_to_id.get(&orphan_desc),
-            Some(&replacement.table_id)
-        );
-        let err = mgr
-            .rename_table(&rename_table_req(orphan_table_name, "hijacked"))
-            .unwrap_err();
-        assert_eq!(
-            (err.code(), err.message()),
-            (expected.code(), expected.message())
-        );
-        assert_eq!(
-            mgr.name_to_id.get(&orphan_desc),
-            Some(&replacement.table_id)
+            mgr.name_to_id
+                .get(&TempTblMgr::temp_table_desc("db", "renamed")),
+            Some(&created.table_id)
         );
     }
 }

--- a/tests/sqllogictests/suites/http_handler/temp_table/create_temp_tables.test
+++ b/tests/sqllogictests/suites/http_handler/temp_table/create_temp_tables.test
@@ -465,6 +465,15 @@ drop table if exists crt1
 statement error 1006
 create temp table t as select number/0 from numbers(1);
 
+# repeated failures must not accumulate CTAS staging entries
+statement error 1006
+create temp table t as select number/0 from numbers(1);
+
+query I
+select count(*) from system.temporary_tables where is_current_session = true and (name = 't' or name like '__tmp_orphan@%');
+----
+0
+
 # table t should not be created
 # expects:  ERROR 1105 (HY000): UnknownTable. Code: 1025, Text = error: ...
 statement error 1025


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Keep in-progress temporary CTAS tables in a dedicated ID-keyed staging map so they do not pollute the user-visible temporary table namespace or `system.temporary_tables`
- Publish staged temporary tables only after CTAS succeeds, and clean up staged metadata and table data when registration, pipeline construction, execution, or completion fails
- Add and update regression tests to verify that repeated failed temporary CTAS attempts leave no stale entries and concurrent replacements publish only their own staged table

Fixes #20243


## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

<!--
See AI_POLICY.md. Agent-opened PRs are welcome; a responsible human on the author side must own the change.
The responsible human is NOT the reviewer — it is the submitter-side owner who has read the diff,
can explain each change, and will answer questions during review.
Write "None" for AI usage if no AI was involved.
-->

- AI usage: An AI coding agent assisted with code analysis, implementation, and test drafting; I reviewed and verified the complete diff.
- Responsible human: @zhyass
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20261)
<!-- Reviewable:end -->
