### PR TITLE
fix(query): skip task cleanup on unassigned nodes

### DIFF
--- a/src/query/service/src/task/service.rs
+++ b/src/query/service/src/task/service.rs
@@ -221,12 +221,7 @@ impl TaskService {
             let (_, task_message) = result?;
             let task_key = TaskMessageIdent::new(tenant, task_message.key());
 
-            // Delete cleanup updates shared metadata, so it must run even if the
-            // task's assigned warehouse currently has no live query node.
             let is_delete = matches!(&task_message, TaskMessage::DeleteTask(_, _, _));
-            if is_delete && self.create_context(None).await?.get_cluster().unassign {
-                continue;
-            }
             if !is_delete {
                 if let Some(WarehouseOptions {
                     warehouse: Some(warehouse),
@@ -515,6 +510,8 @@ impl TaskService {
                     });
                 }
                 TaskMessage::DeleteTask(task_name, _, task_id) => {
+                    // Every node may still hold a local schedule for this task. Cancel it before
+                    // an unassigned node skips the shared metadata cleanup below.
                     if task_id.is_none_or(|task_id| {
                         scheduled_tasks
                             .get(&task_name)
@@ -523,6 +520,9 @@ impl TaskService {
                         if let Some((_, token)) = scheduled_tasks.remove(&task_name) {
                             token.cancel();
                         }
+                    }
+                    if self.create_context(None).await?.get_cluster().unassign {
+                        continue;
                     }
                     if task_mgr
                         .accept(&task_key)

--- a/src/query/service/src/task/service.rs
+++ b/src/query/service/src/task/service.rs
@@ -224,14 +224,7 @@ impl TaskService {
             // Delete cleanup updates shared metadata, so it must run even if the
             // task's assigned warehouse currently has no live query node.
             let is_delete = matches!(&task_message, TaskMessage::DeleteTask(_, _, _));
-            if is_delete
-                && self
-                    .create_context(None)
-                    .await?
-                    .get_cluster()
-                    .get_warehouse_id()
-                    .is_err()
-            {
+            if is_delete && self.create_context(None).await?.get_cluster().unassign {
                 continue;
             }
             if !is_delete {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Prevent unassigned system-managed query nodes from accepting `DeleteTask` cleanup messages.
- Use `Cluster::unassign`, the state checked by SQL execution, instead of treating `get_warehouse_id()` failure as the unassigned signal.
- Fix the race where an unassigned node accepts the message first, fails cleanup with `InvalidWarehouse`, and prevents an assigned node from cancelling open task runs.

The existing `tests/task/test-private-task-warehouse.sh` regression covers this behavior by dropping a task assigned to a suspended warehouse and waiting for its open run to become `CANCELLED`.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - The existing private-task warehouse integration test covers the failure; it requires the enterprise system-managed warehouse CI environment and was not run locally. `cargo fmt --all --check` and `git diff --check` passed.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent analyzed the repeated CI logs, identified the task-message acceptance race, and drafted the one-line fix and PR summary.
- Responsible human: @KKould
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20263)
<!-- Reviewable:end -->
