### PR TITLE
fix(query): allow planner cache for more function calls

### DIFF
--- a/src/query/expression/src/constant_folder.rs
+++ b/src/query/expression/src/constant_folder.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cell::Cell;
 use std::collections::HashMap;
 
 use databend_common_ast::Span;
@@ -24,6 +25,7 @@ use crate::FunctionContext;
 use crate::FunctionDomain;
 use crate::FunctionEval;
 use crate::FunctionRegistry;
+use crate::FunctionVolatility;
 use crate::Scalar;
 use crate::Value;
 use crate::block::DataBlock;
@@ -44,10 +46,39 @@ use crate::types::number::NumberScalar;
 
 const MAX_FUNCTION_ARGS_TO_FOLD: usize = 4096;
 
+/// Controls which functions may be evaluated while folding an expression.
+///
+/// Logical-plan callers that persist the folded result should use the narrowest policy that
+/// matches the lifetime of that result. In particular, a cacheable logical plan should use
+/// [`ConstantFoldPolicy::ImmutableOnly`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConstantFoldPolicy {
+    /// Only functions whose result is independent of execution may be evaluated.
+    ImmutableOnly,
+    /// Statement-stable functions may also be evaluated.
+    AllowStableWithinStatement,
+    /// Preserve the legacy behavior and allow volatile functions to be evaluated.
+    AllowVolatile,
+}
+
+impl ConstantFoldPolicy {
+    pub fn allows(self, volatility: FunctionVolatility) -> bool {
+        match self {
+            ConstantFoldPolicy::ImmutableOnly => volatility == FunctionVolatility::Immutable,
+            ConstantFoldPolicy::AllowStableWithinStatement => {
+                volatility <= FunctionVolatility::StableWithinStatement
+            }
+            ConstantFoldPolicy::AllowVolatile => true,
+        }
+    }
+}
+
 pub struct ConstantFolder<'a, Index: ColumnIndex> {
     input_domains: &'a HashMap<Index, Domain>,
     func_ctx: &'a FunctionContext,
     fn_registry: &'a FunctionRegistry,
+    policy: ConstantFoldPolicy,
+    folded_volatility: Cell<FunctionVolatility>,
 }
 
 impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
@@ -57,15 +88,45 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
         func_ctx: &'a FunctionContext,
         fn_registry: &'a FunctionRegistry,
     ) -> (Expr<Index>, Option<Domain>) {
+        Self::fold_with_policy(
+            expr,
+            func_ctx,
+            fn_registry,
+            ConstantFoldPolicy::AllowVolatile,
+        )
+    }
+
+    /// Fold a single expression without evaluating functions disallowed by `policy`.
+    pub fn fold_with_policy(
+        expr: &Expr<Index>,
+        func_ctx: &'a FunctionContext,
+        fn_registry: &'a FunctionRegistry,
+        policy: ConstantFoldPolicy,
+    ) -> (Expr<Index>, Option<Domain>) {
+        let (expr, domain, _) =
+            Self::fold_with_policy_and_provenance(expr, func_ctx, fn_registry, policy);
+        (expr, domain)
+    }
+
+    /// Fold with an explicit policy and return the maximum volatility actually materialized.
+    pub fn fold_with_policy_and_provenance(
+        expr: &Expr<Index>,
+        func_ctx: &'a FunctionContext,
+        fn_registry: &'a FunctionRegistry,
+        policy: ConstantFoldPolicy,
+    ) -> (Expr<Index>, Option<Domain>, FunctionVolatility) {
         let input_domains = Self::full_input_domains(expr);
 
         let folder = ConstantFolder {
             input_domains: &input_domains,
             func_ctx,
             fn_registry,
+            policy,
+            folded_volatility: Cell::new(FunctionVolatility::Immutable),
         };
 
-        folder.fold_to_stable(expr)
+        let (expr, domain) = folder.fold_to_stable(expr);
+        (expr, domain, folder.folded_volatility.get())
     }
 
     /// Fold a single expression with columns' domain, and then return the new expression and the
@@ -76,10 +137,29 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
         func_ctx: &'a FunctionContext,
         fn_registry: &'a FunctionRegistry,
     ) -> (Expr<Index>, Option<Domain>) {
+        Self::fold_with_domain_and_policy(
+            expr,
+            input_domains,
+            func_ctx,
+            fn_registry,
+            ConstantFoldPolicy::AllowVolatile,
+        )
+    }
+
+    /// Fold a single expression with column domains and an explicit volatility policy.
+    pub fn fold_with_domain_and_policy(
+        expr: &Expr<Index>,
+        input_domains: &'a HashMap<Index, Domain>,
+        func_ctx: &'a FunctionContext,
+        fn_registry: &'a FunctionRegistry,
+        policy: ConstantFoldPolicy,
+    ) -> (Expr<Index>, Option<Domain>) {
         let folder = ConstantFolder {
             input_domains,
             func_ctx,
             fn_registry,
+            policy,
+            folded_volatility: Cell::new(FunctionVolatility::Immutable),
         };
 
         folder.fold_to_stable(expr)
@@ -489,6 +569,15 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                     return_type: return_type.clone(),
                 });
 
