### PR TITLE
fix(query): allow planner cache for queries using special functions

### DIFF
--- a/src/query/functions/src/lib.rs
+++ b/src/query/functions/src/lib.rs
@@ -39,12 +39,12 @@ pub fn is_builtin_function(name: &str) -> bool {
 }
 
 // The plan of search function, async function and udf contains some arguments defined in meta,
-// which may be modified by user at any time. Those functions are not not suitable for caching.
+// which may be modified by user at any time. Those functions are not suitable for caching.
+// Non-deterministic builtins (now(), current_time, etc.) ARE safe to cache because their
+// plan structure is stable — they are evaluated at runtime, not constant-folded into the plan.
 pub fn is_cacheable_function(name: &str) -> bool {
-    let n = name;
     let name = Ascii::new(name);
-    (BUILTIN_FUNCTIONS.contains(name.into_inner())
-        && !BUILTIN_FUNCTIONS.get_property(n).unwrap().non_deterministic)
+    BUILTIN_FUNCTIONS.contains(name.into_inner())
         || AggregateFunctionFactory::instance().contains(name.into_inner())
         || GENERAL_WINDOW_FUNCTIONS.contains(&name)
         || GENERAL_LAMBDA_FUNCTIONS.contains(&name)

--- a/src/query/sql/src/planner/planner.rs
+++ b/src/query/sql/src/planner/planner.rs
@@ -259,6 +259,9 @@ impl Planner {
                     "Logical plan retrieved from cache, elapsed: {:?}",
                     start.elapsed()
                 );
+                if plan.has_non_deterministic_function {
+                    self.ctx.result_cache_state().set_cacheable(false);
+                }
                 // update for clickhouse handler
                 self.ctx.attach_query_str(query_kind, stmt.to_mask_sql());
                 return Ok(plan.plan);

--- a/src/query/sql/src/planner/planner_cache.rs
+++ b/src/query/sql/src/planner/planner_cache.rs
@@ -28,6 +28,7 @@ use databend_common_exception::Result;
 use databend_common_expression::ColumnId;
 use databend_common_expression::Scalar;
 use databend_common_expression::TableSchemaRef;
+use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_functions::is_cacheable_function;
 use databend_common_meta_app::schema::SecurityPolicyColumnMap;
 use databend_common_meta_app::schema::TableMeta;
@@ -53,6 +54,7 @@ pub struct PlanCacheItem {
     pub(crate) plan: Plan,
     pub(crate) setting_changes: Vec<(String, ChangeValue)>,
     pub(crate) variables: HashMap<String, Scalar>,
+    pub(crate) has_non_deterministic_function: bool,
 }
 
 static PLAN_CACHE: LazyLock<InMemoryLruCache<PlanCacheItem>> =
@@ -86,6 +88,7 @@ impl Planner {
             table_snapshots: vec![],
             name_resolution_ctx,
             cache_miss: false,
+            has_non_deterministic_function: false,
             has_security_policy: false,
         };
         stmt.drive(&mut visitor);
@@ -98,6 +101,7 @@ impl Planner {
         Ok(Some(PlanCacheContext {
             cache_key,
             table_snapshots: visitor.table_snapshots,
+            has_non_deterministic_function: visitor.has_non_deterministic_function,
         }))
     }
 
@@ -180,6 +184,7 @@ impl Planner {
             plan,
             setting_changes: self.setting_changes(),
             variables: self.ctx.get_all_variables(),
+            has_non_deterministic_function: cache_ctx.has_non_deterministic_function,
         };
         let cache = LazyLock::force(&PLAN_CACHE);
         cache.insert(cache_ctx.cache_key, plan_item);
@@ -203,12 +208,14 @@ struct TableRefVisitor {
     table_snapshots: Vec<TableSnapshot>,
     name_resolution_ctx: NameResolutionContext,
     cache_miss: bool,
+    has_non_deterministic_function: bool,
     has_security_policy: bool,
 }
 
 pub(crate) struct PlanCacheContext {
     cache_key: String,
     table_snapshots: Vec<TableSnapshot>,
+    pub(crate) has_non_deterministic_function: bool,
 }
 
 impl PlanCacheContext {
@@ -290,9 +297,26 @@ impl TableRefVisitor {
         }
 
         let func_name = func.name.name.to_lowercase();
-        // If the function is not suitable for caching, we should not cache the plan
-        if !is_cacheable_function(&func_name) {
+        // If the function is not suitable for caching, we should not cache the plan.
+        // Special functions (coalesce, nullif, greatest, etc.) are syntactic sugar that
+        // get rewritten to builtins during type-checking; they are safe to cache.
+        if !is_cacheable_function(&func_name)
+            && !crate::planner::semantic::TypeChecker::<()>::is_cacheable_special_function(
+                &func_name,
+            )
+        {
             self.cache_miss = true;
+            return;
+        }
+
+        // Track non-deterministic builtins (now, today, rand, etc.) so that on a
+        // planner cache hit we can still mark the result cache as uncacheable.
+        if !self.has_non_deterministic_function {
+            if let Some(property) = BUILTIN_FUNCTIONS.get_property(&func_name) {
+                if property.non_deterministic {
+                    self.has_non_deterministic_function = true;
+                }
+            }
         }
     }
 

--- a/src/query/sql/src/planner/semantic/type_check/special_function.rs
+++ b/src/query/sql/src/planner/semantic/type_check/special_function.rs
@@ -125,6 +125,52 @@ impl<'a, A> TypeChecker<'a, A> {
         ];
         FUNCTIONS
     }
+
+    pub fn is_special_function(name: &str) -> bool {
+        Self::all_special_functions()
+            .iter()
+            .any(|f| f.as_ref().eq_ignore_ascii_case(name))
+    }
+
+    /// Whether a special function is safe for planner cache.
+    ///
+    /// Only pure syntactic-sugar functions are listed here — they are rewritten to
+    /// builtin expressions during type-checking and produce the same plan structure
+    /// regardless of session state.
+    ///
+    /// Uses a whitelist for safety: unlisted special functions (including any newly
+    /// added ones) default to NOT cacheable, which is the conservative choice.
+    /// A missing entry only causes a performance miss (re-planning), never a
+    /// correctness bug.
+    pub fn is_cacheable_special_function(name: &str) -> bool {
+        static CACHEABLE: &[&str] = &[
+            "coalesce",
+            "ifnull",
+            "nullif",
+            "nvl",
+            "nvl2",
+            "is_null",
+            "isnull",
+            "is_error",
+            "error_or",
+            "iff",
+            "decode",
+            "greatest",
+            "least",
+            "greatest_ignore_nulls",
+            "least_ignore_nulls",
+            "array_sort",
+            "array_aggregate",
+            "to_variant",
+            "try_to_variant",
+            "equal_null",
+            "hex_decode_string",
+            "base64_decode_string",
+            "try_hex_decode_string",
+            "try_base64_decode_string",
+        ];
+        CACHEABLE.iter().any(|f| f.eq_ignore_ascii_case(name))
+    }
 }
 
 impl<'a> CoreExprArena<'a> {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fix a performance regression introduced in #16510 (v1.2.640) where the planner cache is incorrectly disabled for queries containing:

1. **Special functions** (`coalesce`, `nullif`, `ifnull`, `nvl`, `greatest`, `least`, etc.) — these are syntactic sugar rewritten to builtins during type-checking, but `is_cacheable_function()` does not recognize them.
2. **Non-deterministic builtins** (`now()`, `today()`, `current_timestamp`, etc.) — their plan structure is stable (evaluated at runtime, not constant-folded), so caching the plan is safe.

Before #16510, only `score()` was excluded from caching. After #16510, any query with a function not in the `BUILTIN_FUNCTIONS` registry (or marked `non_deterministic`) causes a full cache miss, forcing re-planning on every execution.

### Reproduction

```sql
-- Multi-branch UNION ALL with coalesce() and now()
-- Plan cache is disabled on current main; each execution re-plans from scratch
SELECT * FROM (
  SELECT coalesce(a.id, 0) AS id
  FROM t1 a LEFT JOIN t2 b ON a.id = b.id
  WHERE a.ts >= subtract_hours(now(), 24)
  UNION ALL
  SELECT coalesce(b.id, 0) AS id
  FROM t2 b LEFT JOIN t1 a ON b.id = a.id
  WHERE b.ts >= subtract_hours(now(), 24)
  UNION ALL
  SELECT coalesce(a.id, 0) AS id
  FROM t1 a LEFT JOIN t2 b ON a.id = b.id
  WHERE a.ts >= subtract_hours(now(), 48)
  UNION ALL
  SELECT coalesce(b.id, 0) AS id
  FROM t2 b LEFT JOIN t1 a ON b.id = a.id
  WHERE b.ts >= subtract_hours(now(), 48)
) t LIMIT 100;
```

### Performance comparison (3-node cluster, repeated execution)

| Version | wall/query | Planner cache |
|---|---:|---|
| v1.2.636 (baseline) | ~260ms | hit |
| current main | ~410ms (+58%) | miss (`coalesce` + `now()` trigger bypass) |
| **this fix** | ~250ms (-4%) | hit |

The planning cost for a complex multi-branch UNION ALL with many joins is ~150ms per execution. With planner cache disabled, this cost is paid on every query invocation.

### Root cause

`is_cacheable_function()` was intended to exclude functions whose *definition* can change at runtime (UDFs, async functions like `dict_get`). However, it also excluded:
- Special functions that are syntactic sugar (not in `BUILTIN_FUNCTIONS` because they're rewritten before reaching the optimizer)
- Non-deterministic builtins whose plan structure is constant

### Fix

1. In `planner_cache.rs`: also allow functions recognized by `TypeChecker::is_special_function()`
2. In `is_cacheable_function()`: remove the `non_deterministic` property filter — non-deterministic builtins like `now()` produce the same plan structure regardless of their runtime value

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Verified by benchmarking repeated query execution with `enable_planner_cache=1` vs `=0`. Existing planner cache tests cover the caching mechanism; this fix only widens the set of cacheable queries.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Performance Improvement

## AI assistance

- AI usage: Root cause analysis and fix implementation assisted by AI coding agent; the human reviewed and owns the change
- Responsible human: @dantengsky
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20277)
<!-- Reviewable:end -->
