### PR TITLE
fix(query): resolve correlated internal columns

### DIFF
--- a/src/query/sql/src/planner/binder/bind_context.rs
+++ b/src/query/sql/src/planner/binder/bind_context.rs
@@ -146,6 +146,8 @@ pub struct InternalColumnBinding {
     pub database_name: Option<String>,
     /// Table name of this `InternalColumnBinding` in current context
     pub table_name: Option<String>,
+    /// Owner table, if it has already been resolved.
+    pub table_index: Option<IndexType>,
 
     pub internal_column: InternalColumn,
 }
@@ -693,14 +695,27 @@ impl BindContext {
             return;
         }
 
-        // look up internal column
+        // Look up an internal column only when this scope contains a matching table. If it does
+        // not, recursive name resolution must continue with the parent scope.
         if let Some(internal_column) = INTERNAL_COLUMN_FACTORY.get_internal_column(&column.name) {
-            let column_binding = InternalColumnBinding {
-                database_name: database.map(|n| n.to_owned()),
-                table_name: table.map(|n| n.to_owned()),
-                internal_column,
-            };
-            result.push(NameResolutionResult::InternalColumn(column_binding));
+            for table_index in bind_context
+                .columns
+                .iter()
+                .filter(|binding| {
+                    database.is_none_or(|db| binding.database_name.as_deref() == Some(db))
+                        && table.is_none_or(|table| binding.table_name.as_deref() == Some(table))
+                })
+                .filter_map(|binding| binding.table_index)
+            {
+                result.push(NameResolutionResult::InternalColumn(
+                    InternalColumnBinding {
+                        database_name: database.map(ToOwned::to_owned),
+                        table_name: table.map(ToOwned::to_owned),
+                        table_index: Some(table_index),
+                        internal_column: internal_column.clone(),
+                    },
+                ));
+            }
         }
     }
 
