### PR TITLE
fix(storage): coalesce partitioned hash writes

### DIFF
--- a/src/query/service/src/pipelines/builders/builder_append_table.rs
+++ b/src/query/service/src/pipelines/builders/builder_append_table.rs
@@ -16,14 +16,18 @@ use std::sync::Arc;
 
 use databend_common_catalog::table::Table;
 use databend_common_exception::Result;
+use databend_common_expression::DataBlock;
 use databend_common_expression::DataField;
 use databend_common_expression::DataSchema;
 use databend_common_expression::DataSchemaRef;
 use databend_common_expression::DataSchemaRefExt;
+use databend_common_expression::ProjectedBlock;
 use databend_common_expression::SortColumnDescription;
+use databend_common_expression::group_hash_entries;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_meta_app::schema::UpdateStreamMetaReq;
 use databend_common_meta_app::schema::UpsertTableCopiedFileReq;
+use databend_common_pipeline::basic::Exchange;
 use databend_common_pipeline::core::Pipeline;
 use databend_common_pipeline_transforms::TransformPipelineHelper;
 use databend_common_pipeline_transforms::blocks::CompoundBlockOperator;
@@ -35,6 +39,25 @@ use crate::pipelines::PipelineBuilder;
 use crate::pipelines::builders::SortPipelineBuilder;
 use crate::sessions::QueryContext;
 use crate::sessions::TableContextSettings;
+
+struct PartitionKeyExchange {
+    key_offsets: Vec<usize>,
+}
+
+impl Exchange for PartitionKeyExchange {
+    const NAME: &'static str = "PartitionKey";
+
+    fn partition(&self, data_block: DataBlock, n: usize) -> Result<Vec<DataBlock>> {
+        let hash_columns = ProjectedBlock::project(&self.key_offsets, &data_block);
+        let mut hashes = vec![0; data_block.num_rows()];
+        group_hash_entries(hash_columns, &mut hashes);
+        let indices = hashes
+            .into_iter()
+            .map(|hash| hash % n as u64)
+            .collect::<Vec<_>>();
+        DataBlock::scatter(&data_block, &indices, n)
+    }
+}
 
 /// This file implements append to table pipeline builder.
 impl PipelineBuilder {
@@ -92,6 +115,10 @@ impl PipelineBuilder {
             CompoundBlockOperator::new(vec![op.clone()], func_ctx.clone(), num_input_columns)
         });
 
+        let max_threads = ctx.get_settings().get_max_threads()? as usize;
+        let key_offsets = (num_input_columns..fields.len()).collect();
+        pipeline.exchange(max_threads, Arc::new(PartitionKeyExchange { key_offsets }))?;
+
         let num_sort_columns = fields.len();
         let sort_schema = DataSchemaRefExt::create(fields);
         let enable_fixed_rows = ctx.get_settings().get_enable_fixed_rows_sort()?;
@@ -103,11 +130,7 @@ impl PipelineBuilder {
             enable_fixed_rows,
         )?
         .with_block_size_hit(table.get_block_thresholds().max_rows_per_block);
