### PR TITLE
fix(query): preserve parquet small-file compression ratio

### DIFF
--- a/src/query/storages/parquet/src/parquet_part.rs
+++ b/src/query/storages/parquet/src/parquet_part.rs
@@ -181,7 +181,7 @@ fn collect_small_file_parts(
     partitions: &mut Partitions,
     stats: &mut PartStatistics,
 ) {
-    if max_compression_ratio <= 0.0 || max_compression_ratio >= 1.0 {
+    if max_compression_ratio < 1.0 {
         // just incase
         max_compression_ratio = 1.0;
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Preserve valid Parquet compression ratios greater than `1.0` when estimating the uncompressed size of small files.

`get_compression_ratio()` defines the ratio as:

```text
uncompressed_size / compressed_size
```

A normally compressed Parquet file therefore has a ratio greater than or equal to `1.0`.

However, `collect_small_file_parts()` currently resets every ratio greater than or equal to `1.0`:

```rust
if max_compression_ratio <= 0.0 || max_compression_ratio >= 1.0 {
    max_compression_ratio = 1.0;
}
```

As a result, the estimated uncompressed size of a small file is effectively reduced to its compressed file size:

```rust
estimated_uncompressed_size = compressed_size * 1.0;
```

This underestimated size is subsequently used by Parquet source parallelism calculation. For highly compressed or memory-heavy Parquet data, the planner may allow too many small-file partitions to be decoded concurrently.

## Background

The compression-ratio handling has two historical definitions:

- PR #12044 introduced small-file memory estimation. `get_compression_ratio()` returned `uncompressed / compressed`, while the small-file calculation divided by the ratio and guarded it as though it were `compressed / uncompressed`.
- PR #18333 explicitly clarified that the ratio is `uncompressed / compressed` and changed the estimated-size calculation from division to multiplication.
- The old `ratio >= 1.0` guard was retained, so valid ratios were still reset to `1.0` before the corrected multiplication was applied.

The current data flow is:

```text
compression_ratio = uncompressed / compressed
        ↓
ratio >= 1.0 is reset to 1.0
        ↓
estimated_uncompressed_size = compressed_size
        ↓
memory estimate = 4 * estimated_uncompressed_size + compressed_size
        ↓
small-file source parallelism may be overestimated
```

This PR removes the stale upper-bound guard and only clamps ratios below `1.0`.

## Change

```diff
-if max_compression_ratio <= 0.0 || max_compression_ratio >= 1.0 {
+if max_compression_ratio < 1.0 {
     max_compression_ratio = 1.0;
 }
```

With this change, a valid ratio such as `4.0` is preserved:

```text
compressed size              = 100 MiB
compression ratio            = 4.0
estimated uncompressed size  = 400 MiB
```

Ratios below `1.0` are still clamped to `1.0`, ensuring that the estimated uncompressed size is never lower than the compressed file size.

## Impact

This change can reduce Parquet small-file read parallelism when the sampled Parquet file has a significant compression ratio.

That is intentional: the existing parallelism calculation uses the estimated uncompressed size to limit concurrent readers by available memory. Preserving the ratio prevents compressed file size from being mistaken for decoded size.

The change does not affect:

- Parquet file classification by `parquet_fast_read_bytes`
- Small-file grouping limits
- Parquet decoding results
- Data correctness or storage format

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - This is a one-line correction to the compression-ratio boundary check. The ratio definition and multiplication are already established by the existing implementation and PR #18333.

Validation performed:

```text
git diff --check
cargo fmt --all -- --check
```

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## AI assistance

- AI usage: An AI coding agent investigated the Parquet small-file OOM, traced the compression-ratio behavior through git history, and prepared the one-line patch and PR description.
- Responsible human: @dqhl76
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20283)
<!-- Reviewable:end -->
