### PR TITLE
fix(query): route mutations with internal columns through table scans

### DIFF
--- a/src/query/sql/src/planner/binder/bind_mutation/bind.rs
+++ b/src/query/sql/src/planner/binder/bind_mutation/bind.rs
@@ -179,7 +179,7 @@ impl Binder {
             .await?;
 
         let MutationExpressionBindResult {
-            input,
+            mut input,
             mut bind_context,
             mutation_type,
             mutation_strategy,
@@ -261,6 +261,12 @@ impl Binder {
                 .await?,
             );
         }
+        drop(scalar_binder);
+
+        // Matched expressions are bound after the input plan is built. Add every internal column
+        // discovered there to its scan and keep it through physical column pruning.
+        input = self.add_bound_columns_into_expr(&mut bind_context, input)?;
+        required_columns.extend(bind_context.bound_internal_columns.values().copied());
 
         let mutation = crate::plans::Mutation {
             catalog_name,

--- a/src/query/sql/src/planner/binder/bind_mutation/bind.rs
+++ b/src/query/sql/src/planner/binder/bind_mutation/bind.rs
@@ -168,8 +168,8 @@ impl Binder {
             .await?;
         let table_schema = table.schema();
 
-        let bind_result = expression
-            .bind(
+        let mut bind_result = expression
+            .bind_input(
                 self,
                 bind_context,
                 table.clone(),
@@ -177,17 +177,7 @@ impl Binder {
                 table_schema.clone(),
             )
             .await?;
-
-        let MutationExpressionBindResult {
-            mut input,
-            mut bind_context,
-            mutation_type,
-            mutation_strategy,
-            target_table_index,
-            target_table_row_id_index,
-            mut required_columns,
-            all_source_columns,
-        } = bind_result;
+        let target_table_index = bind_result.target_table_index;
 
         let target_table_name = if let Some(table_name_alias) = &table_name_alias {
             table_name_alias.clone()
@@ -210,7 +200,7 @@ impl Binder {
             }
 
             if table.change_tracking_enabled()
-                && mutation_strategy != MutationStrategy::NotMatchedOnly
+                && bind_result.mutation_strategy != MutationStrategy::NotMatchedOnly
             {
                 for stream_column in table.stream_columns() {
                     let column_index = Self::find_column_index(
@@ -218,14 +208,14 @@ impl Binder {
                         target_table_index,
                         stream_column.column_name(),
                     )?;
-                    required_columns.insert(column_index);
+                    bind_result.required_columns.insert(column_index);
                 }
             }
         }
 
         let name_resolution_ctx = self.name_resolution_ctx.clone();
         let mut scalar_binder = ScalarBinder::new(
-            &mut bind_context,
+            &mut bind_result.bind_context,
             self.ctx.clone(),
             &name_resolution_ctx,
             self.metadata.clone(),
@@ -239,7 +229,7 @@ impl Binder {
                     &mut scalar_binder,
                     clause,
                     table_schema.clone(),
-                    all_source_columns.clone(),
+                    bind_result.all_source_columns.clone(),
                     &target_table_name,
                     &database_name,
                 )
@@ -255,7 +245,7 @@ impl Binder {
                     &mut scalar_binder,
                     clause,
                     table_schema.clone(),
-                    all_source_columns.clone(),
+                    bind_result.all_source_columns.clone(),
                     dest_entity_name.clone(),
                 )
                 .await?,
@@ -263,8 +253,27 @@ impl Binder {
         }
         drop(scalar_binder);
 
-        // Matched expressions are bound after the input plan is built. Add every internal column
-        // discovered there to its scan and keep it through physical column pruning.
+        // Finalize the physical input only after clause binding. UPDATE assignments may bind
+        // internal columns, which must select the scan-based mutation path instead of Direct.
+        let bind_result = expression.finalize_input(
+            self,
+            table.clone(),
+            &target_table_identifier,
+            bind_result,
+        )?;
+        let MutationExpressionBindResult {
+            mut input,
+            mut bind_context,
+            mutation_type,
+            mutation_strategy,
+            target_table_index,
+            target_table_row_id_index,
+            mut required_columns,
+            ..
+        } = bind_result;
+
+        // Add every internal column discovered during binding to its scan and keep it through
+        // physical column pruning.
         input = self.add_bound_columns_into_expr(&mut bind_context, input)?;
         required_columns.extend(bind_context.bound_internal_columns.values().copied());
 

--- a/src/query/sql/src/planner/binder/bind_mutation/mutation_expression.rs
+++ b/src/query/sql/src/planner/binder/bind_mutation/mutation_expression.rs
@@ -69,7 +69,6 @@ pub enum MutationExpression {
         target: TableReference,
         from: Option<TableReference>,
         filter: Option<Expr>,
-        force_non_direct: bool,
     },
     Delete {
         target: TableReference,
@@ -79,7 +78,7 @@ pub enum MutationExpression {
 }
 
 impl MutationExpression {
-    pub async fn bind(
+    pub async fn bind_input(
         &self,
         binder: &mut Binder,
         bind_context: &mut BindContext,
@@ -88,10 +87,6 @@ impl MutationExpression {
         target_table_schema: Arc<TableSchema>,
     ) -> Result<MutationExpressionBindResult> {
         let mutation_type = self.mutation_type();
-        let force_non_direct = matches!(self, MutationExpression::Update {
-            force_non_direct: true,
-            ..
-        });
         let mut required_columns = ColumnSet::new();
         let mut update_stream_columns = target_table.change_tracking_enabled();
 
@@ -219,13 +214,14 @@ impl MutationExpression {
                     all_source_columns,
                     target_table_index,
                     target_table_row_id_index,
+                    source: None,
+                    predicates: vec![],
                 })
             }
             MutationExpression::Update {
                 target,
                 from,
                 filter,
-                ..
             }
             | MutationExpression::Delete {
                 target,
@@ -241,7 +237,7 @@ impl MutationExpression {
                         ));
                     }
                 };
-                let (mut s_expr, mut bind_context) = binder.bind_physical_table(
+                let (s_expr, mut bind_context) = binder.bind_physical_table(
                     bind_context,
                     &target_table_identifier.database_name(),
                     target_table_identifier.table_name_alias(),
@@ -279,135 +275,147 @@ impl MutationExpression {
                     None
                 };
 
-                // Bind the filter first; simple predicates normally use the direct mutation path.
-                let (mut mutation_strategy, predicates) =
+                // Phase 1 only binds the mutation input and filter. UPDATE assignments are bound
+                // by `bind_mutation` before the strategy and physical input are finalized.
+                let (mutation_strategy, predicates) =
                     binder.process_filter(&mut bind_context, filter)?;
 
-                if from_s_expr.is_some()
-                    || force_non_direct
-                    || bind_context
-                        .bound_internal_columns
-                        .keys()
-                        .any(|(table_index, _)| *table_index == target_table_index)
-                {
-                    mutation_strategy = MutationStrategy::MatchedOnly;
-                }
-
-                // Build bind result according to mutation strategy.
-                if mutation_strategy == MutationStrategy::Direct {
-                    let table_schema = target_table
-                        .schema_with_stream()
-                        .remove_virtual_computed_fields();
-                    let mutation_source = MutationSource {
-                        schema: table_schema,
-                        columns: bind_context.column_set(),
-                        table_index: target_table_index,
-                        mutation_type: mutation_type.clone(),
-                        secure_predicates: vec![],
-                        user_predicates: vec![],
-                        predicate_column_index: None,
-                        read_partition_columns: Default::default(),
-                    };
-
-                    // Direct mutation inherits row-access predicates from Scan's
-                    // secure_predicates field.
-                    s_expr = Self::replace_scan_with_mutation_source(&s_expr, mutation_source)?;
-
-                    if !predicates.is_empty() {
-                        s_expr = SExpr::create_unary(
-                            Arc::new(Filter { predicates }.into()),
-                            Arc::new(s_expr),
-                        );
-                    }
-
-                    for column_index in bind_context.column_set().iter() {
-                        required_columns.insert(*column_index);
-                    }
-
-                    Ok(MutationExpressionBindResult {
-                        input: s_expr,
-                        mutation_type,
-                        mutation_strategy,
-                        required_columns,
-                        bind_context,
-                        all_source_columns: None,
-                        target_table_index,
-                        target_table_row_id_index: Symbol::DUMMY_COLUMN,
-                    })
-                } else {
-                    let is_lazy_table = {
-                        let metadata = binder.metadata.read();
-                        mutation_type != MutationType::Delete
-                            && metadata
-                                .table(target_table_index)
-                                .table()
-                                .supported_lazy_materialize()
-                    };
-                    s_expr =
-                        Self::update_target_scan(&s_expr, is_lazy_table, update_stream_columns)?;
-
-                    // Add internal column _row_id for target table.
-                    let target_table_row_id_index = binder.add_row_id_column(
-                        &mut bind_context,
-                        target_table_identifier,
-                        target_table_index,
-                        &mut s_expr,
-                        mutation_type.clone(),
-                    )?;
-
-                    // Add target table row_id column to required columns.
-                    required_columns.insert(target_table_row_id_index);
-
-                    if let Some(from_s_expr) = from_s_expr {
-                        let join_plan = Join {
-                            equi_conditions: vec![],
-                            non_equi_conditions: vec![],
-                            join_type: JoinType::Cross,
-                            marker_index: None,
-                            from_correlated_subquery: true,
-                            need_hold_hash_table: false,
-                            is_lateral: false,
-                            single_to_inner: None,
-                            build_side_cache_info: None,
-                            spatial_join: None,
-                        };
-                        s_expr = SExpr::create_binary(
-                            Arc::new(join_plan.into()),
-                            Arc::new(s_expr.clone()),
-                            Arc::new(from_s_expr),
-                        );
-                    }
-
-                    s_expr = SExpr::create_unary(
-                        Arc::new(Filter { predicates }.into()),
-                        Arc::new(s_expr),
-                    );
-
-                    let opt_ctx =
-                        OptimizerContext::new(binder.ctx.clone(), binder.metadata.clone());
-                    let mut rewriter = SubqueryDecorrelatorOptimizer::new(opt_ctx, None);
-                    let s_expr = rewriter.optimize_sync(&s_expr)?;
-
-                    // The delete operation only requires the row ID to locate the row to be deleted and does not need to extract any other columns.
-                    if !is_lazy_table && mutation_type != MutationType::Delete {
-                        for column_index in bind_context.column_set().iter() {
-                            required_columns.insert(*column_index);
-                        }
-                    }
-
-                    Ok(MutationExpressionBindResult {
-                        input: s_expr,
-                        mutation_type,
-                        mutation_strategy,
-                        required_columns,
-                        bind_context,
-                        all_source_columns: None,
-                        target_table_index,
-                        target_table_row_id_index,
-                    })
-                }
+                Ok(MutationExpressionBindResult {
+                    input: s_expr,
+                    mutation_type,
+                    mutation_strategy,
+                    required_columns,
+                    bind_context,
+                    all_source_columns: None,
+                    target_table_index,
+                    target_table_row_id_index: Symbol::DUMMY_COLUMN,
+                    source: from_s_expr,
+                    predicates,
+                })
             }
         }
+    }
+
+    /// Finalize an UPDATE/DELETE input after all mutation clauses have been bound.
+    ///
+    /// Clause binding may discover internal columns in UPDATE assignments. Delaying strategy
+    /// selection until this point ensures those columns route the mutation through a table scan.
+    pub fn finalize_input(
+        &self,
+        binder: &mut Binder,
+        target_table: Arc<dyn Table>,
+        target_table_identifier: &TableIdentifier,
+        mut result: MutationExpressionBindResult,
+    ) -> Result<MutationExpressionBindResult> {
+        if matches!(self, MutationExpression::Merge { .. }) {
+            return Ok(result);
+        }
+
+        let source = result.source.take();
+        let predicates = std::mem::take(&mut result.predicates);
+
+        if source.is_some()
+            || result
+                .bind_context
+                .bound_internal_columns
+                .keys()
+                .any(|(table_index, _)| *table_index == result.target_table_index)
+        {
+            result.mutation_strategy = MutationStrategy::MatchedOnly;
+        }
+
+        if result.mutation_strategy == MutationStrategy::Direct {
+            let table_schema = target_table
+                .schema_with_stream()
+                .remove_virtual_computed_fields();
+            let mutation_source = MutationSource {
+                schema: table_schema,
+                columns: result.bind_context.column_set(),
+                table_index: result.target_table_index,
+                mutation_type: result.mutation_type.clone(),
+                secure_predicates: vec![],
+                user_predicates: vec![],
+                predicate_column_index: None,
+                read_partition_columns: Default::default(),
+            };
+
+            // Direct mutation inherits row-access predicates from Scan's secure predicates.
+            result.input = Self::replace_scan_with_mutation_source(&result.input, mutation_source)?;
+
+            if !predicates.is_empty() {
+                result.input = SExpr::create_unary(
+                    Arc::new(Filter { predicates }.into()),
+                    Arc::new(result.input),
+                );
+            }
+
+            result
+                .required_columns
+                .extend(result.bind_context.column_set());
+            return Ok(result);
+        }
+
+        let update_stream_columns = target_table.change_tracking_enabled();
+        let is_lazy_table = {
+            let metadata = binder.metadata.read();
+            result.mutation_type != MutationType::Delete
+                && metadata
+                    .table(result.target_table_index)
+                    .table()
+                    .supported_lazy_materialize()
+        };
+        result.input =
+            Self::update_target_scan(&result.input, is_lazy_table, update_stream_columns)?;
+
+        // Add internal column _row_id for target table.
+        result.target_table_row_id_index = binder.add_row_id_column(
+            &mut result.bind_context,
+            target_table_identifier,
+            result.target_table_index,
+            &mut result.input,
+            result.mutation_type.clone(),
+        )?;
+        result
+            .required_columns
+            .insert(result.target_table_row_id_index);
+
+        if let Some(source) = source {
+            let join_plan = Join {
+                equi_conditions: vec![],
+                non_equi_conditions: vec![],
+                join_type: JoinType::Cross,
+                marker_index: None,
+                from_correlated_subquery: true,
+                need_hold_hash_table: false,
+                is_lateral: false,
+                single_to_inner: None,
+                build_side_cache_info: None,
+                spatial_join: None,
+            };
+            result.input = SExpr::create_binary(
+                Arc::new(join_plan.into()),
+                Arc::new(result.input),
+                Arc::new(source),
+            );
+        }
+
+        result.input = SExpr::create_unary(
+            Arc::new(Filter { predicates }.into()),
+            Arc::new(result.input),
+        );
+
+        let opt_ctx = OptimizerContext::new(binder.ctx.clone(), binder.metadata.clone());
+        let mut rewriter = SubqueryDecorrelatorOptimizer::new(opt_ctx, None);
+        result.input = rewriter.optimize_sync(&result.input)?;
+
+        // DELETE only needs the row ID; a non-lazy UPDATE needs all bound target columns.
+        if !is_lazy_table && result.mutation_type != MutationType::Delete {
+            result
+                .required_columns
+                .extend(result.bind_context.column_set());
+        }
+
+        Ok(result)
     }
 
     pub fn mutation_type(&self) -> MutationType {
@@ -699,6 +707,8 @@ pub struct MutationExpressionBindResult {
     pub target_table_row_id_index: Symbol,
     pub required_columns: ColumnSet,
     pub all_source_columns: Option<HashMap<usize, ScalarExpr>>,
+    pub source: Option<SExpr>,
+    pub predicates: Vec<ScalarExpr>,
 }
 
 pub fn target_probe(s_expr: &SExpr, target_table_index: usize) -> Result<bool> {

--- a/src/query/sql/src/planner/binder/bind_mutation/mutation_expression.rs
+++ b/src/query/sql/src/planner/binder/bind_mutation/mutation_expression.rs
@@ -69,6 +69,7 @@ pub enum MutationExpression {
         target: TableReference,
         from: Option<TableReference>,
         filter: Option<Expr>,
+        force_non_direct: bool,
     },
     Delete {
         target: TableReference,
@@ -87,6 +88,10 @@ impl MutationExpression {
         target_table_schema: Arc<TableSchema>,
     ) -> Result<MutationExpressionBindResult> {
         let mutation_type = self.mutation_type();
+        let force_non_direct = matches!(self, MutationExpression::Update {
+            force_non_direct: true,
+            ..
+        });
         let mut required_columns = ColumnSet::new();
         let mut update_stream_columns = target_table.change_tracking_enabled();
 
@@ -220,6 +225,7 @@ impl MutationExpression {
                 target,
                 from,
                 filter,
+                ..
             }
             | MutationExpression::Delete {
                 target,
@@ -273,11 +279,17 @@ impl MutationExpression {
                     None
                 };
 
-                // If the filter is a simple expression, change the mutation strategy to MutationStrategy::Direct.
+                // Bind the filter first; simple predicates normally use the direct mutation path.
                 let (mut mutation_strategy, predicates) =
                     binder.process_filter(&mut bind_context, filter)?;
 
-                if from_s_expr.is_some() {
+                if from_s_expr.is_some()
+                    || force_non_direct
+                    || bind_context
+                        .bound_internal_columns
+                        .keys()
+                        .any(|(table_index, _)| *table_index == target_table_index)
+                {
                     mutation_strategy = MutationStrategy::MatchedOnly;
                 }
 

--- a/src/query/sql/src/planner/binder/bind_mutation/update.rs
+++ b/src/query/sql/src/planner/binder/bind_mutation/update.rs
@@ -15,34 +15,26 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use databend_common_ast::ast::ColumnID;
-use databend_common_ast::ast::Expr;
 use databend_common_ast::ast::MatchOperation;
 use databend_common_ast::ast::MatchedClause;
 use databend_common_ast::ast::MutationUpdateExpr;
 use databend_common_ast::ast::TableRef;
 use databend_common_ast::ast::TableReference;
 use databend_common_ast::ast::UpdateStmt;
-use databend_common_ast::visit::VisitControl;
-use databend_common_ast::visit::Visitor;
-use databend_common_ast::visit::Walk;
 use databend_common_exception::Result;
 
 use crate::BindContext;
 use crate::ColumnBinding;
 use crate::ColumnBindingBuilder;
-use crate::NameResolutionContext;
 use crate::ScalarExpr;
 use crate::Symbol;
 use crate::Visibility;
 use crate::binder::Binder;
-use crate::binder::INTERNAL_COLUMN_FACTORY;
 use crate::binder::aggregate::AggregateRewriter;
 use crate::binder::bind_mutation::bind::Mutation;
 use crate::binder::bind_mutation::bind::MutationStrategy;
 use crate::binder::bind_mutation::mutation_expression::MutationExpression;
 use crate::binder::util::TableIdentifier;
-use crate::normalize_identifier;
 use crate::optimizer::ir::Matcher;
 use crate::plans::AggregateFunction;
 use crate::plans::BoundColumnRef;
@@ -51,38 +43,6 @@ use crate::plans::Plan;
 use crate::plans::RelOp;
 use crate::plans::RelOperator;
 use crate::plans::ScalarItem;
-
-fn references_internal_column(expr: &Expr, name_resolution_ctx: &NameResolutionContext) -> bool {
-    struct InternalColumnVisitor<'a> {
-        name_resolution_ctx: &'a NameResolutionContext,
-        found: bool,
-    }
-
-    impl Visitor for InternalColumnVisitor<'_> {
-        fn visit_expr(
-            &mut self,
-            expr: &Expr,
-        ) -> std::result::Result<VisitControl<Self::Break>, Self::Error> {
-            if let Expr::ColumnRef { column, .. } = expr
-                && let ColumnID::Name(name) = &column.column
-            {
-                let name = normalize_identifier(name, self.name_resolution_ctx).name;
-                if INTERNAL_COLUMN_FACTORY.get_internal_column(&name).is_some() {
-                    self.found = true;
-                    return Ok(VisitControl::Break(()));
-                }
-            }
-            Ok(VisitControl::Continue)
-        }
-    }
-
-    let mut visitor = InternalColumnVisitor {
-        name_resolution_ctx,
-        found: false,
-    };
-    let _ = expr.walk(&mut visitor);
-    visitor.found
-}
 
 impl Binder {
     #[async_backtrace::framed]
@@ -132,9 +92,6 @@ impl Binder {
                 expr: update_expr.expr.clone(),
             })
             .collect::<Vec<_>>();
-        let force_non_direct = update_exprs.iter().any(|update_expr| {
-            references_internal_column(&update_expr.expr, &self.name_resolution_ctx)
-        });
         let matched_clause = MatchedClause {
             selection: None,
             operation: MatchOperation::Update {
@@ -150,7 +107,6 @@ impl Binder {
                 target: target_table_reference,
                 filter: selection.clone(),
                 from,
-                force_non_direct,
             },
             strategy: MutationStrategy::MatchedOnly,
             matched_clauses: vec![matched_clause],

--- a/src/query/sql/src/planner/binder/bind_mutation/update.rs
+++ b/src/query/sql/src/planner/binder/bind_mutation/update.rs
@@ -15,26 +15,34 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use databend_common_ast::ast::ColumnID;
+use databend_common_ast::ast::Expr;
 use databend_common_ast::ast::MatchOperation;
 use databend_common_ast::ast::MatchedClause;
 use databend_common_ast::ast::MutationUpdateExpr;
 use databend_common_ast::ast::TableRef;
 use databend_common_ast::ast::TableReference;
 use databend_common_ast::ast::UpdateStmt;
+use databend_common_ast::visit::VisitControl;
+use databend_common_ast::visit::Visitor;
+use databend_common_ast::visit::Walk;
 use databend_common_exception::Result;
 
 use crate::BindContext;
 use crate::ColumnBinding;
 use crate::ColumnBindingBuilder;
+use crate::NameResolutionContext;
 use crate::ScalarExpr;
 use crate::Symbol;
 use crate::Visibility;
 use crate::binder::Binder;
+use crate::binder::INTERNAL_COLUMN_FACTORY;
 use crate::binder::aggregate::AggregateRewriter;
 use crate::binder::bind_mutation::bind::Mutation;
 use crate::binder::bind_mutation::bind::MutationStrategy;
 use crate::binder::bind_mutation::mutation_expression::MutationExpression;
 use crate::binder::util::TableIdentifier;
+use crate::normalize_identifier;
 use crate::optimizer::ir::Matcher;
 use crate::plans::AggregateFunction;
 use crate::plans::BoundColumnRef;
@@ -43,6 +51,38 @@ use crate::plans::Plan;
 use crate::plans::RelOp;
 use crate::plans::RelOperator;
 use crate::plans::ScalarItem;
+
+fn references_internal_column(expr: &Expr, name_resolution_ctx: &NameResolutionContext) -> bool {
+    struct InternalColumnVisitor<'a> {
+        name_resolution_ctx: &'a NameResolutionContext,
+        found: bool,
+    }
+
+    impl Visitor for InternalColumnVisitor<'_> {
+        fn visit_expr(
+            &mut self,
+            expr: &Expr,
+        ) -> std::result::Result<VisitControl<Self::Break>, Self::Error> {
+            if let Expr::ColumnRef { column, .. } = expr
+                && let ColumnID::Name(name) = &column.column
+            {
+                let name = normalize_identifier(name, self.name_resolution_ctx).name;
+                if INTERNAL_COLUMN_FACTORY.get_internal_column(&name).is_some() {
+                    self.found = true;
+                    return Ok(VisitControl::Break(()));
+                }
+            }
+            Ok(VisitControl::Continue)
+        }
+    }
+
+    let mut visitor = InternalColumnVisitor {
+        name_resolution_ctx,
+        found: false,
+    };
+    let _ = expr.walk(&mut visitor);
+    visitor.found
+}
 
 impl Binder {
     #[async_backtrace::framed]
@@ -92,6 +132,9 @@ impl Binder {
                 expr: update_expr.expr.clone(),
             })
             .collect::<Vec<_>>();
+        let force_non_direct = update_exprs.iter().any(|update_expr| {
+            references_internal_column(&update_expr.expr, &self.name_resolution_ctx)
+        });
         let matched_clause = MatchedClause {
             selection: None,
             operation: MatchOperation::Update {
@@ -107,6 +150,7 @@ impl Binder {
                 target: target_table_reference,
                 filter: selection.clone(),
                 from,
+                force_non_direct,
             },
             strategy: MutationStrategy::MatchedOnly,
             matched_clauses: vec![matched_clause],

--- a/src/query/sql/tests/it/semantic/binder.rs
+++ b/src/query/sql/tests/it/semantic/binder.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use databend_common_exception::Result;
+use databend_common_sql::binder::MutationStrategy;
 use databend_common_sql::optimizer::ir::SExpr;
 use databend_common_sql::plans::Plan;
 use databend_common_sql::plans::RelOperator;
@@ -194,6 +195,40 @@ async fn test_binder_clauses_and_ordering() -> Result<()> {
     ];
 
     run_binder_cases("binder_clauses.txt", &cases).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_binder_mutation_internal_column_strategy() -> Result<()> {
+    let cases = [
+        (
+            "UPDATE t SET b = to_string(_row_id) WHERE a = 1",
+            MutationStrategy::MatchedOnly,
+        ),
+        (
+            "UPDATE t SET b = to_string(a) WHERE a = 1",
+            MutationStrategy::Direct,
+        ),
+    ];
+
+    for (sql, expected_strategy) in cases {
+        let case = SqlTestCase {
+            name: "update_internal_column_strategy",
+            description: "UPDATE strategy is selected after assignment expressions are bound.",
+            setup_sqls: &["CREATE TABLE t(a INT, b STRING)"],
+            sql,
+        };
+        let ctx = setup_context(&case).await?;
+        let plan = ctx.bind_sql(sql).await?;
+        let Plan::DataMutation { s_expr, .. } = plan else {
+            panic!("expected mutation plan for {sql}");
+        };
+        let RelOperator::Mutation(mutation) = s_expr.plan() else {
+            panic!("expected mutation operator for {sql}");
+        };
+        assert_eq!(mutation.strategy, expected_strategy, "sql: {sql}");
+    }
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/tests/sqllogictests/suites/base/issues/issue_20259.test
+++ b/tests/sqllogictests/suites/base/issues/issue_20259.test
@@ -1,0 +1,170 @@
+statement ok
+DROP TABLE IF EXISTS issue_20259;
+
+statement ok
+CREATE TABLE issue_20259(a INT, b STRING);
+
+statement ok
+INSERT INTO issue_20259 VALUES (1, 'a'), (2, 'b'), (3, 'c');
+
+# Internal columns in mutation assignments also use the regular scan-based path.
+statement ok
+UPDATE issue_20259 SET b = to_string(_row_id) WHERE a = 1;
+
+# Internal columns in mutation predicates use the regular scan-based path.
+statement ok
+UPDATE issue_20259 SET a = 20 WHERE _row_id > 0 AND a = 2;
+
+statement ok
+UPDATE issue_20259 SET b = _block_name WHERE a = 3;
+
+statement ok
+UPDATE issue_20259 SET a = 30 WHERE _block_name != '' AND a = 3;
+
+query IB
+SELECT a, length(b) > 0 FROM issue_20259 ORDER BY a;
+----
+1 1
+20 1
+30 1
+
+# Internal columns in DELETE predicates use the regular scan-based path.
+statement ok
+DELETE FROM issue_20259 WHERE _row_id > 0 AND a = 20;
+
+statement ok
+DELETE FROM issue_20259 WHERE _block_name != '' AND a = 30;
+
+query I
+SELECT a FROM issue_20259 ORDER BY a;
+----
+1
+
+# A subquery forces the non-direct mutation path, which materializes the internal column through
+# the regular table scan.
+statement ok
+INSERT INTO issue_20259 VALUES (4, 'd');
+
+statement ok
+UPDATE issue_20259 SET b = _block_name WHERE a IN (SELECT 4);
+
+query IB
+SELECT a, length(b) > 0 FROM issue_20259 ORDER BY a;
+----
+1 1
+4 1
+
+# Qualified internal-column references use the same generic path.
+statement ok
+UPDATE issue_20259 AS t SET b = to_string(t._row_id) WHERE t.a = 4;
+
+query IB
+SELECT a, length(b) > 0 FROM issue_20259 ORDER BY a;
+----
+1 1
+4 1
+
+# Internal columns work with change tracking through the regular scan-based path.
+statement ok
+DROP TABLE IF EXISTS issue_20259_change_tracking;
+
+statement ok
+CREATE TABLE issue_20259_change_tracking(a INT, b STRING) CHANGE_TRACKING = TRUE;
+
+statement ok
+INSERT INTO issue_20259_change_tracking VALUES (1, 'a'), (2, 'b'), (3, 'c');
+
+statement ok
+UPDATE issue_20259_change_tracking
+SET b = to_string(_row_id)
+WHERE _block_name != '' AND a = 1;
+
+statement ok
+DELETE FROM issue_20259_change_tracking WHERE _row_id > 0 AND a = 2;
+
+query IB
+SELECT a, length(b) > 0 FROM issue_20259_change_tracking ORDER BY a;
+----
+1 1
+3 1
+
+statement ok
+DROP TABLE issue_20259_change_tracking;
+
+statement ok
+UPDATE issue_20259 SET b = to_string(_ROW_ID) WHERE a = 1;
+
+query IB
+SELECT a, length(b) > 0 FROM issue_20259 ORDER BY a;
+----
+1 1
+4 1
+
+statement ok
+DROP TABLE issue_20259;
+
+# Source-side internal columns used by UPDATE FROM evaluators must survive column pruning.
+statement ok
+DROP TABLE IF EXISTS issue_20259_target;
+
+statement ok
+DROP TABLE IF EXISTS issue_20259_source;
+
+statement ok
+CREATE TABLE issue_20259_target(a INT, b STRING);
+
+statement ok
+CREATE TABLE issue_20259_source(a INT);
+
+statement ok
+INSERT INTO issue_20259_target VALUES (1, '');
+
+statement ok
+INSERT INTO issue_20259_source VALUES (1);
+
+statement ok
+UPDATE issue_20259_target AS t
+SET b = s._block_name
+FROM issue_20259_source AS s
+WHERE t.a = s.a;
+
+query IB
+SELECT a, length(b) > 0 FROM issue_20259_target;
+----
+1 1
+
+statement ok
+DROP TABLE issue_20259_target;
+
+statement ok
+DROP TABLE issue_20259_source;
+
+# `_snapshot_name` also uses metadata from the regular scan path.
+statement ok
+DROP TABLE IF EXISTS issue_20259_snapshot;
+
+statement ok
+CREATE TABLE issue_20259_snapshot(a INT, b STRING);
+
+statement ok
+INSERT INTO issue_20259_snapshot VALUES (1, 'a'), (2, 'b');
+
+statement ok
+UPDATE issue_20259_snapshot SET b = _snapshot_name WHERE a = 1;
+
+query IB
+SELECT a, length(b) > 0 FROM issue_20259_snapshot ORDER BY a;
+----
+1 1
+2 1
+
+statement ok
+DELETE FROM issue_20259_snapshot WHERE _snapshot_name != '' AND a = 2;
+
+query I
+SELECT a FROM issue_20259_snapshot ORDER BY a;
+----
+1
+
+statement ok
+DROP TABLE issue_20259_snapshot;

--- a/tests/sqllogictests/suites/base/issues/issue_20259.test
+++ b/tests/sqllogictests/suites/base/issues/issue_20259.test
@@ -2,169 +2,47 @@ statement ok
 DROP TABLE IF EXISTS issue_20259;
 
 statement ok
+DROP TABLE IF EXISTS issue_20259_source;
+
+statement ok
 CREATE TABLE issue_20259(a INT, b STRING);
 
 statement ok
-INSERT INTO issue_20259 VALUES (1, 'a'), (2, 'b'), (3, 'c');
-
-# Internal columns in mutation assignments also use the regular scan-based path.
-statement ok
-UPDATE issue_20259 SET b = to_string(_row_id) WHERE a = 1;
-
-# Internal columns in mutation predicates use the regular scan-based path.
-statement ok
-UPDATE issue_20259 SET a = 20 WHERE _row_id > 0 AND a = 2;
+CREATE TABLE issue_20259_source(a INT);
 
 statement ok
-UPDATE issue_20259 SET b = _block_name WHERE a = 3;
+INSERT INTO issue_20259 VALUES (1, ''), (2, ''), (3, '');
 
 statement ok
-UPDATE issue_20259 SET a = 30 WHERE _block_name != '' AND a = 3;
+INSERT INTO issue_20259_source VALUES (20);
+
+# Internal columns in assignments force the scan-based path. The qualified uppercase reference
+# also verifies case-insensitive name normalization.
+statement ok
+UPDATE issue_20259 AS t SET b = to_string(t._ROW_ID) WHERE t.a = 1;
+
+# Internal columns in predicates also force the scan-based path.
+statement ok
+UPDATE issue_20259 SET a = 20 WHERE _block_name != '' AND a = 2;
+
+statement ok
+DELETE FROM issue_20259 WHERE _row_id > 0 AND a = 3;
+
+# Source-side internal columns used by UPDATE FROM must survive physical column pruning.
+statement ok
+UPDATE issue_20259 AS t
+SET b = s._block_name
+FROM issue_20259_source AS s
+WHERE t.a = s.a;
 
 query IB
 SELECT a, length(b) > 0 FROM issue_20259 ORDER BY a;
 ----
 1 1
 20 1
-30 1
-
-# Internal columns in DELETE predicates use the regular scan-based path.
-statement ok
-DELETE FROM issue_20259 WHERE _row_id > 0 AND a = 20;
-
-statement ok
-DELETE FROM issue_20259 WHERE _block_name != '' AND a = 30;
-
-query I
-SELECT a FROM issue_20259 ORDER BY a;
-----
-1
-
-# A subquery forces the non-direct mutation path, which materializes the internal column through
-# the regular table scan.
-statement ok
-INSERT INTO issue_20259 VALUES (4, 'd');
-
-statement ok
-UPDATE issue_20259 SET b = _block_name WHERE a IN (SELECT 4);
-
-query IB
-SELECT a, length(b) > 0 FROM issue_20259 ORDER BY a;
-----
-1 1
-4 1
-
-# Qualified internal-column references use the same generic path.
-statement ok
-UPDATE issue_20259 AS t SET b = to_string(t._row_id) WHERE t.a = 4;
-
-query IB
-SELECT a, length(b) > 0 FROM issue_20259 ORDER BY a;
-----
-1 1
-4 1
-
-# Internal columns work with change tracking through the regular scan-based path.
-statement ok
-DROP TABLE IF EXISTS issue_20259_change_tracking;
-
-statement ok
-CREATE TABLE issue_20259_change_tracking(a INT, b STRING) CHANGE_TRACKING = TRUE;
-
-statement ok
-INSERT INTO issue_20259_change_tracking VALUES (1, 'a'), (2, 'b'), (3, 'c');
-
-statement ok
-UPDATE issue_20259_change_tracking
-SET b = to_string(_row_id)
-WHERE _block_name != '' AND a = 1;
-
-statement ok
-DELETE FROM issue_20259_change_tracking WHERE _row_id > 0 AND a = 2;
-
-query IB
-SELECT a, length(b) > 0 FROM issue_20259_change_tracking ORDER BY a;
-----
-1 1
-3 1
-
-statement ok
-DROP TABLE issue_20259_change_tracking;
-
-statement ok
-UPDATE issue_20259 SET b = to_string(_ROW_ID) WHERE a = 1;
-
-query IB
-SELECT a, length(b) > 0 FROM issue_20259 ORDER BY a;
-----
-1 1
-4 1
 
 statement ok
 DROP TABLE issue_20259;
 
-# Source-side internal columns used by UPDATE FROM evaluators must survive column pruning.
-statement ok
-DROP TABLE IF EXISTS issue_20259_target;
-
-statement ok
-DROP TABLE IF EXISTS issue_20259_source;
-
-statement ok
-CREATE TABLE issue_20259_target(a INT, b STRING);
-
-statement ok
-CREATE TABLE issue_20259_source(a INT);
-
-statement ok
-INSERT INTO issue_20259_target VALUES (1, '');
-
-statement ok
-INSERT INTO issue_20259_source VALUES (1);
-
-statement ok
-UPDATE issue_20259_target AS t
-SET b = s._block_name
-FROM issue_20259_source AS s
-WHERE t.a = s.a;
-
-query IB
-SELECT a, length(b) > 0 FROM issue_20259_target;
-----
-1 1
-
-statement ok
-DROP TABLE issue_20259_target;
-
 statement ok
 DROP TABLE issue_20259_source;
-
-# `_snapshot_name` also uses metadata from the regular scan path.
-statement ok
-DROP TABLE IF EXISTS issue_20259_snapshot;
-
-statement ok
-CREATE TABLE issue_20259_snapshot(a INT, b STRING);
-
-statement ok
-INSERT INTO issue_20259_snapshot VALUES (1, 'a'), (2, 'b');
-
-statement ok
-UPDATE issue_20259_snapshot SET b = _snapshot_name WHERE a = 1;
-
-query IB
-SELECT a, length(b) > 0 FROM issue_20259_snapshot ORDER BY a;
-----
-1 1
-2 1
-
-statement ok
-DELETE FROM issue_20259_snapshot WHERE _snapshot_name != '' AND a = 2;
-
-query I
-SELECT a FROM issue_20259_snapshot ORDER BY a;
-----
-1
-
-statement ok
-DROP TABLE issue_20259_snapshot;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Route UPDATE and DELETE statements that reference internal columns through the regular table-scan mutation path instead of `MutationSource`, which does not materialize internal columns
- Normalize internal-column identifiers before selecting the mutation strategy, so case-insensitive references such as `_ROW_ID` are handled consistently
- Add bound internal columns to their corresponding scans and retain all evaluator-used internal columns, including source-side columns in `UPDATE FROM` and `MERGE`
- Add regression coverage for internal columns in assignments and predicates, qualified and uppercase identifiers, change-tracking tables, `_snapshot_name`, and source tables

Fixes #20259

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent assisted with code analysis, implementation, regression-test drafting, and PR summary drafting; I reviewed and verified the complete diff.
- Responsible human: @zhyass
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20269)
<!-- Reviewable:end -->
