### PR TITLE
fix(storage): map missing NO_CHECK snapshot 404 to TableHistoricalDataNotFound

### DIFF
--- a/src/query/service/tests/it/storages/fuse/operations/navigate.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/navigate.rs
@@ -15,6 +15,7 @@
 use std::time::Duration;
 
 use chrono::Utc;
+use databend_common_catalog::table::NavigationPoint;
 use databend_common_exception::ErrorCode;
 use databend_common_expression::DataBlock;
 use databend_common_storages_fuse::io::SnapshotHistoryReader;
@@ -24,6 +25,8 @@ use databend_query::storages::fuse::FuseTable;
 use databend_query::storages::fuse::io::MetaReaders;
 use databend_query::storages::fuse::io::TableMetaLocationGenerator;
 use databend_query::test_kits::*;
+use databend_storages_common_cache::CacheAccessor;
+use databend_storages_common_cache::CacheManager;
 use futures::TryStreamExt;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -221,6 +224,76 @@ async fn test_navigate_for_purge() -> anyhow::Result<()> {
         .await?;
     assert_eq!(2, files.len());
     assert_eq!(navigate, second_snapshot);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_no_check_timestamp_maps_missing_prev_snapshot() -> anyhow::Result<()> {
+    // When NO_CHECK TIMESTAMP finds a later snapshot whose predecessor object is gone
+    // (vacuumed), it should return TableHistoricalDataNotFound instead of StorageNotFound.
+
+    let fixture = TestFixture::setup().await?;
+    let db = fixture.default_db_name();
+    let tbl = fixture.default_table_name();
+
+    fixture.create_default_database().await?;
+    fixture.create_default_table().await?;
+
+    // first snapshot
+    let qry = format!(
+        "insert into {}.{} values (1, (2, 3)), (2, (4, 6)) ",
+        db, tbl
+    );
+    let strm = fixture.execute_query(qry.as_str()).await?;
+    strm.try_collect::<Vec<DataBlock>>().await?;
+
+    let table = fixture.latest_default_table().await?;
+    let first_snapshot = FuseTable::try_from_table(table.as_ref())?
+        .snapshot_loc()
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(2)).await;
+
+    // second snapshot
+    let qry = format!("insert into {}.{} values (3, (6, 9)) ", db, tbl);
+    let strm = fixture.execute_query(qry.as_str()).await?;
+    strm.try_collect::<Vec<DataBlock>>().await?;
+
+    let table = fixture.latest_default_table().await?;
+    let fuse_table = FuseTable::try_from_table(table.as_ref())?;
+    let second_snapshot = fuse_table.snapshot_loc().unwrap();
+    assert_ne!(second_snapshot, first_snapshot);
+
+    // Simulate vacuum: remove the predecessor snapshot object and drop its cache entry.
+    fuse_table.get_operator().delete(&first_snapshot).await?;
+    if let Some(cache) = CacheManager::instance().get_table_snapshot_cache() {
+        cache.evict(&first_snapshot);
+    }
+
+    // Navigate with NO_CHECK to a time between the two snapshots.
+    // The path should list the second snapshot and try to load its prev_snapshot_id,
+    // which now 404s and must be mapped to TABLE_HISTORICAL_DATA_NOT_FOUND.
+    let second = fuse_table
+        .read_table_snapshot()
+        .await?
+        .expect("second snapshot should exist");
+    let time_point = second.timestamp.unwrap() - chrono::Duration::milliseconds(1);
+
+    let ctx = fixture.new_query_ctx().await?;
+    let tbl_ctx: std::sync::Arc<dyn TableContext> = ctx.clone();
+    let res = fuse_table
+        .navigate_to_point_unchecked(&tbl_ctx, &NavigationPoint::TimePoint(time_point))
+        .await;
+
+    match res {
+        Ok(_) => panic!("expected historical data not found when prev snapshot is missing"),
+        Err(e) => assert_eq!(
+            e.code(),
+            ErrorCode::TABLE_HISTORICAL_DATA_NOT_FOUND,
+            "unexpected error: {e}"
+        ),
+    }
 
     Ok(())
 }

