### PR TITLE
refactor: perf: meta: enable TCP_NODELAY on gRPC listener sockets

### DIFF
--- a/src/meta/core/service/src/api/grpc_server.rs
+++ b/src/meta/core/service/src/api/grpc_server.rs
@@ -102,7 +102,8 @@ impl<SP: SpawnApi> GrpcServer<SP> {
         let addr: SocketAddr = format!("{}:{}", self.config.grpc.listen_host, port).parse()?;
 
         let incoming = TcpIncoming::bind(addr)
-            .map_err(|e| MetaNetworkError::BadAddressFormat(AnyError::new(&e)))?;
+            .map_err(|e| MetaNetworkError::BadAddressFormat(AnyError::new(&e)))?
+            .with_nodelay(Some(true));
 
         Ok(incoming)
     }

--- a/src/meta/core/test-harness/src/service.rs
+++ b/src/meta/core/test-harness/src/service.rs
@@ -62,7 +62,7 @@ pub async fn start_metasrv_with_context<R: RuntimeApi>(
     // This ensures init_cluster (for single=true) uses the correct port.
     let port = tc.config.grpc.listen_port.unwrap_or(0);
     let addr: SocketAddr = format!("{}:{}", tc.config.grpc.listen_host, port).parse()?;
-    let incoming = TcpIncoming::bind(addr)?;
+    let incoming = TcpIncoming::bind(addr)?.with_nodelay(Some(true));
     let actual_port = incoming.local_addr()?.port();
     tc.config.grpc.listen_port = Some(actual_port);
 


### PR DESCRIPTION
# Summary

The meta service gRPC listener now disables Nagle's algorithm, so small gRPC responses go out immediately instead of waiting for the kernel to coalesce them with a later send.

# Details

Without TCP_NODELAY, Nagle's algorithm holds a small outbound segment until the previous one is acknowledged. Combined with delayed ACK on the peer, this adds up to 40ms of latency per round trip, which is severe for meta service traffic since nearly every request and response is a small message.

The option is set at both listener construction sites: the production `GrpcServer::bind()` and the test harness `start_metasrv_with_context()`, so tests measure the same socket behavior as production.

The query-side flight and flight-sql listeners already set this option, so the meta service was the last gRPC listener without it.

Ported from databendlabs/databend-meta#104.

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

<!--
Briefly describe what this PR aims to solve. Include background context that will help reviewers understand the purpose of the PR.

- fixes: #[Link the issue here]
-->

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent has done all of this PR and I reviewed it.
- Responsible human: @drmingdrmer 
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20267)
<!-- Reviewable:end -->
