### PR TITLE
fix(sql): make GROUP BY name resolution column-first

### DIFF
--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -252,13 +252,6 @@ impl DefaultSettings {
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(1..=1024)),
                 }),
-                ("enable_group_by_column_first", DefaultSettingValue {
-                    value: UserSettingValue::UInt64(0),
-                    desc: "Resolve GROUP BY names to input columns before SELECT aliases. Disabled by default for compatibility.",
-                    mode: SettingMode::Both,
-                    scope: SettingScope::Both,
-                    range: Some(SettingRange::Numeric(0..=1)),
-                }),
                 ("max_storage_io_requests", DefaultSettingValue {
                     value: UserSettingValue::UInt64(default_max_storage_io_requests),
                     desc: "Sets the maximum number of concurrent storage I/O requests.",

--- a/src/query/settings/src/settings_getter_setter.rs
+++ b/src/query/settings/src/settings_getter_setter.rs
@@ -615,10 +615,6 @@ impl Settings {
         self.try_get_string("group_by_shuffle_mode")
     }
 
-    pub fn get_enable_group_by_column_first(&self) -> Result<bool> {
-        Ok(self.try_get_u64("enable_group_by_column_first")? != 0)
-    }
-
     pub fn get_grouping_sets_to_union(&self) -> Result<bool> {
         Ok(self.try_get_u64("grouping_sets_to_union")? == 1)
     }

--- a/src/query/sql/src/planner/binder/bind_query/bind_select.rs
+++ b/src/query/sql/src/planner/binder/bind_query/bind_select.rs
@@ -202,8 +202,7 @@ impl Binder {
         // pre-window expressions behind aliases, but SRF aliases must already point
         // at the ProjectSet-produced columns instead of expanding back to raw SRFs.
         let mut semantic_alias = select_list.alias_catalog();
-        let group_by_aliases = semantic_alias
-            .group_by_bindings(self.ctx.get_settings().get_enable_group_by_column_first()?);
+        let group_by_aliases = semantic_alias.group_by_bindings();
 
         // This will potentially add some alias group items to `from_context` if find some.
         if let Some(group_by) = stmt.group_by.as_ref() {

--- a/src/query/sql/src/planner/binder/select.rs
+++ b/src/query/sql/src/planner/binder/select.rs
@@ -26,7 +26,6 @@ use databend_common_ast::ast::SetExpr;
 use databend_common_ast::ast::SetOperator;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
-use databend_common_expression::FunctionKind;
 use databend_common_expression::ROW_ID_COL_NAME;
 use databend_common_expression::ROW_ID_COLUMN_ID;
 use databend_common_expression::type_check::common_super_type;
@@ -71,29 +70,23 @@ pub struct SelectList<'a> {
 #[derive(Debug)]
 pub(crate) struct ClauseAliasBindings<'a> {
     aliases: &'a [(String, ScalarExpr)],
-    preferred: Vec<usize>,
     available: Vec<usize>,
-    group_by_column_first: bool,
 }
 
 pub(crate) type ClauseAliasLookup<'a> = (AliasLookup<'a>, Option<AliasLookup<'a>>);
 
 pub(crate) struct GroupItemAliasState<'a> {
     aliases: &'a [(String, ScalarExpr)],
-    preferred: &'a [usize],
     available: &'a [usize],
     prior_group_aliases: Vec<usize>,
-    group_by_column_first: bool,
 }
 
 impl ClauseAliasBindings<'_> {
     pub(crate) fn group_item_state(&self) -> GroupItemAliasState<'_> {
         GroupItemAliasState {
             aliases: self.aliases,
-            preferred: &self.preferred,
             available: &self.available,
             prior_group_aliases: Vec::new(),
-            group_by_column_first: self.group_by_column_first,
         }
     }
 }
@@ -114,8 +107,8 @@ impl GroupItemAliasState<'_> {
         // `SELECT i AS k FROM t GROUP BY k` may bind `k` as the alias for `i`.
         // `SELECT 1 AS k FROM t GROUP BY k + 1` may bind `k` from the SELECT
         // list if there is no input column named `k`.
-        // `GROUP BY k, abs(k)` should still prefer the earlier GROUP BY item
-        // alias inside later complex items, even if an input column conflicts.
+        // Once `k` falls back to a SELECT alias, `GROUP BY k, abs(k)` should
+        // reuse that earlier GROUP BY item alias inside the later expression.
         if Self::simple_unqualified_column_name(expr).is_none() {
             // GROUPING SETS keep prior alias reuse scoped to the current
             // generated set. A complex item in a later set must not bypass that
@@ -129,24 +122,16 @@ impl GroupItemAliasState<'_> {
             return (self.lookup(&self.prior_group_aliases), fallback_aliases);
         }
 
-        // With `enable_group_by_column_first`, the first binding pass should
-        // use input columns only. Alias fallback is still available for simple
+        // Bind input columns first. Alias fallback remains available for simple
         // names that do not exist in the input scope.
         //
