### PR TITLE
fix(functions): support nullable calendar monotonicity

### DIFF
--- a/src/query/functions/src/scalars/timestamp/src/datetime.rs
+++ b/src/query/functions/src/scalars/timestamp/src/datetime.rs
@@ -2268,17 +2268,25 @@ fn tz_wall_clock_single_segment(tz: &TimeZone, min_us: i64, max_us: i64) -> bool
 
 /// Range-sensitive monotonicity for calendar projections (`to_yyyymm`, `to_start_of_day`,
 /// ...): date inputs are always monotonic, while timestamp inputs are monotonic only when
-/// the range crosses no time-zone transition of the session time zone.
+/// the range crosses no time-zone transition of the session time zone. Nullable domains
+/// are judged by their non-null range; NULLs map to NULL and carry no ordering.
 fn calendar_monotonicity(ctx: &FunctionContext, args: &[Domain]) -> Option<usize> {
     let [domain] = args else {
         return None;
     };
+    calendar_domain_monotonic(ctx, domain).then_some(0)
+}
+
+fn calendar_domain_monotonic(ctx: &FunctionContext, domain: &Domain) -> bool {
     match domain {
-        Domain::Date(_) => Some(0),
-        Domain::Timestamp(simple) => {
-            tz_wall_clock_single_segment(&ctx.tz, simple.min, simple.max).then_some(0)
-        }
-        _ => None,
+        Domain::Date(_) => true,
+        Domain::Timestamp(simple) => tz_wall_clock_single_segment(&ctx.tz, simple.min, simple.max),
+        Domain::Nullable(nullable) => match &nullable.value {
+            Some(inner) => calendar_domain_monotonic(ctx, inner),
+            // An all-NULL input projects to a single NULL output.
+            None => true,
+        },
+        _ => false,
     }
 }
 

--- a/src/query/functions/tests/it/scalars/datetime.rs
+++ b/src/query/functions/tests/it/scalars/datetime.rs
@@ -21,6 +21,7 @@ use databend_common_expression::FunctionContext;
 use databend_common_expression::types::NumberDomain;
 use databend_common_expression::types::date::DATE_MAX;
 use databend_common_expression::types::date::DATE_MIN;
+use databend_common_expression::types::nullable::NullableDomain;
 use databend_common_expression::types::number::SimpleDomain;
 use databend_common_expression::types::*;
 use databend_common_expression::utils::auto_detect_datetime::auto_detect_date;
@@ -1202,6 +1203,19 @@ fn test_calendar_monotonicity_check() {
     });
     // Date inputs ignore the session time zone entirely.
     let dates = Domain::Date(SimpleDomain { min: 0, max: 20000 });
+    // Nullable domains are judged by their non-null range.
+    let nullable_crossing = Domain::Nullable(NullableDomain {
+        has_null: true,
+        value: Some(Box::new(crossing.clone())),
+    });
+    let nullable_clear = Domain::Nullable(NullableDomain {
+        has_null: true,
+        value: Some(Box::new(clear.clone())),
+    });
+    let all_null = Domain::Nullable(NullableDomain {
+        has_null: true,
+        value: None,
+    });
 
     for name in [
         "to_start_of_day",
@@ -1230,6 +1244,21 @@ fn test_calendar_monotonicity_check() {
         );
         assert_eq!(check(&st_johns, std::slice::from_ref(&clear)), Some(0));
         assert_eq!(check(&st_johns, std::slice::from_ref(&dates)), Some(0));
+        assert_eq!(
+            check(&st_johns, std::slice::from_ref(&nullable_crossing)),
+            None,
+            "{name}: nullable wrapper must not bypass the transition check"
+        );
+        assert_eq!(
+            check(&st_johns, std::slice::from_ref(&nullable_clear)),
+            Some(0)
+        );
+        assert_eq!(
+            check(&st_johns, std::slice::from_ref(&all_null)),
+            Some(0),
+            "{}: an all-NULL domain projects to one value",
+            name
+        );
     }
 
     // Sub-day rounders rebuild a local wall-clock time inside the day; every


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fix range-sensitive monotonicity checks for nullable calendar-function inputs.
Calendar projections such as `to_yyyymmdd(nullable_timestamp)` now inspect the
nullable domain's non-null timestamp range instead of rejecting the wrapper.
This allows expression cluster-key pruning to prove monotonicity when the range
stays within one time-zone offset segment, while continuing to fail open across
DST transitions.

An all-NULL domain is treated as monotonic because it projects to one NULL value.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:

- `cargo test -p databend-common-functions --test it test_calendar_monotonicity_check`
- `cargo test -p databend-common-functions --test it` (131 passed)
- `cargo clippy -p databend-functions-scalar-datetime -p databend-common-functions --all-targets -- -D warnings`
- `cargo fmt --all --check`

The regression test covers nullable ranges that cross a DST fallback, nullable
ranges contained in one offset segment, and all-NULL domains for all calendar
functions using the range-sensitive monotonicity check.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent split the nullable-domain fix from a larger storage-indexing branch, added all-NULL regression coverage, ran validation, and drafted this PR description.
- Responsible human: @zhang2014
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20271)
<!-- Reviewable:end -->
