### PR TITLE
docs: guide agents to defer collection

### DIFF
--- a/agents/coding-style.md
+++ b/agents/coding-style.md
@@ -7,6 +7,17 @@
 - Use `CamelCase` for exposed types and traits.
 - Prefer helpers from `common/exception` for error handling.
 - Use `tracing` spans when observability matters.
+- Prefer lazy iterator chains, borrowed iteration, and consuming iteration over
+  eager `collect()` plus a second pass. Only materialize a `Vec`, `HashSet`, or
+  similar collection when an API boundary, ownership requirement, stable order,
+  or repeated traversal needs it.
+- Avoid cloning shared structures, expressions, plans, and metadata only to
+  inspect or filter them. Prefer `iter()`, borrowed helper methods, short-circuit
+  iterator methods such as `any`/`all`/`find`, or consuming traversal when the
+  caller already owns the value.
+- When adding helpers over collections, expose borrowed iterator forms first.
+  Add owned collection-returning helpers only when callers genuinely need owned
+  materialized results.
 
 ## Tests and Fixtures
 - Keep SQL suite file prefixes consistent with the existing numeric ordering in `tests/suites/`.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Add Rust coding guidance for agents to prefer lazy iterator chains, borrowed iteration, and consuming traversal over eager `collect()` followed by another pass.
- Call out avoiding clones used only for inspection or filtering, and prefer borrowed iterator helpers before owned collection-returning helpers.
- This guidance is motivated by the cleanup pattern in https://github.com/databendlabs/databend/pull/20253.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Documentation-only update to agent guidance.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [x] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: Assisted with drafting the agent coding guidance and preparing this documentation PR.
- Responsible human: @KKould
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20287)
<!-- Reviewable:end -->