@@ -902,30 +917,33 @@ impl BindContext {
         &mut self,
         column_binding: &InternalColumnBinding,
         metadata: MetadataRef,
-        table_index: Option<IndexType>,
         visible: bool,
     ) -> Result<ColumnBinding> {
         let column_id = column_binding.internal_column.column_id();
-        let table_index = if let Some(table_index) = table_index {
+        let table_index = if let Some(table_index) = column_binding.table_index {
             table_index
         } else {
             self.get_internal_column_table_index(column_binding)?
         };
+        // Only local internal columns belong in this scope's visible column bindings. Correlated
+        // internal columns are tracked in `bound_internal_columns` but must not pollute the inner
+        // scope's name resolution.
+        let add_to_context = self
+            .columns
+            .iter()
+            .any(|column| column.table_index == Some(table_index));
 
-        let (column_index, is_new) =
-            match self.bound_internal_columns.entry((table_index, column_id)) {
-                btree_map::Entry::Vacant(e) => {
-                    let mut metadata = metadata.write();
-                    let column_index = metadata
-                        .add_internal_column(table_index, column_binding.internal_column.clone());
-                    e.insert(column_index);
-                    (column_index, true)
-                }
-                btree_map::Entry::Occupied(e) => {
-                    let column_index = e.get();
-                    (*column_index, false)
-                }
-            };
+        let key = (table_index, column_id);
+        let inherited =
+            std::iter::successors(self.parent.as_deref(), |context| context.parent.as_deref())
+                .find_map(|context| context.bound_internal_columns.get(&key).copied());
+        let column_index = *self.bound_internal_columns.entry(key).or_insert_with(|| {
+            inherited.unwrap_or_else(|| {
+                metadata
+                    .write()
+                    .add_internal_column(table_index, column_binding.internal_column.clone())
+            })
+        });
 
         let metadata = metadata.read();
         let table = metadata.table(table_index);
@@ -953,8 +971,12 @@ impl BindContext {
         .table_index(Some(table_index))
         .build();
 
-        if is_new {
-            debug_assert!(!self.columns.iter().any(|c| c == &column_binding));
+        if add_to_context
+            && !self
+                .columns
+                .iter()
+                .any(|column| column.index == column_index)
+        {
             self.columns.push(column_binding.clone());
         }
 

--- a/src/query/sql/src/planner/binder/bind_mutation/mutation_expression.rs
+++ b/src/query/sql/src/planner/binder/bind_mutation/mutation_expression.rs
@@ -595,6 +595,7 @@ impl Binder {
         let row_id_column_binding = InternalColumnBinding {
             database_name: Some(target_table_identifier.database_name().clone()),
             table_name: Some(target_table_identifier.table_name().clone()),
+            table_index: Some(table_index),
             internal_column: InternalColumn {
                 column_name: ROW_ID_COL_NAME.to_string(),
                 column_type: InternalColumnType::RowId,
@@ -604,7 +605,6 @@ impl Binder {
         let column_binding = match bind_context.add_internal_column_binding(
             &row_id_column_binding,
             self.metadata.clone(),
-            Some(table_index),
             true,
         ) {
             Ok(column_binding) => column_binding,

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/flatten_plan.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/flatten_plan.rs
@@ -1284,8 +1284,12 @@ impl SubqueryDecorrelatorOptimizer {
             .copied()
             .map(|col| {
                 let column_entry = metadata.column(col).clone();
-                let derived_index =
-                    metadata.add_derived_column(column_entry.name(), column_entry.data_type());
+                let derived_index = match column_entry {
+                    ColumnEntry::InternalColumn(column) => {
+                        metadata.add_internal_column(column.table_index, column.internal_column)
+                    }
+                    _ => metadata.add_derived_column(column_entry.name(), column_entry.data_type()),
+                };
                 derived_columns.record(col, derived_index);
                 derived_index
             })

--- a/src/query/sql/src/planner/semantic/type_check/column.rs
+++ b/src/query/sql/src/planner/semantic/type_check/column.rs
@@ -173,11 +173,9 @@ where A: TypeCheckAdapter
                 }
             }
             NameResolutionResult::InternalColumn(column) => {
-                // add internal column binding into `BindContext`
                 let column = self.bind_context.add_internal_column_binding(
                     &column,
                     self.metadata.clone(),
-                    None,
                     true,
                 )?;
                 let data_type = *column.data_type.clone();

--- a/src/query/sql/src/planner/semantic/type_check/search.rs
+++ b/src/query/sql/src/planner/semantic/type_check/search.rs
@@ -136,12 +136,12 @@ where A: super::TypeCheckAdapter
         let internal_column_binding = InternalColumnBinding {
             database_name: None,
             table_name: None,
+            table_index: None,
             internal_column,
         };
         let column = self.bind_context.add_internal_column_binding(
             &internal_column_binding,
             self.metadata.clone(),
-            None,
             false,
         )?;
 
@@ -623,12 +623,12 @@ where A: super::TypeCheckAdapter
         let internal_column_binding = InternalColumnBinding {
             database_name: column_refs[0].0.column.database_name.clone(),
             table_name: column_refs[0].0.column.table_name.clone(),
+            table_index: Some(table_index),
             internal_column,
         };
         let column = self.bind_context.add_internal_column_binding(
             &internal_column_binding,
             self.metadata.clone(),
-            None,
             false,
         )?;
 

--- a/src/query/sql/src/planner/semantic/type_check/subquery.rs
+++ b/src/query/sql/src/planner/semantic/type_check/subquery.rs
@@ -38,6 +38,7 @@ use super::FullTypeCheckAdapter;
 use super::TypeCheckSubqueryPlan;
 use super::TypeChecker;
 use crate::BindContext;
+use crate::ColumnEntry;
 use crate::ColumnSet;
 use crate::MetadataRef;
 use crate::binder::Binder;
@@ -428,6 +429,19 @@ where A: super::TypeCheckAdapter
 
         let rel_expr = RelExpr::with_s_expr(&s_expr);
         let rel_prop = rel_expr.derive_relational_prop()?;
+
+        let metadata = self.metadata.read();
+        for &column_index in &rel_prop.outer_columns {
+            if let Some(ColumnEntry::InternalColumn(column)) =
+                metadata.columns().get(column_index.as_usize())
+            {
+                self.bind_context.bound_internal_columns.insert(
+                    (column.table_index, column.internal_column.column_id()),
+                    column_index,
+                );
+            }
+        }
+        drop(metadata);
 
         if typ == SubqueryType::Scalar
             && contain_agg == Some(true)

--- a/src/query/sql/src/planner/semantic/type_check/vector.rs
+++ b/src/query/sql/src/planner/semantic/type_check/vector.rs
@@ -160,13 +160,13 @@ where A: TypeCheckAdapter
                                 let internal_column_binding = InternalColumnBinding {
                                     database_name: database_name.clone(),
                                     table_name: table_name.clone(),
+                                    table_index: Some(table_index),
                                     internal_column,
                                 };
                                 let Ok(column_binding) =
                                     self.bind_context.add_internal_column_binding(
                                         &internal_column_binding,
                                         self.metadata.clone(),
-                                        Some(table_index),
                                         false,
                                     )
                                 else {

--- a/tests/sqllogictests/suites/base/issues/issue_20260.test
+++ b/tests/sqllogictests/suites/base/issues/issue_20260.test
@@ -1,0 +1,70 @@
+statement ok
+DROP TABLE IF EXISTS issue_20260;
+
+statement ok
+DROP TABLE IF EXISTS issue_20260_aux;
+
+statement ok
+CREATE TABLE issue_20260(a INT);
+
+statement ok
+ALTER TABLE issue_20260 SET OPTIONS(change_tracking = true);
+
+statement ok
+CREATE TABLE issue_20260_aux(a INT);
+
+statement ok
+INSERT INTO issue_20260 VALUES (1), (2);
+
+statement ok
+INSERT INTO issue_20260_aux VALUES (10), (20);
+
+# Qualified internal column from the outer scope.
+query I
+SELECT count(*) FROM issue_20260 AS t
+WHERE EXISTS (SELECT 1 WHERE t._row_id IS NOT NULL);
+----
+2
+
+# Unqualified internal column falls back to the only outer table.
+query I
+SELECT count(*) FROM issue_20260 AS t
+WHERE EXISTS (SELECT 1 WHERE _row_id IS NOT NULL);
+----
+2
+
+# Outer resolution skips the inner table without polluting nearest-scope lookup.
+query I
+SELECT count(*) FROM issue_20260 AS t
+WHERE EXISTS (
+    SELECT 1 FROM issue_20260_aux AS s
+    WHERE t._row_id IS NOT NULL AND _row_id = s._row_id
+);
+----
+2
+
+# Repeated references reuse the same internal-column symbol.
+query I
+SELECT count(*) FROM issue_20260 AS t
+WHERE EXISTS (SELECT 1 WHERE t._row_id > 0)
+  AND EXISTS (SELECT 1 WHERE t._row_id > 1);
+----
+2
+
+# change$row_id follows the same owner-resolution path.
+query I
+SELECT count(*) FROM issue_20260 AS t
+WHERE EXISTS (SELECT 1 WHERE length(t.change$row_id) = 38);
+----
+2
+
+# An unqualified internal column is ambiguous with multiple outer tables.
+statement error (?s)1065.*ambiguous
+SELECT * FROM issue_20260 AS t, issue_20260_aux AS s
+WHERE EXISTS (SELECT 1 WHERE _row_id > 0);
+
+statement ok
+DROP TABLE issue_20260;
+
+statement ok
+DROP TABLE issue_20260_aux;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Resolve internal columns in correlated subqueries against the table that owns them, while preserving nearest-scope and ambiguity behavior
- Propagate correlated internal-column requirements through nested subqueries so the owning table scan retains columns such as `_row_id` and `change$row_id`
- Reuse the same metadata symbol for repeated references to an internal column and avoid exposing outer bindings in an inner scope
- Add sqllogictest coverage for qualified, unqualified, nested, repeated, shadowing, ambiguity, and change-tracking cases

Fixes #20260

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent assisted with root-cause analysis, implementation, regression-test drafting, local validation, and PR summary drafting; I reviewed and verified the complete diff.
- Responsible human: @zhyass
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20294)
<!-- Reviewable:end -->