-        let max_threads = ctx.get_settings().get_max_threads()? as usize;
-        if pipeline.output_len() == 1 || max_threads == 1 {
-            pipeline.try_resize(max_threads)?;
-        }
-        sort_builder.build_full_sort_pipeline(pipeline, false)?;
+        sort_builder.build_local_full_sort_pipeline(pipeline, false)?;
 
         let projection = (0..num_input_columns).collect::<Vec<_>>();
         pipeline.add_transformer(|| {

--- a/src/query/service/src/pipelines/builders/builder_sort.rs
+++ b/src/query/service/src/pipelines/builders/builder_sort.rs
@@ -113,6 +113,21 @@ impl SortPipelineBuilder {
         self.build_merge_sort_pipeline(pipeline, false, keep_order_col)
     }
 
+    pub fn build_local_full_sort_pipeline(
+        self,
+        pipeline: &mut Pipeline,
+        keep_order_col: bool,
+    ) -> Result<()> {
+        pipeline.add_transformer(|| {
+            TransformSortPartial::new(
+                LimitType::from_limit_rows(self.limit),
+                self.sort_column_desc(),
+            )
+        });
+
+        self.build_merge_sort(pipeline, false, keep_order_col)
+    }
+
     fn build_merge_sort(
         &self,
         pipeline: &mut Pipeline,

--- a/src/query/sql/src/planner/binder/ddl/dynamic_table.rs
+++ b/src/query/sql/src/planner/binder/ddl/dynamic_table.rs
@@ -171,7 +171,7 @@ impl Binder {
         let mut cluster_key = None;
         if let Some(cluster_opt) = cluster_by {
             let keys = self
-                .analyze_cluster_keys(cluster_opt, schema.clone(), None)
+                .analyze_cluster_keys(cluster_opt, schema.clone(), None, true)
                 .await?;
             if !keys.is_empty() {
                 cluster_key = Some(format!("({})", keys.join(", ")));

--- a/src/query/sql/src/planner/binder/ddl/table.rs
+++ b/src/query/sql/src/planner/binder/ddl/table.rs
@@ -1025,7 +1025,12 @@ impl Binder {
         let mut cluster_key = None;
         if let Some(cluster_opt) = cluster_by {
             let keys = self
-                .analyze_cluster_keys(cluster_opt, schema.clone(), table_indexes.as_ref())
+                .analyze_cluster_keys(
+                    cluster_opt,
+                    schema.clone(),
+                    table_indexes.as_ref(),
+                    partition_by.is_none(),
+                )
                 .await?;
             if !keys.is_empty() {
                 options
@@ -1468,6 +1473,10 @@ impl Binder {
                         cluster_by,
                         tbl.schema(),
                         Some(&tbl.get_table_info().meta.indexes),
+                        !tbl.get_table_info()
+                            .meta
+                            .options
+                            .contains_key(OPT_KEY_PARTITION_BY),
                     )
                     .await?;
 
@@ -1513,6 +1522,17 @@ impl Binder {
                     return Err(ErrorCode::UnsupportedEngineParams(format!(
                         "ALTER TABLE PARTITION BY is not supported for engine {engine}"
                     )));
+                }
+
+                if let Some(cluster_keys) = tbl.resolve_cluster_keys() {
+                    self.analyze_table_keys(
+                        &cluster_keys,
+                        tbl.schema(),
+                        Some(&tbl.get_table_info().meta.indexes),
+                        "CLUSTER BY with PARTITION BY",
+                        false,
+                    )
+                    .await?;
                 }
 
                 let partition_keys = self
@@ -2458,13 +2478,18 @@ impl Binder {
         cluster_opt: &ClusterOption,
         schema: TableSchemaRef,
         table_indexes: Option<&BTreeMap<String, TableIndex>>,
+        allow_vector: bool,
     ) -> Result<Vec<String>> {
         self.analyze_table_keys(
             &cluster_opt.cluster_exprs,
             schema,
             table_indexes,
-            "Cluster by",
-            true,
+            if allow_vector {
+                "CLUSTER BY"
+            } else {
+                "CLUSTER BY with PARTITION BY"
+            },
+            allow_vector,
         )
         .await
     }
@@ -2540,7 +2565,12 @@ impl Binder {
 
             let data_type = expr.data_type();
             let (is_valid_type, is_vector_type) = Self::valid_cluster_key_type(data_type);
-            if !is_valid_type || is_vector_type && !allow_vector {
+            if is_vector_type && !allow_vector {
+                return Err(ErrorCode::InvalidClusterKeys(format!(
+                    "Vector data type is not supported for {key_name}"
+                )));
+            }
+            if !is_valid_type {
                 return Err(ErrorCode::InvalidClusterKeys(format!(
                     "Unsupported data type '{data_type}' for {key_name} expression `{key_expr:#}`"
                 )));

--- a/src/query/storages/fuse/src/operations/append.rs
+++ b/src/query/storages/fuse/src/operations/append.rs
@@ -133,6 +133,24 @@ impl FuseTable {
             pipeline.add_pipe(builder.finalize());
         }
 
+        let partition_key_indices: Arc<[_]> = cluster_stats_gen.partition_key_index.clone().into();
+        if !partition_key_indices.is_empty() {
+            let mut builder = pipeline.add_transform_with_specified_len(
+                move |input, output| {
+                    Ok(ProcessorPtr::create(AccumulatingTransformer::create(
+                        input,
+                        output,
+                        TransformPartitionBy::new(partition_key_indices.clone()),
+                    )))
+                },
+                transform_len,
+            )?;
+            if need_match {
+                builder.add_items_prepend(vec![create_dummy_item()]);
+            }
+            pipeline.add_pipe(builder.finalize());
+        }
+
         if let Some(vector_operator) = cluster_stats_gen.vector_operator.clone() {
             let rows_per_block = block_thresholds.max_rows_per_block;
             let mut builder = pipeline.add_transform_with_specified_len(
@@ -164,23 +182,6 @@ impl FuseTable {
                         LimitType::None,
                         sort_desc.clone(),
                     ))
-                },
-                transform_len,
-            )?;
-            if need_match {
-                builder.add_items_prepend(vec![create_dummy_item()]);
-            }
-            pipeline.add_pipe(builder.finalize());
-        }
-        let partition_key_indices: Arc<[_]> = cluster_stats_gen.partition_key_index.clone().into();
-        if !partition_key_indices.is_empty() {
-            let mut builder = pipeline.add_transform_with_specified_len(
-                move |input, output| {
-                    Ok(ProcessorPtr::create(AccumulatingTransformer::create(
-                        input,
-                        output,
-                        TransformPartitionBy::new(partition_key_indices.clone()),
-                    )))
                 },
                 transform_len,
             )?;
@@ -235,6 +236,14 @@ impl FuseTable {
             });
         }
 
+        let partition_key_indices: Arc<[_]> = cluster_stats_gen.partition_key_index.clone().into();
+        if !rewrite_replaced_block && !partition_key_indices.is_empty() {
+            pipeline.add_accumulating_transformer({
+                let partition_key_indices = partition_key_indices.clone();
+                move || TransformPartitionBy::new(partition_key_indices.clone())
+            });
+        }
+
         if let Some(vector_operator) = cluster_stats_gen.vector_operator.clone() {
             let rows_per_block = block_thresholds.max_rows_per_block;
             pipeline.add_accumulating_transformer(move || {
@@ -254,17 +263,10 @@ impl FuseTable {
                 move || TransformSortPartial::new(LimitType::None, sort_desc.clone())
             });
         }
-        let partition_key_indices: Arc<[_]> = cluster_stats_gen.partition_key_index.clone().into();
-        if !partition_key_indices.is_empty() {
-            if rewrite_replaced_block {
-                pipeline.add_accumulating_transformer(move || {
-                    TransformPartitionBy::new_for_update(partition_key_indices.clone())
-                });
-            } else {
-                pipeline.add_accumulating_transformer(move || {
-                    TransformPartitionBy::new(partition_key_indices.clone())
-                });
-            }
+        if rewrite_replaced_block && !partition_key_indices.is_empty() {
+            pipeline.add_accumulating_transformer(move || {
+                TransformPartitionBy::new_for_update(partition_key_indices.clone())
+            });
         }
         Ok(cluster_stats_gen)
     }

--- a/src/query/storages/fuse/src/operations/append.rs
+++ b/src/query/storages/fuse/src/operations/append.rs
@@ -31,6 +31,8 @@ use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_pipeline::core::Pipeline;
 use databend_common_pipeline::core::ProcessorPtr;
 use databend_common_pipeline_transforms::AccumulatingTransformer;
+use databend_common_pipeline_transforms::BlockCompactBuilder;
+use databend_common_pipeline_transforms::TransformCompactBlock;
 use databend_common_pipeline_transforms::TransformPipelineHelper;
 use databend_common_pipeline_transforms::blocks::CompoundBlockOperator;
 use databend_common_pipeline_transforms::build_compact_block_pipeline;
@@ -79,7 +81,13 @@ impl FuseTable {
             });
         } else {
             let block_thresholds = self.get_block_thresholds();
-            build_compact_block_pipeline(pipeline, block_thresholds)?;
+            if self.use_hash_write_distribution() {
+                pipeline
+                    .add_accumulating_transformer(|| BlockCompactBuilder::new(block_thresholds));
+                pipeline.add_block_meta_transformer(|| TransformCompactBlock);
+            } else {
+                build_compact_block_pipeline(pipeline, block_thresholds)?;
+            }
 
             let schema = DataSchema::from(self.schema()).into();
             let cluster_stats_gen =

--- a/src/query/storages/fuse/src/operations/append.rs
+++ b/src/query/storages/fuse/src/operations/append.rs
@@ -134,9 +134,7 @@ impl FuseTable {
         }
 
         let partition_key_indices: Arc<[_]> = cluster_stats_gen.partition_key_index.clone().into();
-        let has_vector_cluster = cluster_stats_gen.vector_operator.is_some();
-        if !has_vector_cluster && !partition_key_indices.is_empty() {
-            let partition_key_indices = partition_key_indices.clone();
+        if !partition_key_indices.is_empty() {
             let mut builder = pipeline.add_transform_with_specified_len(
                 move |input, output| {
                     Ok(ProcessorPtr::create(AccumulatingTransformer::create(
@@ -192,22 +190,6 @@ impl FuseTable {
             }
             pipeline.add_pipe(builder.finalize());
         }
-        if has_vector_cluster && !partition_key_indices.is_empty() {
-            let mut builder = pipeline.add_transform_with_specified_len(
-                move |input, output| {
-                    Ok(ProcessorPtr::create(AccumulatingTransformer::create(
-                        input,
-                        output,
-                        TransformPartitionBy::new(partition_key_indices.clone()),
-                    )))
-                },
-                transform_len,
-            )?;
-            if need_match {
-                builder.add_items_prepend(vec![create_dummy_item()]);
-            }
-            pipeline.add_pipe(builder.finalize());
-        }
         Ok(cluster_stats_gen)
     }
 
@@ -255,8 +237,7 @@ impl FuseTable {
         }
 
         let partition_key_indices: Arc<[_]> = cluster_stats_gen.partition_key_index.clone().into();
-        let has_vector_cluster = cluster_stats_gen.vector_operator.is_some();
-        if !rewrite_replaced_block && !has_vector_cluster && !partition_key_indices.is_empty() {
+        if !rewrite_replaced_block && !partition_key_indices.is_empty() {
             pipeline.add_accumulating_transformer({
                 let partition_key_indices = partition_key_indices.clone();
                 move || TransformPartitionBy::new(partition_key_indices.clone())
@@ -282,16 +263,10 @@ impl FuseTable {
                 move || TransformSortPartial::new(LimitType::None, sort_desc.clone())
             });
         }
-        if (rewrite_replaced_block || has_vector_cluster) && !partition_key_indices.is_empty() {
-            if rewrite_replaced_block {
-                pipeline.add_accumulating_transformer(move || {
-                    TransformPartitionBy::new_for_update(partition_key_indices.clone())
-                });
-            } else {
-                pipeline.add_accumulating_transformer(move || {
-                    TransformPartitionBy::new(partition_key_indices.clone())
-                });
-            }
+        if rewrite_replaced_block && !partition_key_indices.is_empty() {
+            pipeline.add_accumulating_transformer(move || {
+                TransformPartitionBy::new_for_update(partition_key_indices.clone())
+            });
         }
         Ok(cluster_stats_gen)
     }

--- a/src/query/storages/fuse/src/operations/append.rs
+++ b/src/query/storages/fuse/src/operations/append.rs
@@ -134,7 +134,9 @@ impl FuseTable {
         }
 
         let partition_key_indices: Arc<[_]> = cluster_stats_gen.partition_key_index.clone().into();
-        if !partition_key_indices.is_empty() {
+        let has_vector_cluster = cluster_stats_gen.vector_operator.is_some();
+        if !has_vector_cluster && !partition_key_indices.is_empty() {
+            let partition_key_indices = partition_key_indices.clone();
             let mut builder = pipeline.add_transform_with_specified_len(
                 move |input, output| {
                     Ok(ProcessorPtr::create(AccumulatingTransformer::create(
@@ -190,6 +192,22 @@ impl FuseTable {
             }
             pipeline.add_pipe(builder.finalize());
         }
+        if has_vector_cluster && !partition_key_indices.is_empty() {
+            let mut builder = pipeline.add_transform_with_specified_len(
+                move |input, output| {
+                    Ok(ProcessorPtr::create(AccumulatingTransformer::create(
+                        input,
+                        output,
+                        TransformPartitionBy::new(partition_key_indices.clone()),
+                    )))
+                },
+                transform_len,
+            )?;
+            if need_match {
+                builder.add_items_prepend(vec![create_dummy_item()]);
+            }
+            pipeline.add_pipe(builder.finalize());
+        }
         Ok(cluster_stats_gen)
     }
 
@@ -237,7 +255,8 @@ impl FuseTable {
         }
 
         let partition_key_indices: Arc<[_]> = cluster_stats_gen.partition_key_index.clone().into();
-        if !rewrite_replaced_block && !partition_key_indices.is_empty() {
+        let has_vector_cluster = cluster_stats_gen.vector_operator.is_some();
+        if !rewrite_replaced_block && !has_vector_cluster && !partition_key_indices.is_empty() {
             pipeline.add_accumulating_transformer({
                 let partition_key_indices = partition_key_indices.clone();
                 move || TransformPartitionBy::new(partition_key_indices.clone())
@@ -263,10 +282,16 @@ impl FuseTable {
                 move || TransformSortPartial::new(LimitType::None, sort_desc.clone())
             });
         }
-        if rewrite_replaced_block && !partition_key_indices.is_empty() {
-            pipeline.add_accumulating_transformer(move || {
-                TransformPartitionBy::new_for_update(partition_key_indices.clone())
-            });
+        if (rewrite_replaced_block || has_vector_cluster) && !partition_key_indices.is_empty() {
+            if rewrite_replaced_block {
+                pipeline.add_accumulating_transformer(move || {
+                    TransformPartitionBy::new_for_update(partition_key_indices.clone())
+                });
+            } else {
+                pipeline.add_accumulating_transformer(move || {
+                    TransformPartitionBy::new(partition_key_indices.clone())
+                });
+            }
         }
         Ok(cluster_stats_gen)
     }

--- a/src/query/storages/fuse/src/operations/commit.rs
+++ b/src/query/storages/fuse/src/operations/commit.rs
@@ -81,8 +81,11 @@ impl FuseTable {
         table_meta_timestamps: TableMetaTimestamps,
     ) -> Result<()> {
         let block_thresholds = self.get_block_thresholds();
+        let preserve_lanes = self.use_hash_write_distribution();
 
-        pipeline.try_resize(1)?;
+        if !preserve_lanes {
+            pipeline.try_resize(1)?;
+        }
 
         pipeline.add_transform(|input, output| {
             new_serialize_segment_processor(
@@ -93,6 +96,10 @@ impl FuseTable {
                 table_meta_timestamps,
             )
         })?;
+
+        if preserve_lanes {
+            pipeline.try_resize(1)?;
+        }
 
         pipeline.add_async_accumulating_transformer(|| {
             TableMutationAggregator::create(

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0054_partition_by.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0054_partition_by.test
@@ -269,6 +269,23 @@ CREATE TABLE alter_invalid_partition(a INT, b INT)
 statement error PARTITION BY expression `a \+ b` is invalid
 ALTER TABLE alter_invalid_partition PARTITION BY (a + b)
 
+# Vector CLUSTER BY may buffer and concatenate blocks across physical partition
+# boundaries, so the combination is rejected until it has partition-aware batching.
+statement error Vector data type is not supported for CLUSTER BY with PARTITION BY
+CREATE TABLE vector_partition_create(id INT, embedding VECTOR(3), VECTOR INDEX idx (embedding) distance='cosine') PARTITION BY (id) CLUSTER BY (embedding)
+
+statement ok
+CREATE TABLE vector_partition_alter_cluster(id INT, embedding VECTOR(3), VECTOR INDEX idx (embedding) distance='cosine') PARTITION BY (id)
+
+statement error Vector data type is not supported for CLUSTER BY with PARTITION BY
+ALTER TABLE vector_partition_alter_cluster CLUSTER BY (embedding)
+
+statement ok
+CREATE TABLE vector_partition_alter_partition(id INT, embedding VECTOR(3), VECTOR INDEX idx (embedding) distance='cosine') CLUSTER BY (embedding)
+
+statement error Vector data type is not supported for CLUSTER BY with PARTITION BY
+ALTER TABLE vector_partition_alter_partition PARTITION BY (id)
+
 # IF EXISTS must skip partition-key binding when the table is absent.
 statement ok
 ALTER TABLE IF EXISTS alter_missing_partition PARTITION BY (missing_column)

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0054_partition_by.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0054_partition_by.test
@@ -455,6 +455,8 @@ SELECT if(block_count BETWEEN 6 AND 12, 1, 0) FROM fuse_snapshot('db_09_0054', '
 
 # The common write layout prepares the INT table row from a BIGINT input and
 # full-sorts by the physical partition transform before Fuse serialization.
+# CLUSTER BY verifies that partition boundaries are split before its partial
+# sort can interleave rows from a mixed-boundary block.
 statement ok
 SET max_threads=4
 
@@ -462,7 +464,7 @@ statement ok
 SET max_block_size=1000
 
 statement ok
-CREATE TABLE hash_partitioned(id INT) PARTITION BY (bucket(16, id)) WRITE_DISTRIBUTION_MODE='hash' ROW_PER_BLOCK=1000 BLOCK_PER_SEGMENT=1000
+CREATE TABLE hash_partitioned(id INT) PARTITION BY (bucket(16, id)) CLUSTER BY (id) WRITE_DISTRIBUTION_MODE='hash' ROW_PER_BLOCK=1000 BLOCK_PER_SEGMENT=1000
 
 statement ok
 CREATE TABLE hash_partitioned_none(id INT) PARTITION BY (bucket(16, id)) ROW_PER_BLOCK=1000 BLOCK_PER_SEGMENT=1000

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0054_partition_by.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0054_partition_by.test
@@ -50,9 +50,9 @@ SELECT segment_count, block_count FROM fuse_snapshot('db_09_0054', 't') LIMIT 1
 ----
 6 6
 
-# A partition expression may also be a cluster-key expression. Sorting by
-# (c, p % 2) produces partition runs 1, 0, 1 for this input, whereas an implicit
-# partition prefix would produce only the runs 0, 1.
+# A partition expression may also be a cluster-key expression. Partition
+# splitting preserves the input runs 0, 1, 0, 1 before each run is sorted by
+# (c, p % 2); it does not make the partition key an implicit cluster prefix.
 statement ok
 SET max_threads=1
 
@@ -65,13 +65,13 @@ INSERT INTO overlapping_keys VALUES (0, 30), (1, 10), (2, 20), (3, 40)
 query II
 SELECT segment_count, block_count FROM fuse_snapshot('db_09_0054', 'overlapping_keys') LIMIT 1
 ----
-3 3
+4 4
 
-# The three cluster-ordered runs still carry exact partition metadata.
+# The four partition-local runs still carry exact partition metadata.
 query T
 EXPLAIN SELECT p, c FROM overlapping_keys WHERE p % 2 = 0
 ----
-<slt:ignore>partitions total: 3<slt:ignore>partitions scanned: 1<slt:ignore>range pruning: 3 to 1<slt:ignore>
+<slt:ignore>partitions total: 4<slt:ignore>partitions scanned: 2<slt:ignore>range pruning: 4 to 2<slt:ignore>
 
 statement ok
 UNSET max_threads

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0054_partition_by.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0054_partition_by.test
@@ -512,6 +512,23 @@ SELECT count(*) FROM hash_partitioned WHERE id >= 40000
 ----
 3
 
+# Vector clustering buffers and concatenates input blocks. Keep the partition
+# splitter after vector clustering so the serialized blocks remain partition-local.
+statement ok
+CREATE TABLE hash_partitioned_vector(p INT, embedding VECTOR(2), VECTOR INDEX idx (embedding) distance='cosine') PARTITION BY (p) CLUSTER BY (embedding) WRITE_DISTRIBUTION_MODE='hash' ROW_PER_BLOCK=1000 BLOCK_PER_SEGMENT=1000
+
+statement ok
+INSERT INTO hash_partitioned_vector VALUES
+    (0, [0.1, 0.2]),
+    (1, [0.2, 0.3]),
+    (0, [0.3, 0.4]),
+    (1, [0.4, 0.5])
+
+query I
+SELECT count(*) FROM hash_partitioned_vector
+----
+4
+
 statement error write_distribution_mode must be either 'none' or 'hash'
 CREATE TABLE invalid_write_distribution(p INT) PARTITION BY (p) WRITE_DISTRIBUTION_MODE='random'
 

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0054_partition_by.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0054_partition_by.test
@@ -512,23 +512,6 @@ SELECT count(*) FROM hash_partitioned WHERE id >= 40000
 ----
 3
 
-# Vector clustering buffers and concatenates input blocks. Keep the partition
-# splitter after vector clustering so the serialized blocks remain partition-local.
-statement ok
-CREATE TABLE hash_partitioned_vector(p INT, embedding VECTOR(2), VECTOR INDEX idx (embedding) distance='cosine') PARTITION BY (p) CLUSTER BY (embedding) WRITE_DISTRIBUTION_MODE='hash' ROW_PER_BLOCK=1000 BLOCK_PER_SEGMENT=1000
-
-statement ok
-INSERT INTO hash_partitioned_vector VALUES
-    (0, [0.1, 0.2]),
-    (1, [0.2, 0.3]),
-    (0, [0.3, 0.4]),
-    (1, [0.4, 0.5])
-
-query I
-SELECT count(*) FROM hash_partitioned_vector
-----
-4
-
 statement error write_distribution_mode must be either 'none' or 'hash'
 CREATE TABLE invalid_write_distribution(p INT) PARTITION BY (p) WRITE_DISTRIBUTION_MODE='random'
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Split regular Fuse append blocks at physical partition boundaries before scalar cluster sorting
- Reject vector `CLUSTER BY` combined with `PARTITION BY`
- Coalesce hash-distributed partition writes with partition-key routing, lane-local sort, lane-local compact, and lane-local segment serialization

## Implementation

This PR fixes two fragmentation paths for partitioned Fuse writes.

First, regular append now splits blocks at physical partition boundaries after partition/cluster expression evaluation and before scalar cluster sorting. Previously, a block containing the tail of one partition and the head of another partition could be sorted by an independent scalar cluster key before `TransformPartitionBy`, interleaving partition rows and producing many tiny blocks. The UPDATE path keeps `new_for_update` after sorting because it must preserve the existing mutation metadata rewrite behavior. The specified-length append pipeline follows the same ordering.

Second, `WRITE_DISTRIBUTION_MODE='hash'` now preserves partition locality through the local write pipeline. The write layout evaluates partition expressions, routes rows by partition-key hash to local pipeline lanes, runs a lane-local spillable full sort, and then lets Fuse compact blocks within each lane. Commit also serializes segments before gathering lanes, so partition-local block groups are not interleaved again before segment creation.

`TransformVectorCluster` can buffer and concatenate blocks across physical partition boundaries. Supporting vector `CLUSTER BY` together with `PARTITION BY` therefore requires partition-aware vector batching and is outside this PR's scope. The binder explicitly rejects this combination through CREATE and both ALTER directions so the unsafe pipeline cannot be constructed.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [x] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent helped diagnose the partition write fragmentation paths, draft the storage/pipeline changes and SQL regression coverage, update the PR summary, and run focused validation and benchmark checks
- Responsible human: @KKould
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20275)
<!-- Reviewable:end -->