+                let volatility = self
+                    .fn_registry
+                    .get_property(&function.signature.name)
+                    .map(|property| property.volatility)
+                    .unwrap_or(FunctionVolatility::Volatile);
+                if !self.policy.allows(volatility) {
+                    return (func_expr, None);
+                }
+
                 let (calc_domain, eval) = match &function.eval {
                     FunctionEval::Scalar {
                         calc_domain, eval, ..
@@ -576,6 +665,7 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                 });
 
                 if let Some(scalar) = func_domain.as_ref().and_then(Domain::as_singleton) {
+                    self.record_folded_volatility(volatility);
                     return (
                         Expr::Constant(Constant {
                             span: *span,
@@ -599,6 +689,7 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                     // Since we know the expression is constant, it'll be safe to change its column index type.
                     let func_expr = func_expr.project_column_ref(|_| unreachable!()).unwrap();
                     if let Ok(Value::Scalar(scalar)) = evaluator.run(&func_expr) {
+                        self.record_folded_volatility(volatility);
                         return (
                             Expr::Constant(Constant {
                                 span: *span,
@@ -640,12 +731,18 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                     return_type: return_type.clone(),
                 });
 
+                let volatility = lambda_expr.volatility(self.fn_registry);
+                if !self.policy.allows(volatility) {
+                    return (func_expr, None);
+                }
+
                 if all_args_is_scalar {
                     let block = DataBlock::empty_with_rows(1);
                     let evaluator = Evaluator::new(&block, self.func_ctx, self.fn_registry);
                     // Since we know the expression is constant, it'll be safe to change its column index type.
                     let func_expr = func_expr.project_column_ref(|_| unreachable!()).unwrap();
                     if let Ok(Value::Scalar(scalar)) = evaluator.run(&func_expr) {
+                        self.record_folded_volatility(volatility);
                         return (
                             Expr::Constant(Constant {
                                 span: *span,
@@ -745,6 +842,11 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
 
             _ => None,
         }
+    }
+
+    fn record_folded_volatility(&self, volatility: FunctionVolatility) {
+        self.folded_volatility
+            .set(self.folded_volatility.get().max(volatility));
     }
 
     fn calculate_try_cast(
@@ -862,11 +964,12 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
             return None;
         }
 
-        let (_, output_domain) = ConstantFolder::fold_with_domain(
+        let (_, output_domain) = ConstantFolder::fold_with_domain_and_policy(
             &cast_expr,
             &[(0, domain.clone())].into_iter().collect(),
             self.func_ctx,
             self.fn_registry,
+            self.policy,
         );
 
         Some(output_domain)
@@ -1032,6 +1135,8 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
             input_domains,
             func_ctx,
             fn_registry,
+            policy: ConstantFoldPolicy::AllowVolatile,
+            folded_volatility: Cell::new(FunctionVolatility::Immutable),
         }
     }
 }

--- a/src/query/expression/src/expression.rs
+++ b/src/query/expression/src/expression.rs
@@ -1027,6 +1027,11 @@ impl<Index: ColumnIndex> Expr<Index> {
             ) -> Result<Option<Expr<I>>, Self::Error> {
                 if self.non_deterministic {
                     Ok(None)
+                } else if call.lambda_expr.volatility(self.registry)
+                    != FunctionVolatility::Immutable
+                {
+                    self.non_deterministic = true;
+                    Ok(None)
                 } else {
                     Self::visit_lambda_function_call(call, self)
                 }
@@ -1082,6 +1087,34 @@ impl<Index: ColumnIndex> Expr<Index> {
 }
 
 impl<Index: ColumnIndex> RemoteExpr<Index> {
+    /// Return the maximum volatility of functions contained in this expression.
+    #[recursive::recursive]
+    pub fn volatility(&self, fn_registry: &FunctionRegistry) -> FunctionVolatility {
+        match self {
+            RemoteExpr::Constant { .. } | RemoteExpr::ColumnRef { .. } => {
+                FunctionVolatility::Immutable
+            }
+            RemoteExpr::Cast { expr, .. } => expr.volatility(fn_registry),
+            RemoteExpr::FunctionCall { id, args, .. } => {
+                let own_volatility = fn_registry
+                    .get(id)
+                    .and_then(|function| fn_registry.get_property(&function.signature.name))
+                    .map(|property| property.volatility)
+                    .unwrap_or(FunctionVolatility::Volatile);
+                args.iter()
+                    .map(|arg| arg.volatility(fn_registry))
+                    .fold(own_volatility, std::cmp::max)
+            }
+            RemoteExpr::LambdaFunctionCall {
+                args, lambda_expr, ..
+            } => args
+                .iter()
+                .map(|arg| arg.volatility(fn_registry))
+                .chain(std::iter::once(lambda_expr.volatility(fn_registry)))
+                .fold(FunctionVolatility::Immutable, std::cmp::max),
+        }
+    }
+
     pub fn as_expr(&self, fn_registry: &FunctionRegistry) -> Expr<Index> {
         match self {
             RemoteExpr::Constant {

--- a/src/query/expression/src/expression.rs
+++ b/src/query/expression/src/expression.rs
@@ -29,6 +29,7 @@ use crate::Symbol;
 use crate::function::Function;
 use crate::function::FunctionID;
 use crate::function::FunctionRegistry;
+use crate::property::FunctionVolatility;
 use crate::types::DataType;
 use crate::values::Scalar;
 
@@ -1010,7 +1011,8 @@ impl<Index: ColumnIndex> Expr<Index> {
                     .registry
                     .get_property(&function.signature.name)
                     .unwrap()
-                    .non_deterministic
+                    .volatility
+                    != FunctionVolatility::Immutable
                 {
                     self.non_deterministic = true;
                     Ok(None)

--- a/src/query/expression/src/property.rs
+++ b/src/query/expression/src/property.rs
@@ -54,9 +54,19 @@ use crate::with_number_type;
 /// monotonicity cannot be proven for that range.
 pub type MonotonicityCheck = fn(&FunctionContext, &[Domain]) -> Option<usize>;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FunctionVolatility {
+    /// The function always returns the same result for the same arguments.
+    Immutable,
+    /// The function may change between statements but is stable within one statement.
+    StableWithinStatement,
+    /// Repeated calls within one statement may differ or have observable side effects.
+    Volatile,
+}
+
 #[derive(Debug, Clone)]
 pub struct FunctionProperty {
-    pub non_deterministic: bool,
+    pub volatility: FunctionVolatility,
     pub kind: FunctionKind,
     // strictly increasing or strictly decreasing, like y = x + 1
     // y = x ^ 2 is not monotonicity, but it's only monotonicity in [-x, 0] and [0, +x]
@@ -70,8 +80,13 @@ pub struct FunctionProperty {
 }
 
 impl FunctionProperty {
-    pub fn non_deterministic(mut self) -> Self {
-        self.non_deterministic = true;
+    pub fn volatile(mut self) -> Self {
+        self.volatility = FunctionVolatility::Volatile;
+        self
+    }
+
+    pub fn stable_within_statement(mut self) -> Self {
+        self.volatility = FunctionVolatility::StableWithinStatement;
         self
     }
 
@@ -99,7 +114,7 @@ impl FunctionProperty {
 impl Default for FunctionProperty {
     fn default() -> Self {
         FunctionProperty {
-            non_deterministic: false,
+            volatility: FunctionVolatility::Immutable,
             monotonicity: false,
             monotonicity_by_type: vec![],
             monotonicity_check: None,

--- a/src/query/expression/src/utils/display.rs
+++ b/src/query/expression/src/utils/display.rs
@@ -54,6 +54,7 @@ use crate::function::Function;
 use crate::function::FunctionSignature;
 use crate::property::Domain;
 use crate::property::FunctionProperty;
+use crate::property::FunctionVolatility;
 use crate::types::AccessType;
 use crate::types::AnyType;
 use crate::types::DataType;
@@ -1174,8 +1175,10 @@ impl Display for FunctionSignature {
 impl Display for FunctionProperty {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let mut properties = Vec::new();
-        if self.non_deterministic {
-            properties.push("non_deterministic");
+        match self.volatility {
+            FunctionVolatility::Immutable => {}
+            FunctionVolatility::StableWithinStatement => properties.push("stable_within_statement"),
+            FunctionVolatility::Volatile => properties.push("volatile"),
         }
         if !properties.is_empty() {
             write!(f, "{{{}}}", properties.join(", "))?;

--- a/src/query/functions/src/lib.rs
+++ b/src/query/functions/src/lib.rs
@@ -40,10 +40,10 @@ pub fn is_builtin_function(name: &str) -> bool {
 
 /// Returns whether a registered function can safely reuse its logical plan.
 ///
-/// Non-deterministic builtins are included because their runtime values are not folded into the
-/// logical plan cached by the planner. Result-cache eligibility is tracked separately. Search
-/// functions, async functions, and UDFs are excluded because their logical plans may contain
-/// metadata-derived arguments that can change.
+/// Execution-dependent builtins are included; logical-planning rewrites must keep their evaluation
+/// symbolic instead of storing an evaluated value in the cached plan. Result-cache eligibility is
+/// tracked separately. Search functions, async functions, and UDFs are excluded because their
+/// logical plans may contain metadata-derived arguments that can change.
 pub fn is_plan_cacheable_function(name: &str) -> bool {
     let name = Ascii::new(name);
     BUILTIN_FUNCTIONS.contains(name.into_inner())

--- a/src/query/functions/src/lib.rs
+++ b/src/query/functions/src/lib.rs
@@ -38,13 +38,15 @@ pub fn is_builtin_function(name: &str) -> bool {
         || ASYNC_FUNCTIONS.contains(&name)
 }
 
-// The plan of search function, async function and udf contains some arguments defined in meta,
-// which may be modified by user at any time. Those functions are not not suitable for caching.
-pub fn is_cacheable_function(name: &str) -> bool {
-    let n = name;
+/// Returns whether a registered function can safely reuse its logical plan.
+///
+/// Non-deterministic builtins are included because their runtime values are not folded into the
+/// logical plan cached by the planner. Result-cache eligibility is tracked separately. Search
+/// functions, async functions, and UDFs are excluded because their logical plans may contain
+/// metadata-derived arguments that can change.
+pub fn is_plan_cacheable_function(name: &str) -> bool {
     let name = Ascii::new(name);
-    (BUILTIN_FUNCTIONS.contains(name.into_inner())
-        && !BUILTIN_FUNCTIONS.get_property(n).unwrap().non_deterministic)
+    BUILTIN_FUNCTIONS.contains(name.into_inner())
         || AggregateFunctionFactory::instance().contains(name.into_inner())
         || GENERAL_WINDOW_FUNCTIONS.contains(&name)
         || GENERAL_LAMBDA_FUNCTIONS.contains(&name)

--- a/src/query/functions/src/scalars/other.rs
+++ b/src/query/functions/src/scalars/other.rs
@@ -81,15 +81,17 @@ pub fn register(registry: &mut FunctionRegistry) {
     register_grouping(registry);
     register_num_to_char(registry);
 
-    registry.properties.insert(
-        "rand".to_string(),
-        FunctionProperty::default().non_deterministic(),
-    );
+    registry
+        .properties
+        .insert("rand".to_string(), FunctionProperty::default().volatile());
 
     registry.properties.insert(
         "gen_random_uuid".to_string(),
-        FunctionProperty::default().non_deterministic(),
+        FunctionProperty::default().volatile(),
     );
+    registry
+        .properties
+        .insert("sleep".to_string(), FunctionProperty::default().volatile());
 
     registry
         .scalar_builder("humanize_size")

--- a/src/query/functions/src/scalars/timestamp/src/datetime.rs
+++ b/src/query/functions/src/scalars/timestamp/src/datetime.rs
@@ -2123,23 +2123,23 @@ fn register_real_time_functions(registry: &mut FunctionRegistry) {
 
     registry.properties.insert(
         "now".to_string(),
-        FunctionProperty::default().non_deterministic(),
+        FunctionProperty::default().stable_within_statement(),
     );
     registry.properties.insert(
         "current_time".to_string(),
-        FunctionProperty::default().non_deterministic(),
+        FunctionProperty::default().stable_within_statement(),
     );
     registry.properties.insert(
         "today".to_string(),
-        FunctionProperty::default().non_deterministic(),
+        FunctionProperty::default().stable_within_statement(),
     );
     registry.properties.insert(
         "yesterday".to_string(),
-        FunctionProperty::default().non_deterministic(),
+        FunctionProperty::default().stable_within_statement(),
     );
     registry.properties.insert(
         "tomorrow".to_string(),
-        FunctionProperty::default().non_deterministic(),
+        FunctionProperty::default().stable_within_statement(),
     );
 
     // NOTE: `to_timestamp`/`to_timestamp_tz`/`to_date` keep their pre-existing global

--- a/src/query/functions/tests/it/scalars/mod.rs
+++ b/src/query/functions/tests/it/scalars/mod.rs
@@ -19,6 +19,7 @@ use comfy_table::Table;
 use databend_common_exception::Result;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::Column;
+use databend_common_expression::ConstantFoldPolicy;
 use databend_common_expression::ConstantFolder;
 use databend_common_expression::DataBlock;
 use databend_common_expression::Domain;
@@ -89,6 +90,47 @@ fn test_execution_dependent_function_volatility() {
             "unexpected volatility for {name}"
         );
     }
+}
+
+#[test]
+fn test_constant_fold_policy_preserves_execution_dependent_functions() {
+    let raw_expr = parser::parse_raw_expr("to_second(now())", &[], &BUILTIN_FUNCTIONS);
+    let expr = type_check::check(&raw_expr, &BUILTIN_FUNCTIONS).unwrap();
+    let func_ctx = FunctionContext::default();
+
+    let (immutable_only, _, immutable_provenance) = ConstantFolder::fold_with_policy_and_provenance(
+        &expr,
+        &func_ctx,
+        &BUILTIN_FUNCTIONS,
+        ConstantFoldPolicy::ImmutableOnly,
+    );
+    assert!(
+        !matches!(
+            immutable_only,
+            databend_common_expression::Expr::Constant(_)
+        ),
+        "an immutable-only fold must keep now() symbolic"
+    );
+    assert_eq!(immutable_provenance, FunctionVolatility::Immutable);
+
+    let (statement_local, _, statement_provenance) =
+        ConstantFolder::fold_with_policy_and_provenance(
+            &expr,
+            &func_ctx,
+            &BUILTIN_FUNCTIONS,
+            ConstantFoldPolicy::AllowStableWithinStatement,
+        );
+    assert!(
+        matches!(
+            statement_local,
+            databend_common_expression::Expr::Constant(_)
+        ),
+        "an explicitly statement-local fold should evaluate now()"
+    );
+    assert_eq!(
+        statement_provenance,
+        FunctionVolatility::StableWithinStatement
+    );
 }
 
 #[derive(Clone)]

--- a/src/query/functions/tests/it/scalars/mod.rs
+++ b/src/query/functions/tests/it/scalars/mod.rs
@@ -25,6 +25,7 @@ use databend_common_expression::Domain;
 use databend_common_expression::Evaluator;
 use databend_common_expression::FunctionContext;
 use databend_common_expression::FunctionFactory;
+use databend_common_expression::FunctionVolatility;
 use databend_common_expression::Value;
 use databend_common_expression::type_check;
 use databend_common_expression::types::NullableColumn;
@@ -62,6 +63,33 @@ mod variant;
 mod vector;
 
 pub use databend_common_expression_test_support as parser;
+
+#[test]
+fn test_execution_dependent_function_volatility() {
+    for name in [
+        "now",
+        "current_timestamp",
+        "current_time",
+        "today",
+        "current_date",
+        "yesterday",
+        "tomorrow",
+    ] {
+        assert_eq!(
+            BUILTIN_FUNCTIONS.get_property(name).unwrap().volatility,
+            FunctionVolatility::StableWithinStatement,
+            "unexpected volatility for {name}"
+        );
+    }
+
+    for name in ["rand", "gen_random_uuid", "uuid", "sleep"] {
+        assert_eq!(
+            BUILTIN_FUNCTIONS.get_property(name).unwrap().volatility,
+            FunctionVolatility::Volatile,
+            "unexpected volatility for {name}"
+        );
+    }
+}
 
 #[derive(Clone)]
 pub struct TestContext<'a> {

--- a/src/query/service/tests/it/sql/planner/semantic/mod.rs
+++ b/src/query/service/tests/it/sql/planner/semantic/mod.rs
@@ -13,4 +13,5 @@
 // limitations under the License.
 
 mod name_resolution;
+mod planner_cache;
 mod type_check;

--- a/src/query/service/tests/it/sql/planner/semantic/planner_cache.rs
+++ b/src/query/service/tests/it/sql/planner/semantic/planner_cache.rs
@@ -18,9 +18,12 @@ use std::time::Duration;
 use databend_common_expression::ColumnIndex;
 use databend_common_expression::RemoteExpr;
 use databend_common_expression::Scalar;
+use databend_common_expression::ScalarRef;
 use databend_common_sql::MetadataRef;
 use databend_common_sql::Planner;
+use databend_common_sql::optimizer::ir::SExpr;
 use databend_common_sql::plans::Plan;
+use databend_common_sql::plans::RelOperator;
 use databend_query::physical_plans::PhysicalPlanBuilder;
 use databend_query::sessions::QueryContext;
 use databend_query::sessions::TableContextSettings;
@@ -64,10 +67,28 @@ async fn test_planner_cache_folds_statement_stable_subquery_per_physical_plan() 
     let plan_shaping_sql = "SELECT t.ts FROM default.cache_statement_stable_subquery AS t, \
                             numbers(to_uint64(to_second(now())))";
     let first = plan_query(ctx.clone(), plan_shaping_sql).await?;
-    let second = plan_query(ctx, plan_shaping_sql).await?;
+    let second = plan_query(ctx.clone(), plan_shaping_sql).await?;
     assert!(
         !Arc::ptr_eq(query_metadata(&first), query_metadata(&second)),
         "execution-dependent table-function arguments must be rebound"
+    );
+
+    ctx.get_settings()
+        .set_setting("inlist_to_join_threshold".to_string(), "4".to_string())?;
+    let in_list_sql = "SELECT * FROM default.cache_statement_stable_subquery \
+                       WHERE to_second(ts) IN (100.0, 101.0, 102.0, to_second(now()))";
+    let first = plan_query(ctx.clone(), in_list_sql).await?;
+    let first_second = constant_scan_last_second(&first);
+    tokio::time::sleep(Duration::from_millis(1100)).await;
+    let second = plan_query(ctx, in_list_sql).await?;
+    let second_second = constant_scan_last_second(&second);
+    assert!(
+        !Arc::ptr_eq(query_metadata(&first), query_metadata(&second)),
+        "a statement-local constant table must not enter the planner cache"
+    );
+    assert_ne!(
+        first_second, second_second,
+        "the stable IN-list value must be materialized again for each statement"
     );
     Ok(())
 }
@@ -83,6 +104,27 @@ fn query_metadata(plan: &Plan) -> &MetadataRef {
         panic!("expected query plan")
     };
     metadata
+}
+
+fn constant_scan_last_second(plan: &Plan) -> i64 {
+    let Plan::Query { s_expr, .. } = plan else {
+        panic!("expected query plan")
+    };
+    let scan = find_constant_scan(s_expr).expect("expected a ConstantTableScan");
+    let value = scan.values[0]
+        .index(scan.num_rows - 1)
+        .expect("expected the last IN-list value");
+    match value {
+        ScalarRef::Decimal(value) => value.to_float64() as i64,
+        other => panic!("expected a decimal second, got {other:?}"),
+    }
+}
+
+fn find_constant_scan(s_expr: &SExpr) -> Option<&databend_common_sql::plans::ConstantTableScan> {
+    if let RelOperator::ConstantTableScan(scan) = s_expr.plan() {
+        return Some(scan);
+    }
+    s_expr.children().find_map(find_constant_scan)
 }
 
 async fn plan_and_extract_scan_timestamp(

--- a/src/query/service/tests/it/sql/planner/semantic/planner_cache.rs
+++ b/src/query/service/tests/it/sql/planner/semantic/planner_cache.rs
@@ -1,0 +1,147 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use databend_common_expression::ColumnIndex;
+use databend_common_expression::RemoteExpr;
+use databend_common_expression::Scalar;
+use databend_common_sql::MetadataRef;
+use databend_common_sql::Planner;
+use databend_common_sql::plans::Plan;
+use databend_query::physical_plans::PhysicalPlanBuilder;
+use databend_query::sessions::QueryContext;
+use databend_query::sessions::TableContextSettings;
+use databend_query::test_kits::TestFixture;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_planner_cache_folds_statement_stable_subquery_per_physical_plan() -> anyhow::Result<()>
+{
+    let fixture = TestFixture::setup().await?;
+    fixture
+        .execute_command(
+            "CREATE TABLE default.cache_statement_stable_subquery(ts TIMESTAMP) ENGINE = FUSE",
+        )
+        .await?;
+    fixture
+        .execute_command(
+            "INSERT INTO default.cache_statement_stable_subquery VALUES ('2020-01-01 00:00:00')",
+        )
+        .await?;
+
+    let ctx = fixture.new_query_ctx().await?;
+    ctx.get_settings()
+        .set_setting("enable_planner_cache".to_string(), "1".to_string())?;
+    let sql = "SELECT * FROM default.cache_statement_stable_subquery \
+               WHERE ts < (SELECT now())";
+
+    let (first_metadata, first_now) = plan_and_extract_scan_timestamp(ctx.clone(), sql).await?;
+    tokio::time::sleep(Duration::from_millis(5)).await;
+    let (second_metadata, second_now) = plan_and_extract_scan_timestamp(ctx.clone(), sql).await?;
+
+    assert!(
+        Arc::ptr_eq(&first_metadata, &second_metadata),
+        "the second statement should reuse the cached logical plan"
+    );
+    assert!(
+        second_now > first_now,
+        "the Scan pushdown must use the current statement timestamp: \
+         first={first_now}, second={second_now}"
+    );
+
+    let plan_shaping_sql = "SELECT t.ts FROM default.cache_statement_stable_subquery AS t, \
+                            numbers(to_uint64(to_second(now())))";
+    let first = plan_query(ctx.clone(), plan_shaping_sql).await?;
+    let second = plan_query(ctx, plan_shaping_sql).await?;
+    assert!(
+        !Arc::ptr_eq(query_metadata(&first), query_metadata(&second)),
+        "execution-dependent table-function arguments must be rebound"
+    );
+    Ok(())
+}
+
+async fn plan_query(ctx: Arc<QueryContext>, sql: &str) -> anyhow::Result<Plan> {
+    let mut planner = Planner::new(ctx);
+    let (plan, _) = planner.plan_sql(sql).await?;
+    Ok(plan)
+}
+
+fn query_metadata(plan: &Plan) -> &MetadataRef {
+    let Plan::Query { metadata, .. } = plan else {
+        panic!("expected query plan")
+    };
+    metadata
+}
+
+async fn plan_and_extract_scan_timestamp(
+    ctx: Arc<QueryContext>,
+    sql: &str,
+) -> anyhow::Result<(MetadataRef, i64)> {
+    let plan = plan_query(ctx.clone(), sql).await?;
+    let Plan::Query {
+        s_expr,
+        metadata,
+        bind_context,
+        ..
+    } = plan
+    else {
+        panic!("expected query plan")
+    };
+
+    let mut builder = PhysicalPlanBuilder::new(metadata.clone(), ctx, false);
+    let physical = builder.build(&s_expr, bind_context.column_set()).await?;
+    let source = physical
+        .try_find_single_data_source()
+        .expect("expected one table scan");
+    let filter = &source
+        .push_downs
+        .as_ref()
+        .and_then(|push_downs| push_downs.filters.as_ref())
+        .expect("expected a Scan pushdown filter")
+        .filter;
+    let mut timestamps = Vec::new();
+    collect_timestamp_constants(filter, &mut timestamps);
+    let [statement_now] = timestamps.as_slice() else {
+        panic!("expected one timestamp literal in Scan pushdown, got {timestamps:?}")
+    };
+    Ok((metadata, *statement_now))
+}
+
+fn collect_timestamp_constants<Index: ColumnIndex>(
+    expr: &RemoteExpr<Index>,
+    timestamps: &mut Vec<i64>,
+) {
+    match expr {
+        RemoteExpr::Constant {
+            scalar: Scalar::Timestamp(value),
+            ..
+        } => timestamps.push(*value),
+        RemoteExpr::Cast { expr, .. } => collect_timestamp_constants(expr, timestamps),
+        RemoteExpr::FunctionCall { args, .. } => {
+            for arg in args {
+                collect_timestamp_constants(arg, timestamps);
+            }
+        }
+        RemoteExpr::LambdaFunctionCall {
+            args, lambda_expr, ..
+        } => {
+            for arg in args {
+                collect_timestamp_constants(arg, timestamps);
+            }
+            collect_timestamp_constants(lambda_expr, timestamps);
+        }
+        RemoteExpr::Constant { .. } | RemoteExpr::ColumnRef { .. } => {}
+    }
+}

--- a/src/query/sql/src/planner/binder/binder.rs
+++ b/src/query/sql/src/planner/binder/binder.rs
@@ -33,6 +33,7 @@ use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::Constant;
+use databend_common_expression::ConstantFoldPolicy;
 use databend_common_expression::ConstantFolder;
 use databend_common_expression::Expr;
 use databend_common_expression::FunctionKind;
@@ -951,10 +952,17 @@ impl Binder {
             let scalar = wrap_cast(&scalar, &DataType::String);
             let expr = scalar.as_expr()?;
 
-            let (new_expr, _) =
-                ConstantFolder::fold(&expr, &self.ctx.get_function_context()?, &BUILTIN_FUNCTIONS);
+            let (new_expr, _, folded_volatility) = ConstantFolder::fold_with_policy_and_provenance(
+                &expr,
+                &self.ctx.get_function_context()?,
+                &BUILTIN_FUNCTIONS,
+                ConstantFoldPolicy::AllowVolatile,
+            );
             match new_expr {
                 Expr::Constant(Constant { scalar, .. }) => {
+                    self.metadata
+                        .write()
+                        .record_plan_constant(folded_volatility);
                     let value = scalar.into_string().unwrap();
                     if variable.to_lowercase().as_str() == "timezone" {
                         let tz = value.trim_matches(|c| c == '\'' || c == '\"');

--- a/src/query/sql/src/planner/binder/default_expr.rs
+++ b/src/query/sql/src/planner/binder/default_expr.rs
@@ -21,6 +21,7 @@ use databend_common_ast::parser::tokenize_sql;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_expression::ConstantFoldPolicy;
 use databend_common_expression::ConstantFolder;
 use databend_common_expression::DataBlock;
 use databend_common_expression::DataField;
@@ -155,8 +156,12 @@ impl DefaultExprBinder {
         let (expr, is_deterministic) = if is_nextval {
             (expr, false)
         } else if expr.is_deterministic(&BUILTIN_FUNCTIONS) {
-            let (fold_to_constant, _) =
-                ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+            let (fold_to_constant, _) = ConstantFolder::fold_with_policy(
+                &expr,
+                &self.func_ctx,
+                &BUILTIN_FUNCTIONS,
+                ConstantFoldPolicy::ImmutableOnly,
+            );
             (fold_to_constant, true)
         } else {
             (expr, false)

--- a/src/query/sql/src/planner/binder/project.rs
+++ b/src/query/sql/src/planner/binder/project.rs
@@ -35,6 +35,7 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::Column;
 use databend_common_expression::Constant;
+use databend_common_expression::ConstantFoldPolicy;
 use databend_common_expression::ConstantFolder;
 use databend_common_expression::Scalar;
 use databend_common_functions::BUILTIN_FUNCTIONS;
@@ -685,14 +686,21 @@ impl Binder {
             )?;
             let (scalar, _) = *type_checker.resolve(&expr)?;
             let expr = scalar.as_expr()?;
-            let (new_expr, _) =
-                ConstantFolder::fold(&expr, &self.ctx.get_function_context()?, &BUILTIN_FUNCTIONS);
+            let (new_expr, _, folded_volatility) = ConstantFolder::fold_with_policy_and_provenance(
+                &expr,
+                &self.ctx.get_function_context()?,
+                &BUILTIN_FUNCTIONS,
+                ConstantFoldPolicy::AllowVolatile,
+            );
 
             match new_expr {
                 databend_common_expression::Expr::Constant(Constant {
                     scalar: Scalar::Array(Column::Boolean(bitmap)),
                     ..
                 }) => {
+                    self.metadata
+                        .write()
+                        .record_plan_constant(folded_volatility);
                     let mut new_column_idx = Vec::new();
                     for (index, val) in bitmap.iter().enumerate() {
                         if val {

--- a/src/query/sql/src/planner/binder/scalar.rs
+++ b/src/query/sql/src/planner/binder/scalar.rs
@@ -18,6 +18,7 @@ use databend_common_ast::ast::Expr;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
 use databend_common_expression::FunctionContext;
+use databend_common_expression::FunctionVolatility;
 use databend_common_expression::types::DataType;
 
 use crate::MetadataRef;
@@ -72,5 +73,9 @@ impl<'a> ScalarBinder<'a> {
 
     pub fn get_func_ctx(&self) -> Result<FunctionContext> {
         self.ctx.get_function_context()
+    }
+
+    pub fn record_plan_constant(&self, volatility: FunctionVolatility) {
+        self.metadata.write().record_plan_constant(volatility);
     }
 }

--- a/src/query/sql/src/planner/binder/set.rs
+++ b/src/query/sql/src/planner/binder/set.rs
@@ -20,6 +20,7 @@ use databend_common_ast::ast::Statement;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::Constant;
+use databend_common_expression::ConstantFoldPolicy;
 use databend_common_expression::ConstantFolder;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 
@@ -64,10 +65,11 @@ impl Binder {
                     for expr in exprs.iter() {
                         let (scalar, _) = *type_checker.resolve(expr.as_ref())?;
                         let expr = scalar.as_expr()?;
-                        let (new_expr, _) = ConstantFolder::fold(
+                        let (new_expr, _) = ConstantFolder::fold_with_policy(
                             &expr,
                             &self.ctx.get_function_context()?,
                             &BUILTIN_FUNCTIONS,
+                            ConstantFoldPolicy::AllowVolatile,
                         );
                         let Constant { scalar, .. } = new_expr.into_constant().map_err(|_| {
                             ErrorCode::SemanticError("value must be constant value")

--- a/src/query/sql/src/planner/binder/statement_settings.rs
+++ b/src/query/sql/src/planner/binder/statement_settings.rs
@@ -22,6 +22,7 @@ use databend_common_ast::ast::Statement;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::Constant;
+use databend_common_expression::ConstantFoldPolicy;
 use databend_common_expression::ConstantFolder;
 use databend_common_expression::Expr;
 use databend_common_expression::cast_scalar;
@@ -73,10 +74,11 @@ impl Binder {
                             for expr in exprs.iter() {
                                 let (scalar, _) = *type_checker.resolve(expr.as_ref())?;
                                 let expr = scalar.as_expr()?;
-                                let (new_expr, _) = ConstantFolder::fold(
+                                let (new_expr, _) = ConstantFolder::fold_with_policy(
                                     &expr,
                                     &self.ctx.get_function_context()?,
                                     &BUILTIN_FUNCTIONS,
+                                    ConstantFoldPolicy::AllowVolatile,
                                 );
                                 match new_expr {
                                     Expr::Constant(Constant { scalar, .. }) => {

--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -42,6 +42,7 @@ use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::Constant;
+use databend_common_expression::ConstantFoldPolicy;
 use databend_common_expression::ConstantFolder;
 use databend_common_expression::DataField;
 use databend_common_expression::FunctionContext;
@@ -718,11 +719,17 @@ impl Binder {
         )?;
         let box (scalar, _) = type_checker.resolve(expr)?;
         let scalar_expr = scalar.as_expr()?;
-        let (new_expr, _) = ConstantFolder::fold(
+        let (new_expr, _, folded_volatility) = ConstantFolder::fold_with_policy_and_provenance(
             &scalar_expr,
             &self.ctx.get_function_context()?,
             &BUILTIN_FUNCTIONS,
+            ConstantFoldPolicy::AllowVolatile,
         );
+        if matches!(new_expr, databend_common_expression::Expr::Constant(_)) {
+            self.metadata
+                .write()
+                .record_plan_constant(folded_volatility);
+        }
         Ok(new_expr)
     }
 

--- a/src/query/sql/src/planner/binder/table_args.rs
+++ b/src/query/sql/src/planner/binder/table_args.rs
@@ -24,6 +24,7 @@ use databend_common_catalog::table_args::TableArgs;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::Constant;
+use databend_common_expression::ConstantFoldPolicy;
 use databend_common_expression::ConstantFolder;
 use databend_common_expression::DataBlock;
 use databend_common_expression::Scalar;
@@ -123,10 +124,18 @@ fn try_fold_to_scalar(
     subquery_executor: &Option<Arc<dyn QueryExecutor>>,
 ) -> Result<Scalar> {
     let expr = scalar.as_expr()?;
-    let (expr, _) = ConstantFolder::fold(&expr, &scalar_binder.get_func_ctx()?, &BUILTIN_FUNCTIONS);
+    let (expr, _, folded_volatility) = ConstantFolder::fold_with_policy_and_provenance(
+        &expr,
+        &scalar_binder.get_func_ctx()?,
+        &BUILTIN_FUNCTIONS,
+        ConstantFoldPolicy::AllowVolatile,
+    );
 
     match expr.into_constant() {
-        Ok(Constant { scalar, .. }) => Ok(scalar),
+        Ok(Constant { scalar, .. }) => {
+            scalar_binder.record_plan_constant(folded_volatility);
+            Ok(scalar)
+        }
         Err(_) => {
             if contains_subquery(ast_expr) {
                 if let Some(executor) = subquery_executor {

--- a/src/query/sql/src/planner/metadata/metadata.rs
+++ b/src/query/sql/src/planner/metadata/metadata.rs
@@ -27,6 +27,7 @@ use databend_common_catalog::plan::InternalColumn;
 use databend_common_catalog::table::Table;
 use databend_common_expression::ColumnId;
 use databend_common_expression::ComputedExpr;
+use databend_common_expression::FunctionVolatility;
 pub use databend_common_expression::Symbol;
 use databend_common_expression::TableDataType;
 use databend_common_expression::TableField;
@@ -46,6 +47,16 @@ pub type IndexType = usize;
 /// Use IndexType::MAX to represent dummy table.
 pub const DUMMY_TABLE_INDEX: IndexType = IndexType::MAX;
 
+/// The shortest lifetime of values embedded into the logical plan.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum PlanCacheLifetime {
+    /// Every embedded value is reusable across statements.
+    #[default]
+    Reusable,
+    /// At least one embedded value is valid only for the statement that planned it.
+    Statement,
+}
+
 /// ColumnSet represents a set of columns identified by `Symbol`.
 pub type ColumnSet = BTreeSet<Symbol>;
 
@@ -61,6 +72,7 @@ pub type MetadataRef = Arc<RwLock<Metadata>>;
 pub struct Metadata {
     tables: Vec<TableEntry>,
     columns: Vec<ColumnEntry>,
+    plan_cache_lifetime: PlanCacheLifetime,
     removed_mark_indexes: ColumnSet,
     /// Table column indexes that are lazy materialized.
     table_lazy_columns: HashMap<IndexType, ColumnSet>,
@@ -103,6 +115,20 @@ impl Metadata {
 
     pub fn tables(&self) -> &[TableEntry] {
         self.tables.as_slice()
+    }
+
+    /// Record the provenance before an expression is materialized into a plan constant.
+    ///
+    /// Once folded, the literal itself no longer carries the function's volatility. Recording it
+    /// here provides the late planner-cache insertion check with that lost information.
+    pub fn record_plan_constant(&mut self, volatility: FunctionVolatility) {
+        if volatility != FunctionVolatility::Immutable {
+            self.plan_cache_lifetime = PlanCacheLifetime::Statement;
+        }
+    }
+
+    pub fn is_plan_cacheable(&self) -> bool {
+        self.plan_cache_lifetime == PlanCacheLifetime::Reusable
     }
 
     pub fn table_index_by_column_indexes(&self, column_indexes: &ColumnSet) -> Option<IndexType> {

--- a/src/query/sql/src/planner/optimizer/ir/stats/selectivity.rs
+++ b/src/query/sql/src/planner/optimizer/ir/stats/selectivity.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::Constant;
+use databend_common_expression::ConstantFoldPolicy;
 use databend_common_expression::ConstantFolder;
 use databend_common_expression::Domain;
 use databend_common_expression::Expr;
@@ -125,11 +126,12 @@ impl SelectivityEstimator {
         };
         let expr = scalar_expr.as_expr()?;
         let input_domains = self.build_input_domains(&expr)?;
-        let (expr, output_domain) = ConstantFolder::fold_with_domain(
+        let (expr, output_domain) = ConstantFolder::fold_with_domain_and_policy(
             &expr,
             &input_domains,
             &FunctionContext::default(),
             &BUILTIN_FUNCTIONS,
+            ConstantFoldPolicy::ImmutableOnly,
         );
 
         // ConstantFolder owns expression/domain reasoning: boolean shortcuts and

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/decorrelate.rs
@@ -19,6 +19,7 @@ use databend_common_ast::Span;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::ColumnBuilder;
+use databend_common_expression::ConstantFoldPolicy;
 use databend_common_expression::ConstantFolder;
 use databend_common_expression::Expr as EExpr;
 use databend_common_expression::FunctionVolatility;
@@ -630,10 +631,11 @@ impl SubqueryDecorrelatorOptimizer {
                     match scalar_expr.volatility() {
                         FunctionVolatility::Immutable => {
                             let func_ctx = self.ctx.get_function_context()?;
-                            let (folded, _) = ConstantFolder::fold(
+                            let (folded, _) = ConstantFolder::fold_with_policy(
                                 &scalar_expr.as_expr()?,
                                 &func_ctx,
                                 &BUILTIN_FUNCTIONS,
+                                ConstantFoldPolicy::ImmutableOnly,
                             );
                             if let EExpr::Constant(constant) = folded {
                                 replacement_scalar = Some(ScalarExpr::TypedConstantExpr(

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/decorrelate.rs
@@ -21,6 +21,7 @@ use databend_common_exception::Result;
 use databend_common_expression::ColumnBuilder;
 use databend_common_expression::ConstantFolder;
 use databend_common_expression::Expr as EExpr;
+use databend_common_expression::FunctionVolatility;
 use databend_common_expression::Scalar;
 use databend_common_expression::ScalarRef;
 use databend_common_expression::type_check::common_super_type;
@@ -33,6 +34,7 @@ use crate::ColumnSet;
 use crate::binder::ColumnBindingBuilder;
 use crate::binder::JoinPredicate;
 use crate::binder::Visibility;
+use crate::binder::wrap_nullable;
 use crate::optimizer::ir::Matcher;
 use crate::optimizer::ir::RelExpr;
 use crate::optimizer::ir::SExpr;
@@ -561,10 +563,11 @@ impl SubqueryDecorrelatorOptimizer {
         Ok((!can_reuse_inner_columns, derived_columns))
     }
 
-    // Try folding the subquery into a constant value expression,
-    // which turns the join plan into a filter plan, so that the bloom filter
-    // can be used to reduce the amount of data that needs to be read.
-    pub fn try_fold_constant_subquery(
+    // Try replacing the subquery with an immutable value or a statement-stable expression.
+    // This turns the join plan into a filter plan, so that the bloom filter can be used to reduce
+    // the amount of data that needs to be read. Statement-stable expressions are evaluated later
+    // while building the per-statement physical plan and must not become cached logical literals.
+    pub fn try_eliminate_constant_subquery(
         &self,
         subquery: &SubqueryExpr,
     ) -> Result<Option<ScalarExpr>> {
@@ -622,27 +625,37 @@ impl SubqueryDecorrelatorOptimizer {
                     return Ok(None);
                 }
                 let scalar_expr = &eval.items[0].scalar;
-                let mut constant_scalar = None;
+                let mut replacement_scalar = None;
                 if scalar_expr.used_columns().is_empty() && !scalar_expr.has_subquery() {
-                    let func_ctx = self.ctx.get_function_context()?;
-                    let (folded, _) = ConstantFolder::fold(
-                        &scalar_expr.as_expr()?,
-                        &func_ctx,
-                        &BUILTIN_FUNCTIONS,
-                    );
-                    if let EExpr::Constant(constant) = folded {
-                        constant_scalar = Some(ScalarExpr::TypedConstantExpr(
-                            ConstantExpr {
-                                span: scalar_expr.span(),
-                                value: constant.scalar,
-                            },
-                            constant.data_type.wrap_nullable(),
-                        ));
+                    match scalar_expr.volatility() {
+                        FunctionVolatility::Immutable => {
+                            let func_ctx = self.ctx.get_function_context()?;
+                            let (folded, _) = ConstantFolder::fold(
+                                &scalar_expr.as_expr()?,
+                                &func_ctx,
+                                &BUILTIN_FUNCTIONS,
+                            );
+                            if let EExpr::Constant(constant) = folded {
+                                replacement_scalar = Some(ScalarExpr::TypedConstantExpr(
+                                    ConstantExpr {
+                                        span: scalar_expr.span(),
+                                        value: constant.scalar,
+                                    },
+                                    constant.data_type.wrap_nullable(),
+                                ));
+                            }
+                        }
+                        FunctionVolatility::StableWithinStatement => {
+                            let data_type = scalar_expr.data_type()?;
+                            replacement_scalar =
+                                Some(wrap_nullable(scalar_expr.clone(), &data_type));
+                        }
+                        FunctionVolatility::Volatile => return Ok(None),
                     }
                 }
 
-                let scalar = if let Some(constant_scalar) = constant_scalar {
-                    constant_scalar
+                let scalar = if let Some(replacement_scalar) = replacement_scalar {
+                    replacement_scalar
                 } else {
                     let Ok(const_scalar) = ConstantExpr::try_from(scalar_expr.clone()) else {
                         return Ok(None);

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/subquery_decorrelator.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/subquery_decorrelator.rs
@@ -437,7 +437,7 @@ impl SubqueryDecorrelatorOptimizer {
                 let mut subquery = subquery.clone();
                 subquery.subquery = Box::new(self.optimize_sync(&subquery.subquery)?);
 
-                if let Some(constant_subquery) = self.try_fold_constant_subquery(&subquery)? {
+                if let Some(constant_subquery) = self.try_eliminate_constant_subquery(&subquery)? {
                     return Ok((constant_subquery, outer));
                 }
 

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/push_down_filter_join/outer_join_to_inner_join.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/push_down_filter_join/outer_join_to_inner_join.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use databend_common_exception::Result;
+use databend_common_expression::ConstantFoldPolicy;
 use databend_common_expression::ConstantFolder;
 use databend_common_expression::DataBlock;
 use databend_common_expression::DataField;
@@ -56,44 +57,58 @@ pub fn outer_join_to_inner_join(s_expr: &SExpr, metadata: MetadataRef) -> Result
     let mut can_filter_right_null = false;
     let left_prop = join_rel_expr.derive_relational_prop_child(0)?;
     let right_prop = join_rel_expr.derive_relational_prop_child(1)?;
+    let check_left_null = matches!(
+        join.join_type,
+        JoinType::Right | JoinType::RightSingle | JoinType::Full | JoinType::FullAsof
+    );
+    let check_right_null = matches!(
+        join.join_type,
+        JoinType::Left | JoinType::LeftSingle | JoinType::Full | JoinType::FullAsof
+    );
     for predicate in &filter.predicates {
         let pred = JoinPredicate::new(predicate, &left_prop, &right_prop);
         match pred {
             JoinPredicate::Left(_)
-                if can_filter_null(
-                    predicate,
-                    &left_prop.output_columns,
-                    &join.join_type,
-                    metadata.clone(),
-                )? =>
+                if check_left_null
+                    && can_filter_null(
+                        predicate,
+                        &left_prop.output_columns,
+                        &join.join_type,
+                        metadata.clone(),
+                    )? =>
             {
                 can_filter_left_null = true;
             }
             JoinPredicate::Right(_)
-                if can_filter_null(
-                    predicate,
-                    &right_prop.output_columns,
-                    &join.join_type,
-                    metadata.clone(),
-                )? =>
+                if check_right_null
+                    && can_filter_null(
+                        predicate,
+                        &right_prop.output_columns,
+                        &join.join_type,
+                        metadata.clone(),
+                    )? =>
             {
                 can_filter_right_null = true;
             }
             JoinPredicate::Both { .. } | JoinPredicate::Other(_) => {
-                if can_filter_null(
-                    predicate,
-                    &left_prop.output_columns,
-                    &join.join_type,
-                    metadata.clone(),
-                )? {
+                if check_left_null
+                    && can_filter_null(
+                        predicate,
+                        &left_prop.output_columns,
+                        &join.join_type,
+                        metadata.clone(),
+                    )?
+                {
                     can_filter_left_null = true;
                 }
-                if can_filter_null(
-                    predicate,
-                    &right_prop.output_columns,
-                    &join.join_type,
-                    metadata.clone(),
-                )? {
+                if check_right_null
+                    && can_filter_null(
+                        predicate,
+                        &right_prop.output_columns,
+                        &join.join_type,
+                        metadata.clone(),
+                    )?
+                {
                     can_filter_right_null = true;
                 }
             }
@@ -238,11 +253,16 @@ pub fn can_filter_null(
     let mut null_scalar_expr = predicate.clone();
     replace.replace(&mut null_scalar_expr).unwrap();
     if replace.can_replace {
-        let columns = null_scalar_expr.columns_and_data_types(metadata);
+        let columns = null_scalar_expr.columns_and_data_types(metadata.clone());
         let expr = convert_scalar_expr_to_expr(null_scalar_expr, columns)?;
         let func_ctx = &FunctionContext::default();
-        let (expr, _) = ConstantFolder::fold(&expr, func_ctx, &BUILTIN_FUNCTIONS);
-        if expr.contains_column_ref() {
+        let (expr, _, folded_volatility) = ConstantFolder::fold_with_policy_and_provenance(
+            &expr,
+            func_ctx,
+            &BUILTIN_FUNCTIONS,
+            ConstantFoldPolicy::AllowStableWithinStatement,
+        );
+        if expr.contains_column_ref() || !expr.is_deterministic(&BUILTIN_FUNCTIONS) {
             return Ok(false);
         }
         let data_block = DataBlock::empty();
@@ -250,6 +270,7 @@ pub fn can_filter_null(
         if let Value::Scalar(scalar) = evaluator.run(&expr)? {
             // if null column can be filtered, return true.
             if matches!(scalar, Scalar::Boolean(false) | Scalar::Null) {
+                metadata.write().record_plan_constant(folded_volatility);
                 return Ok(true);
             }
         }

--- a/src/query/sql/src/planner/planner.rs
+++ b/src/query/sql/src/planner/planner.rs
@@ -259,7 +259,7 @@ impl Planner {
                     "Logical plan retrieved from cache, elapsed: {:?}",
                     start.elapsed()
                 );
-                if cache_ctx.contains_nondeterministic_function {
+                if cache_ctx.contains_execution_dependent_function {
                     self.ctx.result_cache_state().set_cacheable(false);
                 }
                 // update for clickhouse handler

--- a/src/query/sql/src/planner/planner.rs
+++ b/src/query/sql/src/planner/planner.rs
@@ -259,6 +259,9 @@ impl Planner {
                     "Logical plan retrieved from cache, elapsed: {:?}",
                     start.elapsed()
                 );
+                if cache_ctx.contains_nondeterministic_function {
+                    self.ctx.result_cache_state().set_cacheable(false);
+                }
                 // update for clickhouse handler
                 self.ctx.attach_query_str(query_kind, stmt.to_mask_sql());
                 return Ok(plan.plan);

--- a/src/query/sql/src/planner/planner.rs
+++ b/src/query/sql/src/planner/planner.rs
@@ -312,7 +312,10 @@ impl Planner {
 
         let optimized_plan = optimize(opt_ctx, plan).await?;
 
-        if let Some(cache_ctx) = plan_cache_context {
+        let can_cache_plan = metadata.read().is_plan_cacheable();
+        if let Some(cache_ctx) = plan_cache_context
+            && can_cache_plan
+        {
             self.set_cache(cache_ctx, optimized_plan.clone());
         }
 

--- a/src/query/sql/src/planner/planner_cache.rs
+++ b/src/query/sql/src/planner/planner_cache.rs
@@ -17,15 +17,22 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::LazyLock;
 
+use databend_common_ast::ast::ColumnFilter;
+use databend_common_ast::ast::Expr;
 use databend_common_ast::ast::FunctionCall;
 use databend_common_ast::ast::Identifier;
 use databend_common_ast::ast::IdentifierType;
 use databend_common_ast::ast::Statement;
 use databend_common_ast::ast::TableReference;
+use databend_common_ast::ast::Window;
+use databend_common_ast::ast::WindowDefinition;
+use databend_common_ast::ast::WindowFrame;
+use databend_common_ast::ast::WindowFrameBound;
 use databend_common_catalog::table::Table;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
 use databend_common_expression::ColumnId;
+use databend_common_expression::FunctionVolatility;
 use databend_common_expression::Scalar;
 use databend_common_expression::TableSchemaRef;
 use databend_common_functions::BUILTIN_FUNCTIONS;
@@ -83,12 +90,12 @@ impl Planner {
             return Ok(None);
         }
 
-        let mut visitor = TableRefVisitor {
+        let mut visitor = PlanCacheabilityVisitor {
             ctx: self.ctx.clone(),
             table_snapshots: vec![],
             name_resolution_ctx,
             is_plan_cacheable: true,
-            contains_nondeterministic_function: false,
+            contains_execution_dependent_function: false,
             has_security_policy: false,
         };
         stmt.drive(&mut visitor);
@@ -101,7 +108,7 @@ impl Planner {
         Ok(Some(PlanCacheContext {
             cache_key,
             table_snapshots: visitor.table_snapshots,
-            contains_nondeterministic_function: visitor.contains_nondeterministic_function,
+            contains_execution_dependent_function: visitor.contains_execution_dependent_function,
         }))
     }
 
@@ -201,20 +208,25 @@ impl Planner {
 }
 
 #[derive(Visitor)]
-#[visitor(TableReference(enter), FunctionCall(enter))]
-struct TableRefVisitor {
+#[visitor(
+    TableReference(enter),
+    FunctionCall(enter),
+    WindowDefinition(enter),
+    ColumnFilter(enter)
+)]
+struct PlanCacheabilityVisitor {
     ctx: Arc<dyn TableContext>,
     table_snapshots: Vec<TableSnapshot>,
     name_resolution_ctx: NameResolutionContext,
     is_plan_cacheable: bool,
-    contains_nondeterministic_function: bool,
+    contains_execution_dependent_function: bool,
     has_security_policy: bool,
 }
 
 pub(crate) struct PlanCacheContext {
     cache_key: String,
     table_snapshots: Vec<TableSnapshot>,
-    pub(super) contains_nondeterministic_function: bool,
+    pub(super) contains_execution_dependent_function: bool,
 }
 
 impl PlanCacheContext {
@@ -289,22 +301,85 @@ impl From<&TableMeta> for SecurityPolicySnapshot {
     }
 }
 
-impl TableRefVisitor {
+#[derive(Default, Visitor)]
+#[visitor(FunctionCall(enter))]
+struct ExecutionDependentFunctionVisitor {
+    found: bool,
+}
+
+impl ExecutionDependentFunctionVisitor {
+    fn enter_function_call(&mut self, func: &FunctionCall) {
+        if self.found {
+            return;
+        }
+        self.found = BUILTIN_FUNCTIONS
+            .get_property(&func.name.name)
+            .is_some_and(|property| property.volatility != FunctionVolatility::Immutable);
+    }
+}
+
+fn contains_execution_dependent_function(expr: &Expr) -> bool {
+    let mut visitor = ExecutionDependentFunctionVisitor::default();
+    expr.drive(&mut visitor);
+    visitor.found
+}
+
+fn window_frame_contains_execution_dependent_function(frame: Option<&WindowFrame>) -> bool {
+    let Some(frame) = frame else {
+        return false;
+    };
+    [&frame.start_bound, &frame.end_bound]
+        .into_iter()
+        .filter_map(|bound| match bound {
+            WindowFrameBound::Preceding(Some(expr)) | WindowFrameBound::Following(Some(expr)) => {
+                Some(expr.as_ref())
+            }
+            _ => None,
+        })
+        .any(contains_execution_dependent_function)
+}
+
+impl PlanCacheabilityVisitor {
     fn enter_function_call(&mut self, func: &FunctionCall) {
         if !self.is_plan_cacheable {
             return;
         }
 
         let func_name = func.name.name.to_lowercase();
-        let is_nondeterministic_builtin = BUILTIN_FUNCTIONS
-            .get_property(&func_name)
-            .is_some_and(|property| property.non_deterministic);
 
-        // Non-deterministic builtins are not folded into constants, so their runtime values do not
-        // become part of the cached logical plan and do not block planner caching. Track them
-        // separately so a plan-cache hit still disables result caching.
-        if is_nondeterministic_builtin {
-            self.contains_nondeterministic_function = true;
+        // Function parameters, selected function arguments, and window-frame bounds are resolved
+        // into plan-shaping constants.
+        // Rebind them for every statement instead of caching an execution-dependent value.
+        let has_execution_dependent_parameter = func
+            .params
+            .iter()
+            .any(contains_execution_dependent_function);
+        let has_execution_dependent_plan_shaping_argument =
+            TypeChecker::<()>::plan_shaping_arguments(&func_name, &func.args)
+                .iter()
+                .any(contains_execution_dependent_function);
+        let has_execution_dependent_window_frame = func.window.as_ref().is_some_and(|window| {
+            let Window::WindowSpec(spec) = &window.window else {
+                return false;
+            };
+            window_frame_contains_execution_dependent_function(spec.window_frame.as_ref())
+        });
+        if has_execution_dependent_parameter
+            || has_execution_dependent_plan_shaping_argument
+            || has_execution_dependent_window_frame
+        {
+            self.is_plan_cacheable = false;
+            return;
+        }
+
+        let is_execution_dependent_builtin = BUILTIN_FUNCTIONS
+            .get_property(&func_name)
+            .is_some_and(|property| property.volatility != FunctionVolatility::Immutable);
+
+        // Reusable logical plans keep execution-dependent builtins symbolic. Track them separately
+        // so a plan-cache hit still disables result caching.
+        if is_execution_dependent_builtin {
+            self.contains_execution_dependent_function = true;
         }
 
         let is_plan_cacheable = is_plan_cacheable_function(&func_name)
@@ -319,6 +394,22 @@ impl TableRefVisitor {
         if !self.is_plan_cacheable {
             return;
         }
+        if let TableReference::TableFunction {
+            params,
+            named_params,
+            ..
+        } = table_ref
+        {
+            if params
+                .iter()
+                .chain(named_params.iter().map(|(_, expr)| expr))
+                .any(contains_execution_dependent_function)
+            {
+                self.is_plan_cacheable = false;
+            }
+            return;
+        }
+
         if let TableReference::Table {
             table,
             temporal,
@@ -372,6 +463,20 @@ impl TableRefVisitor {
                 }
                 self.is_plan_cacheable = false;
             });
+        }
+    }
+
+    fn enter_window_definition(&mut self, window: &WindowDefinition) {
+        if window_frame_contains_execution_dependent_function(window.spec.window_frame.as_ref()) {
+            self.is_plan_cacheable = false;
+        }
+    }
+
+    fn enter_column_filter(&mut self, filter: &ColumnFilter) {
+        if let ColumnFilter::Lambda(lambda) = filter
+            && contains_execution_dependent_function(&lambda.expr)
+        {
+            self.is_plan_cacheable = false;
         }
     }
 }

--- a/src/query/sql/src/planner/planner_cache.rs
+++ b/src/query/sql/src/planner/planner_cache.rs
@@ -28,7 +28,8 @@ use databend_common_exception::Result;
 use databend_common_expression::ColumnId;
 use databend_common_expression::Scalar;
 use databend_common_expression::TableSchemaRef;
-use databend_common_functions::is_cacheable_function;
+use databend_common_functions::BUILTIN_FUNCTIONS;
+use databend_common_functions::is_plan_cacheable_function;
 use databend_common_meta_app::schema::SecurityPolicyColumnMap;
 use databend_common_meta_app::schema::TableMeta;
 use databend_common_settings::ChangeValue;
@@ -46,6 +47,7 @@ use crate::NameResolutionContext;
 use crate::Planner;
 use crate::TableEntry;
 use crate::normalize_identifier;
+use crate::planner::semantic::TypeChecker;
 use crate::plans::Plan;
 
 #[derive(Clone)]
@@ -85,12 +87,13 @@ impl Planner {
             ctx: self.ctx.clone(),
             table_snapshots: vec![],
             name_resolution_ctx,
-            cache_miss: false,
+            is_plan_cacheable: true,
+            contains_nondeterministic_function: false,
             has_security_policy: false,
         };
         stmt.drive(&mut visitor);
 
-        if visitor.cache_miss || visitor.table_snapshots.is_empty() {
+        if !visitor.is_plan_cacheable || visitor.table_snapshots.is_empty() {
             return Ok(None);
         }
 
@@ -98,6 +101,7 @@ impl Planner {
         Ok(Some(PlanCacheContext {
             cache_key,
             table_snapshots: visitor.table_snapshots,
+            contains_nondeterministic_function: visitor.contains_nondeterministic_function,
         }))
     }
 
@@ -202,13 +206,15 @@ struct TableRefVisitor {
     ctx: Arc<dyn TableContext>,
     table_snapshots: Vec<TableSnapshot>,
     name_resolution_ctx: NameResolutionContext,
-    cache_miss: bool,
+    is_plan_cacheable: bool,
+    contains_nondeterministic_function: bool,
     has_security_policy: bool,
 }
 
 pub(crate) struct PlanCacheContext {
     cache_key: String,
     table_snapshots: Vec<TableSnapshot>,
+    pub(super) contains_nondeterministic_function: bool,
 }
 
 impl PlanCacheContext {
@@ -285,19 +291,32 @@ impl From<&TableMeta> for SecurityPolicySnapshot {
 
 impl TableRefVisitor {
     fn enter_function_call(&mut self, func: &FunctionCall) {
-        if self.cache_miss {
+        if !self.is_plan_cacheable {
             return;
         }
 
         let func_name = func.name.name.to_lowercase();
-        // If the function is not suitable for caching, we should not cache the plan
-        if !is_cacheable_function(&func_name) {
-            self.cache_miss = true;
+        let is_nondeterministic_builtin = BUILTIN_FUNCTIONS
+            .get_property(&func_name)
+            .is_some_and(|property| property.non_deterministic);
+
+        // Non-deterministic builtins are not folded into constants, so their runtime values do not
+        // become part of the cached logical plan. Track them separately so a plan-cache hit still
+        // disables result caching.
+        if is_nondeterministic_builtin {
+            self.contains_nondeterministic_function = true;
+        }
+
+        let is_plan_cacheable = is_plan_cacheable_function(&func_name)
+            || TypeChecker::<()>::is_rewrite_function(&func_name)
+            || TypeChecker::<()>::is_plan_cacheable_special_function(&func_name);
+        if !is_plan_cacheable {
+            self.is_plan_cacheable = false;
         }
     }
 
     fn enter_table_reference(&mut self, table_ref: &TableReference) {
-        if self.cache_miss {
+        if !self.is_plan_cacheable {
             return;
         }
         if let TableReference::Table {
@@ -308,7 +327,7 @@ impl TableRefVisitor {
         } = table_ref
         {
             if temporal.is_some() || with_options.is_some() {
-                self.cache_miss = true;
+                self.is_plan_cacheable = false;
                 return;
             }
 
@@ -351,7 +370,7 @@ impl TableRefVisitor {
                         return;
                     }
                 }
-                self.cache_miss = true;
+                self.is_plan_cacheable = false;
             });
         }
     }

--- a/src/query/sql/src/planner/planner_cache.rs
+++ b/src/query/sql/src/planner/planner_cache.rs
@@ -28,7 +28,8 @@ use databend_common_exception::Result;
 use databend_common_expression::ColumnId;
 use databend_common_expression::Scalar;
 use databend_common_expression::TableSchemaRef;
-use databend_common_functions::is_cacheable_function;
+use databend_common_functions::BUILTIN_FUNCTIONS;
+use databend_common_functions::is_plan_cacheable_function;
 use databend_common_meta_app::schema::SecurityPolicyColumnMap;
 use databend_common_meta_app::schema::TableMeta;
 use databend_common_settings::ChangeValue;
@@ -46,6 +47,7 @@ use crate::NameResolutionContext;
 use crate::Planner;
 use crate::TableEntry;
 use crate::normalize_identifier;
+use crate::planner::semantic::TypeChecker;
 use crate::plans::Plan;
 
 #[derive(Clone)]
@@ -85,12 +87,13 @@ impl Planner {
             ctx: self.ctx.clone(),
             table_snapshots: vec![],
             name_resolution_ctx,
-            cache_miss: false,
+            is_plan_cacheable: true,
+            contains_nondeterministic_function: false,
             has_security_policy: false,
         };
         stmt.drive(&mut visitor);
 
-        if visitor.cache_miss || visitor.table_snapshots.is_empty() {
+        if !visitor.is_plan_cacheable || visitor.table_snapshots.is_empty() {
             return Ok(None);
         }
 
@@ -98,6 +101,7 @@ impl Planner {
         Ok(Some(PlanCacheContext {
             cache_key,
             table_snapshots: visitor.table_snapshots,
+            contains_nondeterministic_function: visitor.contains_nondeterministic_function,
         }))
     }
 
@@ -202,13 +206,15 @@ struct TableRefVisitor {
     ctx: Arc<dyn TableContext>,
     table_snapshots: Vec<TableSnapshot>,
     name_resolution_ctx: NameResolutionContext,
-    cache_miss: bool,
+    is_plan_cacheable: bool,
+    contains_nondeterministic_function: bool,
     has_security_policy: bool,
 }
 
 pub(crate) struct PlanCacheContext {
     cache_key: String,
     table_snapshots: Vec<TableSnapshot>,
+    pub(super) contains_nondeterministic_function: bool,
 }
 
 impl PlanCacheContext {
@@ -285,19 +291,32 @@ impl From<&TableMeta> for SecurityPolicySnapshot {
 
 impl TableRefVisitor {
     fn enter_function_call(&mut self, func: &FunctionCall) {
-        if self.cache_miss {
+        if !self.is_plan_cacheable {
             return;
         }
 
         let func_name = func.name.name.to_lowercase();
-        // If the function is not suitable for caching, we should not cache the plan
-        if !is_cacheable_function(&func_name) {
-            self.cache_miss = true;
+        let is_nondeterministic_builtin = BUILTIN_FUNCTIONS
+            .get_property(&func_name)
+            .is_some_and(|property| property.non_deterministic);
+
+        // Non-deterministic builtins are not folded into constants, so their runtime values do not
+        // become part of the cached logical plan and do not block planner caching. Track them
+        // separately so a plan-cache hit still disables result caching.
+        if is_nondeterministic_builtin {
+            self.contains_nondeterministic_function = true;
+        }
+
+        let is_plan_cacheable = is_plan_cacheable_function(&func_name)
+            || TypeChecker::<()>::is_rewrite_function(&func_name)
+            || TypeChecker::<()>::is_plan_cacheable_special_function(&func_name);
+        if !is_plan_cacheable {
+            self.is_plan_cacheable = false;
         }
     }
 
     fn enter_table_reference(&mut self, table_ref: &TableReference) {
-        if self.cache_miss {
+        if !self.is_plan_cacheable {
             return;
         }
         if let TableReference::Table {
@@ -308,7 +327,7 @@ impl TableRefVisitor {
         } = table_ref
         {
             if temporal.is_some() || with_options.is_some() {
-                self.cache_miss = true;
+                self.is_plan_cacheable = false;
                 return;
             }
 
@@ -351,7 +370,7 @@ impl TableRefVisitor {
                         return;
                     }
                 }
-                self.cache_miss = true;
+                self.is_plan_cacheable = false;
             });
         }
     }

--- a/src/query/sql/src/planner/plans/scalar_expr.rs
+++ b/src/query/sql/src/planner/plans/scalar_expr.rs
@@ -31,6 +31,7 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::AutoIncrementExpr;
 use databend_common_expression::FunctionKind;
+use databend_common_expression::FunctionVolatility;
 use databend_common_expression::RemoteExpr;
 use databend_common_expression::SEARCH_MATCHED_COL_NAME;
 use databend_common_expression::SEARCH_SCORE_COL_NAME;
@@ -197,20 +198,32 @@ impl ScalarExpr {
     }
 
     pub fn is_deterministic(&self) -> bool {
+        self.volatility() == FunctionVolatility::Immutable
+    }
+
+    pub fn volatility(&self) -> FunctionVolatility {
         match self {
             ScalarExpr::BoundColumnRef(_)
             | ScalarExpr::ConstantExpr(_)
-            | ScalarExpr::TypedConstantExpr(_, _) => true,
+            | ScalarExpr::TypedConstantExpr(_, _) => FunctionVolatility::Immutable,
             ScalarExpr::FunctionCall(func) => {
-                if let Some(property) = BUILTIN_FUNCTIONS.get_property(&func.func_name) {
-                    if property.kind == FunctionKind::SRF || property.non_deterministic {
-                        return false;
-                    }
-                }
-                func.arguments.iter().all(ScalarExpr::is_deterministic)
+                let own_volatility = BUILTIN_FUNCTIONS
+                    .get_property(&func.func_name)
+                    .map(|property| {
+                        if property.kind == FunctionKind::SRF {
+                            FunctionVolatility::Volatile
+                        } else {
+                            property.volatility
+                        }
+                    })
+                    .unwrap_or(FunctionVolatility::Immutable);
+                func.arguments
+                    .iter()
+                    .map(ScalarExpr::volatility)
+                    .fold(own_volatility, std::cmp::max)
             }
-            ScalarExpr::CastExpr(cast) => cast.argument.is_deterministic(),
-            _ => false,
+            ScalarExpr::CastExpr(cast) => cast.argument.volatility(),
+            _ => FunctionVolatility::Volatile,
         }
     }
 

--- a/src/query/sql/src/planner/plans/window.rs
+++ b/src/query/sql/src/planner/plans/window.rs
@@ -20,6 +20,7 @@ use databend_common_ast::Span;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_expression::ConstantFoldPolicy;
 use databend_common_expression::ConstantFolder;
 use databend_common_expression::FunctionContext;
 use databend_common_expression::Scalar;
@@ -401,7 +402,12 @@ enum FoldedConstantStat {
 
 fn fold_constant_stat(expr: &ScalarExpr) -> Result<Option<FoldedConstantStat>> {
     let expr = expr.as_expr()?;
-    let (expr, _) = ConstantFolder::fold(&expr, &FunctionContext::default(), &BUILTIN_FUNCTIONS);
+    let (expr, _) = ConstantFolder::fold_with_policy(
+        &expr,
+        &FunctionContext::default(),
+        &BUILTIN_FUNCTIONS,
+        ConstantFoldPolicy::ImmutableOnly,
+    );
     let Ok(constant) = expr.into_constant() else {
         return Ok(None);
     };

--- a/src/query/sql/src/planner/semantic/aggregating_index_visitor.rs
+++ b/src/query/sql/src/planner/semantic/aggregating_index_visitor.rs
@@ -30,6 +30,7 @@ use databend_common_ast::parser::parse_expr;
 use databend_common_ast::parser::tokenize_sql;
 use databend_common_expression::BLOCK_NAME_COL_NAME;
 use databend_common_expression::FunctionKind;
+use databend_common_expression::FunctionVolatility;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_functions::aggregates::AggregateFunctionFactory;
 use derive_visitor::DriveMut;
@@ -250,8 +251,10 @@ impl AggregatingIndexChecker {
                 self.not_support = true;
             }
         } else if let Some(func_property) = BUILTIN_FUNCTIONS.get_property(func_name) {
-            // set returning functions and non deterministic functions such as `now()` are not supported.
-            if func_property.kind == FunctionKind::SRF || func_property.non_deterministic {
+            // Set-returning and execution-dependent functions such as `now()` are not supported.
+            if func_property.kind == FunctionKind::SRF
+                || func_property.volatility != FunctionVolatility::Immutable
+            {
                 self.not_support = true;
             }
         } else {

--- a/src/query/sql/src/planner/semantic/materialized_view_rewriter.rs
+++ b/src/query/sql/src/planner/semantic/materialized_view_rewriter.rs
@@ -45,6 +45,7 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::BASE_ROW_ID_COL_NAME;
 use databend_common_expression::FunctionKind;
+use databend_common_expression::FunctionVolatility;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_functions::aggregates::AggregateFunctionFactory;
 use databend_common_meta_app::schema::MATERIALIZED_VIEW_SOURCE_ROW_ID_COLUMN;
@@ -642,7 +643,9 @@ impl Visitor for MaterializedViewChecker {
                 self.not_supported = true;
             }
         } else if let Some(property) = BUILTIN_FUNCTIONS.get_property(&name) {
-            if property.kind == FunctionKind::SRF || property.non_deterministic {
+            if property.kind == FunctionKind::SRF
+                || property.volatility != FunctionVolatility::Immutable
+            {
                 self.not_supported = true;
             }
         } else {
@@ -757,11 +760,11 @@ mod tests {
     }
 
     #[test]
-    fn test_materialized_view_checker_rejects_non_deterministic_functions() -> Result<()> {
-        // Non-deterministic functions (and their aliases) must not appear in an MV definition,
-        // because refresh would recompute different values than the original query. Aliases such
-        // as current_timestamp/current_date resolve to canonical functions whose properties mark
-        // them non-deterministic, so they must be rejected just like the canonical names.
+    fn test_materialized_view_checker_rejects_execution_dependent_functions() -> Result<()> {
+        // Statement-stable and volatile functions (and their aliases) must not appear in an MV
+        // definition, because refresh could recompute different values than the original query.
+        // Aliases such as current_timestamp/current_date resolve to canonical functions and must
+        // be rejected just like their canonical names.
         for sql in [
             "SELECT amount, now() AS t FROM t WHERE amount > 0",
             "SELECT amount, current_timestamp AS t FROM t WHERE amount > 0",

--- a/src/query/sql/src/planner/semantic/type_check/aggregate.rs
+++ b/src/query/sql/src/planner/semantic/type_check/aggregate.rs
@@ -19,7 +19,7 @@ use databend_common_ast::ast::Literal;
 use databend_common_ast::ast::Window;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
-use databend_common_expression::FunctionContext;
+use databend_common_expression::ConstantFoldPolicy;
 use databend_common_expression::Scalar;
 use databend_common_expression::type_check::check_number;
 use databend_common_expression::types::DataType;
@@ -411,12 +411,12 @@ where A: TypeCheckAdapter
             && arguments.len() == expected_histogram_args
             && params.is_empty()
         {
-            let max_num_buckets: u64 = check_number(
-                None,
-                &FunctionContext::default(),
-                &arguments[1].as_expr()?,
-                &BUILTIN_FUNCTIONS,
+            let max_num_buckets = self.fold_for_plan_materialization(
+                &arguments[1],
+                ConstantFoldPolicy::AllowStableWithinStatement,
             )?;
+            let max_num_buckets: u64 =
+                check_number(None, &self.func_ctx, &max_num_buckets, &BUILTIN_FUNCTIONS)?;
 
             vec![Scalar::Number(NumberScalar::UInt64(max_num_buckets))]
         } else {

--- a/src/query/sql/src/planner/semantic/type_check/core_expr.rs
+++ b/src/query/sql/src/planner/semantic/type_check/core_expr.rs
@@ -18,10 +18,9 @@ use databend_common_ast::ast::FunctionCall as ASTFunctionCall;
 use databend_common_ast::ast::OrderByExpr;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
-use databend_common_expression::ConstantFolder;
+use databend_common_expression::ConstantFoldPolicy;
 use databend_common_expression::Scalar;
 use databend_common_expression::types::DataType;
-use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_functions::aggregates::AggregateFunctionFactory;
 use smallvec::smallvec;
 
@@ -714,8 +713,10 @@ where A: TypeCheckAdapter
         let mut new_params = Vec::with_capacity(params.len());
         for (display_name, param) in params {
             let box (scalar, _) = self.resolve_core(arena, *param)?;
-            let expr = scalar.as_expr()?;
-            let (expr, _) = ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+            let expr = self.fold_for_plan_materialization(
+                &scalar,
+                ConstantFoldPolicy::AllowStableWithinStatement,
+            )?;
             let constant = expr
                 .into_constant()
                 .map_err(|_| {

--- a/src/query/sql/src/planner/semantic/type_check/date.rs
+++ b/src/query/sql/src/planner/semantic/type_check/date.rs
@@ -22,6 +22,7 @@ use databend_common_ast::ast::Weekday as ASTWeekday;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::Constant;
+use databend_common_expression::ConstantFoldPolicy;
 use databend_common_expression::ConstantFolder;
 use databend_common_expression::Expr as EExpr;
 use databend_common_expression::Scalar;
@@ -421,7 +422,12 @@ impl<'a, A> TypeChecker<'a, A> {
 
     fn interval_contains_only_date_parts(&self, interval_expr: &ScalarExpr) -> Result<bool> {
         let expr = interval_expr.as_expr()?;
-        let (folded, _) = ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+        let (folded, _) = ConstantFolder::fold_with_policy(
+            &expr,
+            &self.func_ctx,
+            &BUILTIN_FUNCTIONS,
+            ConstantFoldPolicy::ImmutableOnly,
+        );
         if let EExpr::Constant(Constant {
             scalar: Scalar::Interval(value),
             ..

--- a/src/query/sql/src/planner/semantic/type_check/in_list.rs
+++ b/src/query/sql/src/planner/semantic/type_check/in_list.rs
@@ -17,9 +17,10 @@ use databend_common_ast::ast::Expr;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::ColumnBuilder;
-use databend_common_expression::ConstantFolder;
+use databend_common_expression::ConstantFoldPolicy;
 use databend_common_expression::DataField;
 use databend_common_expression::DataSchemaRefExt;
+use databend_common_expression::FunctionVolatility;
 use databend_common_expression::Scalar;
 use databend_common_expression::type_check::common_super_type;
 use databend_common_expression::types::DataType;
@@ -38,7 +39,6 @@ use crate::optimizer::ir::SExpr;
 use crate::plans::Aggregate;
 use crate::plans::AggregateMode;
 use crate::plans::BoundColumnRef;
-use crate::plans::ConstantExpr;
 use crate::plans::ConstantTableScan;
 use crate::plans::ScalarExpr;
 use crate::plans::ScalarItem;
@@ -79,8 +79,22 @@ where A: super::TypeCheckAdapter
         let inlist_to_join_threshold = self.adapter.settings().get_inlist_to_join_threshold()?;
         if list.len() >= inlist_to_join_threshold {
             let box (expr_scalar, expr_ty) = self.resolve_core(arena, expr)?;
-            let box (subquery, data_type) =
-                self.resolve_in_list_as_subquery(arena, span, expr_scalar, expr_ty, list)?;
+            let (list_scalars, list_types) = self.resolve_expr_args(arena, list)?;
+            if list_scalars
+                .iter()
+                .any(|scalar| scalar.volatility() == FunctionVolatility::Volatile)
+            {
+                // A ConstantTableScan evaluates its values once. That is not equivalent to the
+                // per-row evaluation scope of a volatile IN-list item, so retain the scalar form.
+                return self.resolve_in_list_as_predicate(span, expr_scalar, list_scalars, not);
+            }
+            let box (subquery, data_type) = self.resolve_in_list_as_subquery(
+                span,
+                expr_scalar,
+                expr_ty,
+                list_scalars,
+                list_types,
+            )?;
             return if not {
                 self.resolve_scalar_function_call(span, "not", vec![], vec![subquery])
             } else {
@@ -113,9 +127,20 @@ where A: super::TypeCheckAdapter
             };
         }
 
-        let mut predicate_levels = Vec::with_capacity(list.len().max(1).ilog2() as usize + 1);
-        for item in list {
-            let box (item, _) = self.resolve_core(arena, *item)?;
+        let (list_scalars, _) = self.resolve_expr_args(arena, list)?;
+        self.resolve_in_list_as_predicate(span, expr_scalar, list_scalars, not)
+    }
+
+    fn resolve_in_list_as_predicate(
+        &mut self,
+        span: Span,
+        expr_scalar: ScalarExpr,
+        list_scalars: Vec<ScalarExpr>,
+        not: bool,
+    ) -> Result<Box<(ScalarExpr, DataType)>> {
+        let mut predicate_levels =
+            Vec::with_capacity(list_scalars.len().max(1).ilog2() as usize + 1);
+        for item in list_scalars {
             let box (predicate, _) =
                 self.resolve_scalar_function_call(span, "eq", vec![], vec![
                     expr_scalar.clone(),
@@ -137,13 +162,12 @@ where A: super::TypeCheckAdapter
 
     fn resolve_in_list_as_subquery(
         &mut self,
-        arena: &CoreExprArena<'_>,
         span: Span,
         child_scalar: ScalarExpr,
         child_type: DataType,
-        list: &CoreExprArgs,
+        list_scalars: Vec<ScalarExpr>,
+        list_types: Vec<DataType>,
     ) -> Result<Box<(ScalarExpr, DataType)>> {
-        let (list_scalars, list_types) = self.resolve_expr_args(arena, list)?;
         let common_type = list_types
             .iter()
             .cloned()
@@ -162,30 +186,21 @@ where A: super::TypeCheckAdapter
         let mut builder = ColumnBuilder::with_capacity(&common_type, num_rows);
         for (scalar, data_type) in list_scalars.into_iter().zip(list_types.iter()) {
             let scalar = if *data_type != common_type {
-                let cast = wrap_cast(&scalar, &common_type);
-                let expr = cast.as_expr()?;
-                let (expr, _) = ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
-                match expr.into_constant() {
-                    Ok(constant) => ScalarExpr::ConstantExpr(ConstantExpr {
-                        span: scalar.span(),
-                        value: constant.scalar,
-                    }),
-                    Err(_) => {
-                        return Err(ErrorCode::SemanticError(
-                            "Values can't contain subquery, aggregate functions, window functions, or UDFs",
-                        ).set_span(span));
-                    }
-                }
+                wrap_cast(&scalar, &common_type)
             } else {
                 scalar
             };
-            let ScalarExpr::ConstantExpr(ConstantExpr { value, .. }) = scalar else {
+            let expr = self.fold_for_plan_materialization(
+                &scalar,
+                ConstantFoldPolicy::AllowStableWithinStatement,
+            )?;
+            let Ok(constant) = expr.into_constant() else {
                 return Err(ErrorCode::SemanticError(
                     "Values can't contain subquery, aggregate functions, window functions, or UDFs",
                 )
                 .set_span(span));
             };
-            builder.push(value.as_ref());
+            builder.push(constant.scalar.as_ref());
         }
 
         let mut metadata = self.metadata.write();

--- a/src/query/sql/src/planner/semantic/type_check/lambda.rs
+++ b/src/query/sql/src/planner/semantic/type_check/lambda.rs
@@ -465,7 +465,11 @@ where A: super::TypeCheckAdapter
                 let expr = lambda_expr
                     .type_check(&lambda_schema)?
                     .project_column_ref(|index| lambda_schema.index_of(&index.to_string()))?;
-                let (expr, _) = ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                let expr = if expr.is_deterministic(&BUILTIN_FUNCTIONS) {
+                    ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS).0
+                } else {
+                    expr
+                };
                 let remote_lambda_expr = expr.as_remote_expr();
                 let lambda_display = format!("{:?} -> {}", params, expr.sql_display());
 

--- a/src/query/sql/src/planner/semantic/type_check/lambda.rs
+++ b/src/query/sql/src/planner/semantic/type_check/lambda.rs
@@ -22,6 +22,7 @@ use databend_common_ast::ast::Identifier;
 use databend_common_ast::ast::Lambda;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_expression::ConstantFoldPolicy;
 use databend_common_expression::ConstantFolder;
 use databend_common_expression::DataField;
 use databend_common_expression::DataSchema;
@@ -466,7 +467,13 @@ where A: super::TypeCheckAdapter
                     .type_check(&lambda_schema)?
                     .project_column_ref(|index| lambda_schema.index_of(&index.to_string()))?;
                 let expr = if expr.is_deterministic(&BUILTIN_FUNCTIONS) {
-                    ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS).0
+                    ConstantFolder::fold_with_policy(
+                        &expr,
+                        &self.func_ctx,
+                        &BUILTIN_FUNCTIONS,
+                        ConstantFoldPolicy::ImmutableOnly,
+                    )
+                    .0
                 } else {
                     expr
                 };

--- a/src/query/sql/src/planner/semantic/type_check/resolve.rs
+++ b/src/query/sql/src/planner/semantic/type_check/resolve.rs
@@ -18,6 +18,7 @@ use databend_common_ast::ast::Expr;
 use databend_common_ast::ast::UnaryOperator;
 use databend_common_exception::Result;
 use databend_common_expression::ColumnIndex;
+use databend_common_expression::ConstantFoldPolicy;
 use databend_common_expression::ConstantFolder;
 use databend_common_expression::Expr as EExpr;
 use databend_common_expression::FunctionKind;
@@ -153,7 +154,12 @@ where A: TypeCheckAdapter
     ) -> Option<Box<(ScalarExpr, DataType)>> {
         if expr.is_deterministic(&BUILTIN_FUNCTIONS) && enable_shrink {
             if let (EExpr::Constant(expr::Constant { scalar, .. }), _) =
-                ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS)
+                ConstantFolder::fold_with_policy(
+                    expr,
+                    &self.func_ctx,
+                    &BUILTIN_FUNCTIONS,
+                    ConstantFoldPolicy::ImmutableOnly,
+                )
             {
                 let scalar = if enable_shrink {
                     shrink_scalar(scalar)
@@ -173,5 +179,34 @@ where A: TypeCheckAdapter
         }
 
         None
+    }
+
+    /// Fold an expression that is about to be embedded as a logical-plan constant.
+    ///
+    /// The caller chooses the maximum volatility allowed by the SQL evaluation scope. If an
+    /// execution-dependent expression becomes a literal, record its original volatility before
+    /// that provenance is lost so the completed plan cannot enter the cross-statement cache.
+    pub(super) fn fold_for_plan_materialization(
+        &self,
+        scalar: &ScalarExpr,
+        policy: ConstantFoldPolicy,
+    ) -> Result<EExpr<crate::ColumnBinding>> {
+        let volatility = scalar.volatility();
+        let expr = scalar.as_expr()?;
+        if !policy.allows(volatility) {
+            return Ok(expr);
+        }
+        let (folded, _, folded_volatility) = ConstantFolder::fold_with_policy_and_provenance(
+            &expr,
+            &self.func_ctx,
+            &BUILTIN_FUNCTIONS,
+            policy,
+        );
+        if matches!(folded, EExpr::Constant(_)) {
+            self.metadata
+                .write()
+                .record_plan_constant(folded_volatility);
+        }
+        Ok(folded)
     }
 }

--- a/src/query/sql/src/planner/semantic/type_check/rewrite_function.rs
+++ b/src/query/sql/src/planner/semantic/type_check/rewrite_function.rs
@@ -131,6 +131,8 @@ impl<'a> CoreExprArena<'a> {
     }
 }
 
+/// Rewrite functions are pure AST rewrites. They must not depend on session, authorization, or
+/// mutable metadata state.
 pub(super) fn all_rewrite_functions() -> &'static [Ascii<&'static str>] {
     static FUNCTIONS: &[Ascii<&'static str>] = &[
         Ascii::new("nullif"),
@@ -150,6 +152,10 @@ pub(super) fn all_rewrite_functions() -> &'static [Ascii<&'static str>] {
 impl<'a, A> TypeChecker<'a, A> {
     pub fn all_rewrite_functions() -> &'static [Ascii<&'static str>] {
         all_rewrite_functions()
+    }
+
+    pub(crate) fn is_rewrite_function(name: &str) -> bool {
+        rewrite_function_name(name).is_some()
     }
 }
 

--- a/src/query/sql/src/planner/semantic/type_check/scalar_function.rs
+++ b/src/query/sql/src/planner/semantic/type_check/scalar_function.rs
@@ -64,6 +64,35 @@ use crate::plans::FunctionCall;
 use crate::plans::ScalarExpr;
 use crate::plans::SubqueryType;
 
+const DECIMAL_SCALE_FUNCTIONS: &[&str] = &["round", "truncate"];
+const DECIMAL_CONVERSION_FUNCTIONS: &[&str] = &[
+    "to_number",
+    "to_numeric",
+    "to_decimal",
+    "try_to_number",
+    "try_to_numeric",
+    "try_to_decimal",
+];
+
+fn function_name_in(name: &str, functions: &[&str]) -> bool {
+    functions
+        .iter()
+        .any(|function| name.eq_ignore_ascii_case(function))
+}
+
+impl<'a, A> TypeChecker<'a, A> {
+    pub(crate) fn plan_shaping_arguments<'b>(func_name: &str, arguments: &'b [Expr]) -> &'b [Expr] {
+        if function_name_in(func_name, DECIMAL_SCALE_FUNCTIONS)
+            || func_name.eq_ignore_ascii_case("as_decimal")
+            || function_name_in(func_name, DECIMAL_CONVERSION_FUNCTIONS)
+        {
+            arguments.get(1..).unwrap_or_default()
+        } else {
+            &[]
+        }
+    }
+}
+
 impl<'a> CoreExprArena<'a> {
     pub(super) fn cast(
         &mut self,
@@ -517,7 +546,7 @@ where A: TypeCheckAdapter
         // Type check
         let mut arguments = args.iter().map(|v| v.as_raw_expr()).collect::<Vec<_>>();
         // inject the params
-        if ["round", "truncate"].contains(&func_name)
+        if function_name_in(func_name, DECIMAL_SCALE_FUNCTIONS)
             && !args.is_empty()
             && params.is_empty()
             && args[0].data_type()?.remove_nullable().is_decimal()
@@ -592,14 +621,7 @@ where A: TypeCheckAdapter
                     }
                 }
             }
-        } else if (func_name.eq_ignore_ascii_case("to_number")
-            || func_name.eq_ignore_ascii_case("to_numeric")
-            || func_name.eq_ignore_ascii_case("to_decimal")
-            || func_name.eq_ignore_ascii_case("try_to_number")
-            || func_name.eq_ignore_ascii_case("try_to_numeric")
-            || func_name.eq_ignore_ascii_case("try_to_decimal"))
-            && params.is_empty()
-        {
+        } else if function_name_in(func_name, DECIMAL_CONVERSION_FUNCTIONS) && params.is_empty() {
             if args.is_empty() || args.len() > 4 {
                 return Err(ErrorCode::SemanticError(format!(
                     "Invalid arguments for `{func_name}`, get {} params and {} arguments",

--- a/src/query/sql/src/planner/semantic/type_check/scalar_function.rs
+++ b/src/query/sql/src/planner/semantic/type_check/scalar_function.rs
@@ -21,9 +21,8 @@ use databend_common_ast::ast::TypeName;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::Constant;
-use databend_common_expression::ConstantFolder;
+use databend_common_expression::ConstantFoldPolicy;
 use databend_common_expression::Expr as EExpr;
-use databend_common_expression::FunctionContext;
 use databend_common_expression::RawExpr;
 use databend_common_expression::Scalar;
 use databend_common_expression::expr;
@@ -552,15 +551,13 @@ where A: TypeCheckAdapter
             && args[0].data_type()?.remove_nullable().is_decimal()
         {
             let scale = if args.len() == 2 {
-                let scalar_expr = &arguments[1];
-                let expr = type_check::check(scalar_expr, &BUILTIN_FUNCTIONS)?;
-
-                let scale: i64 = check_number(
-                    expr.span(),
-                    &FunctionContext::default(),
-                    &expr,
-                    &BUILTIN_FUNCTIONS,
+                let expr = self.fold_for_plan_materialization(
+                    &args[1],
+                    ConstantFoldPolicy::AllowStableWithinStatement,
                 )?;
+
+                let scale: i64 =
+                    check_number(expr.span(), &self.func_ctx, &expr, &BUILTIN_FUNCTIONS)?;
                 scale.clamp(-76, 76)
             } else {
                 0
@@ -583,15 +580,14 @@ where A: TypeCheckAdapter
                         arguments.len()
                     )));
                 }
-                let param_args = arguments.split_off(1);
-                for arg in param_args.into_iter() {
-                    let expr = type_check::check(&arg, &BUILTIN_FUNCTIONS)?;
-                    let param: u8 = check_number(
-                        expr.span(),
-                        &FunctionContext::default(),
-                        &expr,
-                        &BUILTIN_FUNCTIONS,
+                arguments.truncate(1);
+                for arg in args.iter().skip(1) {
+                    let expr = self.fold_for_plan_materialization(
+                        arg,
+                        ConstantFoldPolicy::AllowStableWithinStatement,
                     )?;
+                    let param: u8 =
+                        check_number(expr.span(), &self.func_ctx, &expr, &BUILTIN_FUNCTIONS)?;
                     params.push(Scalar::Number(NumberScalar::UInt8(param)));
                 }
             }
@@ -629,14 +625,16 @@ where A: TypeCheckAdapter
                     arguments.len()
                 )));
             }
-            let func_ctx = self.adapter.function_context()?;
             let arg_fn = |args: &[ScalarExpr],
                           index: usize,
                           arg_name: &str,
                           default: i64|
              -> Result<i64> {
                 Ok(args.get(index).map(|arg| {
-                    match ConstantFolder::fold(&arg.as_expr()?, &func_ctx, &BUILTIN_FUNCTIONS).0 {
+                    match self.fold_for_plan_materialization(
+                        arg,
+                        ConstantFoldPolicy::AllowStableWithinStatement,
+                    )? {
                         EExpr::Constant(Constant {
                             scalar,
                             ..

--- a/src/query/sql/src/planner/semantic/type_check/special_function.rs
+++ b/src/query/sql/src/planner/semantic/type_check/special_function.rs
@@ -38,6 +38,38 @@ use crate::plans::CastExpr;
 use crate::plans::ConstantExpr;
 use crate::plans::ScalarExpr;
 
+const ARRAY_AGGREGATE: &str = "array_aggregate";
+const ARRAY_SORT: &str = "array_sort";
+const BASE64_DECODE_STRING: &str = "base64_decode_string";
+const COALESCE: &str = "coalesce";
+const DECODE: &str = "decode";
+const GREATEST: &str = "greatest";
+const GREATEST_IGNORE_NULLS: &str = "greatest_ignore_nulls";
+const HEX_DECODE_STRING: &str = "hex_decode_string";
+const LEAST: &str = "least";
+const LEAST_IGNORE_NULLS: &str = "least_ignore_nulls";
+const TO_VARIANT: &str = "to_variant";
+const TRY_BASE64_DECODE_STRING: &str = "try_base64_decode_string";
+const TRY_HEX_DECODE_STRING: &str = "try_hex_decode_string";
+const TRY_TO_VARIANT: &str = "try_to_variant";
+
+const PLAN_CACHEABLE_SPECIAL_FUNCTIONS: &[&str] = &[
+    COALESCE,
+    DECODE,
+    ARRAY_SORT,
+    ARRAY_AGGREGATE,
+    TO_VARIANT,
+    TRY_TO_VARIANT,
+    GREATEST,
+    LEAST,
+    GREATEST_IGNORE_NULLS,
+    LEAST_IGNORE_NULLS,
+    HEX_DECODE_STRING,
+    BASE64_DECODE_STRING,
+    TRY_HEX_DECODE_STRING,
+    TRY_BASE64_DECODE_STRING,
+];
+
 pub(super) enum SpecialFunction {
     Namespace(NamespaceFunction),
     Session(SessionFunction<'static>),
@@ -105,25 +137,31 @@ impl<'a, A> TypeChecker<'a, A> {
             Ascii::new("connection_id"),
             Ascii::new("client_session_id"),
             Ascii::new("timezone"),
-            Ascii::new("coalesce"),
-            Ascii::new("decode"),
+            Ascii::new(COALESCE),
+            Ascii::new(DECODE),
             Ascii::new("last_query_id"),
-            Ascii::new("array_sort"),
-            Ascii::new("array_aggregate"),
-            Ascii::new("to_variant"),
-            Ascii::new("try_to_variant"),
-            Ascii::new("greatest"),
-            Ascii::new("least"),
-            Ascii::new("greatest_ignore_nulls"),
-            Ascii::new("least_ignore_nulls"),
+            Ascii::new(ARRAY_SORT),
+            Ascii::new(ARRAY_AGGREGATE),
+            Ascii::new(TO_VARIANT),
+            Ascii::new(TRY_TO_VARIANT),
+            Ascii::new(GREATEST),
+            Ascii::new(LEAST),
+            Ascii::new(GREATEST_IGNORE_NULLS),
+            Ascii::new(LEAST_IGNORE_NULLS),
             Ascii::new("stream_has_data"),
             Ascii::new("getvariable"),
-            Ascii::new("hex_decode_string"),
-            Ascii::new("base64_decode_string"),
-            Ascii::new("try_hex_decode_string"),
-            Ascii::new("try_base64_decode_string"),
+            Ascii::new(HEX_DECODE_STRING),
+            Ascii::new(BASE64_DECODE_STRING),
+            Ascii::new(TRY_HEX_DECODE_STRING),
+            Ascii::new(TRY_BASE64_DECODE_STRING),
         ];
         FUNCTIONS
+    }
+
+    pub(crate) fn is_plan_cacheable_special_function(name: &str) -> bool {
+        PLAN_CACHEABLE_SPECIAL_FUNCTIONS
+            .iter()
+            .any(|candidate| candidate.eq_ignore_ascii_case(name))
     }
 }
 
@@ -206,19 +244,19 @@ impl<'a> CoreExprArena<'a> {
                         .transpose()?,
                 }
             }
-            "coalesce" => {
+            COALESCE => {
                 check_function_arity(span, func_name, args.len(), 1, None)?;
                 SpecialFunction::Coalesce {
                     args: self.lower_display_expr_args(args)?,
                 }
             }
-            "decode" => {
+            DECODE => {
                 check_function_arity(span, func_name, args.len(), 3, None)?;
                 SpecialFunction::Decode {
                     args: self.lower_display_expr_args(args)?,
                 }
             }
-            "array_sort" => {
+            ARRAY_SORT => {
                 check_function_arity(span, func_name, args.len(), 1, Some(3))?;
                 SpecialFunction::ArraySort {
                     array: self.lower_display_expr_arg(&args[0])?,
@@ -232,57 +270,57 @@ impl<'a> CoreExprArena<'a> {
                         .transpose()?,
                 }
             }
-            "array_aggregate" => {
+            ARRAY_AGGREGATE => {
                 check_function_arity(span, func_name, args.len(), 2, Some(2))?;
                 SpecialFunction::ArrayAggregate {
                     array: self.lower_display_expr_arg(&args[0])?,
                     function: self.lower_display_expr_arg(&args[1])?,
                 }
             }
-            "to_variant" => {
+            TO_VARIANT => {
                 check_function_arity(span, func_name, args.len(), 1, Some(1))?;
                 SpecialFunction::CastToVariant {
-                    func_name: "to_variant",
+                    func_name: TO_VARIANT,
                     arg: self.lower_display_expr_arg(&args[0])?,
                     is_try: false,
                 }
             }
-            "try_to_variant" => {
+            TRY_TO_VARIANT => {
                 check_function_arity(span, func_name, args.len(), 1, Some(1))?;
                 SpecialFunction::CastToVariant {
-                    func_name: "try_to_variant",
+                    func_name: TRY_TO_VARIANT,
                     arg: self.lower_display_expr_arg(&args[0])?,
                     is_try: true,
                 }
             }
-            "greatest" => {
+            GREATEST => {
                 check_function_arity(span, func_name, args.len(), 1, None)?;
                 SpecialFunction::GreatestOrLeast {
-                    func_name: "greatest",
+                    func_name: GREATEST,
                     args: self.lower_display_expr_args(args)?,
                     ignore_nulls: false,
                 }
             }
-            "least" => {
+            LEAST => {
                 check_function_arity(span, func_name, args.len(), 1, None)?;
                 SpecialFunction::GreatestOrLeast {
-                    func_name: "least",
+                    func_name: LEAST,
                     args: self.lower_display_expr_args(args)?,
                     ignore_nulls: false,
                 }
             }
-            "greatest_ignore_nulls" => {
+            GREATEST_IGNORE_NULLS => {
                 check_function_arity(span, func_name, args.len(), 1, None)?;
                 SpecialFunction::GreatestOrLeast {
-                    func_name: "greatest_ignore_nulls",
+                    func_name: GREATEST_IGNORE_NULLS,
                     args: self.lower_display_expr_args(args)?,
                     ignore_nulls: true,
                 }
             }
-            "least_ignore_nulls" => {
+            LEAST_IGNORE_NULLS => {
                 check_function_arity(span, func_name, args.len(), 1, None)?;
                 SpecialFunction::GreatestOrLeast {
-                    func_name: "least_ignore_nulls",
+                    func_name: LEAST_IGNORE_NULLS,
                     args: self.lower_display_expr_args(args)?,
                     ignore_nulls: true,
                 }
@@ -293,31 +331,31 @@ impl<'a> CoreExprArena<'a> {
                     arg: self.lower_display_expr_arg(&args[0])?,
                 }
             }
-            "hex_decode_string" => {
+            HEX_DECODE_STRING => {
                 check_function_arity(span, func_name, args.len(), 1, Some(1))?;
                 SpecialFunction::DecodeString {
-                    func_name: "hex_decode_string",
+                    func_name: HEX_DECODE_STRING,
                     arg: self.lower_display_expr_arg(&args[0])?,
                 }
             }
-            "try_hex_decode_string" => {
+            TRY_HEX_DECODE_STRING => {
                 check_function_arity(span, func_name, args.len(), 1, Some(1))?;
                 SpecialFunction::DecodeString {
-                    func_name: "try_hex_decode_string",
+                    func_name: TRY_HEX_DECODE_STRING,
                     arg: self.lower_display_expr_arg(&args[0])?,
                 }
             }
-            "base64_decode_string" => {
+            BASE64_DECODE_STRING => {
                 check_function_arity(span, func_name, args.len(), 1, Some(1))?;
                 SpecialFunction::DecodeString {
-                    func_name: "base64_decode_string",
+                    func_name: BASE64_DECODE_STRING,
                     arg: self.lower_display_expr_arg(&args[0])?,
                 }
             }
-            "try_base64_decode_string" => {
+            TRY_BASE64_DECODE_STRING => {
                 check_function_arity(span, func_name, args.len(), 1, Some(1))?;
                 SpecialFunction::DecodeString {
-                    func_name: "try_base64_decode_string",
+                    func_name: TRY_BASE64_DECODE_STRING,
                     arg: self.lower_display_expr_arg(&args[0])?,
                 }
             }
@@ -748,7 +786,7 @@ where A: TypeCheckAdapter
         args: &[(&str, ScalarExpr, DataType)],
         ignore_nulls: bool,
     ) -> Result<Box<(ScalarExpr, DataType)>> {
-        let array_func = if name.starts_with("greatest") {
+        let array_func = if name.starts_with(GREATEST) {
             "array_max"
         } else {
             "array_min"
@@ -821,5 +859,33 @@ where A: TypeCheckAdapter
             target_type: Box::new(target_type.clone()),
         });
         Ok(Box::new((scalar, target_type)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    #[test]
+    fn plan_cacheable_special_functions_are_classified_as_special_functions() {
+        let plan_cacheable_functions = PLAN_CACHEABLE_SPECIAL_FUNCTIONS
+            .iter()
+            .copied()
+            .map(Ascii::new)
+            .collect::<HashSet<_>>();
+        let special_functions = TypeChecker::<()>::all_special_functions()
+            .iter()
+            .cloned()
+            .collect::<HashSet<_>>();
+
+        assert!(
+            plan_cacheable_functions.is_subset(&special_functions),
+            "plan-cacheable functions not classified as special functions: {:?}",
+            plan_cacheable_functions
+                .difference(&special_functions)
+                .collect::<Vec<_>>()
+        );
     }
 }

--- a/src/query/sql/src/planner/semantic/type_check/special_function.rs
+++ b/src/query/sql/src/planner/semantic/type_check/special_function.rs
@@ -38,6 +38,38 @@ use crate::plans::CastExpr;
 use crate::plans::ConstantExpr;
 use crate::plans::ScalarExpr;
 
+const ARRAY_AGGREGATE: &str = "array_aggregate";
+const ARRAY_SORT: &str = "array_sort";
+const BASE64_DECODE_STRING: &str = "base64_decode_string";
+const COALESCE: &str = "coalesce";
+const DECODE: &str = "decode";
+const GREATEST: &str = "greatest";
+const GREATEST_IGNORE_NULLS: &str = "greatest_ignore_nulls";
+const HEX_DECODE_STRING: &str = "hex_decode_string";
+const LEAST: &str = "least";
+const LEAST_IGNORE_NULLS: &str = "least_ignore_nulls";
+const TO_VARIANT: &str = "to_variant";
+const TRY_BASE64_DECODE_STRING: &str = "try_base64_decode_string";
+const TRY_HEX_DECODE_STRING: &str = "try_hex_decode_string";
+const TRY_TO_VARIANT: &str = "try_to_variant";
+
+const PLAN_CACHEABLE_SPECIAL_FUNCTIONS: &[&str] = &[
+    COALESCE,
+    DECODE,
+    ARRAY_SORT,
+    ARRAY_AGGREGATE,
+    TO_VARIANT,
+    TRY_TO_VARIANT,
+    GREATEST,
+    LEAST,
+    GREATEST_IGNORE_NULLS,
+    LEAST_IGNORE_NULLS,
+    HEX_DECODE_STRING,
+    BASE64_DECODE_STRING,
+    TRY_HEX_DECODE_STRING,
+    TRY_BASE64_DECODE_STRING,
+];
+
 pub(super) enum SpecialFunction {
     Namespace(NamespaceFunction),
     Session(SessionFunction<'static>),
@@ -105,25 +137,31 @@ impl<'a, A> TypeChecker<'a, A> {
             Ascii::new("connection_id"),
             Ascii::new("client_session_id"),
             Ascii::new("timezone"),
-            Ascii::new("coalesce"),
-            Ascii::new("decode"),
+            Ascii::new(COALESCE),
+            Ascii::new(DECODE),
             Ascii::new("last_query_id"),
-            Ascii::new("array_sort"),
-            Ascii::new("array_aggregate"),
-            Ascii::new("to_variant"),
-            Ascii::new("try_to_variant"),
-            Ascii::new("greatest"),
-            Ascii::new("least"),
-            Ascii::new("greatest_ignore_nulls"),
-            Ascii::new("least_ignore_nulls"),
+            Ascii::new(ARRAY_SORT),
+            Ascii::new(ARRAY_AGGREGATE),
+            Ascii::new(TO_VARIANT),
+            Ascii::new(TRY_TO_VARIANT),
+            Ascii::new(GREATEST),
+            Ascii::new(LEAST),
+            Ascii::new(GREATEST_IGNORE_NULLS),
+            Ascii::new(LEAST_IGNORE_NULLS),
             Ascii::new("stream_has_data"),
             Ascii::new("getvariable"),
-            Ascii::new("hex_decode_string"),
-            Ascii::new("base64_decode_string"),
-            Ascii::new("try_hex_decode_string"),
-            Ascii::new("try_base64_decode_string"),
+            Ascii::new(HEX_DECODE_STRING),
+            Ascii::new(BASE64_DECODE_STRING),
+            Ascii::new(TRY_HEX_DECODE_STRING),
+            Ascii::new(TRY_BASE64_DECODE_STRING),
         ];
         FUNCTIONS
+    }
+
+    pub(crate) fn is_plan_cacheable_special_function(name: &str) -> bool {
+        PLAN_CACHEABLE_SPECIAL_FUNCTIONS
+            .iter()
+            .any(|candidate| candidate.eq_ignore_ascii_case(name))
     }
 }
 
@@ -206,19 +244,19 @@ impl<'a> CoreExprArena<'a> {
                         .transpose()?,
                 }
             }
-            "coalesce" => {
+            COALESCE => {
                 check_function_arity(span, func_name, args.len(), 1, None)?;
                 SpecialFunction::Coalesce {
                     args: self.lower_display_expr_args(args)?,
                 }
             }
-            "decode" => {
+            DECODE => {
                 check_function_arity(span, func_name, args.len(), 3, None)?;
                 SpecialFunction::Decode {
                     args: self.lower_display_expr_args(args)?,
                 }
             }
-            "array_sort" => {
+            ARRAY_SORT => {
                 check_function_arity(span, func_name, args.len(), 1, Some(3))?;
                 SpecialFunction::ArraySort {
                     array: self.lower_display_expr_arg(&args[0])?,
@@ -232,57 +270,57 @@ impl<'a> CoreExprArena<'a> {
                         .transpose()?,
                 }
             }
-            "array_aggregate" => {
+            ARRAY_AGGREGATE => {
                 check_function_arity(span, func_name, args.len(), 2, Some(2))?;
                 SpecialFunction::ArrayAggregate {
                     array: self.lower_display_expr_arg(&args[0])?,
                     function: self.lower_display_expr_arg(&args[1])?,
                 }
             }
-            "to_variant" => {
+            TO_VARIANT => {
                 check_function_arity(span, func_name, args.len(), 1, Some(1))?;
                 SpecialFunction::CastToVariant {
-                    func_name: "to_variant",
+                    func_name: TO_VARIANT,
                     arg: self.lower_display_expr_arg(&args[0])?,
                     is_try: false,
                 }
             }
-            "try_to_variant" => {
+            TRY_TO_VARIANT => {
                 check_function_arity(span, func_name, args.len(), 1, Some(1))?;
                 SpecialFunction::CastToVariant {
-                    func_name: "try_to_variant",
+                    func_name: TRY_TO_VARIANT,
                     arg: self.lower_display_expr_arg(&args[0])?,
                     is_try: true,
                 }
             }
-            "greatest" => {
+            GREATEST => {
                 check_function_arity(span, func_name, args.len(), 1, None)?;
                 SpecialFunction::GreatestOrLeast {
-                    func_name: "greatest",
+                    func_name: GREATEST,
                     args: self.lower_display_expr_args(args)?,
                     ignore_nulls: false,
                 }
             }
-            "least" => {
+            LEAST => {
                 check_function_arity(span, func_name, args.len(), 1, None)?;
                 SpecialFunction::GreatestOrLeast {
-                    func_name: "least",
+                    func_name: LEAST,
                     args: self.lower_display_expr_args(args)?,
                     ignore_nulls: false,
                 }
             }
-            "greatest_ignore_nulls" => {
+            GREATEST_IGNORE_NULLS => {
                 check_function_arity(span, func_name, args.len(), 1, None)?;
                 SpecialFunction::GreatestOrLeast {
-                    func_name: "greatest_ignore_nulls",
+                    func_name: GREATEST_IGNORE_NULLS,
                     args: self.lower_display_expr_args(args)?,
                     ignore_nulls: true,
                 }
             }
-            "least_ignore_nulls" => {
+            LEAST_IGNORE_NULLS => {
                 check_function_arity(span, func_name, args.len(), 1, None)?;
                 SpecialFunction::GreatestOrLeast {
-                    func_name: "least_ignore_nulls",
+                    func_name: LEAST_IGNORE_NULLS,
                     args: self.lower_display_expr_args(args)?,
                     ignore_nulls: true,
                 }
@@ -293,31 +331,31 @@ impl<'a> CoreExprArena<'a> {
                     arg: self.lower_display_expr_arg(&args[0])?,
                 }
             }
-            "hex_decode_string" => {
+            HEX_DECODE_STRING => {
                 check_function_arity(span, func_name, args.len(), 1, Some(1))?;
                 SpecialFunction::DecodeString {
-                    func_name: "hex_decode_string",
+                    func_name: HEX_DECODE_STRING,
                     arg: self.lower_display_expr_arg(&args[0])?,
                 }
             }
-            "try_hex_decode_string" => {
+            TRY_HEX_DECODE_STRING => {
                 check_function_arity(span, func_name, args.len(), 1, Some(1))?;
                 SpecialFunction::DecodeString {
-                    func_name: "try_hex_decode_string",
+                    func_name: TRY_HEX_DECODE_STRING,
                     arg: self.lower_display_expr_arg(&args[0])?,
                 }
             }
-            "base64_decode_string" => {
+            BASE64_DECODE_STRING => {
                 check_function_arity(span, func_name, args.len(), 1, Some(1))?;
                 SpecialFunction::DecodeString {
-                    func_name: "base64_decode_string",
+                    func_name: BASE64_DECODE_STRING,
                     arg: self.lower_display_expr_arg(&args[0])?,
                 }
             }
-            "try_base64_decode_string" => {
+            TRY_BASE64_DECODE_STRING => {
                 check_function_arity(span, func_name, args.len(), 1, Some(1))?;
                 SpecialFunction::DecodeString {
-                    func_name: "try_base64_decode_string",
+                    func_name: TRY_BASE64_DECODE_STRING,
                     arg: self.lower_display_expr_arg(&args[0])?,
                 }
             }
@@ -748,7 +786,7 @@ where A: TypeCheckAdapter
         args: &[(&str, ScalarExpr, DataType)],
         ignore_nulls: bool,
     ) -> Result<Box<(ScalarExpr, DataType)>> {
-        let array_func = if name.starts_with("greatest") {
+        let array_func = if name.starts_with(GREATEST) {
             "array_max"
         } else {
             "array_min"
@@ -821,5 +859,24 @@ where A: TypeCheckAdapter
             target_type: Box::new(target_type.clone()),
         });
         Ok(Box::new((scalar, target_type)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_cacheable_special_functions_are_registered() {
+        let special_functions = TypeChecker::<()>::all_special_functions();
+
+        for name in PLAN_CACHEABLE_SPECIAL_FUNCTIONS {
+            assert!(
+                special_functions
+                    .iter()
+                    .any(|function| function.as_ref().eq_ignore_ascii_case(name)),
+                "plan-cacheable function {name} is not registered as a special function"
+            );
+        }
     }
 }

--- a/src/query/sql/src/planner/semantic/type_check/udf.rs
+++ b/src/query/sql/src/planner/semantic/type_check/udf.rs
@@ -34,6 +34,7 @@ use databend_common_config::GlobalConfig;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::BlockEntry;
+use databend_common_expression::ConstantFoldPolicy;
 use databend_common_expression::ConstantFolder;
 use databend_common_expression::FunctionContext;
 use databend_common_expression::Scalar;
@@ -966,7 +967,12 @@ where A: UdfAdapter
                     ));
                 }
                 let expr = argument.scalar.as_expr()?;
-                let (expr, _) = ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                let (expr, _) = ConstantFolder::fold_with_policy(
+                    &expr,
+                    &self.func_ctx,
+                    &BUILTIN_FUNCTIONS,
+                    ConstantFoldPolicy::ImmutableOnly,
+                );
                 let Ok(Some(location)) =
                     expr.into_constant().map(|c| c.scalar.as_string().cloned())
                 else {

--- a/src/query/sql/src/planner/semantic/type_check/window.rs
+++ b/src/query/sql/src/planner/semantic/type_check/window.rs
@@ -22,7 +22,7 @@ use databend_common_ast::ast::WindowFrameUnits;
 use databend_common_ast::ast::WindowSpec;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
-use databend_common_expression::ConstantFolder;
+use databend_common_expression::ConstantFoldPolicy;
 use databend_common_expression::Expr as EExpr;
 use databend_common_expression::Scalar;
 use databend_common_expression::expr;
@@ -557,8 +557,10 @@ where A: TypeCheckAdapter
             CoreWindowFrameBound::Following(Some(expr))
             | CoreWindowFrameBound::Preceding(Some(expr)) => {
                 let box (expr, _) = self.resolve_core(arena, *expr)?;
-                let (expr, _) =
-                    ConstantFolder::fold(&expr.as_expr()?, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                let expr = self.fold_for_plan_materialization(
+                    &expr,
+                    ConstantFoldPolicy::AllowStableWithinStatement,
+                )?;
                 match expr.into_constant() {
                     Ok(expr::Constant { scalar, .. }) => Ok(Some(scalar)),
                     Err(expr) => Err(ErrorCode::SemanticError(

--- a/src/query/sql/tests/it/planner.rs
+++ b/src/query/sql/tests/it/planner.rs
@@ -601,6 +601,7 @@ fn register_planner_cache_table(fixture: &Arc<LiteTableContext>, table_name: &st
         vec![
             TableField::new("a", TableDataType::Number(NumberDataType::Int64)),
             TableField::new("b", TableDataType::Number(NumberDataType::Int64)),
+            TableField::new("ts", TableDataType::Timestamp),
         ],
         None,
         HashMap::new(),
@@ -612,6 +613,27 @@ fn register_planner_cache_table(fixture: &Arc<LiteTableContext>, table_name: &st
             format!("planner-cache-test/{table_name}"),
         )]),
     )
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn planner_cache_ignores_unused_outer_join_null_analysis() -> Result<()> {
+    let fixture = LiteTableContext::create().await?;
+    fixture
+        .get_settings()
+        .set_setting("enable_planner_cache".to_string(), "1".to_string())?;
+    register_planner_cache_table(&fixture, "cache_outer_join_left")?;
+    register_planner_cache_table(&fixture, "cache_outer_join_right")?;
+
+    let sql = "SELECT l.a FROM cache_outer_join_left AS l \
+               LEFT JOIN cache_outer_join_right AS r ON l.a = r.a \
+               WHERE l.ts >= subtract_hours(now(), 24)";
+    let first = plan_sql(&fixture, sql).await?;
+    let second = plan_sql(&fixture, sql).await?;
+    assert!(
+        Arc::ptr_eq(query_metadata(&first), query_metadata(&second)),
+        "a stable predicate on the preserved side must not trigger unused null analysis"
+    );
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -731,10 +753,15 @@ async fn planner_cache_rejects_execution_dependent_plan_shaping_expressions() ->
     fixture
         .get_settings()
         .set_setting("enable_planner_cache".to_string(), "1".to_string())?;
+    fixture
+        .get_settings()
+        .set_setting("inlist_to_join_threshold".to_string(), "4".to_string())?;
     register_planner_cache_table(&fixture, "cache_execution_dependent_plan_shape")?;
 
     for sql in [
         "SELECT quantile_cont(to_second(now()) / 60.0)(a) \
+         FROM cache_execution_dependent_plan_shape",
+        "SELECT histogram(a, to_uint64(1 + to_second(now()))) \
          FROM cache_execution_dependent_plan_shape",
         "SELECT round(a::decimal(10, 2), to_second(now()) % 2) \
          FROM cache_execution_dependent_plan_shape",
@@ -744,6 +771,8 @@ async fn planner_cache_rejects_execution_dependent_plan_shaping_expressions() ->
          AND CURRENT ROW) FROM cache_execution_dependent_plan_shape",
         "SELECT COLUMNS(x -> x = 'a' OR rand() > 0.5) \
          FROM cache_execution_dependent_plan_shape",
+        "SELECT * FROM cache_execution_dependent_plan_shape \
+         WHERE a IN (1.0, 2.0, 3.0, to_second(now()))",
     ] {
         let first = plan_sql(&fixture, sql).await?;
         let second = plan_sql(&fixture, sql).await?;
@@ -751,7 +780,50 @@ async fn planner_cache_rejects_execution_dependent_plan_shaping_expressions() ->
             !Arc::ptr_eq(query_metadata(&first), query_metadata(&second)),
             "plan-shaping execution-dependent expressions must be rebound: {sql}"
         );
+        assert!(
+            !query_metadata(&first).read().is_plan_cacheable(),
+            "the late cache gate must see plan-shaping materialization: {sql}"
+        );
     }
+
+    let stable_in_list_sql = "SELECT * FROM cache_execution_dependent_plan_shape \
+                              WHERE a IN (1.0, 2.0, 3.0, to_second(now()))";
+    let stable_plan = plan_sql(&fixture, stable_in_list_sql).await?;
+    assert!(
+        contains_join(query_s_expr(&stable_plan)),
+        "a statement-local stable IN-list should retain the hash-join rewrite"
+    );
+
+    let volatile_in_list_sql = "SELECT * FROM cache_execution_dependent_plan_shape \
+                                WHERE a IN (1.0, 2.0, 3.0, rand())";
+    let first = plan_sql(&fixture, volatile_in_list_sql).await?;
+    let second = plan_sql(&fixture, volatile_in_list_sql).await?;
+    assert!(
+        Arc::ptr_eq(query_metadata(&first), query_metadata(&second)),
+        "a volatile IN-list that remains symbolic should reuse the cached plan"
+    );
+    assert!(
+        !contains_join(query_s_expr(&first)),
+        "a volatile IN-list must not be materialized into an execute-once constant table"
+    );
+    let formatted_plan = first.format_indent(Default::default())?;
+    assert!(
+        formatted_plan.to_ascii_lowercase().contains("rand"),
+        "the cached plan must retain the volatile expression:\n{formatted_plan}"
+    );
+
+    let immutable_in_list_sql = "SELECT * FROM cache_execution_dependent_plan_shape \
+                                 WHERE a IN (1.0, 2.0, 3.0, 4.0)";
+    let first = plan_sql(&fixture, immutable_in_list_sql).await?;
+    let second = plan_sql(&fixture, immutable_in_list_sql).await?;
+    assert!(
+        Arc::ptr_eq(query_metadata(&first), query_metadata(&second)),
+        "an immutable constant-table scan should remain plan-cacheable"
+    );
+    assert!(
+        contains_join(query_s_expr(&first)),
+        "an immutable large IN-list should retain the hash-join rewrite"
+    );
     Ok(())
 }
 

--- a/src/query/sql/tests/it/planner.rs
+++ b/src/query/sql/tests/it/planner.rs
@@ -583,14 +583,25 @@ fn query_metadata(plan: &Plan) -> &MetadataRef {
     metadata
 }
 
+fn query_s_expr(plan: &Plan) -> &SExpr {
+    let Plan::Query { s_expr, .. } = plan else {
+        panic!("expected query plan")
+    };
+    s_expr
+}
+
+fn contains_join(s_expr: &SExpr) -> bool {
+    matches!(s_expr.plan(), RelOperator::Join(_)) || s_expr.children().any(contains_join)
+}
+
 fn register_planner_cache_table(fixture: &Arc<LiteTableContext>, table_name: &str) -> Result<()> {
     fixture.register_table_with_stats(
         "default",
         table_name,
-        vec![TableField::new(
-            "a",
-            TableDataType::Number(NumberDataType::Int64),
-        )],
+        vec![
+            TableField::new("a", TableDataType::Number(NumberDataType::Int64)),
+            TableField::new("b", TableDataType::Number(NumberDataType::Int64)),
+        ],
         None,
         HashMap::new(),
         HashMap::new(),
@@ -630,7 +641,7 @@ async fn planner_cache_accepts_rewrite_and_cacheable_special_functions() -> Resu
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn planner_cache_hit_preserves_nondeterministic_result_cache_state() -> Result<()> {
+async fn planner_cache_hit_preserves_execution_dependent_result_cache_state() -> Result<()> {
     let fixture = LiteTableContext::create().await?;
     fixture
         .get_settings()
@@ -638,9 +649,9 @@ async fn planner_cache_hit_preserves_nondeterministic_result_cache_state() -> Re
     fixture
         .get_settings()
         .set_setting("enable_query_result_cache".to_string(), "1".to_string())?;
-    register_planner_cache_table(&fixture, "cache_nondeterministic_function")?;
+    register_planner_cache_table(&fixture, "cache_execution_dependent_function")?;
 
-    let sql = "SELECT now() FROM cache_nondeterministic_function";
+    let sql = "SELECT now() FROM cache_execution_dependent_function";
     let first = plan_sql(&fixture, sql).await?;
     assert!(!fixture.result_cache_state().cacheable());
 
@@ -649,12 +660,98 @@ async fn planner_cache_hit_preserves_nondeterministic_result_cache_state() -> Re
     let second = plan_sql(&fixture, sql).await?;
     assert!(
         Arc::ptr_eq(query_metadata(&first), query_metadata(&second)),
-        "non-deterministic builtins should reuse the cached plan"
+        "execution-dependent builtins should reuse the cached plan"
     );
     assert!(
         !fixture.result_cache_state().cacheable(),
-        "a plan-cache hit must not make a non-deterministic query result-cacheable"
+        "a plan-cache hit must not make an execution-dependent query result-cacheable"
     );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn planner_cache_preserves_execution_dependent_evaluation_scope() -> Result<()> {
+    let fixture = LiteTableContext::create().await?;
+    fixture
+        .get_settings()
+        .set_setting("enable_planner_cache".to_string(), "1".to_string())?;
+
+    register_planner_cache_table(&fixture, "cache_statement_stable_subquery")?;
+    let stable_sql = "SELECT * FROM cache_statement_stable_subquery \
+                      WHERE to_timestamp(a) < (SELECT now())";
+    let first = plan_sql(&fixture, stable_sql).await?;
+    let second = plan_sql(&fixture, stable_sql).await?;
+    assert!(
+        Arc::ptr_eq(query_metadata(&first), query_metadata(&second)),
+        "a statement-stable scalar subquery should reuse the cached logical plan"
+    );
+    assert!(
+        !contains_join(query_s_expr(&first)),
+        "a statement-stable scalar subquery should be eliminated"
+    );
+    let formatted_plan = first.format_indent(Default::default())?;
+    assert!(
+        formatted_plan.to_ascii_lowercase().contains("now"),
+        "the cached logical plan must retain the statement-stable expression:\n{formatted_plan}"
+    );
+
+    register_planner_cache_table(&fixture, "cache_volatile_subquery")?;
+    let volatile_sql = "SELECT * FROM cache_volatile_subquery WHERE a < (SELECT rand())";
+    let first = plan_sql(&fixture, volatile_sql).await?;
+    let second = plan_sql(&fixture, volatile_sql).await?;
+    assert!(
+        Arc::ptr_eq(query_metadata(&first), query_metadata(&second)),
+        "a volatile scalar subquery should reuse its structural logical plan"
+    );
+    assert!(
+        contains_join(query_s_expr(&first)),
+        "a volatile scalar subquery must retain its execute-once join"
+    );
+
+    register_planner_cache_table(&fixture, "cache_statement_stable_lambda")?;
+    let lambda_sql = "SELECT array_transform([a], x -> now()) \
+                      FROM cache_statement_stable_lambda";
+    let first = plan_sql(&fixture, lambda_sql).await?;
+    let second = plan_sql(&fixture, lambda_sql).await?;
+    assert!(
+        Arc::ptr_eq(query_metadata(&first), query_metadata(&second)),
+        "a statement-stable lambda should reuse the cached logical plan"
+    );
+    let formatted_plan = first.format_indent(Default::default())?;
+    assert!(
+        formatted_plan.to_ascii_lowercase().contains("now"),
+        "the cached lambda expression must retain the statement-stable function:\n{formatted_plan}"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn planner_cache_rejects_execution_dependent_plan_shaping_expressions() -> Result<()> {
+    let fixture = LiteTableContext::create().await?;
+    fixture
+        .get_settings()
+        .set_setting("enable_planner_cache".to_string(), "1".to_string())?;
+    register_planner_cache_table(&fixture, "cache_execution_dependent_plan_shape")?;
+
+    for sql in [
+        "SELECT quantile_cont(to_second(now()) / 60.0)(a) \
+         FROM cache_execution_dependent_plan_shape",
+        "SELECT round(a::decimal(10, 2), to_second(now()) % 2) \
+         FROM cache_execution_dependent_plan_shape",
+        "SELECT to_decimal(a, 10 + to_second(now()) % 10, 2) \
+         FROM cache_execution_dependent_plan_shape",
+        "SELECT sum(a) OVER (ORDER BY a RANGE BETWEEN to_uint64(to_second(now())) PRECEDING \
+         AND CURRENT ROW) FROM cache_execution_dependent_plan_shape",
+        "SELECT COLUMNS(x -> x = 'a' OR rand() > 0.5) \
+         FROM cache_execution_dependent_plan_shape",
+    ] {
+        let first = plan_sql(&fixture, sql).await?;
+        let second = plan_sql(&fixture, sql).await?;
+        assert!(
+            !Arc::ptr_eq(query_metadata(&first), query_metadata(&second)),
+            "plan-shaping execution-dependent expressions must be rebound: {sql}"
+        );
+    }
     Ok(())
 }
 

--- a/src/query/sql/tests/it/planner.rs
+++ b/src/query/sql/tests/it/planner.rs
@@ -12,16 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
 
 use databend_common_ast::ast::FormatTreeNode;
+use databend_common_catalog::table_context::TableContext;
 use databend_common_catalog::table_context::TableContextSettings;
 use databend_common_catalog::table_context::TableContextVariables;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::Scalar;
+use databend_common_expression::TableDataType;
+use databend_common_expression::TableField;
+use databend_common_expression::types::NumberDataType;
 use databend_common_meta_app::schema::CatalogOption;
 use databend_common_sql::FormatOptions;
 use databend_common_sql::MetadataRef;
@@ -35,6 +41,7 @@ use databend_common_sql_test_support::TestCaseRunner;
 use databend_common_sql_test_support::TestSuite;
 use databend_common_sql_test_support::TestSuiteMints;
 use databend_common_sql_test_support::run_test_case_core;
+use databend_storages_common_table_meta::table::OPT_KEY_SNAPSHOT_LOCATION;
 
 use crate::framework::LiteTableContext;
 use crate::framework::golden::open_golden_file;
@@ -567,6 +574,88 @@ async fn plan_sql(fixture: &Arc<LiteTableContext>, sql: &str) -> Result<Plan> {
     let mut planner = Planner::new(fixture.clone());
     let (plan, _) = planner.plan_sql(sql).await?;
     Ok(plan)
+}
+
+fn query_metadata(plan: &Plan) -> &MetadataRef {
+    let Plan::Query { metadata, .. } = plan else {
+        panic!("expected query plan")
+    };
+    metadata
+}
+
+fn register_planner_cache_table(fixture: &Arc<LiteTableContext>, table_name: &str) -> Result<()> {
+    fixture.register_table_with_stats(
+        "default",
+        table_name,
+        vec![TableField::new(
+            "a",
+            TableDataType::Number(NumberDataType::Int64),
+        )],
+        None,
+        HashMap::new(),
+        HashMap::new(),
+        // Planner-cache hits use this option as the table snapshot identity. This test does not
+        // read an actual snapshot file.
+        BTreeMap::from([(
+            OPT_KEY_SNAPSHOT_LOCATION.to_string(),
+            format!("planner-cache-test/{table_name}"),
+        )]),
+    )
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn planner_cache_accepts_rewrite_and_cacheable_special_functions() -> Result<()> {
+    let fixture = LiteTableContext::create().await?;
+    fixture
+        .get_settings()
+        .set_setting("enable_planner_cache".to_string(), "1".to_string())?;
+    register_planner_cache_table(&fixture, "cache_function_classification")?;
+
+    let sql = "SELECT coalesce(a, 0), ifnull(a, 0) FROM cache_function_classification";
+    let first = plan_sql(&fixture, sql).await?;
+    let second = plan_sql(&fixture, sql).await?;
+    assert!(
+        Arc::ptr_eq(query_metadata(&first), query_metadata(&second)),
+        "rewrite and cacheable special functions should reuse the cached plan"
+    );
+
+    let sql = "SELECT current_user() FROM cache_function_classification";
+    let first = plan_sql(&fixture, sql).await?;
+    let second = plan_sql(&fixture, sql).await?;
+    assert!(
+        !Arc::ptr_eq(query_metadata(&first), query_metadata(&second)),
+        "session-dependent special functions must not reuse a cached plan"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn planner_cache_hit_preserves_nondeterministic_result_cache_state() -> Result<()> {
+    let fixture = LiteTableContext::create().await?;
+    fixture
+        .get_settings()
+        .set_setting("enable_planner_cache".to_string(), "1".to_string())?;
+    fixture
+        .get_settings()
+        .set_setting("enable_query_result_cache".to_string(), "1".to_string())?;
+    register_planner_cache_table(&fixture, "cache_nondeterministic_function")?;
+
+    let sql = "SELECT now() FROM cache_nondeterministic_function";
+    let first = plan_sql(&fixture, sql).await?;
+    assert!(!fixture.result_cache_state().cacheable());
+
+    // A real query gets a fresh state. Reset this shared test context to model the next query.
+    fixture.result_cache_state().set_cacheable(true);
+    let second = plan_sql(&fixture, sql).await?;
+    assert!(
+        Arc::ptr_eq(query_metadata(&first), query_metadata(&second)),
+        "non-deterministic builtins should reuse the cached plan"
+    );
+    assert!(
+        !fixture.result_cache_state().cacheable(),
+        "a plan-cache hit must not make a non-deterministic query result-cacheable"
+    );
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/src/query/sql/tests/it/planner.rs
+++ b/src/query/sql/tests/it/planner.rs
@@ -12,16 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
 
 use databend_common_ast::ast::FormatTreeNode;
+use databend_common_catalog::table_context::TableContext;
 use databend_common_catalog::table_context::TableContextSettings;
 use databend_common_catalog::table_context::TableContextVariables;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::Scalar;
+use databend_common_expression::TableDataType;
+use databend_common_expression::TableField;
+use databend_common_expression::types::NumberDataType;
 use databend_common_meta_app::schema::CatalogOption;
 use databend_common_sql::FormatOptions;
 use databend_common_sql::MetadataRef;
@@ -35,6 +41,7 @@ use databend_common_sql_test_support::TestCaseRunner;
 use databend_common_sql_test_support::TestSuite;
 use databend_common_sql_test_support::TestSuiteMints;
 use databend_common_sql_test_support::run_test_case_core;
+use databend_storages_common_table_meta::table::OPT_KEY_SNAPSHOT_LOCATION;
 
 use crate::framework::LiteTableContext;
 use crate::framework::golden::open_golden_file;
@@ -567,6 +574,86 @@ async fn plan_sql(fixture: &Arc<LiteTableContext>, sql: &str) -> Result<Plan> {
     let mut planner = Planner::new(fixture.clone());
     let (plan, _) = planner.plan_sql(sql).await?;
     Ok(plan)
+}
+
+fn query_metadata(plan: &Plan) -> &MetadataRef {
+    let Plan::Query { metadata, .. } = plan else {
+        panic!("expected query plan")
+    };
+    metadata
+}
+
+fn register_planner_cache_table(fixture: &Arc<LiteTableContext>, table_name: &str) -> Result<()> {
+    fixture.register_table_with_stats(
+        "default",
+        table_name,
+        vec![TableField::new(
+            "a",
+            TableDataType::Number(NumberDataType::Int64),
+        )],
+        None,
+        HashMap::new(),
+        HashMap::new(),
+        BTreeMap::from([(
+            OPT_KEY_SNAPSHOT_LOCATION.to_string(),
+            format!("planner-cache-test/{table_name}"),
+        )]),
+    )
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn planner_cache_accepts_rewrite_and_cacheable_special_functions() -> Result<()> {
+    let fixture = LiteTableContext::create().await?;
+    fixture
+        .get_settings()
+        .set_setting("enable_planner_cache".to_string(), "1".to_string())?;
+    register_planner_cache_table(&fixture, "cache_function_classification")?;
+
+    let sql = "SELECT coalesce(a, 0), ifnull(a, 0) FROM cache_function_classification";
+    let first = plan_sql(&fixture, sql).await?;
+    let second = plan_sql(&fixture, sql).await?;
+    assert!(
+        Arc::ptr_eq(query_metadata(&first), query_metadata(&second)),
+        "rewrite and cacheable special functions should reuse the cached plan"
+    );
+
+    let sql = "SELECT current_user() FROM cache_function_classification";
+    let first = plan_sql(&fixture, sql).await?;
+    let second = plan_sql(&fixture, sql).await?;
+    assert!(
+        !Arc::ptr_eq(query_metadata(&first), query_metadata(&second)),
+        "session-dependent special functions must not reuse a cached plan"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn planner_cache_hit_preserves_nondeterministic_result_cache_state() -> Result<()> {
+    let fixture = LiteTableContext::create().await?;
+    fixture
+        .get_settings()
+        .set_setting("enable_planner_cache".to_string(), "1".to_string())?;
+    fixture
+        .get_settings()
+        .set_setting("enable_query_result_cache".to_string(), "1".to_string())?;
+    register_planner_cache_table(&fixture, "cache_nondeterministic_function")?;
+
+    let sql = "SELECT now() FROM cache_nondeterministic_function";
+    let first = plan_sql(&fixture, sql).await?;
+    assert!(!fixture.result_cache_state().cacheable());
+
+    // A real query gets a fresh state. Reset this shared test context to model the next query.
+    fixture.result_cache_state().set_cacheable(true);
+    let second = plan_sql(&fixture, sql).await?;
+    assert!(
+        Arc::ptr_eq(query_metadata(&first), query_metadata(&second)),
+        "non-deterministic builtins should reuse the cached plan"
+    );
+    assert!(
+        !fixture.result_cache_state().cacheable(),
+        "a plan-cache hit must not make a non-deterministic query result-cacheable"
+    );
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR removes a planner-cache regression for queries containing:

- expression forms handled by context-independent special-function or rewrite paths, such as `coalesce` and `ifnull`;
- execution-dependent expressions that can remain symbolic in the logical plan, such as statement-stable `now()` and volatile `rand()` calls.

Here, execution-dependent means that an expression's value may differ between executions.

It also prevents stale results: if binding or optimization evaluates an execution-dependent expression and stores the value in the logical plan, that plan is used for the current execution but is not cached.

Existing rewrites for immutable scalar subqueries and immutable large `IN` lists are kept as they are. The evaluation scope of volatile expressions is also preserved.

## Problem

Planner cache reuses the result of binding and logical optimization. The motivating query has wide tables, outer joins, subqueries, and eight `UNION ALL` branches, so repeating that work is expensive.

The motivating query does not enter planner cache in 1.2.911 for two independent reasons:

1. It contains `coalesce`, an example of an expression handled through a context-independent special-function path. The existing check does not distinguish this class from special functions that depend on session state. Context-independent rewrite expressions such as `ifnull` have the same problem through a different type-checking path.
2. It contains `now()`, an example of a statement-stable expression. The existing check rejects execution-dependent functions as a class. This is unnecessarily strict when the logical plan can keep the call symbolic and evaluate it for each execution.

For example, `coalesce` is rewritten during type checking to `if`, `is_not_null`, and `assume_not_null`. The rewrite itself does not depend on time or session state. This reasoning applies to every handler classified as context-independent, not only to `coalesce` and `ifnull`; nested argument expressions are still checked separately. Session-dependent expressions such as `current_user()` remain excluded.

Simply adding the example function names to an allow-list is not sufficient. The cache decision must be based on the expression category and on what binding and optimization have put into the completed logical plan.

## Correctness rule

A logical plan can be reused across executions only if it contains no planning-time value whose validity ends with the execution that produced the plan.

The cache decision depends on whether the plan keeps an expression or stores its value:

| State in the logical plan | Reusable? | Reason |
| --- | --- | --- |
| Literal produced only from immutable inputs | Yes | The value is the same for every execution |
| Symbolic statement-stable expression, for example `now()` | Yes | The expression is evaluated again for each execution |
| Symbolic volatile expression, for example `rand()` | Yes, if its operator scope is unchanged | Each execution evaluates it with the SQL-defined scope |
| Literal produced by evaluating an execution-dependent expression during planning | No | A later execution would reuse the earlier execution's value |

### Scalar subqueries

For example:

```sql
CREATE TABLE t(ts TIMESTAMP);

SELECT * FROM t WHERE ts < (SELECT now());
```

Before this PR, decorrelation can evaluate the scalar subquery and produce:

```text
Filter: ts < <timestamp from the current execution>
```

This is not a correctness bug on the base branch: `now()` prevents the plan from entering planner cache, so the next execution builds a new plan and obtains a new timestamp.

If the cache check were changed only to allow `now()`, the literal above would be cached. The next execution would then use the previous execution's timestamp.

This PR instead produces a reusable plan containing:

```text
Filter: ts < nullable(now())
```

The scalar-subquery Join is still removed, but the statement-stable expression remains symbolic and is evaluated for each execution. `now()` is the concrete example here; the rule is based on volatility rather than its function name.

A volatile scalar subquery requires different treatment. For example, `(SELECT rand())` is evaluated once and its result is shared by all outer rows. Moving the volatile call into the outer expression would evaluate it per row and change the result. The PR therefore keeps the Join for this class; it does not fold or decorrelate away the execute-once scope.

### Values embedded during planning

Some logical-plan fields require a value rather than an expression. Examples include aggregate parameters, decimal precision or scale, window-frame bounds, table-function arguments, time-travel points, and the values in a `ConstantTableScan`.

If one of these paths evaluates an execution-dependent expression, the original expression disappears and only its result remains. The early AST check can no longer tell that the literal is valid for only one execution. This PR records that fact when the value is materialized and rejects the completed plan from planner cache.

Large `IN` lists show all three cases:

- immutable values keep the existing `ConstantTableScan + HashJoin` rewrite, and the plan is cached;
- a statement-stable expression, such as `now()`, may still use that rewrite, but the materialized table is rebuilt for each execution and the plan is not cached;
- a volatile expression, such as `rand()`, remains symbolic because moving its value into `ConstantTableScan` would change per-row evaluation into execute-once evaluation. The symbolic plan can be cached.

## Implementation

### 1. Admit reusable expression forms

The planner-cache check now accepts reusable expression categories: registered builtin calls that can remain symbolic, and expression forms handled by context-independent rewrite or special-function paths. Nested expressions are checked independently. Expressions that depend on session, authorization, or mutable metadata remain excluded. Query-result cache also remains disabled when a cached logical plan contains an execution-dependent expression.

### 2. Make logical-plan constant folding explicit

`ConstantFolder` now accepts one of three policies:

- `ImmutableOnly`: evaluate only functions whose result is identical across executions;
- `AllowStableWithinStatement`: also evaluate statement-stable expressions when a planning path requires their value;
- `AllowVolatile`: preserve the existing behavior for callers that explicitly require it.

Logical planning uses `ImmutableOnly` by default. A path that must materialize a statement-stable value requests `AllowStableWithinStatement` explicitly. Folding reports the volatility of any function whose result became a literal.

### 3. Decide cache safety after optimization

When a non-immutable value is embedded in the plan, planner metadata marks the plan as valid only for the current execution. After logical optimization finishes, planner-cache insertion checks this metadata.

The early AST check and the final plan check answer different questions:

- the early check decides whether the expressions themselves are safe to carry in a reusable plan;
- the final check decides whether planning has replaced any of those expressions with an execution-specific value.

This also covers materialization that happens after the initial AST check.

### 4. Preserve optimizer semantics

- Immutable scalar subquery, for example `(SELECT 1 + 1)`: fold the expression and remove the Join.
- Statement-stable scalar subquery, for example `(SELECT now())`: keep the expression symbolic and remove the Join.
- Volatile scalar subquery, for example `(SELECT rand())`: keep the Join and its execute-once scope.
- Immutable large `IN` list: keep `ConstantTableScan + HashJoin` and cache the plan.
- Large `IN` list containing a materialized statement-stable value: keep the hash join, but rebuild the plan for each execution.
- Large `IN` list containing a volatile value: keep the value symbolic and do not create a constant table.

Outer-join null-rejection analysis now examines only a join's null-supplying side. For a `LEFT JOIN`, a predicate on the preserved left side cannot convert the join to an inner join. Avoiding that unused analysis also avoids evaluating a preserved-side statement-stable expression and rejecting an otherwise reusable plan.

## Performance

The benefit depends on how much time a query normally spends in binding and logical optimization.

The benchmark uses generated data and a sanitized query with the same planning shape as the motivating query:

- 8 `UNION ALL` branches, 9 `LEFT OUTER JOIN`s, and 2 `NOT IN` subqueries;
- 19 `now()` calls, 8 `CASE` expressions, and 2 `coalesce` calls;
- 5 synthetic tables with the referenced fields plus 40 unused `UInt64` fields each.

Each table has one row outside the 24-hour filter. Every run returns no rows and reports zero scanned rows, keeping execution cost small. These are planning-dominated end-to-end measurements, not an optimizer-only timer.

Only the default planner-cache setting is compared: `enable_planner_cache = 1` for every version. 636 and this PR hit after warm-up; 911 has planner cache enabled but does not admit the query.

Method:

- `databend-meta v1.2.879-patch.2-567cf763e1`, with server-side `tcp_nodelay`;
- each query version runs alone as a single-node cluster;
- all versions read the same snapshot written by 636;
- optimized release builds, query-result cache disabled;
- 5 warm-up runs and 60 measured runs per version.

| Version | Default planner-cache behavior | Server p50 | Wall p50 | Wall p95 |
| --- | --- | ---: | ---: | ---: |
| `v1.2.636-rc8.6-93d82fc91f` | Hit | 104 ms | 107.269 ms | 110.618 ms |
| `v1.2.911-rc7.4.8-eaa6f977c5` | Not admitted | 163 ms | 167.684 ms | 170.035 ms |
| This PR | Hit | 94 ms | 97.669 ms | 100.741 ms |

Planner-cache metrics show one miss followed by 64 hits for 636 and this PR. 911 records no planner-cache access. With default settings, this PR removes the regression relative to 636 and lowers median wall time by about 70 ms relative to 911 for this query.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [x] Benchmark Test
- [ ] No Test - _Explain why_

Regression tests cover:

- representative cache hits for context-independent special and rewrite expressions (`coalesce` and `ifnull`), while a session-dependent expression (`current_user()`) remains excluded;
- volatility classification and constant-fold policies;
- a fresh value for a cached statement-stable scalar subquery (`SELECT now()`) on each execution, with its Join removed;
- execute-once behavior for a volatile scalar subquery (`SELECT rand()`);
- rejection of plans containing execution-dependent values materialized during planning;
- immutable, statement-stable, and volatile large `IN`-list behavior;
- preserved-side outer-join predicates and query-result cache state on planner-cache hits.

Validation completed:

```text
cargo test -p databend-common-sql --test it --no-fail-fast
cargo clippy -p databend-common-sql --tests -- -D warnings
cargo fmt --all -- --check
git diff --check
release build
```

The focused physical-plan planner-cache integration test and function constant-fold-policy tests also pass.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent assisted with root-cause analysis, implementation, regression tests, correctness review, synthetic benchmarking, and drafting this PR description.
- Responsible human: @dantengsky
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20278)

<!-- Reviewable:end -->