--- a/src/query/service/tests/it/storages/fuse/operations/navigate.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/navigate.rs
@@ -253,8 +253,6 @@ async fn test_no_check_timestamp_maps_missing_prev_snapshot() -> anyhow::Result<
         .snapshot_loc()
         .unwrap();
 
-    tokio::time::sleep(Duration::from_millis(2)).await;
-
     // second snapshot
     let qry = format!("insert into {}.{} values (3, (6, 9)) ", db, tbl);
     let strm = fixture.execute_query(qry.as_str()).await?;

--- a/src/query/storages/fuse/src/operations/navigate.rs
+++ b/src/query/storages/fuse/src/operations/navigate.rs
@@ -351,7 +351,7 @@ impl FuseTable {
         match first_snapshot_after {
             Some(location) => {
                 let (snapshot, _format_version) =
-                    SnapshotsIO::read_snapshot(location, op.clone(), true).await?;
+                    Self::read_snapshot_for_no_check(location, op.clone()).await?;
 
                 match snapshot.prev_snapshot_id {
                     Some((prev_id, prev_ver)) => {
@@ -365,7 +365,7 @@ impl FuseTable {
                             .meta_location_generator()
                             .gen_snapshot_location(&prev_id, prev_ver)?;
                         let (prev_snapshot, prev_format_version) =
-                            SnapshotsIO::read_snapshot(prev_location, op, true).await?;
+                            Self::read_snapshot_for_no_check(prev_location, op).await?;
                         self.load_table_by_snapshot(
                             prev_snapshot.as_ref(),
                             prev_format_version,
@@ -385,9 +385,29 @@ impl FuseTable {
                     ));
                 };
                 let (snapshot, format_version) =
-                    SnapshotsIO::read_snapshot(location, op, true).await?;
+                    Self::read_snapshot_for_no_check(location, op).await?;
                 self.load_table_by_snapshot(snapshot.as_ref(), format_version, s3_storage_class)
             }
+        }
+    }
+
+    /// Read a snapshot for NO_CHECK navigation.
+    ///
+    /// Missing objects are mapped to `TableHistoricalDataNotFound` so vacuumed
+    /// predecessor snapshots do not surface as raw `StorageNotFound` errors.
+    async fn read_snapshot_for_no_check(
+        location: String,
+        op: opendal::Operator,
+    ) -> Result<(Arc<TableSnapshot>, u64)> {
+        match SnapshotsIO::read_snapshot(location, op, true).await {
+            Ok(v) => Ok(v),
+            Err(e) if e.code() == ErrorCode::STORAGE_NOT_FOUND => {
+                Err(ErrorCode::TableHistoricalDataNotFound(
+                    "No historical data found at given point with NO_CHECK \
+                     (snapshot object is missing, possibly vacuumed)",
+                ))
+            }
+            Err(e) => Err(e),
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fixes: #20264
- When `AT (TIMESTAMP => ..., NO_CHECK => true)` finds a later V4 snapshot whose predecessor object was already vacuumed/purged, map the object-store 404 to `TableHistoricalDataNotFound` instead of surfacing raw `StorageNotFound`.
- Aligns the NO_CHECK TIMESTAMP path with checked navigation and SNAPSHOT `NO_CHECK` behavior.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Added unit test `test_no_check_timestamp_maps_missing_prev_snapshot` that:
1. Creates two snapshots
2. Deletes the predecessor snapshot object (and evicts cache)
3. Navigates with NO_CHECK TIMESTAMP between them
4. Asserts `TABLE_HISTORICAL_DATA_NOT_FOUND` instead of `STORAGE_NOT_FOUND`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent drafted the NO_CHECK snapshot error mapping patch and unit test; I reviewed the navigate path and validated the regression case
- Responsible human: @dantengsky
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20265)
<!-- Reviewable:end -->
