### PR TITLE
feat: meta: upgrade databend-meta to v260629.2.0, add raft protocol secret, compatible mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3777,7 +3777,7 @@ dependencies = [
  "databend-enterprise-query",
  "databend-meta",
  "databend-meta-cli-config",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "databend-meta-runtime",
  "databend-query",
  "form_urlencoded",
@@ -3885,7 +3885,7 @@ dependencies = [
  "databend-common-exception",
  "enquote",
  "futures",
- "hickory-resolver 0.25.2",
+ "hickory-resolver",
  "libc",
  "log",
  "micromarshal",
@@ -3963,7 +3963,7 @@ dependencies = [
  "databend-common-statistics",
  "databend-common-storage",
  "databend-common-users",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "databend-meta-runtime",
  "databend-storages-common-session",
  "databend-storages-common-table-meta",
@@ -4077,7 +4077,7 @@ dependencies = [
  "databend-common-meta-app",
  "databend-common-storage",
  "databend-common-tracing",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "log",
  "serde",
  "serde_ignored",
@@ -4326,7 +4326,7 @@ dependencies = [
  "anyhow",
  "databend-common-base",
  "databend-common-exception",
- "hickory-resolver 0.25.2",
+ "hickory-resolver",
  "hyper 1.8.1",
  "hyper-util",
  "log",
@@ -4434,7 +4434,7 @@ dependencies = [
  "databend-common-meta-store",
  "databend-common-proto-conv",
  "databend-common-version",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "databend-meta-plugin-cache",
  "databend-meta-runtime",
  "enumflags2",
@@ -4463,7 +4463,7 @@ dependencies = [
  "databend-common-meta-app",
  "databend-common-meta-store",
  "databend-common-proto-conv",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "databend-meta-runtime",
  "display-more 0.2.6",
  "fastrace",
@@ -4499,7 +4499,7 @@ dependencies = [
  "databend-common-expression",
  "databend-common-io",
  "databend-common-meta-app-storage",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "derive_more 1.0.0",
  "display-more 0.2.6",
  "encoding_rs",
@@ -4545,13 +4545,14 @@ dependencies = [
  "databend-common-tracing",
  "databend-meta",
  "databend-meta-admin",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "databend-meta-runtime",
  "databend-meta-test-harness",
  "display-more 0.2.6",
  "futures",
  "mlua",
  "prost 0.14.3",
+ "raft-log",
  "reqwest",
  "serde",
  "serde_json",
@@ -4588,7 +4589,7 @@ dependencies = [
  "databend-common-meta-api",
  "databend-common-meta-app",
  "databend-common-proto-conv",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "fastrace",
  "log",
  "maplit",
@@ -4604,7 +4605,7 @@ dependencies = [
  "databend-common-meta-schema-api-test-suite",
  "databend-common-meta-store",
  "databend-common-version",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "databend-meta-runtime",
  "databend-meta-test-harness",
  "fastrace",
@@ -4620,7 +4621,7 @@ dependencies = [
  "databend-base",
  "databend-common-tracing",
  "databend-meta",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "databend-meta-plugin-semaphore",
  "databend-meta-runtime",
  "fastrace",
@@ -4714,7 +4715,7 @@ dependencies = [
  "databend-common-io",
  "databend-common-meta-app",
  "databend-common-protos",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "enumflags2",
  "fastrace",
  "log",
@@ -4822,7 +4823,7 @@ dependencies = [
  "databend-common-users",
  "databend-enterprise-data-mask-feature",
  "databend-enterprise-row-access-policy-feature",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "databend-meta-runtime",
  "databend-storages-common-cache",
  "databend-storages-common-session",
@@ -4886,7 +4887,7 @@ dependencies = [
  "databend-common-statistics",
  "databend-common-storage",
  "databend-common-users",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "databend-meta-runtime",
  "databend-storages-common-session",
  "databend-storages-common-table-meta",
@@ -4962,7 +4963,7 @@ dependencies = [
  "databend-common-pipeline",
  "databend-common-storage",
  "databend-common-storages-parquet",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "databend-storages-common-blocks",
  "databend-storages-common-table-meta",
  "log",
@@ -5062,7 +5063,7 @@ dependencies = [
  "databend-common-users",
  "databend-enterprise-fail-safe",
  "databend-enterprise-vacuum-handler",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "databend-storages-common-blocks",
  "databend-storages-common-cache",
  "databend-storages-common-index",
@@ -5122,7 +5123,7 @@ dependencies = [
  "databend-common-storage",
  "databend-common-storages-parquet",
  "databend-common-users",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "databend-storages-common-pruner",
  "databend-storages-common-table-meta",
  "fastrace",
@@ -5160,7 +5161,7 @@ dependencies = [
  "databend-common-storages-orc",
  "databend-common-storages-parquet",
  "databend-common-users",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "databend-storages-common-cache",
  "databend-storages-common-stage",
  "databend-storages-common-table-meta",
@@ -5242,7 +5243,7 @@ dependencies = [
  "databend-common-pipeline",
  "databend-common-pipeline-transforms",
  "databend-common-users",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "databend-storages-common-table-meta",
  "databend_educe",
  "futures",
@@ -5400,7 +5401,7 @@ dependencies = [
  "databend-common-storages-fuse",
  "databend-common-storages-stream",
  "databend-common-users",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "databend-storages-common-cache",
  "databend-storages-common-table-meta",
  "futures",
@@ -5493,7 +5494,7 @@ dependencies = [
  "databend-common-meta-store",
  "databend-common-metrics",
  "databend-common-version",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "databend-meta-plugin-cache",
  "databend-meta-runtime",
  "divan",
@@ -5554,7 +5555,7 @@ dependencies = [
  "databend-common-exception",
  "databend-common-meta-app",
  "databend-common-meta-store",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
 ]
 
 [[package]]
@@ -5608,7 +5609,7 @@ dependencies = [
  "databend-enterprise-stream-handler",
  "databend-enterprise-table-ref-handler",
  "databend-enterprise-vacuum-handler",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "databend-meta-runtime",
  "databend-query",
  "databend-storages-common-cache",
@@ -5636,7 +5637,7 @@ dependencies = [
  "databend-common-config",
  "databend-common-exception",
  "databend-common-management",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
 ]
 
 [[package]]
@@ -5648,7 +5649,7 @@ dependencies = [
  "databend-common-exception",
  "databend-common-meta-app",
  "databend-common-meta-store",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
 ]
 
 [[package]]
@@ -5785,8 +5786,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta"
-version = "260629.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.0.0#d2e1eefa576c1ed6bcc86fb54b5c2c46a8de3018"
+version = "260629.2.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.2.0#5fce7d6d99e347ac6076bdb3a1c1f5848f2d0bd7"
 dependencies = [
  "anyerror",
  "anyhow",
@@ -5796,14 +5797,20 @@ dependencies = [
  "base2histogram",
  "chrono",
  "databend-base",
- "databend-meta-client 260629.0.0",
- "databend-meta-kvapi 260629.0.0",
- "databend-meta-raft-store",
- "databend-meta-runtime-api 260629.0.0",
+ "databend-meta-client 260629.2.0",
+ "databend-meta-kvapi 260629.2.0",
+ "databend-meta-leveled-store",
+ "databend-meta-metrics",
+ "databend-meta-raft-config",
+ "databend-meta-raft-log",
+ "databend-meta-runtime-api 260629.2.0",
  "databend-meta-sled-store",
- "databend-meta-types 260629.0.0",
- "databend-meta-version 260629.0.0",
- "deepsize",
+ "databend-meta-snapshot-db",
+ "databend-meta-snapshot-store",
+ "databend-meta-state-machine",
+ "databend-meta-store-compat",
+ "databend-meta-types 260629.2.0",
+ "databend-meta-version 260629.2.0",
  "derive_more 2.1.1",
  "display-more 0.2.6",
  "fastrace",
@@ -5825,6 +5832,7 @@ dependencies = [
  "serde",
  "serde_json",
  "state-machine-api",
+ "subtle",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
@@ -5863,15 +5871,14 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-base"
-version = "260629.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.0.0#d2e1eefa576c1ed6bcc86fb54b5c2c46a8de3018"
+version = "260629.2.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.2.0#5fce7d6d99e347ac6076bdb3a1c1f5848f2d0bd7"
 dependencies = [
  "anyerror",
  "deepsize",
  "derive_more 2.1.1",
  "display-more 0.2.6",
  "map-api",
- "seq-marked",
  "serde",
  "state-machine-api",
  "thiserror 1.0.69",
@@ -5898,7 +5905,7 @@ dependencies = [
  "databend-meta",
  "databend-meta-admin",
  "databend-meta-cli-config",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "databend-meta-plugin-semaphore",
  "databend-meta-runtime",
  "databend-meta-ver",
@@ -5928,6 +5935,7 @@ dependencies = [
  "databend-meta-ver",
  "env_logger 0.11.8",
  "serde",
+ "serde_json",
  "serfig",
  "temp-env",
  "tempfile",
@@ -5935,19 +5943,19 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client"
-version = "260205.13.1"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.1#e89a7f59b16f4021851b8199ed5b2fcef3c85faf"
+version = "260205.13.2"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.2#d322db0ac3528b44510855271811a4983f347fe8"
 dependencies = [
  "anyerror",
  "arrow-flight 56.2.0",
  "async-backtrace",
  "chrono",
  "databend-base",
- "databend-meta-kvapi 260205.13.1",
- "databend-meta-kvapi-test-suite 260205.13.1",
- "databend-meta-runtime-api 260205.13.1",
- "databend-meta-types 260205.13.1",
- "databend-meta-version 260205.13.1",
+ "databend-meta-kvapi 260205.13.2",
+ "databend-meta-kvapi-test-suite 260205.13.2",
+ "databend-meta-runtime-api 260205.13.2",
+ "databend-meta-types 260205.13.2",
+ "databend-meta-version 260205.13.2",
  "derive_more 2.1.1",
  "display-more 0.2.6",
  "fastrace",
@@ -5967,8 +5975,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client"
-version = "260629.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.0.0#d2e1eefa576c1ed6bcc86fb54b5c2c46a8de3018"
+version = "260629.2.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.2.0#5fce7d6d99e347ac6076bdb3a1c1f5848f2d0bd7"
 dependencies = [
  "anyerror",
  "arrow-flight 56.2.0",
@@ -5977,10 +5985,10 @@ dependencies = [
  "chrono",
  "databend-base",
  "databend-meta-client-types",
- "databend-meta-kvapi 260629.0.0",
- "databend-meta-kvapi-test-suite 260629.0.0",
- "databend-meta-runtime-api 260629.0.0",
- "databend-meta-version 260629.0.0",
+ "databend-meta-kvapi 260629.2.0",
+ "databend-meta-kvapi-test-suite 260629.2.0",
+ "databend-meta-runtime-api 260629.2.0",
+ "databend-meta-version 260629.2.0",
  "derive_more 2.1.1",
  "display-more 0.2.6",
  "fastrace",
@@ -6001,8 +6009,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client-types"
-version = "260629.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.0.0#d2e1eefa576c1ed6bcc86fb54b5c2c46a8de3018"
+version = "260629.2.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.2.0#5fce7d6d99e347ac6076bdb3a1c1f5848f2d0bd7"
 dependencies = [
  "anyerror",
  "databend-meta-proto",
@@ -6025,18 +6033,18 @@ dependencies = [
  "databend-common-meta-api",
  "databend-common-meta-app",
  "databend-common-meta-store",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "databend-meta-test-harness",
  "tokio",
 ]
 
 [[package]]
 name = "databend-meta-kvapi"
-version = "260205.13.1"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.1#e89a7f59b16f4021851b8199ed5b2fcef3c85faf"
+version = "260205.13.2"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.2#d322db0ac3528b44510855271811a4983f347fe8"
 dependencies = [
  "async-trait",
- "databend-meta-types 260205.13.1",
+ "databend-meta-types 260205.13.2",
  "display-more 0.2.6",
  "futures-util",
  "log",
@@ -6046,8 +6054,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi"
-version = "260629.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.0.0#d2e1eefa576c1ed6bcc86fb54b5c2c46a8de3018"
+version = "260629.2.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.2.0#5fce7d6d99e347ac6076bdb3a1c1f5848f2d0bd7"
 dependencies = [
  "async-trait",
  "databend-meta-client-types",
@@ -6060,12 +6068,12 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi-test-suite"
-version = "260205.13.1"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.1#e89a7f59b16f4021851b8199ed5b2fcef3c85faf"
+version = "260205.13.2"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.2#d322db0ac3528b44510855271811a4983f347fe8"
 dependencies = [
  "anyhow",
- "databend-meta-kvapi 260205.13.1",
- "databend-meta-types 260205.13.1",
+ "databend-meta-kvapi 260205.13.2",
+ "databend-meta-types 260205.13.2",
  "display-more 0.2.6",
  "fastrace",
  "futures-util",
@@ -6076,18 +6084,56 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi-test-suite"
-version = "260629.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.0.0#d2e1eefa576c1ed6bcc86fb54b5c2c46a8de3018"
+version = "260629.2.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.2.0#5fce7d6d99e347ac6076bdb3a1c1f5848f2d0bd7"
 dependencies = [
  "anyhow",
  "databend-meta-client-types",
- "databend-meta-kvapi 260629.0.0",
+ "databend-meta-kvapi 260629.2.0",
  "display-more 0.2.6",
  "fastrace",
  "futures-util",
  "log",
  "state-machine-api",
  "tokio",
+]
+
+[[package]]
+name = "databend-meta-leveled-store"
+version = "260629.2.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.2.0#5fce7d6d99e347ac6076bdb3a1c1f5848f2d0bd7"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "databend-base",
+ "databend-meta-snapshot-db",
+ "databend-meta-types 260629.2.0",
+ "display-more 0.2.6",
+ "futures",
+ "futures-async-stream",
+ "futures-util",
+ "log",
+ "map-api",
+ "maplit",
+ "openraft",
+ "rotbl",
+ "seq-marked",
+ "serde_json",
+ "state-machine-api",
+ "stream-more",
+ "tokio",
+]
+
+[[package]]
+name = "databend-meta-metrics"
+version = "260629.2.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.2.0#5fce7d6d99e347ac6076bdb3a1c1f5848f2d0bd7"
+dependencies = [
+ "databend-base",
+ "databend-meta-raft-log",
+ "databend-meta-types 260629.2.0",
+ "log",
+ "prometheus-client 0.22.3",
 ]
 
 [[package]]
@@ -6096,7 +6142,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "databend-meta-runtime",
  "databend-meta-test-harness",
  "fastrace",
@@ -6114,7 +6160,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "codeq 0.5.2",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "databend-meta-runtime",
  "databend-meta-test-harness",
  "display-more 0.2.6",
@@ -6132,8 +6178,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-proto"
-version = "260629.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.0.0#d2e1eefa576c1ed6bcc86fb54b5c2c46a8de3018"
+version = "260629.2.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.2.0#5fce7d6d99e347ac6076bdb3a1c1f5848f2d0bd7"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -6154,42 +6200,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "databend-meta-raft-store"
-version = "260629.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.0.0#d2e1eefa576c1ed6bcc86fb54b5c2c46a8de3018"
+name = "databend-meta-raft-config"
+version = "260629.2.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.2.0#5fce7d6d99e347ac6076bdb3a1c1f5848f2d0bd7"
 dependencies = [
  "anyerror",
- "anyhow",
- "async-trait",
- "bincode 2.0.1",
- "databend-base",
- "databend-meta-kvapi 260629.0.0",
- "databend-meta-runtime-api 260629.0.0",
- "databend-meta-sled-store",
- "databend-meta-types 260629.0.0",
- "deepsize",
- "derive_more 2.1.1",
- "display-more 0.2.6",
- "fastrace",
- "fs_extra",
- "futures",
- "futures-util",
+ "databend-meta-runtime-api 260629.2.0",
+ "databend-meta-types 260629.2.0",
  "hostname",
  "log",
- "map-api",
  "maplit",
  "openraft",
  "raft-log",
- "rmp-serde",
  "rotbl",
  "semver",
- "seq-marked",
  "serde",
  "serde_json",
- "state-machine-api",
- "stream-more",
  "strum 0.24.1",
  "strum_macros 0.24.3",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "databend-meta-raft-log"
+version = "260629.2.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.2.0#5fce7d6d99e347ac6076bdb3a1c1f5848f2d0bd7"
+dependencies = [
+ "anyerror",
+ "databend-meta-types 260629.2.0",
+ "deepsize",
+ "display-more 0.2.6",
+ "fastrace",
+ "itertools 0.13.0",
+ "log",
+ "openraft",
+ "raft-log",
+ "rmp-serde",
+ "serde",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -6203,7 +6250,7 @@ dependencies = [
  "databend-common-metrics",
  "databend-common-tracing",
  "databend-meta",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "fastrace",
  "hyper-util",
  "tokio",
@@ -6212,11 +6259,11 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-runtime-api"
-version = "260205.13.1"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.1#e89a7f59b16f4021851b8199ed5b2fcef3c85faf"
+version = "260205.13.2"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.2#d322db0ac3528b44510855271811a4983f347fe8"
 dependencies = [
  "env_logger 0.11.8",
- "hickory-resolver 0.25.2",
+ "hickory-resolver",
  "log",
  "thiserror 1.0.69",
  "tokio",
@@ -6225,11 +6272,10 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-runtime-api"
-version = "260629.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.0.0#d2e1eefa576c1ed6bcc86fb54b5c2c46a8de3018"
+version = "260629.2.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.2.0#5fce7d6d99e347ac6076bdb3a1c1f5848f2d0bd7"
 dependencies = [
  "env_logger 0.11.8",
- "hickory-resolver 0.26.1",
  "log",
  "thiserror 1.0.69",
  "tokio",
@@ -6238,12 +6284,12 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-sled-store"
-version = "260629.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.0.0#d2e1eefa576c1ed6bcc86fb54b5c2c46a8de3018"
+version = "260629.2.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.2.0#5fce7d6d99e347ac6076bdb3a1c1f5848f2d0bd7"
 dependencies = [
  "anyerror",
  "byteorder",
- "databend-meta-types 260629.0.0",
+ "databend-meta-types 260629.2.0",
  "fastrace",
  "log",
  "serde",
@@ -6255,17 +6301,116 @@ dependencies = [
 ]
 
 [[package]]
+name = "databend-meta-snapshot-db"
+version = "260629.2.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.2.0#5fce7d6d99e347ac6076bdb3a1c1f5848f2d0bd7"
+dependencies = [
+ "bincode 2.0.1",
+ "databend-meta-types 260629.2.0",
+ "futures-util",
+ "log",
+ "map-api",
+ "openraft",
+ "rotbl",
+ "seq-marked",
+ "serde_json",
+ "state-machine-api",
+]
+
+[[package]]
+name = "databend-meta-snapshot-store"
+version = "260629.2.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.2.0#5fce7d6d99e347ac6076bdb3a1c1f5848f2d0bd7"
+dependencies = [
+ "databend-meta-leveled-store",
+ "databend-meta-raft-config",
+ "databend-meta-runtime-api 260629.2.0",
+ "databend-meta-snapshot-db",
+ "databend-meta-types 260629.2.0",
+ "futures",
+ "futures-util",
+ "log",
+ "openraft",
+ "rotbl",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "databend-meta-state-machine"
+version = "260629.2.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.2.0#5fce7d6d99e347ac6076bdb3a1c1f5848f2d0bd7"
+dependencies = [
+ "async-trait",
+ "databend-base",
+ "databend-meta-kvapi 260629.2.0",
+ "databend-meta-leveled-store",
+ "databend-meta-metrics",
+ "databend-meta-raft-config",
+ "databend-meta-runtime-api 260629.2.0",
+ "databend-meta-snapshot-db",
+ "databend-meta-snapshot-store",
+ "databend-meta-types 260629.2.0",
+ "display-more 0.2.6",
+ "fastrace",
+ "futures",
+ "futures-util",
+ "log",
+ "map-api",
+ "openraft",
+ "rotbl",
+ "seq-marked",
+ "serde_json",
+ "state-machine-api",
+ "tokio",
+]
+
+[[package]]
+name = "databend-meta-store-compat"
+version = "260629.2.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.2.0#5fce7d6d99e347ac6076bdb3a1c1f5848f2d0bd7"
+dependencies = [
+ "anyerror",
+ "anyhow",
+ "databend-meta-leveled-store",
+ "databend-meta-raft-config",
+ "databend-meta-raft-log",
+ "databend-meta-runtime-api 260629.2.0",
+ "databend-meta-sled-store",
+ "databend-meta-snapshot-db",
+ "databend-meta-snapshot-store",
+ "databend-meta-types 260629.2.0",
+ "derive_more 2.1.1",
+ "fastrace",
+ "fs_extra",
+ "futures",
+ "futures-util",
+ "log",
+ "map-api",
+ "openraft",
+ "raft-log",
+ "rotbl",
+ "serde",
+ "serde_json",
+ "state-machine-api",
+ "tokio",
+]
+
+[[package]]
 name = "databend-meta-test-harness"
-version = "260629.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.0.0#d2e1eefa576c1ed6bcc86fb54b5c2c46a8de3018"
+version = "260629.2.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.2.0#5fce7d6d99e347ac6076bdb3a1c1f5848f2d0bd7"
 dependencies = [
  "anyhow",
  "databend-base",
  "databend-meta",
- "databend-meta-runtime-api 260629.0.0",
- "databend-meta-types 260629.0.0",
+ "databend-meta-runtime-api 260629.2.0",
+ "databend-meta-types 260629.2.0",
  "fastrace",
  "log",
+ "maplit",
+ "openraft",
  "tempfile",
  "tokio",
  "tonic 0.13.1",
@@ -6273,8 +6418,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-types"
-version = "260205.13.1"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.1#e89a7f59b16f4021851b8199ed5b2fcef3c85faf"
+version = "260205.13.2"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.2#d322db0ac3528b44510855271811a4983f347fe8"
 dependencies = [
  "anyerror",
  "deepsize",
@@ -6301,8 +6446,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-types"
-version = "260629.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.0.0#d2e1eefa576c1ed6bcc86fb54b5c2c46a8de3018"
+version = "260629.2.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.2.0#5fce7d6d99e347ac6076bdb3a1c1f5848f2d0bd7"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -6310,16 +6455,11 @@ dependencies = [
  "deepsize",
  "derive_more 2.1.1",
  "display-more 0.2.6",
- "futures-util",
  "log",
  "map-api",
- "num-derive",
  "num-traits",
  "num_cpus",
  "openraft",
- "pretty_assertions",
- "prost 0.13.5",
- "rotbl",
  "serde",
  "serde_json",
  "state-machine-api",
@@ -6336,16 +6476,16 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-version"
-version = "260205.13.1"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.1#e89a7f59b16f4021851b8199ed5b2fcef3c85faf"
+version = "260205.13.2"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.2#d322db0ac3528b44510855271811a4983f347fe8"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "databend-meta-version"
-version = "260629.0.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.0.0#d2e1eefa576c1ed6bcc86fb54b5c2c46a8de3018"
+version = "260629.2.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.2.0#5fce7d6d99e347ac6076bdb3a1c1f5848f2d0bd7"
 dependencies = [
  "semver",
 ]
@@ -6452,7 +6592,7 @@ dependencies = [
  "databend-enterprise-stream-handler",
  "databend-enterprise-table-ref-handler",
  "databend-enterprise-vacuum-handler",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "databend-meta-plugin-semaphore",
  "databend-meta-runtime",
  "databend-query-script-udf-support",
@@ -6776,7 +6916,7 @@ dependencies = [
  "databend-common-exception",
  "databend-common-meta-app",
  "databend-common-storage",
- "databend-meta-client 260205.13.1",
+ "databend-meta-client 260205.13.2",
  "databend-storages-common-blocks",
  "databend-storages-common-table-meta",
  "log",
@@ -9917,30 +10057,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-net"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "futures-channel",
- "futures-io",
- "futures-util",
- "hickory-proto 0.26.1",
- "idna",
- "ipnet",
- "jni",
- "rand 0.10.1",
- "thiserror 2.0.18",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
 name = "hickory-proto"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9966,26 +10082,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-proto"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
-dependencies = [
- "data-encoding",
- "idna",
- "ipnet",
- "jni",
- "once_cell",
- "prefix-trie",
- "rand 0.10.1",
- "ring",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "url",
-]
-
-[[package]]
 name = "hickory-resolver"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9993,7 +10089,7 @@ checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-proto 0.25.2",
+ "hickory-proto",
  "ipconfig",
  "moka",
  "once_cell",
@@ -10001,32 +10097,6 @@ dependencies = [
  "rand 0.9.2",
  "resolv-conf",
  "smallvec",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "hickory-resolver"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-net",
- "hickory-proto 0.26.1",
- "ipconfig",
- "ipnet",
- "jni",
- "moka",
- "ndk-context",
- "once_cell",
- "parking_lot 0.12.3",
- "rand 0.10.1",
- "resolv-conf",
- "smallvec",
- "system-configuration 0.7.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10342,7 +10412,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.3",
- "system-configuration 0.6.1",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
@@ -10914,9 +10984,6 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "iri-string"
@@ -11144,55 +11211,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
 dependencies = [
  "jiff-tzdb",
-]
-
-[[package]]
-name = "jni"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
-dependencies = [
- "cfg-if",
- "combine",
- "jni-macros",
- "jni-sys",
- "log",
- "simd_cesu8",
- "thiserror 2.0.18",
- "walkdir",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "jni-macros"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
-dependencies = [
- "jni-sys-macros",
-]
-
-[[package]]
-name = "jni-sys-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
-dependencies = [
- "quote",
- "syn 2.0.106",
 ]
 
 [[package]]
@@ -12069,8 +12087,8 @@ dependencies = [
 
 [[package]]
 name = "map-api"
-version = "0.4.2"
-source = "git+https://github.com/databendlabs/map-api?tag=v0.4.2#0fee58dfa938b7234723dd3d383f71e559c202b4"
+version = "0.5.0"
+source = "git+https://github.com/databendlabs/map-api?tag=v0.5.0#556bde7103fb9f52a3b55f1d025339bc48a2ac05"
 dependencies = [
  "async-trait",
  "deepsize",
@@ -12606,12 +12624,6 @@ dependencies = [
  "num-traits",
  "rawpointer",
 ]
-
-[[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nix"
@@ -14205,17 +14217,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prefix-trie"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
-dependencies = [
- "either",
- "ipnet",
- "num-traits",
-]
-
-[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15527,7 +15528,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4466c6958bbbd3024ace15426f7b5369222c0ad517167d10056fd5cc76aec99b"
 dependencies = [
- "hickory-resolver 0.25.2",
+ "hickory-resolver",
  "rand 0.9.2",
  "reqwest",
 ]
@@ -16580,16 +16581,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
-name = "simd_cesu8"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
-dependencies = [
- "rustc_version",
- "simdutf8",
-]
-
-[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17164,8 +17155,8 @@ dependencies = [
 
 [[package]]
 name = "state-machine-api"
-version = "0.3.4"
-source = "git+https://github.com/databendlabs/state-machine-api.git?tag=v0.3.4#d5bfbe8dc459ba7a68eaa1526cacffcf4c9f1982"
+version = "0.4.0"
+source = "git+https://github.com/databendlabs/state-machine-api.git?tag=v0.4.0#7abd898d3dfd20a6aa67971dcf0e79cd3c9e1d0a"
 dependencies = [
  "async-trait",
  "display-more 0.2.0",
@@ -17585,17 +17576,6 @@ name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags 2.9.0",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.9.0",
  "core-foundation 0.9.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,11 +167,11 @@ databend-storages-common-stage = { path = "src/query/storages/common/stage" }
 databend-storages-common-table-meta = { path = "src/query/storages/common/table_meta" }
 
 # External meta service
-databend-meta = "260629.0.0"
-databend-meta-test-harness = "260629.0.0"
+databend-meta = "260629.2.0"
+databend-meta-test-harness = "260629.2.0"
 
 # External meta client
-databend-meta-client = "260205.13.1"
+databend-meta-client = "260205.13.2"
 structkey = "0.1.1"
 
 # Crates.io dependencies
@@ -412,6 +412,7 @@ proptest = { version = "1", default-features = false, features = ["std"] }
 prost = { version = "0.14.3" }
 prost-build = { version = "0.14.3" }
 prqlc = "0.11.3"
+raft-log = "0.4.4"
 rand = { version = "0.8.5", features = ["small_rng", "serde1"] }
 rand_distr = "0.4.3"
 rayon = "1.9.0"
@@ -637,9 +638,9 @@ backtrace = { git = "https://github.com/rust-lang/backtrace-rs.git", rev = "7226
 color-eyre = { git = "https://github.com/eyre-rs/eyre.git", rev = "e5d92c3" }
 csv-core = { git = "https://github.com/youngsofun/rust-csv.git", rev = "44a0b3c" }
 databend-base = { git = "https://github.com/databendlabs/databend-base", tag = "v0.4.0" }
-databend-meta = { git = "https://github.com/databendlabs/databend-meta.git", tag = "v260629.0.0" }
-databend-meta-client = { git = "https://github.com/databendlabs/databend-meta.git", tag = "v260205.13.1" }
-databend-meta-test-harness = { git = "https://github.com/databendlabs/databend-meta.git", tag = "v260629.0.0" }
+databend-meta = { git = "https://github.com/databendlabs/databend-meta.git", tag = "v260629.2.0" }
+databend-meta-client = { git = "https://github.com/databendlabs/databend-meta.git", tag = "v260205.13.2" }
+databend-meta-test-harness = { git = "https://github.com/databendlabs/databend-meta.git", tag = "v260629.2.0" }
 deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "9954bff" }
 jsonb = { git = "https://github.com/databendlabs/jsonb.git", rev = "a16344417d1fec6df4a62d8e77679211e909f86e" }
 lance-arrow = { git = "https://github.com/datafuse-extras/lance", rev = "85f9401d3246d52a287bca21457dbae0466858ee" }
@@ -648,13 +649,13 @@ lance-encoding = { git = "https://github.com/datafuse-extras/lance", rev = "85f9
 lance-file = { git = "https://github.com/datafuse-extras/lance", rev = "85f9401d3246d52a287bca21457dbae0466858ee" }
 lance-io = { git = "https://github.com/datafuse-extras/lance", rev = "85f9401d3246d52a287bca21457dbae0466858ee" }
 lance-table = { git = "https://github.com/datafuse-extras/lance", rev = "85f9401d3246d52a287bca21457dbae0466858ee" }
-map-api = { git = "https://github.com/databendlabs/map-api", tag = "v0.4.2" }
+map-api = { git = "https://github.com/databendlabs/map-api", tag = "v0.5.0" }
 # Keep ORC on a patch while the upstream crate has not caught up with Arrow 58 yet.
 orc-rust = { git = "https://github.com/datafuse-extras/orc-rust", rev = "fc17101f1c96e1ea7c7a19e931110471a4bd7e21" }
 parquet = { git = "https://github.com/datafuse-extras/arrow-rs.git", rev = "bbbe79543" }
 recursive = { git = "https://github.com/datafuse-extras/recursive.git", rev = "16e433a" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1" }
-state-machine-api = { git = "https://github.com/databendlabs/state-machine-api.git", tag = "v0.3.4" }
+state-machine-api = { git = "https://github.com/databendlabs/state-machine-api.git", tag = "v0.4.0" }
 sub-cache = { git = "https://github.com/databendlabs/sub-cache", tag = "v0.2.1" }
 tantivy = { git = "https://github.com/datafuse-extras/tantivy", rev = "b600b0e" }
 tantivy-common = { git = "https://github.com/datafuse-extras/tantivy", rev = "b600b0e", package = "tantivy-common" }

--- a/src/meta/admin/src/v1/features.rs
+++ b/src/meta/admin/src/v1/features.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use databend_meta::meta_node::errors::MetaNodeStopped;
 use databend_meta::meta_node::meta_handle::MetaHandle;
 use databend_meta::openraft::rt::watch::WatchReceiver;
-use databend_meta::raft_store::StateMachineFeature;
+use databend_meta::raft_config::StateMachineFeature;
 use databend_meta::runtime_api::SpawnApi;
 use http::StatusCode;
 use log::info;

--- a/src/meta/admin/tests/it/features.rs
+++ b/src/meta/admin/tests/it/features.rs
@@ -17,7 +17,7 @@
 use std::time::Duration;
 
 use databend_meta::openraft::rt::watch::WatchReceiver;
-use databend_meta::raft_store::StateMachineFeature;
+use databend_meta::raft_config::StateMachineFeature;
 use databend_meta_admin::HttpService;
 use databend_meta_admin::HttpServiceConfig;
 use databend_meta_admin::v1::features::FeatureResponse;

--- a/src/meta/binaries/meta/entry.rs
+++ b/src/meta/binaries/meta/entry.rs
@@ -40,16 +40,16 @@ use databend_meta::meta_service::MetaNode;
 use databend_meta::meta_service::meta_leader::MetaLeader;
 use databend_meta::metrics::server_metrics;
 use databend_meta::openraft::MessageSummary;
-use databend_meta::raft_store::config::RaftConfig;
-use databend_meta::raft_store::ondisk::DATA_VERSION;
-use databend_meta::raft_store::ondisk::OnDisk;
+use databend_meta::raft_config::config::RaftConfig;
+use databend_meta::raft_config::data_version::DATA_VERSION;
+use databend_meta::raft_secret::connect_raft_service;
 use databend_meta::raft_version::raft_client_requires;
 use databend_meta::raft_version::raft_server_provides;
 use databend_meta::runtime_api::RuntimeApi;
+use databend_meta::store_compat::ondisk::OnDisk;
 use databend_meta::types::Cmd;
 use databend_meta::types::LogEntry;
 use databend_meta::types::node::Node;
-use databend_meta::types::protobuf::raft_service_client::RaftServiceClient;
 use databend_meta::types::raft_types::NodeId;
 use databend_meta::util::reply_to_api_result;
 use databend_meta_admin::HttpService;
@@ -165,7 +165,7 @@ pub async fn entry<RT: RuntimeApi>(conf: MetaConfig) -> anyhow::Result<()> {
     );
 
     let runtime = RT::new(Some(32), Some("meta-io-rt".to_string())).map_err(|e| {
-        databend_meta::raft_store::MetaStartupError::MetaServiceError(format!(
+        databend_meta::raft_config::MetaStartupError::MetaServiceError(format!(
             "Cannot create meta IO runtime: {}",
             e
         ))
@@ -264,13 +264,14 @@ async fn do_register<RT: RuntimeApi>(
             .ok_or_else(|| anyhow::anyhow!("leader node {} not found", leader_id))?;
         let leader_raft_endpoint = leader_node.endpoint;
 
-        let addr = format!("http://{}", leader_raft_endpoint);
         info!(
             "Forwarding register request to leader {} at {}",
-            leader_id, addr
+            leader_id, leader_raft_endpoint
         );
 
-        let client = RaftServiceClient::connect(addr).await?;
+        // Not the generated stub: a raft RPC that carries no shared secret is
+        // refused by a leader running with `raft_secret_strict` on.
+        let client = connect_raft_service(&leader_raft_endpoint, &config.raft_config).await?;
 
         let max_msg_size = config.raft_config.raft_grpc_max_message_size();
         let mut client = client

--- a/src/meta/cli-config/Cargo.toml
+++ b/src/meta/cli-config/Cargo.toml
@@ -22,6 +22,7 @@ databend-meta-ver = { workspace = true }
 [dev-dependencies]
 anyhow = { workspace = true }
 env_logger = { workspace = true }
+serde_json = { workspace = true }
 temp-env = { workspace = true }
 tempfile = { workspace = true }
 

--- a/src/meta/cli-config/src/lib.rs
+++ b/src/meta/cli-config/src/lib.rs
@@ -48,10 +48,11 @@ use databend_meta::configs::AdminConfig;
 use databend_meta::configs::GrpcConfig;
 use databend_meta::configs::MetaServiceConfig;
 use databend_meta::configs::TlsConfig;
-use databend_meta::raft_store::MetaStartupError;
-use databend_meta::raft_store::config::RaftConfig as InnerRaftConfig;
-use databend_meta::raft_store::config::get_default_raft_advertise_host;
-use databend_meta::raft_store::ondisk::DATA_VERSION;
+use databend_meta::raft_config::MetaStartupError;
+use databend_meta::raft_config::Secret;
+use databend_meta::raft_config::config::RaftConfig as InnerRaftConfig;
+use databend_meta::raft_config::config::get_default_raft_advertise_host;
+use databend_meta::raft_config::data_version::DATA_VERSION;
 use databend_meta_ver::MIN_QUERY_VER_FOR_METASRV;
 use serde::Deserialize;
 use serde::Serialize;
@@ -455,6 +456,38 @@ pub struct RaftConfig {
     /// Default: 32MB (33554432).
     #[clap(long)]
     pub raft_grpc_max_message_size: Option<usize>,
+
+    /// The secret this node attaches to the raft RPCs it sends.
+    ///
+    /// Unset sends nothing, which is how a not yet configured node behaves.
+    /// Peers that are not strict still accept such a node, so a cluster can
+    /// adopt the secret without downtime.
+    ///
+    /// Held as a plain `String` rather than the inner `Secret`, because
+    /// `serfig` merges the config sources by serializing this struct, and
+    /// `Secret` serializes to `***` on purpose: it would overwrite the real
+    /// value with the redaction. The conversion to `Secret` happens on the way
+    /// to `InnerRaftConfig`, which is the only form that outlives loading and
+    /// the only one ever logged.
+    #[clap(long)]
+    pub raft_secret: Option<String>,
+
+    /// The secrets this node accepts on the raft RPCs it receives.
+    ///
+    /// Accepting more than one is what makes rotation possible without
+    /// downtime: add the new secret here on every node first, then move
+    /// `raft_secret` over node by node, then drop the old one from here.
+    #[clap(long)]
+    pub raft_accepted_secrets: Vec<String>,
+
+    /// Whether to reject a received raft RPC carrying no or an unaccepted
+    /// secret.
+    ///
+    /// Must stay off until every node of the cluster sends a secret: turning
+    /// it on earlier makes the nodes declare each other unreachable.
+    /// Default: false.
+    #[clap(long)]
+    pub raft_secret_strict: Option<bool>,
 }
 
 // TODO(rotbl): should not be used.
@@ -498,6 +531,13 @@ impl From<RaftConfig> for InnerRaftConfig {
             cluster_name: x.cluster_name,
             wait_leader_timeout: x.wait_leader_timeout,
             raft_grpc_max_message_size: x.raft_grpc_max_message_size,
+            raft_secret: x.raft_secret.map(Secret::new),
+            raft_accepted_secrets: x
+                .raft_accepted_secrets
+                .into_iter()
+                .map(Secret::new)
+                .collect(),
+            raft_secret_strict: x.raft_secret_strict,
         }
     }
 }
@@ -535,6 +575,13 @@ impl From<InnerRaftConfig> for RaftConfig {
             cluster_name: inner.cluster_name,
             wait_leader_timeout: inner.wait_leader_timeout,
             raft_grpc_max_message_size: inner.raft_grpc_max_message_size,
+            raft_secret: inner.raft_secret.map(|s| s.expose().to_string()),
+            raft_accepted_secrets: inner
+                .raft_accepted_secrets
+                .iter()
+                .map(|s| s.expose().to_string())
+                .collect(),
+            raft_secret_strict: inner.raft_secret_strict,
         }
     }
 }
@@ -821,6 +868,7 @@ mod tests {
 
     use crate::Config;
     use crate::MetaConfig;
+    use crate::RaftConfig;
 
     #[test]
     fn test_load_config() -> anyhow::Result<()> {
@@ -887,6 +935,80 @@ cluster_name = "foo_cluster"
             assert_eq!(cfg.service.raft_config.id, 20);
             assert_eq!(cfg.service.raft_config.cluster_name, "foo_cluster");
         });
+
+        Ok(())
+    }
+
+    /// The config file is mid-rotation: the node still sends the old secret
+    /// while already accepting both.
+    #[test]
+    fn test_load_raft_secret_from_file() -> anyhow::Result<()> {
+        let d = tempdir()?;
+        let file_path = d.path().join("secret.toml");
+        let mut file = File::create(&file_path)?;
+        write!(
+            file,
+            r#"
+[raft_config]
+raft_secret = "old-secret"
+raft_accepted_secrets = ["old-secret", "new-secret"]
+raft_secret_strict = true
+             "#
+        )?;
+
+        temp_env::with_var("METASRV_CONFIG_FILE", Some(file_path.clone()), || {
+            let cfg: MetaConfig = Config::load(false)
+                .expect("load must success")
+                .try_into()
+                .expect("conversion must success");
+
+            let raft = &cfg.service.raft_config;
+            assert_eq!(
+                raft.raft_secret.as_ref().map(|s| s.expose()),
+                Some("old-secret")
+            );
+            assert_eq!(
+                raft.raft_accepted_secrets
+                    .iter()
+                    .map(|s| s.expose())
+                    .collect::<Vec<_>>(),
+                vec!["old-secret", "new-secret"],
+                "a rotation keeps both the old and the new secret accepted"
+            );
+            assert_eq!(raft.raft_secret_strict, Some(true));
+        });
+
+        Ok(())
+    }
+
+    /// `Secret` redacts itself, so a config dump must not contain the value.
+    /// Both places that log the config serialize `MetaConfig`, not the CLI
+    /// `Config`, which is why the CLI layer may hold a plain `String`.
+    #[test]
+    fn test_logged_config_redacts_the_raft_secret() -> anyhow::Result<()> {
+        let cli = Config {
+            raft_config: RaftConfig {
+                raft_secret: Some("hunter2".to_string()),
+                raft_accepted_secrets: vec!["hunter2".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // The CLI struct itself does leak, which is the whole reason it must
+        // not be the one that gets logged, and the reason `serfig` can merge
+        // it faithfully.
+        assert!(serde_json::to_string(&cli)?.contains("hunter2"));
+
+        let inner: MetaConfig = cli.try_into().expect("conversion must success");
+        let dumped = serde_json::to_string(&inner)?;
+
+        assert!(
+            !dumped.contains("hunter2"),
+            "the secret must not reach a config dump: {}",
+            dumped
+        );
+        assert!(dumped.contains("***"), "and it must be visibly redacted");
 
         Ok(())
     }

--- a/src/meta/control/Cargo.toml
+++ b/src/meta/control/Cargo.toml
@@ -20,6 +20,7 @@ clap = { workspace = true }
 display-more = { workspace = true }
 futures = { workspace = true }
 mlua = { workspace = true }
+raft-log = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/meta/control/src/args.rs
+++ b/src/meta/control/src/args.rs
@@ -18,7 +18,7 @@ use clap::Command;
 use clap::Error;
 use clap::FromArgMatches;
 use databend_common_tracing::CONFIG_DEFAULT_LOG_LEVEL;
-use databend_meta::raft_store::config::RaftConfig;
+use databend_meta::raft_config::config::RaftConfig;
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize, Args)]

--- a/src/meta/control/src/dump_raft_log_wal.rs
+++ b/src/meta/control/src/dump_raft_log_wal.rs
@@ -20,14 +20,14 @@ use std::sync::Arc;
 
 use databend_common_meta_process::pb_value_decoder::decode_cmd_values;
 use databend_common_meta_process::pb_value_decoder::raw_cmd_values;
-use databend_meta::raft_store::raft_log::Config;
-use databend_meta::raft_store::raft_log::Dump;
-use databend_meta::raft_store::raft_log::DumpApi;
-use databend_meta::raft_store::raft_log::RaftLogAction;
-use databend_meta::raft_store::raft_log::WALRecord;
-use databend_meta::raft_store::raft_log::dump_writer::write_record_display;
-use databend_meta::raft_store::raft_log_v004::RaftLogTypes;
+use databend_meta::log_store::RaftLogTypes;
 use databend_meta::types::raft_types::EntryPayload;
+use raft_log::Config;
+use raft_log::Dump;
+use raft_log::DumpApi;
+use raft_log::RaftLogAction;
+use raft_log::WALRecord;
+use raft_log::dump_writer::write_record_display;
 
 use crate::args::DumpRaftLogWalArgs;
 
@@ -91,17 +91,17 @@ mod tests {
     use chrono::Utc;
     use databend_common_meta_app::schema::DatabaseMeta;
     use databend_common_proto_conv::FromToProto;
-    use databend_meta::raft_store::raft_log::Config;
-    use databend_meta::raft_store::raft_log::api::raft_log_writer::RaftLogWriter;
-    use databend_meta::raft_store::raft_log_v004::Cw;
-    use databend_meta::raft_store::raft_log_v004::RaftLogV004;
-    use databend_meta::raft_store::raft_log_v004::util::blocking_flush;
+    use databend_meta::log_store::Cw;
+    use databend_meta::log_store::RaftLog;
+    use databend_meta::log_store::util::blocking_flush;
     use databend_meta::types::Cmd;
     use databend_meta::types::LogEntry;
     use databend_meta::types::UpsertKV;
     use databend_meta::types::raft_types::EntryPayload;
     use databend_meta::types::raft_types::new_log_id;
     use prost::Message;
+    use raft_log::Config;
+    use raft_log::api::raft_log_writer::RaftLogWriter;
 
     use super::*;
 
@@ -113,7 +113,7 @@ mod tests {
 
         let config = Arc::new(Config::new(wal_dir.to_string_lossy().to_string()));
 
-        let mut log = RaftLogV004::open(config)?;
+        let mut log = RaftLog::open(config)?;
         log.append([(Cw(new_log_id(1, 0, 0)), Cw(EntryPayload::Blank))])?;
         blocking_flush(&mut log).await?;
         drop(log);
@@ -164,7 +164,7 @@ mod tests {
         let log_entry = LogEntry::new(cmd);
         let payload = EntryPayload::Normal(log_entry);
 
-        let mut log = RaftLogV004::open(config)?;
+        let mut log = RaftLog::open(config)?;
         log.append([(Cw(new_log_id(1, 0, 0)), Cw(payload))])?;
         blocking_flush(&mut log).await?;
         drop(log);
@@ -224,7 +224,7 @@ mod tests {
         let log_entry = LogEntry::new(cmd);
         let payload = EntryPayload::Normal(log_entry);
 
-        let mut log = RaftLogV004::open(config)?;
+        let mut log = RaftLog::open(config)?;
         log.append([(Cw(new_log_id(1, 0, 0)), Cw(payload))])?;
         blocking_flush(&mut log).await?;
         drop(log);

--- a/src/meta/control/src/export_from_disk.rs
+++ b/src/meta/control/src/export_from_disk.rs
@@ -15,7 +15,7 @@
 use std::fs::File;
 use std::io::Write;
 
-use databend_meta::raft_store::config::RaftConfig;
+use databend_meta::raft_config::config::RaftConfig;
 use databend_meta::runtime_api::SpawnApi;
 use databend_meta::store::RaftStore;
 use futures::TryStreamExt;

--- a/src/meta/control/src/export_from_grpc.rs
+++ b/src/meta/control/src/export_from_grpc.rs
@@ -19,7 +19,7 @@ use std::net::SocketAddr;
 use std::net::ToSocketAddrs;
 
 use anyhow::anyhow;
-use databend_meta::raft_store::key_spaces::RaftStoreEntry;
+use databend_meta::store_compat::sled_compat::key_spaces::RaftStoreEntry;
 use databend_meta_client::DEFAULT_GRPC_MESSAGE_SIZE;
 use databend_meta_client::MetaGrpcClient;
 use databend_meta_client::types::protobuf;

--- a/src/meta/control/src/import.rs
+++ b/src/meta/control/src/import.rs
@@ -23,12 +23,11 @@ use std::io::Lines;
 use std::path::Path;
 use std::str::FromStr;
 
+use databend_meta::log_store;
 use databend_meta::openraft::storage::RaftLogStorageExt;
 use databend_meta::openraft::storage::RaftSnapshotBuilder;
-use databend_meta::raft_store::config::RaftConfig;
-use databend_meta::raft_store::ondisk::DataVersion;
-use databend_meta::raft_store::raft_log::api::raft_log_writer::RaftLogWriter;
-use databend_meta::raft_store::raft_log_v004;
+use databend_meta::raft_config::config::RaftConfig;
+use databend_meta::raft_config::data_version::DataVersion;
 use databend_meta::runtime_api::SpawnApi;
 use databend_meta::sled_store::init_get_sled_db;
 use databend_meta::store::RaftStore;
@@ -44,6 +43,7 @@ use databend_meta::types::raft_types::NodeId;
 use databend_meta::types::raft_types::StoredMembership;
 use databend_meta::types::raft_types::new_log_id;
 use display_more::display_option::DisplayOptionExt;
+use raft_log::api::raft_log_writer::RaftLogWriter;
 use url::Url;
 
 use crate::args::ImportArgs;
@@ -207,7 +207,7 @@ async fn init_new_cluster<SP: SpawnApi>(
     let sto = RaftStore::<SP>::open(&raft_config).await?;
 
     let last_applied = {
-        let sm2 = sto.get_sm_v003();
+        let sm2 = sto.get_state_machine();
         *sm2.sys_data().last_applied_ref()
     };
 
@@ -218,12 +218,12 @@ async fn init_new_cluster<SP: SpawnApi>(
 
     // Update snapshot: Replace nodes set and membership config.
     {
-        let sm2 = sto.get_sm_v003();
+        let sm2 = sto.get_state_machine();
 
         // It must set membership to state machine because
         // the snapshot may contain more logs than the last_log_id.
         // In which case, logs will be purged upon startup.
-        sm2.with_sys_data(|s| {
+        sm2.data().with_sys_data(|s| {
             *s.nodes_mut() = nodes.clone();
             *s.last_membership_mut() = StoredMembership::new(last_applied, membership.clone());
         });
@@ -272,10 +272,10 @@ async fn init_new_cluster<SP: SpawnApi>(
     // Reset node id
     {
         let mut log = sto.log().write().await;
-        log.save_user_data(Some(raft_log_v004::LogStoreMeta {
+        log.save_user_data(Some(log_store::LogStoreMeta {
             node_id: Some(args.id),
         }))?;
-        raft_log_v004::util::blocking_flush(&mut log).await?;
+        log_store::util::blocking_flush(&mut log).await?;
     }
 
     Ok(())

--- a/src/meta/control/src/import_v004.rs
+++ b/src/meta/control/src/import_v004.rs
@@ -16,19 +16,20 @@ use std::io;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use databend_meta::raft_store::config::RaftConfig;
-use databend_meta::raft_store::key_spaces::RaftStoreEntry;
-use databend_meta::raft_store::key_spaces::SMEntry;
-use databend_meta::raft_store::ondisk::DataVersion;
-use databend_meta::raft_store::ondisk::Header;
-use databend_meta::raft_store::ondisk::OnDisk;
-use databend_meta::raft_store::raft_log_v004;
-use databend_meta::raft_store::raft_log_v004::RaftLogV004;
-use databend_meta::raft_store::sm_v003::SnapshotStoreV004;
-use databend_meta::raft_store::sm_v003::WriteEntry;
-use databend_meta::raft_store::sm_v003::adapter::SMEntryV002ToV004;
-use databend_meta::raft_store::state_machine::MetaSnapshotId;
+use databend_meta::log_store::RaftLog;
+use databend_meta::raft_config::config::RaftConfig;
+use databend_meta::raft_config::data_dir;
+use databend_meta::raft_config::data_version::DataVersion;
+use databend_meta::raft_config::header::Header;
 use databend_meta::runtime_api::SpawnApi;
+use databend_meta::snapshot_store::MetaSnapshotId;
+use databend_meta::snapshot_store::SnapshotStore;
+use databend_meta::snapshot_store::WriteEntry;
+use databend_meta::store_compat::ondisk::OnDisk;
+use databend_meta::store_compat::sled_compat::adapter::SMEntryV002ToV004;
+use databend_meta::store_compat::sled_compat::key_spaces::RaftStoreEntry;
+use databend_meta::store_compat::sled_compat::key_spaces::SMEntry;
+use databend_meta::store_compat::sled_compat::log_importer::Importer;
 use databend_meta::types::raft_types::LogId;
 use databend_meta::types::sys_data::SysData;
 
@@ -43,19 +44,19 @@ pub async fn import_v004<SP: SpawnApi>(
 ) -> anyhow::Result<Option<LogId>> {
     let data_version = DataVersion::V004;
 
-    OnDisk::ensure_dirs(&raft_config.raft_dir)?;
+    data_dir::ensure_dirs(&raft_config.raft_dir)?;
 
     let mut n = 0;
 
     let mut raft_log_importer = {
         let raft_log_config = raft_config.clone().to_raft_log_config();
         let raft_log_config = Arc::new(raft_log_config);
-        let raft_log = RaftLogV004::open(raft_log_config)?;
+        let raft_log = RaftLog::open(raft_log_config)?;
 
-        raft_log_v004::Importer::new(raft_log)
+        Importer::new(raft_log)
     };
 
-    let snapshot_store: SnapshotStoreV004<SP> = SnapshotStoreV004::new(raft_config.clone());
+    let snapshot_store: SnapshotStore<SP> = SnapshotStore::new(raft_config.clone());
     let writer = snapshot_store.new_writer()?;
     let (tx, join_handle) = writer.spawn_writer_thread("import_v004");
 

--- a/src/meta/control/src/reading.rs
+++ b/src/meta/control/src/reading.rs
@@ -18,10 +18,10 @@ use std::io::BufRead;
 use std::io::Lines;
 use std::iter::Peekable;
 
-use databend_meta::raft_store::key_spaces::RaftStoreEntry;
-use databend_meta::raft_store::ondisk::DATA_VERSION;
-use databend_meta::raft_store::ondisk::DataVersion;
-use databend_meta::raft_store::ondisk::TREE_HEADER;
+use databend_meta::raft_config::data_version::DATA_VERSION;
+use databend_meta::raft_config::data_version::DataVersion;
+use databend_meta::store_compat::ondisk::TREE_HEADER;
+use databend_meta::store_compat::sled_compat::key_spaces::RaftStoreEntry;
 
 /// Import from lines of exported data and Return the max log id that is found.
 pub fn validate_version<B: BufRead + 'static>(
@@ -60,7 +60,7 @@ pub fn read_version(first_line: &str) -> anyhow::Result<DataVersion> {
         // There is a explicit header.
         if let RaftStoreEntry::DataHeader { key, value } = &kv_entry {
             assert_eq!(key, "header", "The key can only be 'header'");
-            value.version
+            value.0.version
         } else {
             unreachable!("The header tree can only contain DataHeader");
         }

--- a/src/meta/control/src/upgrade.rs
+++ b/src/meta/control/src/upgrade.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use databend_meta::raft_store::config::RaftConfig;
-use databend_meta::raft_store::ondisk::OnDisk;
+use databend_meta::raft_config::config::RaftConfig;
 use databend_meta::runtime_api::SpawnApi;
+use databend_meta::store_compat::ondisk::OnDisk;
 
 /// Upgrade the data in raft_dir to the latest version.
 pub async fn upgrade<SP: SpawnApi>(raft_config: &RaftConfig) -> anyhow::Result<()> {

--- a/src/meta/process/src/filter_tenant.rs
+++ b/src/meta/process/src/filter_tenant.rs
@@ -31,7 +31,7 @@ use databend_common_meta_app::schema::DbIdList;
 use databend_common_meta_app::schema::IndexMeta;
 use databend_common_meta_app::schema::TableIdList;
 use databend_common_proto_conv::FromToProto;
-use databend_meta::raft_store::key_spaces::RaftStoreEntry;
+use databend_meta::store_compat::sled_compat::key_spaces::RaftStoreEntry;
 use databend_meta::types::SeqV;
 use serde::de::DeserializeOwned;
 
@@ -1220,7 +1220,7 @@ mod tests {
     use databend_common_meta_app::schema::IndexNameIdentRaw;
     use databend_common_meta_app::schema::TableMeta;
     use databend_common_meta_app::schema::database_name_ident::DatabaseNameIdentRaw;
-    use databend_meta::raft_store::key_spaces::RaftStoreEntry;
+    use databend_meta::store_compat::sled_compat::key_spaces::RaftStoreEntry;
     use databend_meta::types::SeqV;
 
     use super::*;

--- a/src/meta/runtime/src/lib.rs
+++ b/src/meta/runtime/src/lib.rs
@@ -236,7 +236,7 @@ impl SpawnApi for DatabendRuntime {
         })
     }
 
-    fn resolve(hostname: &str) -> BoxFuture<'static, std::io::Result<Vec<IpAddr>>> {
+    fn lookup_host(hostname: &str) -> BoxFuture<'static, std::io::Result<Vec<IpAddr>>> {
         let hostname = hostname.to_string();
         Box::pin(async move {
             let resolver: Arc<databend_common_grpc::DNSResolver> =


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### feat: meta: upgrade databend-meta to v260629.2.0
# Summary

databend-meta can now authenticate its raft RPCs with a shared secret,
and the meta crates build against the store crates that v260629.2.0
split out of `raft_store`.

# Details

The raft config gains the three settings that back the shared secret:
what this node sends, what it accepts, and whether an RPC carrying no or
an unaccepted secret is rejected. All three are optional and default to
the behavior of a cluster that has never heard of the secret, so an
existing deployment is unaffected until it opts in. The CLI layer holds
the secrets as plain strings because `serfig` merges config sources by
serializing that struct and `Secret` serializes to its redaction; only
the inner config, which is the one ever logged, holds `Secret`. An added
test pins that a config dump stays redacted.

`databend-meta-client` stays on the 260205 line but moves to
v260205.13.2. v260205.13.1 predates the map-api 0.5.0 and
state-machine-api 0.4.0 upgrade the new server needs, and
`[patch.crates-io]` pins one version of each across the whole graph, so
the old client no longer resolves alongside it.

`databend_meta::raft_store` no longer exists: the store was split into
one crate per concern, each re-exported from the service under its own
alias, and the import paths follow that split. `src/meta/control` picks
up a direct `raft-log` dependency, because the alias for the external
WAL crate was dropped rather than renamed, to keep `use raft_log::…`
unambiguous inside databend-meta.

Two adaptations are more than a path rewrite. Mutating the state
machine's `SysData` now goes through `LeveledMap`, since the state
machine's own accessor became internal to keep unguarded mutation off
the public API; the offline import path is safe there because it holds
the store with no concurrent writers. `SpawnApi::resolve` became a
provided method that rejects an empty answer and orders IPv4 first, so
`DatabendRuntime` supplies only the `lookup_host` beneath it — meaning
the meta service now gets that ordering guarantee from Databend's DNS
resolver as well.

Example:

    databend-meta \
      --raft-secret new-secret \
      --raft-accepted-secrets old-secret \
      --raft-accepted-secrets new-secret

Upgrade tip:

`raft_secret_strict` must stay off until every node of the cluster sends
a secret; turning it on earlier makes the nodes declare each other
unreachable. Roll out in this order: add the secret to
`raft_accepted_secrets` on every node, then set `raft_secret` node by
node, then turn on `raft_secret_strict`.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] New Feature (non-breaking change which adds functionality)

## AI assistance

- AI usage: An AI coding agent generated code and wrote tests; I reviewed and confirmed every line before committing it.
- Responsible human: @drmingdrmer
- [x] The responsible human has read every line of this diff and can explain each change

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20280)
<!-- Reviewable:end -->
