### PR TITLE
fix(query): avoid repeated recluster vacuum

### DIFF
--- a/src/query/expression/src/utils/block_thresholds.rs
+++ b/src/query/expression/src/utils/block_thresholds.rs
@@ -168,7 +168,7 @@ impl BlockThresholds {
         total_bytes: usize,
         total_compressed: usize,
     ) -> (usize, usize) {
-        debug_assert!(total_rows > 0);
+        debug_assert!(total_rows > 0 && total_bytes > 0 && total_compressed > 0);
 
         let default_bytes_per_block = self
             .max_bytes_per_block
@@ -199,6 +199,7 @@ impl BlockThresholds {
                 (total_bytes / self.min_bytes_per_block).max(min_block_num_by_bytes);
             block_num_by_compressed.clamp(min_block_num_by_bytes, max_block_num_by_bytes)
         };
+        let block_nums = block_nums.max(1);
 
         (
             total_rows.div_ceil(block_nums),

--- a/src/query/expression/src/utils/block_thresholds.rs
+++ b/src/query/expression/src/utils/block_thresholds.rs
@@ -182,31 +182,27 @@ impl BlockThresholds {
 
         let block_num_by_rows = std::cmp::max(total_rows / self.min_rows_per_block, 1);
         let block_num_by_compressed = total_compressed.div_ceil(self.max_compressed_per_block);
-        // If row-based block count exceeds compressed-based block count, use max rows per block.
-        if block_num_by_rows >= block_num_by_compressed {
-            return (self.max_rows_per_block, default_bytes_per_block);
-        }
 
-        let bytes_per_block = total_bytes.div_ceil(block_num_by_compressed);
-        // Adjust the number of blocks based on block size thresholds.
         let max_bytes_per_block =
             default_bytes_per_block + default_bytes_per_block.min(DEFAULT_BLOCK_BUFFER_SIZE);
-        if bytes_per_block > max_bytes_per_block {
-            // Case 1: If the block size is too bigger.
-            let bytes_per_block = max_bytes_per_block;
-            let block_nums = total_bytes.div_ceil(bytes_per_block);
-            (total_rows.div_ceil(block_nums).max(1), bytes_per_block)
-        } else if bytes_per_block < self.min_bytes_per_block {
-            // Case 2: If the block size is too smaller.
-            let bytes_per_block = self.min_bytes_per_block;
-            let block_nums = std::cmp::max(total_bytes / bytes_per_block, 1);
-            (total_rows.div_ceil(block_nums).max(1), bytes_per_block)
+        let min_block_num_by_bytes = total_bytes.div_ceil(max_bytes_per_block);
+
+        // When rows require the most blocks, preserve the row-based sizing decision.
+        let block_nums = if block_num_by_rows >= block_num_by_compressed
+            && block_num_by_rows >= min_block_num_by_bytes
+        {
+            block_num_by_rows
         } else {
-            // Case 3: Otherwise, use the compressed-based block count.
-            (
-                total_rows.div_ceil(block_num_by_compressed).max(1),
-                bytes_per_block,
-            )
-        }
+            // Otherwise, choose the block count closest to the compressed-size target while
+            // keeping the uncompressed block size within the configured range.
+            let max_block_num_by_bytes =
+                (total_bytes / self.min_bytes_per_block).max(min_block_num_by_bytes);
+            block_num_by_compressed.clamp(min_block_num_by_bytes, max_block_num_by_bytes)
+        };
+
+        (
+            total_rows.div_ceil(block_nums),
+            total_bytes.div_ceil(block_nums),
+        )
     }
 }

--- a/src/query/expression/tests/it/block_thresholds.rs
+++ b/src/query/expression/tests/it/block_thresholds.rs
@@ -110,6 +110,9 @@ fn test_calc_rows_for_recluster() {
         (500, 800_000)
     );
 
+    // The smallest valid byte size still keeps the selected block count nonzero.
+    assert_eq!(t.calc_rows_for_recluster(2_000, 1, 300_000), (2_000, 1));
+
     // The compressed-size target is within the byte-size range.
     assert_eq!(
         t.calc_rows_for_recluster(4_000, 10_000_000, 600_000),

--- a/src/query/expression/tests/it/block_thresholds.rs
+++ b/src/query/expression/tests/it/block_thresholds.rs
@@ -92,21 +92,27 @@ fn test_calc_rows_for_recluster() {
         (1000, 1_000_000)
     );
 
-    // row-based block count exceeds compressed-based block count, use max rows per block.
+    // Row-based block count is the largest, so derive both targets from that block count.
     assert_eq!(
         t.calc_rows_for_recluster(10_000, 2_000_000, 100_000),
-        (t.max_rows_per_block, 1_000_000)
+        (834, 166_667)
     );
 
-    // Case 1: If the block size is too bigger.
-    let result = t.calc_rows_for_recluster(4_000, 30_000_000, 600_000);
-    assert_eq!(result, (267, 2_000_000));
+    // The max-byte constraint requires more blocks than rows and compressed size.
+    assert_eq!(
+        t.calc_rows_for_recluster(10_000, 30_000_000, 1_000_000),
+        (667, 2_000_000)
+    );
 
-    // Case 2: If the block size is too smaller.
-    let result = t.calc_rows_for_recluster(4_000, 1_600_000, 600_000);
-    assert_eq!(result, (2000, 800_000));
+    // The compressed-size target would create blocks below min_bytes_per_block.
+    assert_eq!(
+        t.calc_rows_for_recluster(1_000, 1_600_000, 600_000),
+        (500, 800_000)
+    );
 
-    // Case 3: use the compressed-based block count.
-    let result = t.calc_rows_for_recluster(4_000, 10_000_000, 600_000);
-    assert_eq!(result, (667, 1_666_667));
+    // The compressed-size target is within the byte-size range.
+    assert_eq!(
+        t.calc_rows_for_recluster(4_000, 10_000_000, 600_000),
+        (667, 1_666_667)
+    );
 }

--- a/src/query/service/src/interpreters/interpreter_table_recluster.rs
+++ b/src/query/service/src/interpreters/interpreter_table_recluster.rs
@@ -27,6 +27,8 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::type_check::check_function;
 use databend_common_functions::BUILTIN_FUNCTIONS;
+use databend_common_license::license::Feature::Vacuum;
+use databend_common_license::license_manager::LicenseManagerSwitch;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_pipeline::core::ExecutionInfo;
 use databend_common_pipeline::core::always_callback;
@@ -41,6 +43,8 @@ use databend_common_storages_fuse::FUSE_OPT_KEY_AGGRESSIVE_RECLUSTER;
 use databend_common_storages_fuse::FuseTable;
 use databend_common_storages_fuse::operations::ReclusterFinalCarry;
 use databend_common_storages_fuse::operations::ReclusterMode;
+use databend_common_storages_fuse::operations::is_auto_vacuum_enabled;
+use databend_enterprise_vacuum_handler::get_vacuum_handler;
 use databend_storages_common_table_meta::meta::TableMetaTimestamps;
 use databend_storages_common_table_meta::meta::TableSnapshot;
 use log::debug;
@@ -64,6 +68,7 @@ use crate::pipelines::executor::PipelineCompleteExecutor;
 use crate::schedulers::build_query_pipeline_without_render_result_set;
 use crate::sessions::QueryContext;
 use crate::sessions::TableContext;
+use crate::sessions::TableContextLicense;
 use crate::sessions::TableContextQueryState;
 use crate::sessions::TableContextSettings;
 use crate::sessions::TableContextTableAccess;
@@ -113,13 +118,14 @@ impl Interpreter for ReclusterTableInterpreter {
         let start = SystemTime::now();
         let timeout = Duration::from_secs(recluster_timeout_secs);
         let is_final = self.plan.is_final;
-        loop {
+        let mut committed = false;
+        let result = loop {
             if let Err(err) = ctx.check_aborting() {
                 error!(
                     "recluster: statement aborted, server is shutting down or the query was killed, round={}",
                     times + 1
                 );
-                return Err(err.with_context("failed to execute"));
+                break Err(err.with_context("failed to execute"));
             }
 
             let res = self
@@ -127,15 +133,14 @@ impl Interpreter for ReclusterTableInterpreter {
                 .await;
 
             match res {
-                Ok(is_break) => {
-                    if is_break {
-                        debug!(
-                            "recluster: final loop stop reason=no_recluster_parts round={}",
-                            times + 1,
-                        );
-                        break;
-                    }
+                Ok(true) => {
+                    debug!(
+                        "recluster: final loop stop reason=no_recluster_parts round={}",
+                        times + 1,
+                    );
+                    break Ok(());
                 }
+                Ok(false) => committed = true,
                 Err(e) => {
                     if is_final
                         && matches!(
@@ -162,7 +167,7 @@ impl Interpreter for ReclusterTableInterpreter {
                             e.code(),
                             e,
                         );
-                        return Err(e);
+                        break Err(e);
                     }
                 }
             }
@@ -179,7 +184,7 @@ impl Interpreter for ReclusterTableInterpreter {
             }
 
             if !is_final {
-                break;
+                break Ok(());
             }
 
             if elapsed_time >= timeout {
@@ -187,15 +192,61 @@ impl Interpreter for ReclusterTableInterpreter {
                     "recluster: final loop stop reason=timeout round={} timeout={:?}",
                     times, timeout,
                 );
-                break;
+                break Ok(());
             }
+        };
+
+        if committed {
+            self.vacuum_table_history().await;
         }
 
+        result?;
         Ok(PipelineBuildResult::create())
     }
 }
 
 impl ReclusterTableInterpreter {
+    async fn vacuum_table_history(&self) {
+        if LicenseManagerSwitch::instance()
+            .check_enterprise_enabled(self.ctx.get_license_key(), Vacuum)
+            .is_err()
+        {
+            return;
+        }
+
+        let result = async {
+            // RECLUSTER resolves the table by name for every round. The deferred vacuum follows
+            // the same name-bound semantics and bypasses the query-level table cache instead of
+            // pinning the table ID for the statement.
+            let table = self
+                .ctx
+                .get_catalog(&self.plan.catalog)
+                .await?
+                .get_table(
+                    &self.ctx.get_tenant(),
+                    &self.plan.database,
+                    &self.plan.table,
+                )
+                .await?;
+            let fuse_table = FuseTable::try_from_table(table.as_ref())?;
+            // Transient tables retain their existing per-commit PurgeAllHistory behavior.
+            if fuse_table.is_transient() {
+                return Ok::<_, ErrorCode>(());
+            }
+            if is_auto_vacuum_enabled(self.ctx.as_ref(), fuse_table)? {
+                fuse_table
+                    .vacuum_table(self.ctx.clone(), &get_vacuum_handler(), true)
+                    .await;
+            }
+            Ok::<_, ErrorCode>(())
+        }
+        .await;
+
+        if let Err(error) = result {
+            warn!("recluster: final table-history vacuum failed: {error}");
+        }
+    }
+
     async fn execute_recluster(
         &self,
         push_downs: &mut Option<PushDownInfo>,

--- a/src/query/service/src/interpreters/util.rs
+++ b/src/query/service/src/interpreters/util.rs
@@ -40,6 +40,7 @@ use crate::interpreters::InterpreterFactory;
 use crate::interpreters::common::QueryFinishHooks;
 use crate::interpreters::interpreter::auto_commit_if_not_allowed_in_transaction;
 use crate::sessions::QueryContext;
+use crate::sessions::TableContextCluster;
 use crate::sessions::TableContextSettings;
 
 pub fn check_system_history(
@@ -146,11 +147,11 @@ impl Client for ScriptClient {
     async fn query(&self, query: &str) -> databend_common_exception::Result<Self::Set> {
         // Note: we can't use `QueryContext::create_from`, which does not create a new query.
         // It clones the outer QueryContext and, crucially, shares the same QueryContextShared that the HTTP query engine is already using for the top‑level EXECUTE IMMEDIATE. That shared state contains the running executor and the HTTP PageManager (see HttpQuery::try_create and ExecuteState::pull_and_send). When the RETURN TABLE sub‑query is executed with that shared context, its batches are published straight into the HTTP response queue as if they were the final query result. The HTTP handler drains those pages immediately, so by the time the script engine tries to build the ReturnValue::Set, blocks is empty and the returned table has zero rows. Running the same SELECT outside of the script still works because that query isn’t executed inside an already running HTTP context.
+        // Each script statement is a new query, but must plan against the parent's cluster.
         let ctx = self
             .ctx
             .get_current_session()
-            .create_query_context(&BUILD_INFO)
-            .await?;
+            .create_query_context_with_cluster(self.ctx.get_cluster(), &BUILD_INFO)?;
         Self::inherit_query_ctx(&self.ctx, &ctx);
 
         let mut planner = Planner::new(ctx.clone());

--- a/src/query/service/src/task/service.rs
+++ b/src/query/service/src/task/service.rs
@@ -612,6 +612,9 @@ impl TaskService {
     async fn spawn_task(task: Task, user: UserInfo) -> Result<()> {
         let task_service = TaskService::instance();
         let context = task_service.create_task_context(user, &task).await?;
+        // Task ownership remains on this node, while the SQL planner must see the complete
+        // warehouse before constructing a distributed physical plan.
+        context.set_cluster(context.get_warehouse_cluster().await?);
 
         match &task.task_sql {
             TaskSql::Sql(sql) => {

--- a/src/query/sql/src/planner/binder/ddl/table.rs
+++ b/src/query/sql/src/planner/binder/ddl/table.rs
@@ -183,8 +183,6 @@ use crate::plans::VacuumTableOption;
 use crate::plans::VacuumTablePlan;
 use crate::plans::VacuumTemporaryFilesPlan;
 
-const FUSE_OPT_KEY_AGGRESSIVE_RECLUSTER: &str = "aggressive_recluster";
-
 #[derive(Visitor)]
 #[visitor(FunctionCall(enter))]
 struct PartitionBucketValidator {
@@ -1029,7 +1027,7 @@ impl Binder {
                 .await?;
             if !keys.is_empty() {
                 options
-                    .entry(FUSE_OPT_KEY_AGGRESSIVE_RECLUSTER.to_owned())
+                    .entry("aggressive_recluster".to_owned())
                     .or_insert_with(|| "1".to_owned());
                 cluster_key = Some(format!("({})", keys.join(", ")));
             }

--- a/src/query/storages/fuse/src/operations/common/generators/mutation_generator.rs
+++ b/src/query/storages/fuse/src/operations/common/generators/mutation_generator.rs
@@ -69,6 +69,10 @@ impl SnapshotGenerator for MutationGenerator {
         self.logical_change_delta
     }
 
+    fn skip_auto_vacuum(&self) -> bool {
+        matches!(self.mutation_kind, MutationKind::Recluster)
+    }
+
     fn do_generate_new_snapshot(
         &self,
         table_info: &TableInfo,

--- a/src/query/storages/fuse/src/operations/common/generators/snapshot_generator.rs
+++ b/src/query/storages/fuse/src/operations/common/generators/snapshot_generator.rs
@@ -42,6 +42,10 @@ pub trait SnapshotGenerator {
         (0, 0)
     }
 
+    fn skip_auto_vacuum(&self) -> bool {
+        false
+    }
+
     async fn fill_default_values(
         &mut self,
         _schema: &TableSchema,

--- a/src/query/storages/fuse/src/operations/common/processors/mod.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/mod.rs
@@ -25,6 +25,7 @@ mod transform_vector_cluster;
 
 pub use multi_table_insert_commit::CommitMultiTableInsert;
 pub use sink_commit::CommitSink;
+pub use sink_commit::is_auto_vacuum_enabled;
 pub use transform_block_writer::TransformBlockBuilder;
 pub use transform_block_writer::TransformBlockWriter;
 pub use transform_constraint_verify::TransformConstraintVerify;

--- a/src/query/storages/fuse/src/operations/common/processors/sink_commit.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/sink_commit.rs
@@ -208,7 +208,9 @@ where F: SnapshotGenerator + Send + Sync + 'static
     ) -> Result<Option<PurgeMode>> {
         let mode = if Self::need_to_purge_all_history(table, snapshot_gen) {
             Some(PurgeMode::PurgeAllHistory)
-        } else if Self::is_auto_vacuum_enabled(ctx, table)? {
+        } else if snapshot_gen.skip_auto_vacuum() {
+            None
+        } else if is_auto_vacuum_enabled(ctx, table)? {
             Some(PurgeMode::PurgeAccordingToRetention)
         } else {
             None
@@ -246,23 +248,6 @@ where F: SnapshotGenerator + Send + Sync + 'static
                         | MutationKind::Replace
                 )
             })
-    }
-
-    fn is_auto_vacuum_enabled(ctx: &dyn TableContext, table: &FuseTable) -> Result<bool> {
-        // Priority for auto vacuum:
-        // - If table-level option `FUSE_OPT_KEY_ENABLE_AUTO_VACUUM` is set, it takes precedence
-        // - If table-level option is not set, fall back to the setting
-        match table
-            .table_info
-            .options()
-            .get(FUSE_OPT_KEY_ENABLE_AUTO_VACUUM)
-        {
-            Some(v) => {
-                let enabled = v.parse::<u32>()? != 0;
-                Ok(enabled)
-            }
-            None => ctx.get_settings().get_enable_auto_vacuum(),
-        }
     }
 
     fn is_error_recoverable(&self, e: &ErrorCode) -> bool {
@@ -861,5 +846,19 @@ where F: SnapshotGenerator + Send + Sync + 'static
             _ => return Err(ErrorCode::Internal("It's a bug.")),
         }
         Ok(())
+    }
+}
+
+pub fn is_auto_vacuum_enabled(ctx: &dyn TableContext, table: &FuseTable) -> Result<bool> {
+    // Priority for auto vacuum:
+    // - If table-level option `FUSE_OPT_KEY_ENABLE_AUTO_VACUUM` is set, it takes precedence.
+    // - If table-level option is not set, fall back to the setting.
+    match table
+        .table_info
+        .options()
+        .get(FUSE_OPT_KEY_ENABLE_AUTO_VACUUM)
+    {
+        Some(value) => Ok(value.parse::<u32>()? != 0),
+        None => ctx.get_settings().get_enable_auto_vacuum(),
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Restore the complete warehouse cluster before TASK SQL planning while keeping TASK ownership and coordination on one node
- Make recluster output row and byte targets derive from one coherent output block count
- Skip per-commit table-history auto vacuum only for RECLUSTER mutations and run one best-effort deferred vacuum after at least one successful round
- Preserve per-commit `PurgeAllHistory` for transient tables and existing auto-vacuum behavior for COMPACT, REFRESH, and other mutations
- Preserve the original RECLUSTER error when deferred vacuum fails, including when a later round aborts or returns a fatal error

In the reported `RECLUSTER FINAL`, TASK SQL was planned with a single-node context, so the physical plan did not contain distributed exchanges despite a two-node warehouse. In addition, each of 1,295 successful internal rounds ran table-history vacuum; log analysis attributed about 90 hours to those repeated vacuums, versus about 7.3 hours to rewrite/sort/commit work.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent assisted with code analysis, log analysis, implementation review, validation, and PR summary drafting; I reviewed and verified the complete diff.
- Responsible human: @zhyass
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20285)
<!-- Reviewable:end -->