-        // GROUPING SETS items (disable_select_alias_fallback = true) also prefer
-        // input columns: a SELECT alias like `if(grouping(x)=1, 0, x) AS x`
-        // must not shadow the underlying column `x` inside GROUP BY sets.
-        if self.group_by_column_first || disable_select_alias_fallback {
-            return (
-                self.lookup(&[]),
-                (!self.available.is_empty()).then(|| self.lookup(self.available)),
-            );
-        }
-
-        let fallback =
-            (self.preferred.len() != self.available.len()).then(|| self.lookup(self.available));
-
-        (self.lookup(self.preferred), fallback)
+        // GROUPING SETS items also prefer input columns: a SELECT alias like
+        // `if(grouping(x)=1, 0, x) AS x` must not shadow the underlying column
+        // `x` inside GROUP BY sets.
+        (
+            self.lookup(&[]),
+            (!self.available.is_empty()).then(|| self.lookup(self.available)),
+        )
     }
 
     pub(crate) fn matched_group_item_alias(
@@ -211,41 +196,10 @@ impl SelectClauseFact {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum GroupByAliasPolicy {
-    Preferred,
-    FallbackOnly,
-}
-
-impl GroupByAliasPolicy {
-    fn from_item(item: &SelectItem<'_>) -> Self {
-        if item.used_functions.iter().any(|name| {
-            BUILTIN_FUNCTIONS
-                .get_property(name)
-                .map(|property| property.kind == FunctionKind::SRF)
-                .unwrap_or(false)
-        }) {
-            return Self::FallbackOnly;
-        }
-
-        let predicate = |expr: &ScalarExpr| {
-            expr.is_aggregate() || matches!(expr, ScalarExpr::WindowFunction(_))
-        };
-        let mut any = Any::new(&predicate);
-        any.visit(&item.scalar).unwrap();
-        if !any.result() {
-            Self::Preferred
-        } else {
-            Self::FallbackOnly
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 struct SelectAliasEntry {
     alias_index: usize,
     explicit_expr_alias: bool,
-    group_by_policy: GroupByAliasPolicy,
     aggregate_expr_info: Option<AggregateExprInfo>,
 }
 
@@ -257,7 +211,6 @@ impl SelectAliasEntry {
                 alias: Some(_),
                 ..
             }),
-            group_by_policy: GroupByAliasPolicy::from_item(item),
             aggregate_expr_info: None,
         }
     }
@@ -275,21 +228,16 @@ impl SelectAliasCatalog {
         &self.aliases
     }
 
-    pub(crate) fn group_by_bindings(&self, group_by_column_first: bool) -> ClauseAliasBindings<'_> {
+    pub(crate) fn group_by_bindings(&self) -> ClauseAliasBindings<'_> {
         let mut bindings = ClauseAliasBindings {
             aliases: &self.aliases,
-            preferred: Vec::new(),
             available: Vec::new(),
-            group_by_column_first,
         };
         for item in &self.items {
             if !item.explicit_expr_alias {
                 continue;
             }
 
-            if item.group_by_policy == GroupByAliasPolicy::Preferred {
-                bindings.preferred.push(item.alias_index);
-            }
             bindings.available.push(item.alias_index);
         }
         bindings

--- a/src/query/sql/src/planner/dataframe.rs
+++ b/src/query/sql/src/planner/dataframe.rs
@@ -235,11 +235,7 @@ impl Dataframe {
         let alias_catalog = select_list.alias_catalog();
         let aliases = alias_catalog.all_aliases();
 
-        let group_by_aliases = alias_catalog.group_by_bindings(
-            self.query_ctx
-                .get_settings()
-                .get_enable_group_by_column_first()?,
-        );
+        let group_by_aliases = alias_catalog.group_by_bindings();
         self.binder.analyze_group_items(
             &mut self.bind_context,
             &select_list,

--- a/src/query/sql/tests/it/semantic/binder/alias_resolution.rs
+++ b/src/query/sql/tests/it/semantic/binder/alias_resolution.rs
@@ -18,7 +18,6 @@ use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
 
-use databend_common_catalog::table_context::TableContextSettings;
 use databend_common_exception::Result;
 use databend_common_sql::plans::Plan;
 use serde::Deserialize;
@@ -126,16 +125,7 @@ struct AliasMatrixYamlCase {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct AliasMatrixYamlRun {
-    #[serde(default)]
-    settings: AliasMatrixYamlSettings,
     sql: String,
-}
-
-#[derive(Debug, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct AliasMatrixYamlSettings {
-    #[serde(default)]
-    enable_group_by_column_first: bool,
 }
 
 impl AliasMatrixFile {
@@ -725,28 +715,8 @@ impl AliasMatrixYamlCase {
         }
         let multi_run = self.runs.len() > 1;
         for (index, run) in self.runs.iter().enumerate() {
-            ctx.get_settings().set_setting(
-                "enable_group_by_column_first".to_string(),
-                if run.settings.enable_group_by_column_first {
-                    "1"
-                } else {
-                    "0"
-                }
-                .to_string(),
-            )?;
-
             let run_name = if multi_run {
-                format!(
-                    "{}__{}__group_by_column_first_{}__run_{}",
-                    matrix.matrix,
-                    self.name,
-                    if run.settings.enable_group_by_column_first {
-                        "on"
-                    } else {
-                        "off"
-                    },
-                    index + 1,
-                )
+                format!("{}__{}__run_{}", matrix.matrix, self.name, index + 1,)
             } else {
                 format!("{}__{}", matrix.matrix, self.name)
             };
@@ -754,15 +724,6 @@ impl AliasMatrixYamlCase {
             write_case_title(file, &run_name, "")?;
             writeln!(file, "matrix: {}", matrix.matrix)?;
             writeln!(file, "key: {}", self.key)?;
-            writeln!(
-                file,
-                "setting: enable_group_by_column_first={}",
-                if run.settings.enable_group_by_column_first {
-                    1
-                } else {
-                    0
-                }
-            )?;
             writeln!(file, "sql: {}", run.sql)?;
             let outcome = match ctx.bind_sql(&run.sql).await {
                 Ok(plan) => SqlTestOutcome::Plan(plan.format_indent(Default::default())?),

--- a/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/aggregate_argument_alias.txt
+++ b/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/aggregate_argument_alias.txt
@@ -1,7 +1,6 @@
 === aggregate_argument_alias__aggregate_argument_prefers_input_column ===
 matrix: aggregate_argument_alias
 key: A0N0S0_0_00
-setting: enable_group_by_column_first=0
 sql: SELECT a AS c2, sum(c2) FROM t GROUP BY a
 status: ok
 EvalScalar
@@ -21,7 +20,6 @@ EvalScalar
 === aggregate_argument_alias__aggregate_argument_falls_back_to_prior_select_alias ===
 matrix: aggregate_argument_alias
 key: A0N0S0_0_10
-setting: enable_group_by_column_first=0
 sql: SELECT number % 3 AS c1, sum(c1) FROM t GROUP BY number % 3
 status: ok
 EvalScalar
@@ -41,7 +39,6 @@ EvalScalar
 === aggregate_argument_alias__udaf_argument_prefers_input_column ===
 matrix: aggregate_argument_alias
 key: A0N0S0_0_01
-setting: enable_group_by_column_first=0
 sql: SELECT a AS c2, weighted_avg(c2, 1) FROM udaf_prior_t GROUP BY a
 status: ok
 EvalScalar
@@ -61,7 +58,6 @@ EvalScalar
 === aggregate_argument_alias__udaf_argument_falls_back_to_prior_select_alias ===
 matrix: aggregate_argument_alias
 key: A0N0S0_0_11
-setting: enable_group_by_column_first=0
 sql: SELECT number % 3 AS c1, weighted_avg(c1, 1) FROM udaf_prior_t GROUP BY number % 3
 status: ok
 EvalScalar
@@ -81,7 +77,6 @@ EvalScalar
 === aggregate_argument_alias__aggregate_argument_prefers_input_column_over_prior_aggregate_alias ===
 matrix: aggregate_argument_alias
 key: A0N0S2_1_000
-setting: enable_group_by_column_first=0
 sql: SELECT count(*) AS c, sum(c) FROM t
 status: ok
 EvalScalar
@@ -101,7 +96,6 @@ EvalScalar
 === aggregate_argument_alias__aggregate_argument_consumes_unique_prior_aggregate_alias ===
 matrix: aggregate_argument_alias
 key: A0N0S2_1_100
-setting: enable_group_by_column_first=0
 sql: SELECT count(*) AS c, sum(c) FROM t
 status: ok
 EvalScalar
@@ -121,7 +115,6 @@ EvalScalar
 === aggregate_argument_alias__aggregate_argument_rejects_duplicate_prior_aggregate_alias ===
 matrix: aggregate_argument_alias
 key: A0N0S2_1_110
-setting: enable_group_by_column_first=0
 sql: SELECT count(*) AS c, max(number) AS c, sum(c) FROM t
 status: error
 code: 1065
@@ -130,7 +123,6 @@ message: column c reference or alias is ambiguous, please use another alias name
 === aggregate_argument_alias__udaf_argument_prefers_input_column_over_prior_aggregate_alias ===
 matrix: aggregate_argument_alias
 key: A0N0S2_1_001
-setting: enable_group_by_column_first=0
 sql: SELECT count(*) AS c, weighted_avg(c, 1) FROM udaf_t
 status: ok
 EvalScalar
@@ -150,7 +142,6 @@ EvalScalar
 === aggregate_argument_alias__udaf_argument_consumes_unique_prior_aggregate_alias ===
 matrix: aggregate_argument_alias
 key: A0N0S2_1_101
-setting: enable_group_by_column_first=0
 sql: SELECT count(*) AS c, weighted_avg(c, 1) FROM udaf_t
 status: ok
 EvalScalar
@@ -170,7 +161,6 @@ EvalScalar
 === aggregate_argument_alias__udaf_argument_rejects_duplicate_prior_aggregate_alias ===
 matrix: aggregate_argument_alias
 key: A0N0S2_1_111
-setting: enable_group_by_column_first=0
 sql: SELECT count(*) AS c, max(number) AS c, weighted_avg(c, 1) FROM udaf_t
 status: error
 code: 1065
@@ -179,7 +169,6 @@ message: column c reference or alias is ambiguous, please use another alias name
 === aggregate_argument_alias__aggregate_argument_qualified_name_does_not_consume_prior_select_alias ===
 matrix: aggregate_argument_alias
 key: A0N1S0_3_
-setting: enable_group_by_column_first=0
 sql: SELECT number % 3 AS c1, sum(t.c1) FROM t AS t GROUP BY number % 3
 status: error
 code: 1065
@@ -188,7 +177,6 @@ message: column c1 doesn't exist
 === aggregate_argument_alias__aggregate_argument_qualified_name_does_not_consume_aggregate_alias ===
 matrix: aggregate_argument_alias
 key: A0N1S2_3_
-setting: enable_group_by_column_first=0
 sql: SELECT count(*) AS c, sum(t.c) FROM t AS t
 status: error
 code: 1065

--- a/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/group_by_alias.txt
+++ b/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/group_by_alias.txt
@@ -1,27 +1,6 @@
-=== group_by_alias__group_by_bare_select_alias_conflict_alias_first ===
+=== group_by_alias__group_by_bare_select_alias_conflict_uses_input ===
 matrix: group_by_alias
-key: G0N0S1_0_00
-setting: enable_group_by_column_first=0
-sql: SELECT i AS x, count(*) FROM t GROUP BY x
-status: ok
-EvalScalar
-├── scalars: [t.i (#0) AS (#0), COUNT(*) (#2) AS (#2)]
-└── Aggregate(Initial)
-    ├── group items: [t.i (#0) AS (#0)]
-    ├── aggregate functions: [count() AS (#2)]
-    └── EvalScalar
-        ├── scalars: [t.i (#0) AS (#0)]
-        └── Scan
-            ├── table: default.t (#0)
-            ├── filters: []
-            ├── order by: []
-            └── limit: NONE
-
-
-=== group_by_alias__group_by_bare_select_alias_conflict_column_first ===
-matrix: group_by_alias
-key: G0N0S1_0_01
-setting: enable_group_by_column_first=1
+key: G0N0S1_0_0
 sql: SELECT i AS x, count(*) FROM t GROUP BY x
 status: error
 code: 1065
@@ -29,8 +8,7 @@ message: column "i" must appear in the GROUP BY clause or be used in an aggregat
 
 === group_by_alias__group_by_bare_select_alias_no_input ===
 matrix: group_by_alias
-key: G0N0S1_0_10
-setting: enable_group_by_column_first=0
+key: G0N0S1_0_1
 sql: SELECT i AS k, count(*) FROM t GROUP BY k
 status: ok
 EvalScalar
@@ -47,43 +25,9 @@ EvalScalar
             └── limit: NONE
 
 
-=== group_by_alias__group_by_bare_select_alias_ambiguous_input_alias_first ===
+=== group_by_alias__group_by_bare_select_alias_ambiguous_input_rejected ===
 matrix: group_by_alias
-key: G0N0S1_0_20
-setting: enable_group_by_column_first=0
-sql: SELECT t1.x AS x, count(*) FROM t AS t1 INNER JOIN t AS t2 ON true GROUP BY x
-status: ok
-EvalScalar
-├── scalars: [t.x (#0) AS (#0), COUNT(*) (#2) AS (#2)]
-└── Aggregate(Initial)
-    ├── group items: [t.x (#0) AS (#0)]
-    ├── aggregate functions: [count() AS (#2)]
-    └── EvalScalar
-        ├── scalars: [t.x (#0) AS (#0)]
-        └── Join(Inner)
-            ├── build keys: []
-            ├── probe keys: []
-            ├── other filters: []
-            ├── Filter
-            │   ├── filters: [true]
-            │   └── Scan
-            │       ├── table: default.t (#1)
-            │       ├── filters: []
-            │       ├── order by: []
-            │       └── limit: NONE
-            └── Filter
-                ├── filters: [true]
-                └── Scan
-                    ├── table: default.t (#0)
-                    ├── filters: []
-                    ├── order by: []
-                    └── limit: NONE
-
-
-=== group_by_alias__group_by_bare_select_alias_ambiguous_input_column_first ===
-matrix: group_by_alias
-key: G0N0S1_0_21
-setting: enable_group_by_column_first=1
+key: G0N0S1_0_2
 sql: SELECT t1.x AS x, count(*) FROM t AS t1 INNER JOIN t AS t2 ON true GROUP BY x
 status: error
 code: 1065
@@ -91,8 +35,7 @@ message: column x reference or alias is ambiguous, please use another alias name
 
 === group_by_alias__group_by_expression_uses_prior_group_alias ===
 matrix: group_by_alias
-key: G0N2G0_1_00
-setting: enable_group_by_column_first=0
+key: G0N2G0_1_0
 sql: SELECT i AS k, abs(i) AS ak, count(*) FROM t GROUP BY k, abs(k)
 status: ok
 EvalScalar
@@ -111,8 +54,7 @@ EvalScalar
 
 === group_by_alias__rollup_same_list_uses_prior_group_alias ===
 matrix: group_by_alias
-key: G2N2G0_1_00
-setting: enable_group_by_column_first=0
+key: G2N2G0_1_0
 sql: SELECT i AS k, abs(i) AS ak, count(*) FROM t GROUP BY ROLLUP(k, abs(k))
 status: ok
 EvalScalar
@@ -122,66 +64,6 @@ EvalScalar
     ├── aggregate functions: [count() AS (#5)]
     └── EvalScalar
         ├── scalars: [t.i (#0) AS (#0), abs(t.i (#0)) AS (#1)]
-        └── Scan
-            ├── table: default.t (#0)
-            ├── filters: []
-            ├── order by: []
-            └── limit: NONE
-
-
-=== group_by_alias__group_by_expression_uses_prior_group_alias_column_first ===
-matrix: group_by_alias
-key: G0N2G0_2_01
-setting: enable_group_by_column_first=1
-sql: SELECT i AS k, abs(i) AS ak, count(*) FROM t GROUP BY k, abs(k)
-status: ok
-EvalScalar
-├── scalars: [t.i (#0) AS (#0), COUNT(*) (#2) AS (#2), abs(t.i (#0)) AS (#3)]
-└── Aggregate(Initial)
-    ├── group items: [t.i (#0) AS (#0)]
-    ├── aggregate functions: [count() AS (#2)]
-    └── EvalScalar
-        ├── scalars: [t.i (#0) AS (#0)]
-        └── Scan
-            ├── table: default.t (#0)
-            ├── filters: []
-            ├── order by: []
-            └── limit: NONE
-
-
-=== group_by_alias__rollup_same_list_uses_prior_group_alias_column_first ===
-matrix: group_by_alias
-key: G2N2G0_2_01
-setting: enable_group_by_column_first=1
-sql: SELECT i AS k, abs(i) AS ak, count(*) FROM t GROUP BY ROLLUP(k, abs(k))
-status: ok
-EvalScalar
-├── scalars: [t.i (#0) AS (#0), COUNT(*) (#5) AS (#5), abs(k) (#1) AS (#6)]
-└── Aggregate(Initial)
-    ├── group items: [t.i (#0) AS (#0), abs(t.i (#0)) AS (#1), _grouping_id (#4) AS (#4)]
-    ├── aggregate functions: [count() AS (#5)]
-    └── EvalScalar
-        ├── scalars: [t.i (#0) AS (#0), abs(t.i (#0)) AS (#1)]
-        └── Scan
-            ├── table: default.t (#0)
-            ├── filters: []
-            ├── order by: []
-            └── limit: NONE
-
-
-=== group_by_alias__group_by_expression_prefers_prior_group_alias_over_input_column ===
-matrix: group_by_alias
-key: G0N2G0_3_000
-setting: enable_group_by_column_first=0
-sql: SELECT i AS k, abs(i) AS ak, count(*) FROM t GROUP BY k, abs(k)
-status: ok
-EvalScalar
-├── scalars: [t.i (#0) AS (#0), COUNT(*) (#3) AS (#3), abs(t.i (#0)) AS (#4)]
-└── Aggregate(Initial)
-    ├── group items: [t.i (#0) AS (#0)]
-    ├── aggregate functions: [count() AS (#3)]
-    └── EvalScalar
-        ├── scalars: [t.i (#0) AS (#0)]
         └── Scan
             ├── table: default.t (#0)
             ├── filters: []
@@ -191,8 +73,7 @@ EvalScalar
 
 === group_by_alias__grouping_sets_same_set_uses_prior_group_alias ===
 matrix: group_by_alias
-key: G1N2G0_4_10
-setting: enable_group_by_column_first=0
+key: G1N2G0_2_1
 sql: SELECT i AS k, abs(i) AS ak, count(*) FROM t GROUP BY GROUPING SETS ((k, abs(k)))
 status: ok
 EvalScalar
@@ -211,8 +92,7 @@ EvalScalar
 
 === group_by_alias__grouping_sets_separate_set_does_not_share_prior_alias ===
 matrix: group_by_alias
-key: G1N2G0_4_21
-setting: enable_group_by_column_first=1
+key: G1N2G0_2_2
 sql: SELECT i AS k, abs(i) AS ak, count(*) FROM t GROUP BY GROUPING SETS ((k), (abs(k)))
 status: error
 code: 1065
@@ -220,8 +100,7 @@ message: column k doesn't exist
 
 === group_by_alias__cube_generated_set_does_not_share_prior_alias ===
 matrix: group_by_alias
-key: G3N2G0_5_1
-setting: enable_group_by_column_first=1
+key: G3N2G0_3_
 sql: SELECT i AS k, abs(i) AS ak, count(*) FROM t GROUP BY CUBE(k, abs(k))
 status: error
 code: 1065
@@ -229,8 +108,7 @@ message: column k doesn't exist
 
 === group_by_alias__combined_grouping_sets_uses_prior_group_alias ===
 matrix: group_by_alias
-key: G4N2G0_6_0
-setting: enable_group_by_column_first=0
+key: G4N2G0_4_
 sql: SELECT i AS k, abs(i) AS ak, count(*) FROM t GROUP BY k, GROUPING SETS ((abs(k)))
 status: ok
 EvalScalar
@@ -249,8 +127,7 @@ EvalScalar
 
 === group_by_alias__group_by_complex_select_alias_conflict_uses_input ===
 matrix: group_by_alias
-key: G0N2S1_7_0
-setting: enable_group_by_column_first=0
+key: G0N2S1_5_0
 sql: SELECT 1 AS k, count(*) FROM t GROUP BY k + 1
 status: ok
 EvalScalar
@@ -267,30 +144,9 @@ EvalScalar
             └── limit: NONE
 
 
-=== group_by_alias__group_by_complex_select_alias_no_input_fallback__group_by_column_first_off__run_1 ===
+=== group_by_alias__group_by_complex_select_alias_no_input_fallback ===
 matrix: group_by_alias
-key: G0N2S1_7_1
-setting: enable_group_by_column_first=0
-sql: SELECT 1 AS k, count(*) FROM t GROUP BY k + 1
-status: ok
-EvalScalar
-├── scalars: [COUNT(*) (#2) AS (#2), 1 AS (#3)]
-└── Aggregate(Initial)
-    ├── group items: [2 AS (#1)]
-    ├── aggregate functions: [count() AS (#2)]
-    └── EvalScalar
-        ├── scalars: [2 AS (#1)]
-        └── Scan
-            ├── table: default.t (#0)
-            ├── filters: []
-            ├── order by: []
-            └── limit: NONE
-
-
-=== group_by_alias__group_by_complex_select_alias_no_input_fallback__group_by_column_first_on__run_2 ===
-matrix: group_by_alias
-key: G0N2S1_7_1
-setting: enable_group_by_column_first=1
+key: G0N2S1_5_1
 sql: SELECT 1 AS k, count(*) FROM t GROUP BY k + 1
 status: ok
 EvalScalar
@@ -309,8 +165,7 @@ EvalScalar
 
 === group_by_alias__group_by_complex_select_alias_ambiguous_input_rejected ===
 matrix: group_by_alias
-key: G0N2S1_7_2
-setting: enable_group_by_column_first=0
+key: G0N2S1_5_2
 sql: SELECT 1 AS k, count(*) FROM t AS t1 INNER JOIN t AS t2 ON true GROUP BY k + 1
 status: error
 code: 1065
@@ -318,8 +173,7 @@ message: column k reference or alias is ambiguous, please use another alias name
 
 === group_by_alias__group_by_aggregate_alias_conflict_uses_input ===
 matrix: group_by_alias
-key: G0N0S2_9_0
-setting: enable_group_by_column_first=0
+key: G0N0S2_7_0
 sql: SELECT count(*) AS x FROM (SELECT 1 AS x UNION ALL SELECT 2 AS x) GROUP BY x
 status: ok
 EvalScalar
@@ -345,8 +199,7 @@ EvalScalar
 
 === group_by_alias__group_by_aggregate_alias_no_input_rejected ===
 matrix: group_by_alias
-key: G0N0S2_9_1
-setting: enable_group_by_column_first=0
+key: G0N0S2_7_1
 sql: SELECT count(*) AS c FROM t GROUP BY c
 status: error
 code: 1065
@@ -354,8 +207,7 @@ message: GROUP BY items can't contain aggregate functions or window functions: C
 
 === group_by_alias__group_by_srf_alias_conflict_uses_input ===
 matrix: group_by_alias
-key: G0N0S4_10_0
-setting: enable_group_by_column_first=0
+key: G0N0S4_8_0
 sql: SELECT t.col1 AS col1, unnest(split(t.col2, ',')) AS col2 FROM t_str AS t GROUP BY col1, col2 ORDER BY col2
 status: ok
 Sort
@@ -378,8 +230,7 @@ Sort
 
 === group_by_alias__group_by_srf_alias_no_input ===
 matrix: group_by_alias
-key: G0N0S4_10_1
-setting: enable_group_by_column_first=0
+key: G0N0S4_8_1
 sql: SELECT t.col1 AS col1, unnest(split(t.col2, ',')) AS col3 FROM t_str AS t GROUP BY col1, col3 ORDER BY col3
 status: ok
 Sort
@@ -402,8 +253,7 @@ Sort
 
 === group_by_alias__group_by_ordinal_uses_select_item_position ===
 matrix: group_by_alias
-key: G0N4N0_12_
-setting: enable_group_by_column_first=0
+key: G0N4N0_10_
 sql: SELECT i AS k, count(*) FROM t GROUP BY 1
 status: ok
 EvalScalar
@@ -422,8 +272,7 @@ EvalScalar
 
 === group_by_alias__group_by_all_expands_non_aggregate_select_items ===
 matrix: group_by_alias
-key: G5N5N0_13_
-setting: enable_group_by_column_first=0
+key: G5N5N0_11_
 sql: SELECT i AS k, count(*) FROM t GROUP BY ALL
 status: ok
 EvalScalar
@@ -442,8 +291,7 @@ EvalScalar
 
 === group_by_alias__group_by_qualified_name_does_not_consume_prior_group_alias ===
 matrix: group_by_alias
-key: G0N1G0_14_
-setting: enable_group_by_column_first=0
+key: G0N1G0_12_
 sql: SELECT i AS k, count(*) FROM t GROUP BY k, t.k
 status: error
 code: 1065
@@ -451,8 +299,7 @@ message: column k doesn't exist
 
 === group_by_alias__group_by_qualified_complex_does_not_fallback_to_select_alias ===
 matrix: group_by_alias
-key: G0N3S1_14_
-setting: enable_group_by_column_first=0
+key: G0N3S1_12_
 sql: SELECT i AS k, count(*) FROM t GROUP BY t.k + 1
 status: error
 code: 1065
@@ -460,8 +307,7 @@ message: column k doesn't exist
 
 === group_by_alias__grouping_sets_qualified_name_does_not_fallback_to_select_alias ===
 matrix: group_by_alias
-key: G1N1S1_14_
-setting: enable_group_by_column_first=0
+key: G1N1S1_12_
 sql: SELECT i AS k, count(*) FROM t GROUP BY GROUPING SETS ((t.k))
 status: error
 code: 1065
@@ -469,8 +315,7 @@ message: column k doesn't exist
 
 === group_by_alias__grouping_sets_complex_select_alias_does_not_fallback ===
 matrix: group_by_alias
-key: G1N2S1_14_
-setting: enable_group_by_column_first=0
+key: G1N2S1_12_
 sql: SELECT i AS k, count(*) FROM t GROUP BY GROUPING SETS ((abs(k)))
 status: error
 code: 1065
@@ -478,8 +323,7 @@ message: column k doesn't exist
 
 === group_by_alias__rollup_complex_select_alias_does_not_fallback ===
 matrix: group_by_alias
-key: G2N2S1_14_
-setting: enable_group_by_column_first=0
+key: G2N2S1_12_
 sql: SELECT i AS k, count(*) FROM t GROUP BY ROLLUP(abs(k))
 status: error
 code: 1065
@@ -487,8 +331,7 @@ message: column k doesn't exist
 
 === group_by_alias__cube_complex_select_alias_does_not_fallback ===
 matrix: group_by_alias
-key: G3N2S1_14_
-setting: enable_group_by_column_first=0
+key: G3N2S1_12_
 sql: SELECT i AS k, count(*) FROM t GROUP BY CUBE(abs(k))
 status: error
 code: 1065
@@ -496,8 +339,7 @@ message: column k doesn't exist
 
 === group_by_alias__combined_normal_complex_select_alias_fallback ===
 matrix: group_by_alias
-key: G4N2S1_14_
-setting: enable_group_by_column_first=0
+key: G4N2S1_12_
 sql: SELECT 1 AS k, count(*) FROM t GROUP BY k + 1, GROUPING SETS (())
 status: ok
 EvalScalar

--- a/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/group_by_alias.yaml
+++ b/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/group_by_alias.yaml
@@ -4,66 +4,33 @@ local_dimensions:
     values: [input-conflict, no-input, input-ambiguous]
   - name: scope
     values: [same-list-exact, same-set, separate-set]
-  - name: setting
-    values: [alias-first, column-first]
 regions:
-  - description: bare GROUP BY lookup of SELECT scalar aliases under alias-first and column-first settings
+  - description: bare GROUP BY names bind input columns first and fall back to SELECT scalar aliases
     main:
       consumers: [G0]
       name_shapes: [N0]
       producers: [S1]
     local:
       relation: [input-conflict, no-input, input-ambiguous]
-      setting: [alias-first, column-first]
-    masks:
-      - when:
-          main:
-            consumers: [G0]
-            name_shapes: [N0]
-            producers: [S1]
-          local:
-            relation: [no-input]
-            setting: [column-first]
-        reason: without an input-column conflict, column-first and alias-first collapse to the same alias fallback behavior
     cases:
-      - key: G0N0S1_0_00
-        name: group_by_bare_select_alias_conflict_alias_first
+      - key: G0N0S1_0_0
+        name: group_by_bare_select_alias_conflict_uses_input
         setup_sqls:
           - "CREATE TABLE t(i Int32, x Int32)"
         runs:
-          - settings:
-              enable_group_by_column_first: false
-            sql: "SELECT i AS x, count(*) FROM t GROUP BY x"
-      - key: G0N0S1_0_01
-        name: group_by_bare_select_alias_conflict_column_first
-        setup_sqls:
-          - "CREATE TABLE t(i Int32, x Int32)"
-        runs:
-          - settings:
-              enable_group_by_column_first: true
-            sql: "SELECT i AS x, count(*) FROM t GROUP BY x"
-      - key: G0N0S1_0_10
+          - sql: "SELECT i AS x, count(*) FROM t GROUP BY x"
+      - key: G0N0S1_0_1
         name: group_by_bare_select_alias_no_input
         setup_sqls:
           - "CREATE TABLE t(i Int32)"
         runs:
           - sql: "SELECT i AS k, count(*) FROM t GROUP BY k"
-      - key: G0N0S1_0_20
-        name: group_by_bare_select_alias_ambiguous_input_alias_first
+      - key: G0N0S1_0_2
+        name: group_by_bare_select_alias_ambiguous_input_rejected
         setup_sqls:
           - "CREATE TABLE t(x Int32)"
         runs:
-          - settings:
-              enable_group_by_column_first: false
-            sql: "SELECT t1.x AS x, count(*) FROM t AS t1 INNER JOIN t AS t2 ON true GROUP BY x"
-      - key: G0N0S1_0_21
-        name: group_by_bare_select_alias_ambiguous_input_column_first
-        setup_sqls:
-          - "CREATE TABLE t(x Int32)"
-        runs:
-          - settings:
-              enable_group_by_column_first: true
-            sql: "SELECT t1.x AS x, count(*) FROM t AS t1 INNER JOIN t AS t2 ON true GROUP BY x"
+          - sql: "SELECT t1.x AS x, count(*) FROM t AS t1 INNER JOIN t AS t2 ON true GROUP BY x"
   - description: prior GROUP BY aliases reused by later expressions in the same ordinary grouping list
     main:
       consumers: [G0, G2]
@@ -71,61 +38,19 @@ regions:
       producers: [G0]
     local:
       scope: [same-list-exact]
-      setting: [alias-first]
     cases:
-      - key: G0N2G0_1_00
+      - key: G0N2G0_1_0
         name: group_by_expression_uses_prior_group_alias
         setup_sqls:
           - "CREATE TABLE t(i Int32)"
         runs:
           - sql: "SELECT i AS k, abs(i) AS ak, count(*) FROM t GROUP BY k, abs(k)"
-      - key: G2N2G0_1_00
+      - key: G2N2G0_1_0
         name: rollup_same_list_uses_prior_group_alias
         setup_sqls:
           - "CREATE TABLE t(i Int32)"
         runs:
           - sql: "SELECT i AS k, abs(i) AS ak, count(*) FROM t GROUP BY ROLLUP(k, abs(k))"
-  - description: prior GROUP BY alias reuse is independent of column-first mode once the earlier item fell back to an alias
-    main:
-      consumers: [G0, G2]
-      name_shapes: [N2]
-      producers: [G0]
-    local:
-      scope: [same-list-exact]
-      setting: [column-first]
-    cases:
-      - key: G0N2G0_2_01
-        name: group_by_expression_uses_prior_group_alias_column_first
-        setup_sqls:
-          - "CREATE TABLE t(i Int32)"
-        runs:
-          - settings:
-              enable_group_by_column_first: true
-            sql: "SELECT i AS k, abs(i) AS ak, count(*) FROM t GROUP BY k, abs(k)"
-      - key: G2N2G0_2_01
-        name: rollup_same_list_uses_prior_group_alias_column_first
-        setup_sqls:
-          - "CREATE TABLE t(i Int32)"
-        runs:
-          - settings:
-              enable_group_by_column_first: true
-            sql: "SELECT i AS k, abs(i) AS ak, count(*) FROM t GROUP BY ROLLUP(k, abs(k))"
-  - description: prior GROUP BY aliases still win inside later expressions when an input column has the same name
-    main:
-      consumers: [G0]
-      name_shapes: [N2]
-      producers: [G0]
-    local:
-      relation: [input-conflict]
-      scope: [same-list-exact]
-      setting: [alias-first]
-    cases:
-      - key: G0N2G0_3_000
-        name: group_by_expression_prefers_prior_group_alias_over_input_column
-        setup_sqls:
-          - "CREATE TABLE t(i Int32, k Int32)"
-        runs:
-          - sql: "SELECT i AS k, abs(i) AS ak, count(*) FROM t GROUP BY k, abs(k)"
   - description: GROUPING SETS scope boundaries for prior GROUP BY alias reuse
     main:
       consumers: [G1]
@@ -133,62 +58,38 @@ regions:
       producers: [G0]
     local:
       scope: [same-set, separate-set]
-      setting: [alias-first, column-first]
-    masks:
-      - when:
-          main:
-            consumers: [G1]
-          local:
-            scope: [same-set]
-            setting: [column-first]
-        reason: grouping-set same-set alias visibility is independent of GROUP BY column-first mode
-      - when:
-          main:
-            consumers: [G1]
-          local:
-            scope: [separate-set]
-            setting: [alias-first]
-        reason: separate grouping sets isolate prior aliases regardless of GROUP BY alias-first mode
     cases:
-      - key: G1N2G0_4_10
+      - key: G1N2G0_2_1
         name: grouping_sets_same_set_uses_prior_group_alias
         setup_sqls:
           - "CREATE TABLE t(i Int32)"
         runs:
           - sql: "SELECT i AS k, abs(i) AS ak, count(*) FROM t GROUP BY GROUPING SETS ((k, abs(k)))"
-      - key: G1N2G0_4_21
+      - key: G1N2G0_2_2
         name: grouping_sets_separate_set_does_not_share_prior_alias
         setup_sqls:
           - "CREATE TABLE t(i Int32)"
         runs:
-          - settings:
-              enable_group_by_column_first: true
-            sql: "SELECT i AS k, abs(i) AS ak, count(*) FROM t GROUP BY GROUPING SETS ((k), (abs(k)))"
+          - sql: "SELECT i AS k, abs(i) AS ak, count(*) FROM t GROUP BY GROUPING SETS ((k), (abs(k)))"
   - description: CUBE-generated grouping sets that do not preserve prior alias visibility
     main:
       consumers: [G3]
       name_shapes: [N2]
       producers: [G0]
-    local:
-      setting: [column-first]
     cases:
-      - key: G3N2G0_5_1
+      - key: G3N2G0_3_
         name: cube_generated_set_does_not_share_prior_alias
         setup_sqls:
           - "CREATE TABLE t(i Int32)"
         runs:
-          - settings:
-              enable_group_by_column_first: true
-            sql: "SELECT i AS k, abs(i) AS ak, count(*) FROM t GROUP BY CUBE(k, abs(k))"
+          - sql: "SELECT i AS k, abs(i) AS ak, count(*) FROM t GROUP BY CUBE(k, abs(k))"
   - description: combined GROUP BY forms where normal items seed later grouping-set expressions
     main:
       consumers: [G4]
       name_shapes: [N2]
       producers: [G0]
-    local:
-      setting: [alias-first]
     cases:
-      - key: G4N2G0_6_0
+      - key: G4N2G0_4_
         name: combined_grouping_sets_uses_prior_group_alias
         setup_sqls:
           - "CREATE TABLE t(i Int32)"
@@ -202,22 +103,19 @@ regions:
     local:
       relation: [input-conflict, no-input, input-ambiguous]
     cases:
-      - key: G0N2S1_7_0
+      - key: G0N2S1_5_0
         name: group_by_complex_select_alias_conflict_uses_input
         setup_sqls:
           - "CREATE TABLE t(i Int32, k Int32)"
         runs:
           - sql: "SELECT 1 AS k, count(*) FROM t GROUP BY k + 1"
-      - key: G0N2S1_7_1
+      - key: G0N2S1_5_1
         name: group_by_complex_select_alias_no_input_fallback
         setup_sqls:
           - "CREATE TABLE t(i Int32)"
         runs:
           - sql: "SELECT 1 AS k, count(*) FROM t GROUP BY k + 1"
-          - settings:
-              enable_group_by_column_first: true
-            sql: "SELECT 1 AS k, count(*) FROM t GROUP BY k + 1"
-      - key: G0N2S1_7_2
+      - key: G0N2S1_5_2
         name: group_by_complex_select_alias_ambiguous_input_rejected
         setup_sqls:
           - "CREATE TABLE t(k Int32)"
@@ -230,14 +128,12 @@ regions:
       producers: [S1]
     local:
       relation: [no-input]
-      setting: [alias-first]
     masks:
       - when:
           main:
             name_shapes: [N1]
           local:
             relation: [no-input]
-            setting: [alias-first]
         reason: qualified GROUP BY names bypass SELECT output aliases and belong to relation-name resolution
   - description: GROUP BY references to aggregate SELECT aliases distinguish conflict from no-input legality
     main:
@@ -247,12 +143,12 @@ regions:
     local:
       relation: [input-conflict, no-input]
     cases:
-      - key: G0N0S2_9_0
+      - key: G0N0S2_7_0
         name: group_by_aggregate_alias_conflict_uses_input
         setup_sqls: []
         runs:
           - sql: "SELECT count(*) AS x FROM (SELECT 1 AS x UNION ALL SELECT 2 AS x) GROUP BY x"
-      - key: G0N0S2_9_1
+      - key: G0N0S2_7_1
         name: group_by_aggregate_alias_no_input_rejected
         setup_sqls:
           - "CREATE TABLE t(i Int32)"
@@ -266,13 +162,13 @@ regions:
     local:
       relation: [input-conflict, no-input]
     cases:
-      - key: G0N0S4_10_0
+      - key: G0N0S4_8_0
         name: group_by_srf_alias_conflict_uses_input
         setup_sqls:
           - "CREATE TABLE t_str(col1 String, col2 String)"
         runs:
           - sql: "SELECT t.col1 AS col1, unnest(split(t.col2, ',')) AS col2 FROM t_str AS t GROUP BY col1, col2 ORDER BY col2"
-      - key: G0N0S4_10_1
+      - key: G0N0S4_8_1
         name: group_by_srf_alias_no_input
         setup_sqls:
           - "CREATE TABLE t_str(col1 String, col2 String)"
@@ -298,7 +194,7 @@ regions:
       name_shapes: [N4]
       producers: [N0]
     cases:
-      - key: G0N4N0_12_
+      - key: G0N4N0_10_
         name: group_by_ordinal_uses_select_item_position
         setup_sqls:
           - "CREATE TABLE t(i Int32)"
@@ -310,7 +206,7 @@ regions:
       name_shapes: [N5]
       producers: [N0]
     cases:
-      - key: G5N5N0_13_
+      - key: G5N5N0_11_
         name: group_by_all_expands_non_aggregate_select_items
         setup_sqls:
           - "CREATE TABLE t(i Int32)"
@@ -324,43 +220,43 @@ regions:
       name_shapes: [N0, N1, N2, N3, N4, N5]
       producers: [I0, S0, S1, S2, S3, S4, G0, N0]
     cases:
-      - key: G0N1G0_14_
+      - key: G0N1G0_12_
         name: group_by_qualified_name_does_not_consume_prior_group_alias
         setup_sqls:
           - "CREATE TABLE t(i Int32)"
         runs:
           - sql: "SELECT i AS k, count(*) FROM t GROUP BY k, t.k"
-      - key: G0N3S1_14_
+      - key: G0N3S1_12_
         name: group_by_qualified_complex_does_not_fallback_to_select_alias
         setup_sqls:
           - "CREATE TABLE t(i Int32)"
         runs:
           - sql: "SELECT i AS k, count(*) FROM t GROUP BY t.k + 1"
-      - key: G1N1S1_14_
+      - key: G1N1S1_12_
         name: grouping_sets_qualified_name_does_not_fallback_to_select_alias
         setup_sqls:
           - "CREATE TABLE t(i Int32)"
         runs:
           - sql: "SELECT i AS k, count(*) FROM t GROUP BY GROUPING SETS ((t.k))"
-      - key: G1N2S1_14_
+      - key: G1N2S1_12_
         name: grouping_sets_complex_select_alias_does_not_fallback
         setup_sqls:
           - "CREATE TABLE t(i Int32)"
         runs:
           - sql: "SELECT i AS k, count(*) FROM t GROUP BY GROUPING SETS ((abs(k)))"
-      - key: G2N2S1_14_
+      - key: G2N2S1_12_
         name: rollup_complex_select_alias_does_not_fallback
         setup_sqls:
           - "CREATE TABLE t(i Int32)"
         runs:
           - sql: "SELECT i AS k, count(*) FROM t GROUP BY ROLLUP(abs(k))"
-      - key: G3N2S1_14_
+      - key: G3N2S1_12_
         name: cube_complex_select_alias_does_not_fallback
         setup_sqls:
           - "CREATE TABLE t(i Int32)"
         runs:
           - sql: "SELECT i AS k, count(*) FROM t GROUP BY CUBE(abs(k))"
-      - key: G4N2S1_14_
+      - key: G4N2S1_12_
         name: combined_normal_complex_select_alias_fallback
         setup_sqls:
           - "CREATE TABLE t(i Int32)"

--- a/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/order_by_alias.txt
+++ b/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/order_by_alias.txt
@@ -1,7 +1,6 @@
 === order_by_alias__order_by_scalar_alias_conflict_prefers_select_alias ===
 matrix: order_by_alias
 key: O0N0S1_0_0
-setting: enable_group_by_column_first=0
 sql: SELECT i AS x FROM t ORDER BY x
 status: ok
 Sort
@@ -19,7 +18,6 @@ Sort
 === order_by_alias__order_by_aggregate_alias_no_input ===
 matrix: order_by_alias
 key: O0N0S2_1_1
-setting: enable_group_by_column_first=0
 sql: SELECT sum(number) AS s FROM t ORDER BY s
 status: ok
 Sort
@@ -42,7 +40,6 @@ Sort
 === order_by_alias__order_by_duplicate_aggregate_alias_is_ambiguous ===
 matrix: order_by_alias
 key: O0N0S2_2_
-setting: enable_group_by_column_first=0
 sql: SELECT sum(number) AS s, max(number) AS s FROM t ORDER BY s
 status: error
 code: 1065
@@ -51,7 +48,6 @@ message: column s reference or alias is ambiguous, please use another alias name
 === order_by_alias__order_by_window_alias_expression ===
 matrix: order_by_alias
 key: O0N2S3_3_1
-setting: enable_group_by_column_first=0
 sql: SELECT number, row_number() OVER (ORDER BY number) AS rn FROM t ORDER BY rn + 1
 status: ok
 Sort
@@ -79,7 +75,6 @@ Sort
 === order_by_alias__order_by_qualified_name_binds_input_column ===
 matrix: order_by_alias
 key: O0N1I0_5_
-setting: enable_group_by_column_first=0
 sql: SELECT i AS k FROM t ORDER BY t.k
 status: ok
 Sort
@@ -97,7 +92,6 @@ Sort
 === order_by_alias__order_by_qualified_name_binds_relation_not_select_alias ===
 matrix: order_by_alias
 key: O0N1S1_5_
-setting: enable_group_by_column_first=0
 sql: SELECT i AS k FROM t ORDER BY t.k
 status: error
 code: 1065

--- a/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/predicate_alias.txt
+++ b/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/predicate_alias.txt
@@ -1,7 +1,6 @@
 === predicate_alias__where_scalar_alias_no_input ===
 matrix: predicate_alias
 key: P0N0S1_0_1
-setting: enable_group_by_column_first=0
 sql: SELECT i > 0 AS ok FROM t WHERE ok
 status: ok
 EvalScalar
@@ -18,7 +17,6 @@ EvalScalar
 === predicate_alias__where_scalar_alias_conflict_prefers_input_column ===
 matrix: predicate_alias
 key: P0N0S1_1_0
-setting: enable_group_by_column_first=0
 sql: SELECT i > 0 AS ok FROM t WHERE ok
 status: ok
 EvalScalar
@@ -35,7 +33,6 @@ EvalScalar
 === predicate_alias__having_aggregate_alias_conflict_prefers_aggregate_alias ===
 matrix: predicate_alias
 key: P1N0S2_2_0
-setting: enable_group_by_column_first=0
 sql: SELECT sum(number) > 0 AS ok FROM t HAVING ok
 status: ok
 EvalScalar
@@ -57,7 +54,6 @@ EvalScalar
 === predicate_alias__having_aggregate_alias_no_input ===
 matrix: predicate_alias
 key: P1N0S2_2_1
-setting: enable_group_by_column_first=0
 sql: SELECT sum(number) > 0 AS ok FROM t HAVING ok
 status: ok
 EvalScalar
@@ -79,7 +75,6 @@ EvalScalar
 === predicate_alias__qualify_window_alias_no_input ===
 matrix: predicate_alias
 key: P2N0S3_3_1
-setting: enable_group_by_column_first=0
 sql: SELECT number, row_number() OVER (ORDER BY number) AS rn FROM t QUALIFY rn = 1
 status: ok
 EvalScalar
@@ -106,7 +101,6 @@ EvalScalar
 === predicate_alias__qualify_window_alias_conflict_prefers_window_alias ===
 matrix: predicate_alias
 key: P2N0S3_4_0
-setting: enable_group_by_column_first=0
 sql: SELECT number, row_number() OVER (ORDER BY number) AS rn FROM t QUALIFY rn = 1
 status: ok
 EvalScalar
@@ -133,7 +127,6 @@ EvalScalar
 === predicate_alias__where_aggregate_alias_no_input_rejected ===
 matrix: predicate_alias
 key: P0N0S2_5_1
-setting: enable_group_by_column_first=0
 sql: SELECT sum(number) > 0 AS ok FROM t WHERE ok
 status: error
 code: 1065
@@ -142,7 +135,6 @@ message: Where clause can't contain aggregate or window functions
 === predicate_alias__qualify_aggregate_alias_no_input_rejected ===
 matrix: predicate_alias
 key: P2N0S2_5_1
-setting: enable_group_by_column_first=0
 sql: SELECT sum(number) > 0 AS ok FROM t QUALIFY ok
 status: error
 code: 1065
@@ -151,7 +143,6 @@ message: Qualify clause must not contain aggregate functions
 === predicate_alias__where_qualified_name_does_not_consume_scalar_alias ===
 matrix: predicate_alias
 key: P0N1S1_7_
-setting: enable_group_by_column_first=0
 sql: SELECT i > 0 AS ok FROM t AS t WHERE t.ok
 status: error
 code: 1065
@@ -160,7 +151,6 @@ message: column ok doesn't exist
 === predicate_alias__having_qualified_name_does_not_consume_aggregate_alias ===
 matrix: predicate_alias
 key: P1N1S2_7_
-setting: enable_group_by_column_first=0
 sql: SELECT sum(number) > 0 AS ok FROM t AS t HAVING t.ok
 status: error
 code: 1065
@@ -169,7 +159,6 @@ message: column ok doesn't exist
 === predicate_alias__qualify_qualified_name_does_not_consume_window_alias ===
 matrix: predicate_alias
 key: P2N1S3_7_
-setting: enable_group_by_column_first=0
 sql: SELECT number, row_number() OVER (ORDER BY number) AS rn FROM t AS t QUALIFY t.rn = 1
 status: error
 code: 1065
@@ -178,7 +167,6 @@ message: column rn doesn't exist
 === predicate_alias__where_duplicate_scalar_alias_is_ambiguous ===
 matrix: predicate_alias
 key: P0N0S1_7_
-setting: enable_group_by_column_first=0
 sql: SELECT i > 0 AS ok, i < 10 AS ok FROM t WHERE ok
 status: error
 code: 1065
@@ -187,7 +175,6 @@ message: column ok reference or alias is ambiguous, please use another alias nam
 === predicate_alias__having_duplicate_aggregate_alias_is_ambiguous ===
 matrix: predicate_alias
 key: P1N0S2_7_
-setting: enable_group_by_column_first=0
 sql: SELECT sum(number) > 0 AS ok, count(*) > 0 AS ok FROM t HAVING ok
 status: error
 code: 1065
@@ -196,7 +183,6 @@ message: column ok reference or alias is ambiguous, please use another alias nam
 === predicate_alias__qualify_duplicate_window_alias_is_ambiguous ===
 matrix: predicate_alias
 key: P2N0S3_7_
-setting: enable_group_by_column_first=0
 sql: SELECT number, row_number() OVER (ORDER BY number) AS rn, rank() OVER (ORDER BY number) AS rn FROM t QUALIFY rn = 1
 status: error
 code: 1065
@@ -205,7 +191,6 @@ message: column rn reference or alias is ambiguous, please use another alias nam
 === predicate_alias__where_window_alias_no_input_rejected ===
 matrix: predicate_alias
 key: P0N0S3_7_
-setting: enable_group_by_column_first=0
 sql: SELECT row_number() OVER (ORDER BY number) AS rn FROM t WHERE rn = 1
 status: error
 code: 1065
@@ -214,7 +199,6 @@ message: Where clause can't contain aggregate or window functions
 === predicate_alias__having_window_alias_no_input_rejected ===
 matrix: predicate_alias
 key: P1N0S3_7_
-setting: enable_group_by_column_first=0
 sql: SELECT row_number() OVER (ORDER BY number) AS rn FROM t HAVING rn = 1
 status: error
 code: 1065

--- a/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/query_block_boundary_alias.txt
+++ b/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/query_block_boundary_alias.txt
@@ -1,7 +1,6 @@
 === query_block_boundary_alias__subquery_exposes_select_alias_as_output_name ===
 matrix: query_block_boundary_alias
 key: B0N0S1_0_0
-setting: enable_group_by_column_first=0
 sql: SELECT k FROM (SELECT i AS k FROM t) AS q
 status: ok
 EvalScalar
@@ -18,7 +17,6 @@ EvalScalar
 === query_block_boundary_alias__cte_exposes_select_alias_as_output_name ===
 matrix: query_block_boundary_alias
 key: B0N0S1_0_1
-setting: enable_group_by_column_first=0
 sql: WITH q AS (SELECT i AS k FROM t) SELECT k FROM q
 status: ok
 EvalScalar
@@ -35,7 +33,6 @@ EvalScalar
 === query_block_boundary_alias__named_window_subquery_keeps_query_block_boundary ===
 matrix: query_block_boundary_alias
 key: B0N0S3_1_2
-setting: enable_group_by_column_first=0
 sql: SELECT i, p, o, row_number() OVER w AS rn FROM qt WINDOW w AS (PARTITION BY p ORDER BY o) QUALIFY rn = (SELECT i FROM qt LIMIT 1)
 status: ok
 EvalScalar
@@ -77,7 +74,6 @@ EvalScalar
 === query_block_boundary_alias__query_block_boundary_does_not_expose_inner_input_name_after_alias ===
 matrix: query_block_boundary_alias
 key: B0N0I0_3_
-setting: enable_group_by_column_first=0
 sql: SELECT i FROM (SELECT i AS k FROM t) AS q
 status: error
 code: 1065
@@ -86,7 +82,6 @@ message: column i doesn't exist
 === query_block_boundary_alias__query_block_boundary_does_not_expose_prior_group_alias_namespace ===
 matrix: query_block_boundary_alias
 key: B0N0G0_3_
-setting: enable_group_by_column_first=0
 sql: SELECT k FROM (SELECT i, count(*) FROM t GROUP BY i, abs(i)) AS q
 status: error
 code: 1065

--- a/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/select_list_alias.txt
+++ b/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/select_list_alias.txt
@@ -1,7 +1,6 @@
 === select_list_alias__select_list_bare_prior_alias ===
 matrix: select_list_alias
 key: S0N0S0_0_1
-setting: enable_group_by_column_first=0
 sql: SELECT i AS k, k FROM t
 status: ok
 EvalScalar
@@ -16,7 +15,6 @@ EvalScalar
 === select_list_alias__select_list_expression_prior_alias ===
 matrix: select_list_alias
 key: S0N2S0_0_1
-setting: enable_group_by_column_first=0
 sql: SELECT number + 1 AS s, s + 1 AS next FROM t
 status: ok
 EvalScalar
@@ -31,7 +29,6 @@ EvalScalar
 === select_list_alias__select_list_qualified_name_binds_relation_not_prior_alias ===
 matrix: select_list_alias
 key: S0N1S0_1_
-setting: enable_group_by_column_first=0
 sql: SELECT i AS k, t.k FROM t
 status: ok
 EvalScalar
@@ -46,7 +43,6 @@ EvalScalar
 === select_list_alias__select_list_ordinal_is_literal_expression_not_alias_lookup ===
 matrix: select_list_alias
 key: S0N4N0_1_
-setting: enable_group_by_column_first=0
 sql: SELECT i AS k, 1 FROM t
 status: ok
 EvalScalar

--- a/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/window_spec_alias.txt
+++ b/src/query/sql/tests/it/semantic/binder/alias_resolution_matrices/window_spec_alias.txt
@@ -1,7 +1,6 @@
 === window_spec_alias__window_order_reuses_having_aggregate_alias ===
 matrix: window_spec_alias
 key: W0N0S2_0_
-setting: enable_group_by_column_first=0
 sql: SELECT sum(number) AS s, row_number() OVER (ORDER BY s) FROM t HAVING s > 0
 status: ok
 EvalScalar
@@ -33,7 +32,6 @@ EvalScalar
 === window_spec_alias__window_spec_reuses_group_item_alias ===
 matrix: window_spec_alias
 key: W0N2G0_0_
-setting: enable_group_by_column_first=0
 sql: SELECT number % 3 AS a, number % 4 AS b, row_number() OVER (PARTITION BY b % 2 ORDER BY a) FROM t GROUP BY a, b
 status: ok
 EvalScalar
@@ -65,7 +63,6 @@ EvalScalar
 === window_spec_alias__window_order_rejects_recursive_window_alias ===
 matrix: window_spec_alias
 key: W0N0S3_1_
-setting: enable_group_by_column_first=0
 sql: SELECT row_number() OVER () AS rn, row_number() OVER (ORDER BY rn) FROM t
 status: error
 code: 1065
@@ -74,7 +71,6 @@ message: Window function cannot contain another window function
 === window_spec_alias__window_spec_qualified_name_does_not_consume_group_alias ===
 matrix: window_spec_alias
 key: W0N1G0_3_
-setting: enable_group_by_column_first=0
 sql: SELECT i AS k, row_number() OVER (ORDER BY t.k) FROM t AS t GROUP BY k
 status: error
 code: 1065
@@ -83,7 +79,6 @@ message: column k doesn't exist
 === window_spec_alias__window_spec_qualified_name_does_not_consume_aggregate_alias ===
 matrix: window_spec_alias
 key: W0N1S2_3_
-setting: enable_group_by_column_first=0
 sql: SELECT sum(number) AS s, row_number() OVER (ORDER BY t.s) FROM t AS t
 status: error
 code: 1065

--- a/tests/sqllogictests/suites/base/03_common/03_0003_select_group_by.test
+++ b/tests/sqllogictests/suites/base/03_common/03_0003_select_group_by.test
@@ -24,9 +24,16 @@ SELECT number%3 as c1 FROM numbers_mt(10) where number > 2 group by number%3 ord
 query II
 SELECT number % 3 AS number, count() FROM numbers(10) GROUP BY number ORDER BY number
 ----
-0 4
-1 3
-2 3
+0 1
+0 1
+0 1
+0 1
+1 1
+1 1
+1 1
+2 1
+2 1
+2 1
 
 statement error must appear in the GROUP BY clause or be used in an aggregate function
 SELECT i, SUM(j), j FROM (SELECT 3 AS i, 4 AS j UNION ALL SELECT 3, 4 UNION ALL SELECT 2, 4) AS integers GROUP BY i ORDER BY i
@@ -37,10 +44,16 @@ SELECT 1 AS k, SUM(i) FROM (SELECT 3 AS i UNION ALL SELECT 3 UNION ALL SELECT 2)
 1 8
 
 query II
-settings(enable_group_by_column_first=1) SELECT 1 AS i, SUM(i) FROM (SELECT 3 AS i UNION ALL SELECT 3 UNION ALL SELECT 2) AS integers GROUP BY i ORDER BY 2
+SELECT 1 AS i, SUM(i) FROM (SELECT 3 AS i UNION ALL SELECT 3 UNION ALL SELECT 2) AS integers GROUP BY i ORDER BY 2
 ----
 1 2
 1 6
+
+query ITI
+SELECT to_int16(number) AS number, if(number < 1, 'small', 'large') AS value_band, min(number) FROM numbers(2) GROUP BY number ORDER BY number
+----
+0 small 0
+1 large 1
 
 query II
 SELECT i % 2 AS k, SUM(i) FROM (SELECT 3 AS i UNION ALL SELECT 3 UNION ALL SELECT 2) AS integers GROUP BY k, k ORDER BY 1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This fixes a `GROUP BY` name-resolution regression introduced by #19750.

Before #19750, an unqualified `GROUP BY` name was resolved against input columns first, with SELECT aliases used only as a fallback. The binder alias refactor in #19750 changed simple scalar aliases to take precedence over same-name input columns.

#19806 reported this conflict, but #19808 addressed it by adding `enable_group_by_column_first` with a default value of `0`. As a result, column-first resolution became opt-in while the affected alias-first behavior remained the default. #19814 later restored column-first resolution for names inside complex `GROUP BY` expressions, but simple names continued to use the setting-controlled alias-first path.

This causes queries such as the reproducer in #20273 to bind `GROUP BY source_value` to a transformed SELECT alias instead of the input column. Other SELECT expressions still reference the input column, so the aggregate checker reports that the column is not grouped.

This PR removes `enable_group_by_column_first` and the legacy alias-first branch. `GROUP BY` now consistently:

1. Resolves names against input columns first.
2. Falls back to SELECT aliases only when no input column matches.

The alias-resolution matrix and SQLLogic coverage are updated for the single column-first rule, including same-name transformed aliases and alias fallback without an input-column match.

This is a behavior change for queries that intentionally relied on alias-first resolution when an input column and SELECT alias had the same name.

- fixes: #20273

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [x] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent assisted with implementation
- Responsible human: @forsaken628 
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20274)
<!-- Reviewable:end -->
