### PR TITLE
refactor(query): move lambda detection out of parser

### DIFF
--- a/src/query/ast/src/ast/expr.rs
+++ b/src/query/ast/src/ast/expr.rs
@@ -1107,6 +1107,25 @@ impl Display for Literal {
     }
 }
 
+#[derive(Educe, Clone, PartialEq, Drive, DriveMut)]
+#[educe(Debug)]
+pub enum LambdaArgument {
+    /// A lambda that has no ordinary-expression interpretation.
+    Lambda(Lambda),
+    /// A trailing `param -> expr` that is also a valid JSON-arrow expression.
+    ///
+    /// The ordinary interpretation is kept as the last item in
+    /// [`FunctionCall::args`]. Semantic analysis selects this lambda
+    /// interpretation only when the function is a lambda function.
+    Ambiguous(#[educe(Debug(ignore))] Lambda),
+}
+
+impl FunctionCall {
+    pub fn has_explicit_lambda(&self) -> bool {
+        matches!(self.lambda, Some(LambdaArgument::Lambda(_)))
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Drive, DriveMut)]
 pub struct FunctionCall {
     /// Set to true if the function is aggregate function with `DISTINCT`, like `COUNT(DISTINCT a)`
@@ -1117,7 +1136,7 @@ pub struct FunctionCall {
     pub order_by: Vec<OrderByExpr>,
     pub filter: Option<Box<Expr>>,
     pub window: Option<WindowDesc>,
-    pub lambda: Option<Lambda>,
+    pub lambda: Option<LambdaArgument>,
 }
 
 impl Default for FunctionCall {
@@ -1158,7 +1177,7 @@ impl Display for FunctionCall {
             write!(f, "DISTINCT ")?;
         }
         write_comma_separated_list(f, args)?;
-        if let Some(lambda) = lambda {
+        if let Some(LambdaArgument::Lambda(lambda)) = lambda {
             if !args.is_empty() {
                 write!(f, ", ")?;
             }

--- a/src/query/ast/src/parser/expr.rs
+++ b/src/query/ast/src/parser/expr.rs
@@ -2636,38 +2636,6 @@ fn aggregate_filter(i: Input) -> IResult<Expr> {
     .parse(i)
 }
 
-/// Functions that accept a trailing lambda in their call body:
-/// `f([arg, ...,] params -> expr)`. `->` is also the json arrow operator,
-/// so this grammar is only enabled for these names.
-///
-/// This list is the single source of truth: `GENERAL_LAMBDA_FUNCTIONS` in
-/// `databend-common-functions` is derived from it.
-pub const LAMBDA_FUNCTION_NAMES: &[&str] = &[
-    "array_transform",
-    "array_apply",
-    "array_map",
-    "array_filter",
-    "array_reduce",
-    "json_array_transform",
-    "json_array_apply",
-    "json_array_map",
-    "json_array_filter",
-    "json_array_reduce",
-    "map_filter",
-    "map_transform_keys",
-    "map_transform_values",
-    "json_map_filter",
-    "json_map_transform_keys",
-    "json_map_transform_values",
-    "json_path_transform",
-];
-
-fn is_lambda_function_name(name: &str) -> bool {
-    LAMBDA_FUNCTION_NAMES
-        .iter()
-        .any(|lambda_name| name.eq_ignore_ascii_case(lambda_name))
-}
-
 pub fn function_call(i: Input) -> IResult<ExprElement> {
     enum FunctionCallSuffix {
         Simple {
@@ -2727,59 +2695,23 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
         }
     }
 
-    // Parses `function([arg, ...,] params -> expr)`. A `params -> expr` that
-    // does not close the call is re-parsed as an ordinary argument, e.g. the
-    // first argument of `f(a -> 'k', x -> y)`.
-    fn lambda_last_call_body<'a>(input: Input<'a>) -> IResult<'a, FunctionCallSuffix> {
-        let original = input;
-        let (mut rest, _) = match_text("(").parse(input)?;
-        let mut args = Vec::new();
-
-        loop {
-            match followed_by_text(lambda_params, "->").parse(rest) {
-                Ok((after_params, params)) => {
-                    let (after_arrow, _) = match_text("->").parse(after_params)?;
-                    if let Ok((after_expr, expr)) = subexpr(0).parse(after_arrow)
-                        && let Ok((rest, _)) = match_text(")").parse(after_expr)
-                    {
-                        return Ok((rest, FunctionCallSuffix::Lambda {
-                            args,
-                            params,
-                            expr: Box::new(expr),
-                        }));
-                    }
-                }
-                Err(nom::Err::Error(_)) => {}
-                Err(error) => return Err(error),
-            }
-
-            let (after_arg, arg) = match subexpr(0).parse(rest) {
-                Ok(result) => result,
-                Err(_) => {
-                    return Err(nom::Err::Error(Error::from_error_kind(
-                        original,
-                        ErrorKind::other("expected lambda expression"),
-                    )));
-                }
-            };
-            let (after_comma, _) = match match_text(",").parse(after_arg) {
-                Ok(result) => result,
-                Err(_) => {
-                    return Err(nom::Err::Error(Error::from_error_kind(
-                        original,
-                        ErrorKind::other("expected lambda expression"),
-                    )));
-                }
-            };
-            args.push(arg);
-            rest = after_comma;
-        }
+    fn merge_args(
+        first_param: Option<Expr>,
+        leading_params: Vec<Expr>,
+        params: Option<Vec<Expr>>,
+    ) -> Vec<Expr> {
+        first_param
+            .into_iter()
+            .chain(leading_params)
+            .chain(params.unwrap_or_default())
+            .collect()
     }
 
     let lambda_params = followed_by_text(lambda_params, "->");
-    let general_function_call_body = map_res(
+    let leading_param = map(rule! { #subexpr(0) ~ "," }, |(arg, _)| arg);
+    let function_call_body = map_res(
         rule! {
-            "(" ~ DISTINCT? ~ #subexpr(0)? ~ ","? ~ (#lambda_params ~ "->" ~ ^#subexpr(0))? ~ #comma_separated_list1(subexpr(0))? ~ #aggregate_order_by? ~ ")"
+            "(" ~ DISTINCT? ~ #subexpr(0)? ~ ","? ~ #leading_param* ~ (#lambda_params ~ "->" ~ ^#subexpr(0))? ~ #comma_separated_list1(subexpr(0))? ~ #aggregate_order_by? ~ ")"
             ~ ("(" ~ DISTINCT? ~ #comma_separated_list0(subexpr(0))? ~ #aggregate_order_by? ~ ")")?
             ~ #within_group?
             ~ #aggregate_filter?
@@ -2790,6 +2722,7 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
             opt_distinct_0,
             first_param,
             _,
+            leading_params,
             opt_lambda,
             params_0,
             argument_order_by,
@@ -2801,6 +2734,7 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
         )| {
             match (
                 first_param,
+                leading_params,
                 opt_lambda,
                 opt_distinct_0,
                 params_0,
@@ -2812,6 +2746,7 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
             ) {
                 (
                     Some(first_param),
+                    leading_params,
                     Some((lambda_params, _, lambda_body)),
                     None,
                     None,
@@ -2821,12 +2756,13 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
                     None,
                     None,
                 ) => Ok(FunctionCallSuffix::Lambda {
-                    args: vec![first_param],
+                    args: merge_args(Some(first_param), leading_params, None),
                     params: lambda_params,
                     expr: Box::new(lambda_body),
                 }),
                 (
                     Some(first_param),
+                    leading_params,
                     None,
                     None,
                     params_0,
@@ -2836,12 +2772,7 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
                     filter,
                     window,
                 ) => {
-                    let params = params_0
-                        .map(|mut params| {
-                            params.insert(0, first_param.clone());
-                            params
-                        })
-                        .unwrap_or_else(|| vec![first_param]);
+                    let params = merge_args(Some(first_param), leading_params, params_0);
                     let order_by = merge_aggregate_order_by(param_order_by, within_group_order_by)?;
 
                     Ok(FunctionCallSuffix::ParamsWindow {
@@ -2853,22 +2784,38 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
                         window,
                     })
                 }
-                (first_param, None, opt_distinct, params, None, None, None, None, None) => {
-                    let mut args = params.unwrap_or_default();
-                    if let Some(first_param) = first_param {
-                        args.insert(0, first_param)
-                    }
+                (
+                    first_param,
+                    leading_params,
+                    None,
+                    opt_distinct,
+                    params,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                ) => {
+                    let args = merge_args(first_param, leading_params, params);
 
                     Ok(FunctionCallSuffix::Simple {
                         distinct: opt_distinct.is_some(),
                         args,
                     })
                 }
-                (first_param, None, opt_distinct, params, None, None, None, Some(filter), None) => {
-                    let mut args = params.unwrap_or_default();
-                    if let Some(first_param) = first_param {
-                        args.insert(0, first_param)
-                    }
+                (
+                    first_param,
+                    leading_params,
+                    None,
+                    opt_distinct,
+                    params,
+                    None,
+                    None,
+                    None,
+                    Some(filter),
+                    None,
+                ) => {
+                    let args = merge_args(first_param, leading_params, params);
 
                     Ok(FunctionCallSuffix::Filter {
                         distinct: opt_distinct.is_some(),
@@ -2878,6 +2825,7 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
                 }
                 (
                     first_param,
+                    leading_params,
                     None,
                     opt_distinct,
                     params,
@@ -2887,10 +2835,7 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
                     filter,
                     Some(window),
                 ) => {
-                    let mut args = params.unwrap_or_default();
-                    if let Some(first_param) = first_param {
-                        args.insert(0, first_param)
-                    }
+                    let args = merge_args(first_param, leading_params, params);
 
                     Ok(FunctionCallSuffix::Window {
                         distinct: opt_distinct.is_some(),
@@ -2901,6 +2846,7 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
                 }
                 (
                     first_param,
+                    leading_params,
                     None,
                     opt_distinct,
                     params,
@@ -2910,10 +2856,7 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
                     filter,
                     window,
                 ) => {
-                    let mut args = params.unwrap_or_default();
-                    if let Some(first_param) = first_param {
-                        args.insert(0, first_param)
-                    }
+                    let args = merge_args(first_param, leading_params, params);
 
                     Ok(FunctionCallSuffix::ArgumentOrderBy {
                         distinct: opt_distinct.is_some(),
@@ -2925,6 +2868,7 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
                 }
                 (
                     first_param,
+                    leading_params,
                     None,
                     opt_distinct,
                     params,
@@ -2934,10 +2878,7 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
                     filter,
                     window,
                 ) => {
-                    let mut args = params.unwrap_or_default();
-                    if let Some(first_param) = first_param {
-                        args.insert(0, first_param)
-                    }
+                    let args = merge_args(first_param, leading_params, params);
 
                     Ok(FunctionCallSuffix::WithInGroupWindow {
                         distinct: opt_distinct.is_some(),
@@ -2947,7 +2888,7 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
                         window,
                     })
                 }
-                (_, None, _, _, Some(_), None, Some(_), _, _) => {
+                (_, _, None, _, _, Some(_), None, Some(_), _, _) => {
                     Err(nom::Err::Error(ErrorKind::other(
                         "ORDER BY inside aggregate arguments cannot be combined with WITHIN GROUP",
                     )))
@@ -2959,26 +2900,12 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
         },
     );
 
-    let mut general_function_call_body = context(
-        "`function(... [ ORDER BY <expr>, ... ] [ , x -> ... ] ) [ (...) ] [ WITHIN GROUP ( ORDER BY <expr>, ... ) ] [ FILTER ( WHERE <expr> ) ] [ OVER ([ PARTITION BY <expr>, ... ] [ ORDER BY <expr>, ... ] [ <window frame> ]) ]`",
-        general_function_call_body,
-    );
-
-    let (rest, name) = function_name.parse(i)?;
-
-    // Lambda functions must try the trailing-lambda body first: the general
-    // grammar would swallow `params -> expr` as a json arrow argument.
-    let (rest, suffix) = if is_lambda_function_name(&name.name) {
-        match lambda_last_call_body(rest) {
-            Ok(result) => result,
-            Err(nom::Err::Error(_)) => general_function_call_body.parse(rest)?,
-            Err(error) => return Err(error),
-        }
-    } else {
-        general_function_call_body.parse(rest)?
-    };
-
-    let elem = match suffix {
+    map(
+        rule!(
+            #function_name
+            ~ #function_call_body : "`function(... [ ORDER BY <expr>, ... ] [ , x -> ... ] ) [ (...) ] [ WITHIN GROUP ( ORDER BY <expr>, ... ) ] [ FILTER ( WHERE <expr> ) ] [ OVER ([ PARTITION BY <expr>, ... ] [ ORDER BY <expr>, ... ] [ <window frame> ]) ]`"
+        ),
+        |(name, suffix)| match suffix {
         FunctionCallSuffix::Simple { distinct, args } => ExprElement::FunctionCall {
             func: FunctionCall {
                 distinct,
@@ -3080,9 +3007,9 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
                 lambda: None,
             },
         },
-    };
-
-    Ok((rest, elem))
+        },
+    )
+    .parse(i)
 }
 
 pub fn parse_float(text: &str) -> Result<Literal, ErrorKind> {

--- a/src/query/ast/src/parser/expr.rs
+++ b/src/query/ast/src/parser/expr.rs
@@ -2760,6 +2760,23 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
             filter,
             window,
         )| {
+            let can_preserve_lambda = first_param.is_some()
+                && opt_distinct_0.is_none()
+                && params_0.is_none()
+                && argument_order_by.is_none()
+                && params_1.is_none()
+                && within_group_order_by.is_none()
+                && filter.is_none()
+                && window.is_none();
+            let (leading_params, ambiguous_lambda) = match ambiguous_lambda {
+                Some((ordinary_expr, _)) if !can_preserve_lambda => {
+                    let mut leading_params = leading_params;
+                    leading_params.push(ordinary_expr);
+                    (leading_params, None)
+                }
+                ambiguous_lambda => (leading_params, ambiguous_lambda),
+            };
+
             match (
                 first_param,
                 leading_params,

--- a/src/query/ast/src/parser/expr.rs
+++ b/src/query/ast/src/parser/expr.rs
@@ -683,10 +683,10 @@ impl<'a, I: Iterator<Item = WithSpan<'a, ExprElement>>> PrattParser<I> for ExprP
                             order_by: vec![],
                             filter: None,
                             window: None,
-                            lambda: Some(Lambda {
+                            lambda: Some(LambdaArgument::Lambda(Lambda {
                                 params: vec![param.clone()],
                                 expr: Box::new(filter),
-                            }),
+                            })),
                         },
                     };
                 }
@@ -701,10 +701,10 @@ impl<'a, I: Iterator<Item = WithSpan<'a, ExprElement>>> PrattParser<I> for ExprP
                         order_by: vec![],
                         filter: None,
                         window: None,
-                        lambda: Some(Lambda {
+                        lambda: Some(LambdaArgument::Lambda(Lambda {
                             params: vec![param.clone()],
                             expr: Box::new(result),
-                        }),
+                        })),
                     },
                 }
             }
@@ -922,7 +922,7 @@ impl<'a, I: Iterator<Item = WithSpan<'a, ExprElement>>> PrattParser<I> for ExprP
                     order_by: vec![],
                     filter: None,
                     window: None,
-                    lambda,
+                    lambda: lambda.map(LambdaArgument::Lambda),
                 },
             },
             ExprElement::IsNull { not } => Expr::IsNull {
@@ -2707,11 +2707,39 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
             .collect()
     }
 
-    let lambda_params = followed_by_text(lambda_params, "->");
+    fn ambiguous_lambda_arg(i: Input) -> IResult<(Expr, Lambda)> {
+        let original = i;
+        let (rest, params) = followed_by_text(lambda_params, "->").parse(i)?;
+        let (rest, _) = match_text("->").parse(rest)?;
+        let (lambda_rest, expr) = subexpr(0).parse(rest)?;
+
+        // Preserve the complete ordinary-expression parse as well. Requiring
+        // both parses to stop immediately before the closing parenthesis keeps
+        // the ambiguity limited to the top-level trailing argument.
+        let (ordinary_rest, ordinary_expr) = subexpr(0).parse(original)?;
+        if lambda_rest.tokens.as_ptr() != ordinary_rest.tokens.as_ptr()
+            || lambda_rest.tokens.len() != ordinary_rest.tokens.len()
+            || match_text(")").parse(lambda_rest).is_err()
+        {
+            return Err(nom::Err::Error(Error::from_error_kind(
+                original,
+                ErrorKind::other("expected trailing lambda argument"),
+            )));
+        }
+
+        Ok((
+            lambda_rest,
+            (ordinary_expr, Lambda {
+                params,
+                expr: Box::new(expr),
+            }),
+        ))
+    }
+
     let leading_param = map(rule! { #subexpr(0) ~ "," }, |(arg, _)| arg);
     let function_call_body = map_res(
         rule! {
-            "(" ~ DISTINCT? ~ #subexpr(0)? ~ ","? ~ #leading_param* ~ (#lambda_params ~ "->" ~ ^#subexpr(0))? ~ #comma_separated_list1(subexpr(0))? ~ #aggregate_order_by? ~ ")"
+            "(" ~ DISTINCT? ~ #subexpr(0)? ~ ","? ~ #leading_param* ~ #ambiguous_lambda_arg? ~ #comma_separated_list1(subexpr(0))? ~ #aggregate_order_by? ~ ")"
             ~ ("(" ~ DISTINCT? ~ #comma_separated_list0(subexpr(0))? ~ #aggregate_order_by? ~ ")")?
             ~ #within_group?
             ~ #aggregate_filter?
@@ -2723,7 +2751,7 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
             first_param,
             _,
             leading_params,
-            opt_lambda,
+            ambiguous_lambda,
             params_0,
             argument_order_by,
             _,
@@ -2735,7 +2763,7 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
             match (
                 first_param,
                 leading_params,
-                opt_lambda,
+                ambiguous_lambda,
                 opt_distinct_0,
                 params_0,
                 argument_order_by,
@@ -2747,7 +2775,7 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
                 (
                     Some(first_param),
                     leading_params,
-                    Some((lambda_params, _, lambda_body)),
+                    Some((ordinary_expr, lambda)),
                     None,
                     None,
                     None,
@@ -2756,9 +2784,9 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
                     None,
                     None,
                 ) => Ok(FunctionCallSuffix::Lambda {
-                    args: merge_args(Some(first_param), leading_params, None),
-                    params: lambda_params,
-                    expr: Box::new(lambda_body),
+                    args: merge_args(Some(first_param), leading_params, Some(vec![ordinary_expr])),
+                    params: lambda.params,
+                    expr: lambda.expr,
                 }),
                 (
                     Some(first_param),
@@ -2900,12 +2928,14 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
         },
     );
 
-    map(
-        rule!(
-            #function_name
-            ~ #function_call_body : "`function(... [ ORDER BY <expr>, ... ] [ , x -> ... ] ) [ (...) ] [ WITHIN GROUP ( ORDER BY <expr>, ... ) ] [ FILTER ( WHERE <expr> ) ] [ OVER ([ PARTITION BY <expr>, ... ] [ ORDER BY <expr>, ... ] [ <window frame> ]) ]`"
-        ),
-        |(name, suffix)| match suffix {
+    let (rest, name) = function_name.parse(i)?;
+    let (rest, suffix) = context(
+        "`function(... [ ORDER BY <expr>, ... ] [ , x -> ... ] ) [ (...) ] [ WITHIN GROUP ( ORDER BY <expr>, ... ) ] [ FILTER ( WHERE <expr> ) ] [ OVER ([ PARTITION BY <expr>, ... ] [ ORDER BY <expr>, ... ] [ <window frame> ]) ]`",
+        function_call_body,
+    )
+    .parse(rest)?;
+
+    let elem = match suffix {
         FunctionCallSuffix::Simple { distinct, args } => ExprElement::FunctionCall {
             func: FunctionCall {
                 distinct,
@@ -2985,7 +3015,7 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
                 order_by: vec![],
                 filter: None,
                 window: None,
-                lambda: Some(Lambda { params, expr }),
+                lambda: Some(LambdaArgument::Ambiguous(Lambda { params, expr })),
             },
         },
         FunctionCallSuffix::ParamsWindow {
@@ -3007,9 +3037,9 @@ pub fn function_call(i: Input) -> IResult<ExprElement> {
                 lambda: None,
             },
         },
-        },
-    )
-    .parse(i)
+    };
+
+    Ok((rest, elem))
 }
 
 pub fn parse_float(text: &str) -> Result<Literal, ErrorKind> {

--- a/src/query/ast/src/visit/expr.rs
+++ b/src/query/ast/src/visit/expr.rs
@@ -15,6 +15,7 @@
 use crate::ast::Expr;
 use crate::ast::FunctionCall;
 use crate::ast::Identifier;
+use crate::ast::LambdaArgument;
 use crate::ast::MapAccessor;
 use crate::ast::WindowDesc;
 use crate::visit::VisitControl;
@@ -406,7 +407,12 @@ impl Walk for FunctionCall {
         if let Some(window) = &self.window {
             try_walk!(window.walk(visitor));
         }
-        if let Some(lambda) = &self.lambda {
+        if let Some(LambdaArgument::Lambda(lambda)) = &self.lambda {
+            try_walk!(lambda.walk(visitor));
+        } else if let Some(LambdaArgument::Ambiguous(lambda)) = &self.lambda {
+            // The ordinary interpretation is walked through `args`; walk the
+            // lambda interpretation as well because the function kind has not
+            // been resolved at the AST layer yet.
             try_walk!(lambda.walk(visitor));
         }
 
@@ -437,7 +443,9 @@ impl WalkMut for FunctionCall {
         if let Some(window) = &mut self.window {
             try_walk!(window.walk_mut(visitor));
         }
-        if let Some(lambda) = &mut self.lambda {
+        if let Some(LambdaArgument::Lambda(lambda)) = &mut self.lambda {
+            try_walk!(lambda.walk_mut(visitor));
+        } else if let Some(LambdaArgument::Ambiguous(lambda)) = &mut self.lambda {
             try_walk!(lambda.walk_mut(visitor));
         }
 

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -1803,6 +1803,25 @@ fn test_ambiguous_trailing_lambda_argument() {
     assert!(matches!(*lambda.expr, Expr::Literal { .. }));
 }
 
+#[test]
+fn test_json_arrow_argument_before_aggregate_filter() {
+    let tokens = tokenize_sql("json_object_agg('k', doc -> 'v') FILTER (WHERE ok)").unwrap();
+    let input = Input {
+        tokens: &tokens,
+        dialect: Dialect::PostgreSQL,
+        mode: ParseMode::Default,
+    };
+    let (_, expr) = expr(input).unwrap();
+    let Expr::FunctionCall { func, .. } = expr else {
+        panic!("expected a function call");
+    };
+
+    assert_eq!(func.args.len(), 2);
+    assert!(matches!(func.args[1], Expr::JsonOp { .. }));
+    assert!(func.lambda.is_none());
+    assert!(func.filter.is_some());
+}
+
 // FIXME: this test cause stack overflow
 // https://github.com/databendlabs/databend/issues/18625
 #[test]

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -1762,6 +1762,8 @@ fn test_expr() {
         r#"ARRAY_MAP(v -> v + 1)"#,
         r#"ARRAY_FILTER(a, v -> v + 1)"#,
         r#"JSON_PATH_TRANSFORM(a, b, v -> v + 1)"#,
+        r#"JSON_PATH_TRANSFORM(a, b, v -> v -> 'name')"#,
+        r#"ARRAY_TRANSFORM(a, (v -> v) + 1)"#,
         r#"MAP_FILTER(a, b, c, (k, v) -> k + v)"#,
         r#"JSON_ARRAY_MAP(doc -> 'items', v -> upper(v))"#,
         r#"TO_STRING(col -> 'name')"#,

--- a/src/query/ast/tests/it/parser.rs
+++ b/src/query/ast/tests/it/parser.rs
@@ -16,6 +16,8 @@ use std::fmt::Debug;
 use std::fmt::Display;
 use std::io::Write;
 
+use databend_common_ast::ast::Expr;
+use databend_common_ast::ast::LambdaArgument;
 use databend_common_ast::ast::quote::QuotedIdent;
 use databend_common_ast::ast::quote::ident_needs_quote;
 use databend_common_ast::parser::expr::*;
@@ -1767,6 +1769,7 @@ fn test_expr() {
         r#"MAP_FILTER(a, b, c, (k, v) -> k + v)"#,
         r#"JSON_ARRAY_MAP(doc -> 'items', v -> upper(v))"#,
         r#"TO_STRING(col -> 'name')"#,
+        r#"CONCAT(a, b, doc -> 'key')"#,
         r#"CONCAT(a -> 'k', b)"#,
         r#"INTERVAL '1 YEAR'"#,
         r#"(?, ?)"#,
@@ -1776,6 +1779,28 @@ fn test_expr() {
     for case in cases {
         run_parser(file, expr, case);
     }
+}
+
+#[test]
+fn test_ambiguous_trailing_lambda_argument() {
+    let tokens = tokenize_sql("concat(a, b, doc -> 'key')").unwrap();
+    let input = Input {
+        tokens: &tokens,
+        dialect: Dialect::PostgreSQL,
+        mode: ParseMode::Default,
+    };
+    let (_, expr) = expr(input).unwrap();
+    let Expr::FunctionCall { func, .. } = expr else {
+        panic!("expected a function call");
+    };
+
+    assert_eq!(func.args.len(), 3);
+    assert!(matches!(func.args[2], Expr::JsonOp { .. }));
+    let Some(LambdaArgument::Ambiguous(lambda)) = func.lambda else {
+        panic!("expected an ambiguous trailing lambda argument");
+    };
+    assert_eq!(lambda.params[0].name, "doc");
+    assert!(matches!(*lambda.expr, Expr::Literal { .. }));
 }
 
 // FIXME: this test cause stack overflow

--- a/src/query/ast/tests/it/testdata/dialect.txt
+++ b/src/query/ast/tests/it/testdata/dialect.txt
@@ -1038,65 +1038,67 @@ FunctionCall {
                     filter: None,
                     window: None,
                     lambda: Some(
-                        Lambda {
-                            params: [
-                                Identifier {
-                                    span: Some(
-                                        14..15,
-                                    ),
-                                    name: "x",
-                                    quote: None,
-                                    ident_type: None,
-                                },
-                            ],
-                            expr: BinaryOp {
-                                span: Some(
-                                    36..37,
-                                ),
-                                op: Eq,
-                                left: BinaryOp {
-                                    span: Some(
-                                        32..33,
-                                    ),
-                                    op: Modulo,
-                                    left: ColumnRef {
+                        Lambda(
+                            Lambda {
+                                params: [
+                                    Identifier {
                                         span: Some(
-                                            30..31,
+                                            14..15,
                                         ),
-                                        column: ColumnRef {
-                                            database: None,
-                                            table: None,
-                                            column: Name(
-                                                Identifier {
-                                                    span: Some(
-                                                        30..31,
-                                                    ),
-                                                    name: "x",
-                                                    quote: None,
-                                                    ident_type: None,
-                                                },
+                                        name: "x",
+                                        quote: None,
+                                        ident_type: None,
+                                    },
+                                ],
+                                expr: BinaryOp {
+                                    span: Some(
+                                        36..37,
+                                    ),
+                                    op: Eq,
+                                    left: BinaryOp {
+                                        span: Some(
+                                            32..33,
+                                        ),
+                                        op: Modulo,
+                                        left: ColumnRef {
+                                            span: Some(
+                                                30..31,
+                                            ),
+                                            column: ColumnRef {
+                                                database: None,
+                                                table: None,
+                                                column: Name(
+                                                    Identifier {
+                                                        span: Some(
+                                                            30..31,
+                                                        ),
+                                                        name: "x",
+                                                        quote: None,
+                                                        ident_type: None,
+                                                    },
+                                                ),
+                                            },
+                                        },
+                                        right: Literal {
+                                            span: Some(
+                                                34..35,
+                                            ),
+                                            value: UInt64(
+                                                2,
                                             ),
                                         },
                                     },
                                     right: Literal {
                                         span: Some(
-                                            34..35,
+                                            38..39,
                                         ),
                                         value: UInt64(
-                                            2,
+                                            0,
                                         ),
                                     },
                                 },
-                                right: Literal {
-                                    span: Some(
-                                        38..39,
-                                    ),
-                                    value: UInt64(
-                                        0,
-                                    ),
-                                },
                             },
-                        },
+                        ),
                     ),
                 },
             },
@@ -1106,51 +1108,53 @@ FunctionCall {
         filter: None,
         window: None,
         lambda: Some(
-            Lambda {
-                params: [
-                    Identifier {
+            Lambda(
+                Lambda {
+                    params: [
+                        Identifier {
+                            span: Some(
+                                14..15,
+                            ),
+                            name: "x",
+                            quote: None,
+                            ident_type: None,
+                        },
+                    ],
+                    expr: BinaryOp {
                         span: Some(
-                            14..15,
+                            4..5,
                         ),
-                        name: "x",
-                        quote: None,
-                        ident_type: None,
-                    },
-                ],
-                expr: BinaryOp {
-                    span: Some(
-                        4..5,
-                    ),
-                    op: Multiply,
-                    left: ColumnRef {
-                        span: Some(
-                            2..3,
-                        ),
-                        column: ColumnRef {
-                            database: None,
-                            table: None,
-                            column: Name(
-                                Identifier {
-                                    span: Some(
-                                        2..3,
-                                    ),
-                                    name: "x",
-                                    quote: None,
-                                    ident_type: None,
-                                },
+                        op: Multiply,
+                        left: ColumnRef {
+                            span: Some(
+                                2..3,
+                            ),
+                            column: ColumnRef {
+                                database: None,
+                                table: None,
+                                column: Name(
+                                    Identifier {
+                                        span: Some(
+                                            2..3,
+                                        ),
+                                        name: "x",
+                                        quote: None,
+                                        ident_type: None,
+                                    },
+                                ),
+                            },
+                        },
+                        right: Literal {
+                            span: Some(
+                                6..9,
+                            ),
+                            value: UInt64(
+                                100,
                             ),
                         },
                     },
-                    right: Literal {
-                        span: Some(
-                            6..9,
-                        ),
-                        value: UInt64(
-                            100,
-                        ),
-                    },
                 },
-            },
+            ),
         ),
     },
 }

--- a/src/query/ast/tests/it/testdata/expr.txt
+++ b/src/query/ast/tests/it/testdata/expr.txt
@@ -6696,29 +6696,36 @@ FunctionCall {
                     },
                 ],
             },
-        ],
-        params: [],
-        order_by: [],
-        filter: None,
-        window: None,
-        lambda: Some(
-            Lambda {
-                params: [
-                    Identifier {
+            BinaryOp {
+                span: Some(
+                    28..29,
+                ),
+                op: Plus,
+                left: JsonOp {
+                    span: Some(
+                        23..25,
+                    ),
+                    op: Arrow,
+                    left: ColumnRef {
                         span: Some(
                             21..22,
                         ),
-                        name: "x",
-                        quote: None,
-                        ident_type: None,
+                        column: ColumnRef {
+                            database: None,
+                            table: None,
+                            column: Name(
+                                Identifier {
+                                    span: Some(
+                                        21..22,
+                                    ),
+                                    name: "x",
+                                    quote: None,
+                                    ident_type: None,
+                                },
+                            ),
+                        },
                     },
-                ],
-                expr: BinaryOp {
-                    span: Some(
-                        28..29,
-                    ),
-                    op: Plus,
-                    left: ColumnRef {
+                    right: ColumnRef {
                         span: Some(
                             26..27,
                         ),
@@ -6737,16 +6744,23 @@ FunctionCall {
                             ),
                         },
                     },
-                    right: Literal {
-                        span: Some(
-                            30..31,
-                        ),
-                        value: UInt64(
-                            1,
-                        ),
-                    },
+                },
+                right: Literal {
+                    span: Some(
+                        30..31,
+                    ),
+                    value: UInt64(
+                        1,
+                    ),
                 },
             },
+        ],
+        params: [],
+        order_by: [],
+        filter: None,
+        window: None,
+        lambda: Some(
+            Ambiguous,
         ),
     },
 }
@@ -6791,34 +6805,41 @@ FunctionCall {
                     ),
                 },
             },
-        ],
-        params: [],
-        order_by: [],
-        filter: None,
-        window: None,
-        lambda: Some(
-            Lambda {
-                params: [
-                    Identifier {
-                        span: Some(
-                            18..19,
-                        ),
-                        name: "y",
-                        quote: None,
-                        ident_type: None,
-                    },
-                ],
-                expr: BinaryOp {
+            BinaryOp {
+                span: Some(
+                    29..30,
+                ),
+                op: Eq,
+                left: BinaryOp {
                     span: Some(
-                        29..30,
+                        25..26,
                     ),
-                    op: Eq,
-                    left: BinaryOp {
+                    op: Modulo,
+                    left: JsonOp {
                         span: Some(
-                            25..26,
+                            20..22,
                         ),
-                        op: Modulo,
+                        op: Arrow,
                         left: ColumnRef {
+                            span: Some(
+                                18..19,
+                            ),
+                            column: ColumnRef {
+                                database: None,
+                                table: None,
+                                column: Name(
+                                    Identifier {
+                                        span: Some(
+                                            18..19,
+                                        ),
+                                        name: "y",
+                                        quote: None,
+                                        ident_type: None,
+                                    },
+                                ),
+                            },
+                        },
+                        right: ColumnRef {
                             span: Some(
                                 23..24,
                             ),
@@ -6837,25 +6858,32 @@ FunctionCall {
                                 ),
                             },
                         },
-                        right: Literal {
-                            span: Some(
-                                27..28,
-                            ),
-                            value: UInt64(
-                                2,
-                            ),
-                        },
                     },
                     right: Literal {
                         span: Some(
-                            31..32,
+                            27..28,
                         ),
                         value: UInt64(
-                            0,
+                            2,
                         ),
                     },
                 },
+                right: Literal {
+                    span: Some(
+                        31..32,
+                    ),
+                    value: UInt64(
+                        0,
+                    ),
+                },
             },
+        ],
+        params: [],
+        order_by: [],
+        filter: None,
+        window: None,
+        lambda: Some(
+            Ambiguous,
         ),
     },
 }
@@ -6992,37 +7020,62 @@ FunctionCall {
                     },
                 ],
             },
-        ],
-        params: [],
-        order_by: [],
-        filter: None,
-        window: None,
-        lambda: Some(
-            Lambda {
-                params: [
-                    Identifier {
-                        span: Some(
-                            23..26,
-                        ),
-                        name: "acc",
-                        quote: None,
-                        ident_type: None,
-                    },
-                    Identifier {
-                        span: Some(
-                            27..28,
-                        ),
-                        name: "t",
-                        quote: None,
-                        ident_type: None,
-                    },
-                ],
-                expr: BinaryOp {
+            BinaryOp {
+                span: Some(
+                    37..38,
+                ),
+                op: Plus,
+                left: JsonOp {
                     span: Some(
-                        37..38,
+                        30..32,
                     ),
-                    op: Plus,
-                    left: ColumnRef {
+                    op: Arrow,
+                    left: Tuple {
+                        span: Some(
+                            22..29,
+                        ),
+                        exprs: [
+                            ColumnRef {
+                                span: Some(
+                                    23..26,
+                                ),
+                                column: ColumnRef {
+                                    database: None,
+                                    table: None,
+                                    column: Name(
+                                        Identifier {
+                                            span: Some(
+                                                23..26,
+                                            ),
+                                            name: "acc",
+                                            quote: None,
+                                            ident_type: None,
+                                        },
+                                    ),
+                                },
+                            },
+                            ColumnRef {
+                                span: Some(
+                                    27..28,
+                                ),
+                                column: ColumnRef {
+                                    database: None,
+                                    table: None,
+                                    column: Name(
+                                        Identifier {
+                                            span: Some(
+                                                27..28,
+                                            ),
+                                            name: "t",
+                                            quote: None,
+                                            ident_type: None,
+                                        },
+                                    ),
+                                },
+                            },
+                        ],
+                    },
+                    right: ColumnRef {
                         span: Some(
                             33..36,
                         ),
@@ -7041,27 +7094,34 @@ FunctionCall {
                             ),
                         },
                     },
-                    right: ColumnRef {
-                        span: Some(
-                            39..40,
+                },
+                right: ColumnRef {
+                    span: Some(
+                        39..40,
+                    ),
+                    column: ColumnRef {
+                        database: None,
+                        table: None,
+                        column: Name(
+                            Identifier {
+                                span: Some(
+                                    39..40,
+                                ),
+                                name: "t",
+                                quote: None,
+                                ident_type: None,
+                            },
                         ),
-                        column: ColumnRef {
-                            database: None,
-                            table: None,
-                            column: Name(
-                                Identifier {
-                                    span: Some(
-                                        39..40,
-                                    ),
-                                    name: "t",
-                                    quote: None,
-                                    ident_type: None,
-                                },
-                            ),
-                        },
                     },
                 },
             },
+        ],
+        params: [],
+        order_by: [],
+        filter: None,
+        window: None,
+        lambda: Some(
+            Ambiguous,
         ),
     },
 }
@@ -7133,37 +7193,62 @@ FunctionCall {
                     ),
                 ],
             },
-        ],
-        params: [],
-        order_by: [],
-        filter: None,
-        window: None,
-        lambda: Some(
-            Lambda {
-                params: [
-                    Identifier {
-                        span: Some(
-                            27..28,
-                        ),
-                        name: "k",
-                        quote: None,
-                        ident_type: None,
-                    },
-                    Identifier {
-                        span: Some(
-                            30..31,
-                        ),
-                        name: "v",
-                        quote: None,
-                        ident_type: None,
-                    },
-                ],
-                expr: BinaryOp {
+            BinaryOp {
+                span: Some(
+                    38..39,
+                ),
+                op: Gt,
+                left: JsonOp {
                     span: Some(
-                        38..39,
+                        33..35,
                     ),
-                    op: Gt,
-                    left: ColumnRef {
+                    op: Arrow,
+                    left: Tuple {
+                        span: Some(
+                            26..32,
+                        ),
+                        exprs: [
+                            ColumnRef {
+                                span: Some(
+                                    27..28,
+                                ),
+                                column: ColumnRef {
+                                    database: None,
+                                    table: None,
+                                    column: Name(
+                                        Identifier {
+                                            span: Some(
+                                                27..28,
+                                            ),
+                                            name: "k",
+                                            quote: None,
+                                            ident_type: None,
+                                        },
+                                    ),
+                                },
+                            },
+                            ColumnRef {
+                                span: Some(
+                                    30..31,
+                                ),
+                                column: ColumnRef {
+                                    database: None,
+                                    table: None,
+                                    column: Name(
+                                        Identifier {
+                                            span: Some(
+                                                30..31,
+                                            ),
+                                            name: "v",
+                                            quote: None,
+                                            ident_type: None,
+                                        },
+                                    ),
+                                },
+                            },
+                        ],
+                    },
+                    right: ColumnRef {
                         span: Some(
                             36..37,
                         ),
@@ -7182,27 +7267,34 @@ FunctionCall {
                             ),
                         },
                     },
-                    right: ColumnRef {
-                        span: Some(
-                            40..41,
+                },
+                right: ColumnRef {
+                    span: Some(
+                        40..41,
+                    ),
+                    column: ColumnRef {
+                        database: None,
+                        table: None,
+                        column: Name(
+                            Identifier {
+                                span: Some(
+                                    40..41,
+                                ),
+                                name: "v",
+                                quote: None,
+                                ident_type: None,
+                            },
                         ),
-                        column: ColumnRef {
-                            database: None,
-                            table: None,
-                            column: Name(
-                                Identifier {
-                                    span: Some(
-                                        40..41,
-                                    ),
-                                    name: "v",
-                                    quote: None,
-                                    ident_type: None,
-                                },
-                            ),
-                        },
                     },
                 },
             },
+        ],
+        params: [],
+        order_by: [],
+        filter: None,
+        window: None,
+        lambda: Some(
+            Ambiguous,
         ),
     },
 }
@@ -7274,37 +7366,62 @@ FunctionCall {
                     ),
                 ],
             },
-        ],
-        params: [],
-        order_by: [],
-        filter: None,
-        window: None,
-        lambda: Some(
-            Lambda {
-                params: [
-                    Identifier {
-                        span: Some(
-                            38..39,
-                        ),
-                        name: "k",
-                        quote: None,
-                        ident_type: None,
-                    },
-                    Identifier {
-                        span: Some(
-                            41..42,
-                        ),
-                        name: "v",
-                        quote: None,
-                        ident_type: None,
-                    },
-                ],
-                expr: BinaryOp {
+            BinaryOp {
+                span: Some(
+                    49..50,
+                ),
+                op: Plus,
+                left: JsonOp {
                     span: Some(
-                        49..50,
+                        44..46,
                     ),
-                    op: Plus,
-                    left: ColumnRef {
+                    op: Arrow,
+                    left: Tuple {
+                        span: Some(
+                            37..43,
+                        ),
+                        exprs: [
+                            ColumnRef {
+                                span: Some(
+                                    38..39,
+                                ),
+                                column: ColumnRef {
+                                    database: None,
+                                    table: None,
+                                    column: Name(
+                                        Identifier {
+                                            span: Some(
+                                                38..39,
+                                            ),
+                                            name: "k",
+                                            quote: None,
+                                            ident_type: None,
+                                        },
+                                    ),
+                                },
+                            },
+                            ColumnRef {
+                                span: Some(
+                                    41..42,
+                                ),
+                                column: ColumnRef {
+                                    database: None,
+                                    table: None,
+                                    column: Name(
+                                        Identifier {
+                                            span: Some(
+                                                41..42,
+                                            ),
+                                            name: "v",
+                                            quote: None,
+                                            ident_type: None,
+                                        },
+                                    ),
+                                },
+                            },
+                        ],
+                    },
+                    right: ColumnRef {
                         span: Some(
                             47..48,
                         ),
@@ -7323,16 +7440,23 @@ FunctionCall {
                             ),
                         },
                     },
-                    right: Literal {
-                        span: Some(
-                            51..52,
-                        ),
-                        value: UInt64(
-                            1,
-                        ),
-                    },
+                },
+                right: Literal {
+                    span: Some(
+                        51..52,
+                    ),
+                    value: UInt64(
+                        1,
+                    ),
                 },
             },
+        ],
+        params: [],
+        order_by: [],
+        filter: None,
+        window: None,
+        lambda: Some(
+            Ambiguous,
         ),
     },
 }
@@ -7404,37 +7528,62 @@ FunctionCall {
                     ),
                 ],
             },
-        ],
-        params: [],
-        order_by: [],
-        filter: None,
-        window: None,
-        lambda: Some(
-            Lambda {
-                params: [
-                    Identifier {
-                        span: Some(
-                            40..41,
-                        ),
-                        name: "k",
-                        quote: None,
-                        ident_type: None,
-                    },
-                    Identifier {
-                        span: Some(
-                            43..44,
-                        ),
-                        name: "v",
-                        quote: None,
-                        ident_type: None,
-                    },
-                ],
-                expr: BinaryOp {
+            BinaryOp {
+                span: Some(
+                    51..52,
+                ),
+                op: Plus,
+                left: JsonOp {
                     span: Some(
-                        51..52,
+                        46..48,
                     ),
-                    op: Plus,
-                    left: ColumnRef {
+                    op: Arrow,
+                    left: Tuple {
+                        span: Some(
+                            39..45,
+                        ),
+                        exprs: [
+                            ColumnRef {
+                                span: Some(
+                                    40..41,
+                                ),
+                                column: ColumnRef {
+                                    database: None,
+                                    table: None,
+                                    column: Name(
+                                        Identifier {
+                                            span: Some(
+                                                40..41,
+                                            ),
+                                            name: "k",
+                                            quote: None,
+                                            ident_type: None,
+                                        },
+                                    ),
+                                },
+                            },
+                            ColumnRef {
+                                span: Some(
+                                    43..44,
+                                ),
+                                column: ColumnRef {
+                                    database: None,
+                                    table: None,
+                                    column: Name(
+                                        Identifier {
+                                            span: Some(
+                                                43..44,
+                                            ),
+                                            name: "v",
+                                            quote: None,
+                                            ident_type: None,
+                                        },
+                                    ),
+                                },
+                            },
+                        ],
+                    },
+                    right: ColumnRef {
                         span: Some(
                             49..50,
                         ),
@@ -7453,16 +7602,23 @@ FunctionCall {
                             ),
                         },
                     },
-                    right: Literal {
-                        span: Some(
-                            53..54,
-                        ),
-                        value: UInt64(
-                            1,
-                        ),
-                    },
+                },
+                right: Literal {
+                    span: Some(
+                        53..54,
+                    ),
+                    value: UInt64(
+                        1,
+                    ),
                 },
             },
+        ],
+        params: [],
+        order_by: [],
+        filter: None,
+        window: None,
+        lambda: Some(
+            Ambiguous,
         ),
     },
 }
@@ -7515,24 +7671,31 @@ FunctionCall {
                     "$[*].name",
                 ),
             },
-        ],
-        params: [],
-        order_by: [],
-        filter: None,
-        window: None,
-        lambda: Some(
-            Lambda {
-                params: [
-                    Identifier {
-                        span: Some(
-                            38..39,
+            JsonOp {
+                span: Some(
+                    40..42,
+                ),
+                op: Arrow,
+                left: ColumnRef {
+                    span: Some(
+                        38..39,
+                    ),
+                    column: ColumnRef {
+                        database: None,
+                        table: None,
+                        column: Name(
+                            Identifier {
+                                span: Some(
+                                    38..39,
+                                ),
+                                name: "v",
+                                quote: None,
+                                ident_type: None,
+                            },
                         ),
-                        name: "v",
-                        quote: None,
-                        ident_type: None,
                     },
-                ],
-                expr: FunctionCall {
+                },
+                right: FunctionCall {
                     span: Some(
                         43..51,
                     ),
@@ -7575,6 +7738,13 @@ FunctionCall {
                     },
                 },
             },
+        ],
+        params: [],
+        order_by: [],
+        filter: None,
+        window: None,
+        lambda: Some(
+            Ambiguous,
         ),
     },
 }
@@ -7707,29 +7877,36 @@ FunctionCall {
                     ),
                 },
             },
-        ],
-        params: [],
-        order_by: [],
-        filter: None,
-        window: None,
-        lambda: Some(
-            Lambda {
-                params: [
-                    Identifier {
+            BinaryOp {
+                span: Some(
+                    23..24,
+                ),
+                op: Plus,
+                left: JsonOp {
+                    span: Some(
+                        18..20,
+                    ),
+                    op: Arrow,
+                    left: ColumnRef {
                         span: Some(
                             16..17,
                         ),
-                        name: "v",
-                        quote: None,
-                        ident_type: None,
+                        column: ColumnRef {
+                            database: None,
+                            table: None,
+                            column: Name(
+                                Identifier {
+                                    span: Some(
+                                        16..17,
+                                    ),
+                                    name: "v",
+                                    quote: None,
+                                    ident_type: None,
+                                },
+                            ),
+                        },
                     },
-                ],
-                expr: BinaryOp {
-                    span: Some(
-                        23..24,
-                    ),
-                    op: Plus,
-                    left: ColumnRef {
+                    right: ColumnRef {
                         span: Some(
                             21..22,
                         ),
@@ -7748,16 +7925,23 @@ FunctionCall {
                             ),
                         },
                     },
-                    right: Literal {
-                        span: Some(
-                            25..26,
-                        ),
-                        value: UInt64(
-                            1,
-                        ),
-                    },
+                },
+                right: Literal {
+                    span: Some(
+                        25..26,
+                    ),
+                    value: UInt64(
+                        1,
+                    ),
                 },
             },
+        ],
+        params: [],
+        order_by: [],
+        filter: None,
+        window: None,
+        lambda: Some(
+            Ambiguous,
         ),
     },
 }
@@ -7821,29 +8005,36 @@ FunctionCall {
                     ),
                 },
             },
-        ],
-        params: [],
-        order_by: [],
-        filter: None,
-        window: None,
-        lambda: Some(
-            Lambda {
-                params: [
-                    Identifier {
+            BinaryOp {
+                span: Some(
+                    33..34,
+                ),
+                op: Plus,
+                left: JsonOp {
+                    span: Some(
+                        28..30,
+                    ),
+                    op: Arrow,
+                    left: ColumnRef {
                         span: Some(
                             26..27,
                         ),
-                        name: "v",
-                        quote: None,
-                        ident_type: None,
+                        column: ColumnRef {
+                            database: None,
+                            table: None,
+                            column: Name(
+                                Identifier {
+                                    span: Some(
+                                        26..27,
+                                    ),
+                                    name: "v",
+                                    quote: None,
+                                    ident_type: None,
+                                },
+                            ),
+                        },
                     },
-                ],
-                expr: BinaryOp {
-                    span: Some(
-                        33..34,
-                    ),
-                    op: Plus,
-                    left: ColumnRef {
+                    right: ColumnRef {
                         span: Some(
                             31..32,
                         ),
@@ -7862,16 +8053,23 @@ FunctionCall {
                             ),
                         },
                     },
-                    right: Literal {
-                        span: Some(
-                            35..36,
-                        ),
-                        value: UInt64(
-                            1,
-                        ),
-                    },
+                },
+                right: Literal {
+                    span: Some(
+                        35..36,
+                    ),
+                    value: UInt64(
+                        1,
+                    ),
                 },
             },
+        ],
+        params: [],
+        order_by: [],
+        filter: None,
+        window: None,
+        lambda: Some(
+            Ambiguous,
         ),
     },
 }
@@ -7935,29 +8133,36 @@ FunctionCall {
                     ),
                 },
             },
-        ],
-        params: [],
-        order_by: [],
-        filter: None,
-        window: None,
-        lambda: Some(
-            Lambda {
-                params: [
-                    Identifier {
-                        span: Some(
-                            26..27,
-                        ),
-                        name: "v",
-                        quote: None,
-                        ident_type: None,
-                    },
-                ],
-                expr: JsonOp {
+            JsonOp {
+                span: Some(
+                    33..35,
+                ),
+                op: Arrow,
+                left: JsonOp {
                     span: Some(
-                        33..35,
+                        28..30,
                     ),
                     op: Arrow,
                     left: ColumnRef {
+                        span: Some(
+                            26..27,
+                        ),
+                        column: ColumnRef {
+                            database: None,
+                            table: None,
+                            column: Name(
+                                Identifier {
+                                    span: Some(
+                                        26..27,
+                                    ),
+                                    name: "v",
+                                    quote: None,
+                                    ident_type: None,
+                                },
+                            ),
+                        },
+                    },
+                    right: ColumnRef {
                         span: Some(
                             31..32,
                         ),
@@ -7976,16 +8181,23 @@ FunctionCall {
                             ),
                         },
                     },
-                    right: Literal {
-                        span: Some(
-                            36..42,
-                        ),
-                        value: String(
-                            "name",
-                        ),
-                    },
+                },
+                right: Literal {
+                    span: Some(
+                        36..42,
+                    ),
+                    value: String(
+                        "name",
+                    ),
                 },
             },
+        ],
+        params: [],
+        order_by: [],
+        filter: None,
+        window: None,
+        lambda: Some(
+            Ambiguous,
         ),
     },
 }
@@ -8175,37 +8387,62 @@ FunctionCall {
                     ),
                 },
             },
-        ],
-        params: [],
-        order_by: [],
-        filter: None,
-        window: None,
-        lambda: Some(
-            Lambda {
-                params: [
-                    Identifier {
-                        span: Some(
-                            21..22,
-                        ),
-                        name: "k",
-                        quote: None,
-                        ident_type: None,
-                    },
-                    Identifier {
-                        span: Some(
-                            24..25,
-                        ),
-                        name: "v",
-                        quote: None,
-                        ident_type: None,
-                    },
-                ],
-                expr: BinaryOp {
+            BinaryOp {
+                span: Some(
+                    32..33,
+                ),
+                op: Plus,
+                left: JsonOp {
                     span: Some(
-                        32..33,
+                        27..29,
                     ),
-                    op: Plus,
-                    left: ColumnRef {
+                    op: Arrow,
+                    left: Tuple {
+                        span: Some(
+                            20..26,
+                        ),
+                        exprs: [
+                            ColumnRef {
+                                span: Some(
+                                    21..22,
+                                ),
+                                column: ColumnRef {
+                                    database: None,
+                                    table: None,
+                                    column: Name(
+                                        Identifier {
+                                            span: Some(
+                                                21..22,
+                                            ),
+                                            name: "k",
+                                            quote: None,
+                                            ident_type: None,
+                                        },
+                                    ),
+                                },
+                            },
+                            ColumnRef {
+                                span: Some(
+                                    24..25,
+                                ),
+                                column: ColumnRef {
+                                    database: None,
+                                    table: None,
+                                    column: Name(
+                                        Identifier {
+                                            span: Some(
+                                                24..25,
+                                            ),
+                                            name: "v",
+                                            quote: None,
+                                            ident_type: None,
+                                        },
+                                    ),
+                                },
+                            },
+                        ],
+                    },
+                    right: ColumnRef {
                         span: Some(
                             30..31,
                         ),
@@ -8224,27 +8461,34 @@ FunctionCall {
                             ),
                         },
                     },
-                    right: ColumnRef {
-                        span: Some(
-                            34..35,
+                },
+                right: ColumnRef {
+                    span: Some(
+                        34..35,
+                    ),
+                    column: ColumnRef {
+                        database: None,
+                        table: None,
+                        column: Name(
+                            Identifier {
+                                span: Some(
+                                    34..35,
+                                ),
+                                name: "v",
+                                quote: None,
+                                ident_type: None,
+                            },
                         ),
-                        column: ColumnRef {
-                            database: None,
-                            table: None,
-                            column: Name(
-                                Identifier {
-                                    span: Some(
-                                        34..35,
-                                    ),
-                                    name: "v",
-                                    quote: None,
-                                    ident_type: None,
-                                },
-                            ),
-                        },
                     },
                 },
             },
+        ],
+        params: [],
+        order_by: [],
+        filter: None,
+        window: None,
+        lambda: Some(
+            Ambiguous,
         ),
     },
 }
@@ -8303,24 +8547,31 @@ FunctionCall {
                     ),
                 },
             },
-        ],
-        params: [],
-        order_by: [],
-        filter: None,
-        window: None,
-        lambda: Some(
-            Lambda {
-                params: [
-                    Identifier {
-                        span: Some(
-                            31..32,
+            JsonOp {
+                span: Some(
+                    33..35,
+                ),
+                op: Arrow,
+                left: ColumnRef {
+                    span: Some(
+                        31..32,
+                    ),
+                    column: ColumnRef {
+                        database: None,
+                        table: None,
+                        column: Name(
+                            Identifier {
+                                span: Some(
+                                    31..32,
+                                ),
+                                name: "v",
+                                quote: None,
+                                ident_type: None,
+                            },
                         ),
-                        name: "v",
-                        quote: None,
-                        ident_type: None,
                     },
-                ],
-                expr: FunctionCall {
+                },
+                right: FunctionCall {
                     span: Some(
                         36..44,
                     ),
@@ -8363,6 +8614,13 @@ FunctionCall {
                     },
                 },
             },
+        ],
+        params: [],
+        order_by: [],
+        filter: None,
+        window: None,
+        lambda: Some(
+            Ambiguous,
         ),
     },
 }
@@ -8427,6 +8685,109 @@ FunctionCall {
         filter: None,
         window: None,
         lambda: None,
+    },
+}
+
+
+---------- Input ----------
+CONCAT(a, b, doc -> 'key')
+---------- Output ---------
+CONCAT(a, b, doc -> 'key')
+---------- AST ------------
+FunctionCall {
+    span: Some(
+        0..26,
+    ),
+    func: FunctionCall {
+        distinct: false,
+        name: Identifier {
+            span: Some(
+                0..6,
+            ),
+            name: "CONCAT",
+            quote: None,
+            ident_type: None,
+        },
+        args: [
+            ColumnRef {
+                span: Some(
+                    7..8,
+                ),
+                column: ColumnRef {
+                    database: None,
+                    table: None,
+                    column: Name(
+                        Identifier {
+                            span: Some(
+                                7..8,
+                            ),
+                            name: "a",
+                            quote: None,
+                            ident_type: None,
+                        },
+                    ),
+                },
+            },
+            ColumnRef {
+                span: Some(
+                    10..11,
+                ),
+                column: ColumnRef {
+                    database: None,
+                    table: None,
+                    column: Name(
+                        Identifier {
+                            span: Some(
+                                10..11,
+                            ),
+                            name: "b",
+                            quote: None,
+                            ident_type: None,
+                        },
+                    ),
+                },
+            },
+            JsonOp {
+                span: Some(
+                    17..19,
+                ),
+                op: Arrow,
+                left: ColumnRef {
+                    span: Some(
+                        13..16,
+                    ),
+                    column: ColumnRef {
+                        database: None,
+                        table: None,
+                        column: Name(
+                            Identifier {
+                                span: Some(
+                                    13..16,
+                                ),
+                                name: "doc",
+                                quote: None,
+                                ident_type: None,
+                            },
+                        ),
+                    },
+                },
+                right: Literal {
+                    span: Some(
+                        20..25,
+                    ),
+                    value: String(
+                        "key",
+                    ),
+                },
+            },
+        ],
+        params: [],
+        order_by: [],
+        filter: None,
+        window: None,
+        lambda: Some(
+            Ambiguous,
+        ),
     },
 }
 

--- a/src/query/ast/tests/it/testdata/expr.txt
+++ b/src/query/ast/tests/it/testdata/expr.txt
@@ -7599,29 +7599,37 @@ FunctionCall {
             quote: None,
             ident_type: None,
         },
-        args: [],
-        params: [],
-        order_by: [],
-        filter: None,
-        window: None,
-        lambda: Some(
-            Lambda {
-                params: [
-                    Identifier {
+        args: [
+            BinaryOp {
+                span: Some(
+                    17..18,
+                ),
+                op: Plus,
+                left: JsonOp {
+                    span: Some(
+                        12..14,
+                    ),
+                    op: Arrow,
+                    left: ColumnRef {
                         span: Some(
                             10..11,
                         ),
-                        name: "v",
-                        quote: None,
-                        ident_type: None,
+                        column: ColumnRef {
+                            database: None,
+                            table: None,
+                            column: Name(
+                                Identifier {
+                                    span: Some(
+                                        10..11,
+                                    ),
+                                    name: "v",
+                                    quote: None,
+                                    ident_type: None,
+                                },
+                            ),
+                        },
                     },
-                ],
-                expr: BinaryOp {
-                    span: Some(
-                        17..18,
-                    ),
-                    op: Plus,
-                    left: ColumnRef {
+                    right: ColumnRef {
                         span: Some(
                             15..16,
                         ),
@@ -7640,17 +7648,22 @@ FunctionCall {
                             ),
                         },
                     },
-                    right: Literal {
-                        span: Some(
-                            19..20,
-                        ),
-                        value: UInt64(
-                            1,
-                        ),
-                    },
+                },
+                right: Literal {
+                    span: Some(
+                        19..20,
+                    ),
+                    value: UInt64(
+                        1,
+                    ),
                 },
             },
-        ),
+        ],
+        params: [],
+        order_by: [],
+        filter: None,
+        window: None,
+        lambda: None,
     },
 }
 
@@ -7860,6 +7873,227 @@ FunctionCall {
                 },
             },
         ),
+    },
+}
+
+
+---------- Input ----------
+JSON_PATH_TRANSFORM(a, b, v -> v -> 'name')
+---------- Output ---------
+JSON_PATH_TRANSFORM(a, b, v -> v -> 'name')
+---------- AST ------------
+FunctionCall {
+    span: Some(
+        0..43,
+    ),
+    func: FunctionCall {
+        distinct: false,
+        name: Identifier {
+            span: Some(
+                0..19,
+            ),
+            name: "JSON_PATH_TRANSFORM",
+            quote: None,
+            ident_type: None,
+        },
+        args: [
+            ColumnRef {
+                span: Some(
+                    20..21,
+                ),
+                column: ColumnRef {
+                    database: None,
+                    table: None,
+                    column: Name(
+                        Identifier {
+                            span: Some(
+                                20..21,
+                            ),
+                            name: "a",
+                            quote: None,
+                            ident_type: None,
+                        },
+                    ),
+                },
+            },
+            ColumnRef {
+                span: Some(
+                    23..24,
+                ),
+                column: ColumnRef {
+                    database: None,
+                    table: None,
+                    column: Name(
+                        Identifier {
+                            span: Some(
+                                23..24,
+                            ),
+                            name: "b",
+                            quote: None,
+                            ident_type: None,
+                        },
+                    ),
+                },
+            },
+        ],
+        params: [],
+        order_by: [],
+        filter: None,
+        window: None,
+        lambda: Some(
+            Lambda {
+                params: [
+                    Identifier {
+                        span: Some(
+                            26..27,
+                        ),
+                        name: "v",
+                        quote: None,
+                        ident_type: None,
+                    },
+                ],
+                expr: JsonOp {
+                    span: Some(
+                        33..35,
+                    ),
+                    op: Arrow,
+                    left: ColumnRef {
+                        span: Some(
+                            31..32,
+                        ),
+                        column: ColumnRef {
+                            database: None,
+                            table: None,
+                            column: Name(
+                                Identifier {
+                                    span: Some(
+                                        31..32,
+                                    ),
+                                    name: "v",
+                                    quote: None,
+                                    ident_type: None,
+                                },
+                            ),
+                        },
+                    },
+                    right: Literal {
+                        span: Some(
+                            36..42,
+                        ),
+                        value: String(
+                            "name",
+                        ),
+                    },
+                },
+            },
+        ),
+    },
+}
+
+
+---------- Input ----------
+ARRAY_TRANSFORM(a, (v -> v) + 1)
+---------- Output ---------
+ARRAY_TRANSFORM(a, v -> v + 1)
+---------- AST ------------
+FunctionCall {
+    span: Some(
+        0..32,
+    ),
+    func: FunctionCall {
+        distinct: false,
+        name: Identifier {
+            span: Some(
+                0..15,
+            ),
+            name: "ARRAY_TRANSFORM",
+            quote: None,
+            ident_type: None,
+        },
+        args: [
+            ColumnRef {
+                span: Some(
+                    16..17,
+                ),
+                column: ColumnRef {
+                    database: None,
+                    table: None,
+                    column: Name(
+                        Identifier {
+                            span: Some(
+                                16..17,
+                            ),
+                            name: "a",
+                            quote: None,
+                            ident_type: None,
+                        },
+                    ),
+                },
+            },
+            BinaryOp {
+                span: Some(
+                    28..29,
+                ),
+                op: Plus,
+                left: JsonOp {
+                    span: Some(
+                        22..24,
+                    ),
+                    op: Arrow,
+                    left: ColumnRef {
+                        span: Some(
+                            20..21,
+                        ),
+                        column: ColumnRef {
+                            database: None,
+                            table: None,
+                            column: Name(
+                                Identifier {
+                                    span: Some(
+                                        20..21,
+                                    ),
+                                    name: "v",
+                                    quote: None,
+                                    ident_type: None,
+                                },
+                            ),
+                        },
+                    },
+                    right: ColumnRef {
+                        span: Some(
+                            25..26,
+                        ),
+                        column: ColumnRef {
+                            database: None,
+                            table: None,
+                            column: Name(
+                                Identifier {
+                                    span: Some(
+                                        25..26,
+                                    ),
+                                    name: "v",
+                                    quote: None,
+                                    ident_type: None,
+                                },
+                            ),
+                        },
+                    },
+                },
+                right: Literal {
+                    span: Some(
+                        30..31,
+                    ),
+                    value: UInt64(
+                        1,
+                    ),
+                },
+            },
+        ],
+        params: [],
+        order_by: [],
+        filter: None,
+        window: None,
+        lambda: None,
     },
 }
 

--- a/src/query/functions/Cargo.toml
+++ b/src/query/functions/Cargo.toml
@@ -13,7 +13,6 @@ borsh = { workspace = true }
 bstr = { workspace = true }
 bumpalo = { workspace = true }
 ctor = { workspace = true }
-databend-common-ast = { workspace = true }
 databend-common-base = { workspace = true }
 databend-common-column = { workspace = true }
 databend-common-exception = { workspace = true }
@@ -62,6 +61,7 @@ uuid = { workspace = true }
 [dev-dependencies]
 anyhow = { workspace = true }
 comfy-table = { workspace = true }
+databend-common-ast = { workspace = true }
 databend-common-expression-test-support = { workspace = true }
 divan = { workspace = true }
 goldenfile = { workspace = true }

--- a/src/query/functions/src/lib.rs
+++ b/src/query/functions/src/lib.rs
@@ -20,7 +20,6 @@
 
 use aggregates::AggregateFunctionFactory;
 use ctor::ctor;
-use databend_common_ast::parser::expr::LAMBDA_FUNCTION_NAMES;
 use databend_common_expression::FunctionRegistry;
 use unicase::Ascii;
 
@@ -87,18 +86,25 @@ pub const GENERAL_WINDOW_FUNCTIONS: [Ascii<&str>; 13] = [
 pub const RANK_WINDOW_FUNCTIONS: [&str; 5] =
     ["first_value", "first", "last_value", "last", "nth_value"];
 
-/// The general lambda function names, derived from the parser's
-/// [`LAMBDA_FUNCTION_NAMES`] so the trailing-lambda call grammar and the
-/// semantic lambda registry always agree.
-pub const GENERAL_LAMBDA_FUNCTIONS: [Ascii<&str>; LAMBDA_FUNCTION_NAMES.len()] = {
-    let mut names = [Ascii::new(""); LAMBDA_FUNCTION_NAMES.len()];
-    let mut i = 0;
-    while i < names.len() {
-        names[i] = Ascii::new(LAMBDA_FUNCTION_NAMES[i]);
-        i += 1;
-    }
-    names
-};
+pub const GENERAL_LAMBDA_FUNCTIONS: [Ascii<&str>; 17] = [
+    Ascii::new("array_transform"),
+    Ascii::new("array_apply"),
+    Ascii::new("array_map"),
+    Ascii::new("array_filter"),
+    Ascii::new("array_reduce"),
+    Ascii::new("json_array_transform"),
+    Ascii::new("json_array_apply"),
+    Ascii::new("json_array_map"),
+    Ascii::new("json_array_filter"),
+    Ascii::new("json_array_reduce"),
+    Ascii::new("map_filter"),
+    Ascii::new("map_transform_keys"),
+    Ascii::new("map_transform_values"),
+    Ascii::new("json_map_filter"),
+    Ascii::new("json_map_transform_keys"),
+    Ascii::new("json_map_transform_values"),
+    Ascii::new("json_path_transform"),
+];
 
 pub const GENERAL_SEARCH_FUNCTIONS: [Ascii<&str>; 3] = [
     Ascii::new("match"),

--- a/src/query/sql/src/planner/binder/bind_query/bind_select.rs
+++ b/src/query/sql/src/planner/binder/bind_query/bind_select.rs
@@ -28,6 +28,7 @@ use databend_common_ast::ast::Indirection;
 use databend_common_ast::ast::Join;
 use databend_common_ast::ast::JoinCondition;
 use databend_common_ast::ast::JoinOperator;
+use databend_common_ast::ast::LambdaArgument;
 use databend_common_ast::ast::Literal;
 use databend_common_ast::ast::OrderByExpr;
 use databend_common_ast::ast::Pivot;
@@ -47,9 +48,12 @@ use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
 use databend_common_expression::ScalarRef;
 use databend_common_expression::display::scalar_ref_to_string;
+use databend_common_functions::GENERAL_LAMBDA_FUNCTIONS;
 use log::warn;
+use unicase::Ascii;
 
 use crate::AsyncFunctionRewriter;
+use crate::NameResolutionContext;
 use crate::optimizer::ir::SExpr;
 use crate::planner::QueryExecutor;
 use crate::planner::binder::BindContext;
@@ -155,7 +159,7 @@ impl Binder {
             return self.bind_dummy_table(bind_context, &stmt.select_list);
         }
 
-        let mut max_column_position = MaxColumnPosition::default();
+        let mut max_column_position = MaxColumnPosition::new(self.name_resolution_ctx.clone());
         stmt.walk(&mut max_column_position)?;
         self.metadata.write().set_stage_column_references(
             max_column_position.max_pos,
@@ -1016,6 +1020,17 @@ impl SelectRewriter {
 pub struct MaxColumnPosition {
     pub max_pos: usize,
     pub has_name_ref: bool,
+    name_resolution_ctx: NameResolutionContext,
+    lambda_params: Vec<HashSet<String>>,
+}
+
+impl MaxColumnPosition {
+    pub fn new(name_resolution_ctx: NameResolutionContext) -> Self {
+        Self {
+            name_resolution_ctx,
+            ..Default::default()
+        }
+    }
 }
 
 impl Visitor for MaxColumnPosition {
@@ -1025,6 +1040,17 @@ impl Visitor for MaxColumnPosition {
                 ColumnID::Position(pos) if pos.pos > self.max_pos => {
                     self.max_pos = pos.pos;
                 }
+                ColumnID::Name(name)
+                    if column.database.is_none()
+                        && column.table.is_none()
+                        && self.lambda_params.iter().rev().any(|params| {
+                            params
+                                .contains(&self.name_resolution_ctx.normalize_identifier(name).name)
+                        }) =>
+                {
+                    // Lambda parameters are resolved locally and do not refer
+                    // to columns in the stage schema.
+                }
                 ColumnID::Name(_) => {
                     self.has_name_ref = true;
                 }
@@ -1032,5 +1058,77 @@ impl Visitor for MaxColumnPosition {
             }
         }
         Ok(VisitControl::Continue)
+    }
+
+    fn visit_function_call(&mut self, func: &FunctionCall) -> std::result::Result<VisitControl, !> {
+        let Some(lambda_arg) = &func.lambda else {
+            return Ok(VisitControl::Continue);
+        };
+
+        let semantic_lambda = match lambda_arg {
+            LambdaArgument::Lambda(lambda) => Some((func.args.as_slice(), lambda)),
+            LambdaArgument::Ambiguous(lambda)
+                if GENERAL_LAMBDA_FUNCTIONS.contains(&Ascii::new(func.name.name.as_str())) =>
+            {
+                let Some((_, args)) = func.args.split_last() else {
+                    return Ok(VisitControl::Continue);
+                };
+                Some((args, lambda))
+            }
+            // For non-lambda functions the trailing arrow remains an ordinary
+            // JSON expression, so let the normal AST walk visit `args`.
+            LambdaArgument::Ambiguous(_) => None,
+        };
+        let Some((args, lambda)) = semantic_lambda else {
+            return Ok(VisitControl::Continue);
+        };
+
+        for arg in args {
+            if let VisitControl::Break(value) = arg.walk(self)? {
+                return Ok(VisitControl::Break(value));
+            }
+        }
+
+        self.lambda_params.push(
+            lambda
+                .params
+                .iter()
+                .map(|param| self.name_resolution_ctx.normalize_identifier(param).name)
+                .collect(),
+        );
+        let result = lambda.expr.walk(self);
+        self.lambda_params.pop();
+        match result? {
+            VisitControl::Break(value) => Ok(VisitControl::Break(value)),
+            VisitControl::Continue | VisitControl::SkipChildren => Ok(VisitControl::SkipChildren),
+        }
+    }
+}
+
+#[cfg(test)]
+mod max_column_position_tests {
+    use databend_common_ast::parser::Dialect;
+    use databend_common_ast::parser::parse_expr;
+    use databend_common_ast::parser::tokenize_sql;
+
+    use super::*;
+
+    fn has_column_name_ref(sql: &str) -> bool {
+        let tokens = tokenize_sql(sql).unwrap();
+        let expr = parse_expr(&tokens, Dialect::PostgreSQL).unwrap();
+        let mut visitor = MaxColumnPosition::default();
+        expr.walk(&mut visitor).unwrap();
+        visitor.has_name_ref
+    }
+
+    #[test]
+    fn ignores_lambda_params_but_preserves_ordinary_json_arrow_columns() {
+        assert!(!has_column_name_ref("array_transform([1], x -> 1)"));
+        assert!(!has_column_name_ref("array_transform([1], x -> x)"));
+        assert!(!has_column_name_ref("array_transform([1], X -> x)"));
+        assert!(has_column_name_ref(
+            "array_transform([1], x -> x + stage_column)"
+        ));
+        assert!(has_column_name_ref("concat(1, 2, doc -> 'key')"));
     }
 }

--- a/src/query/sql/src/planner/binder/copy_into_table.rs
+++ b/src/query/sql/src/planner/binder/copy_into_table.rs
@@ -101,7 +101,8 @@ impl Binder {
                 from,
                 alias_name,
             } => {
-                let mut max_column_position = MaxColumnPosition::default();
+                let mut max_column_position =
+                    MaxColumnPosition::new(self.name_resolution_ctx.clone());
                 for target in select_list.iter() {
                     if let SelectTarget::AliasedExpr { expr, .. } = target {
                         expr.walk(&mut max_column_position)?;

--- a/src/query/sql/src/planner/binder/ddl/row_access_policy.rs
+++ b/src/query/sql/src/planner/binder/ddl/row_access_policy.rs
@@ -66,7 +66,7 @@ impl Binder {
                             || TypeChecker::<()>::all_rewrite_functions()
                                 .contains(&uni_case_func_name)
                             || func.window.is_none()
-                            || func.lambda.is_none()
+                            || !func.has_explicit_lambda()
                             || func.order_by.is_empty())
                         {
                             return Err(ErrorCode::InvalidArgument(

--- a/src/query/sql/src/planner/binder/project.rs
+++ b/src/query/sql/src/planner/binder/project.rs
@@ -24,6 +24,7 @@ use databend_common_ast::ast::Expr;
 use databend_common_ast::ast::FunctionCall;
 use databend_common_ast::ast::Identifier;
 use databend_common_ast::ast::Indirection;
+use databend_common_ast::ast::LambdaArgument;
 use databend_common_ast::ast::Literal;
 use databend_common_ast::ast::SelectTarget;
 use databend_common_ast::parser::parse_expr;
@@ -665,7 +666,7 @@ impl Binder {
                 func: FunctionCall {
                     name: Identifier::from_name(span, "array_apply"),
                     args: vec![input_array],
-                    lambda: lambda.cloned(),
+                    lambda: lambda.cloned().map(LambdaArgument::Lambda),
                     distinct: false,
                     params: vec![],
                     order_by: vec![],

--- a/src/query/sql/src/planner/expression/udf_validator.rs
+++ b/src/query/sql/src/planner/expression/udf_validator.rs
@@ -18,14 +18,17 @@ use databend_common_ast::ast::ColumnRef;
 use databend_common_ast::ast::Expr;
 use databend_common_ast::ast::FunctionCall;
 use databend_common_ast::ast::Lambda;
+use databend_common_ast::ast::LambdaArgument;
 use databend_common_config::GlobalConfig;
 use databend_common_config::InnerConfig;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_exception::ToErrorCode;
+use databend_common_functions::GENERAL_LAMBDA_FUNCTIONS;
 use databend_common_functions::is_builtin_function;
 use derive_visitor::Drive;
 use derive_visitor::Visitor;
+use unicase::Ascii;
 
 use crate::plans::UDFLanguage;
 
@@ -62,7 +65,7 @@ impl Default for UdfValidationConfig {
 }
 
 #[derive(Default, Visitor)]
-#[visitor(ColumnRef(enter), FunctionCall(enter), Lambda(enter))]
+#[visitor(ColumnRef(enter), FunctionCall(enter))]
 pub struct UDFValidator {
     pub name: String,
     pub parameters: Vec<String>,
@@ -78,6 +81,19 @@ impl UDFValidator {
     }
 
     fn enter_function_call(&mut self, func: &FunctionCall) {
+        let lambda = match &func.lambda {
+            Some(LambdaArgument::Lambda(lambda)) => Some(lambda),
+            Some(LambdaArgument::Ambiguous(lambda))
+                if GENERAL_LAMBDA_FUNCTIONS.contains(&Ascii::new(func.name.name.as_str())) =>
+            {
+                Some(lambda)
+            }
+            Some(LambdaArgument::Ambiguous(_)) | None => None,
+        };
+        if let Some(lambda) = lambda {
+            self.enter_lambda(lambda);
+        }
+
         let name = &func.name.name;
         if !is_builtin_function(name) && self.name.eq_ignore_ascii_case(name) {
             self.has_recursive = true;
@@ -216,5 +232,38 @@ impl UDFValidator {
             )));
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_ast::parser::Dialect;
+    use databend_common_ast::parser::parse_expr;
+    use databend_common_ast::parser::tokenize_sql;
+
+    use super::*;
+
+    fn parse(sql: &str) -> Expr {
+        let tokens = tokenize_sql(sql).unwrap();
+        parse_expr(&tokens, Dialect::PostgreSQL).unwrap()
+    }
+
+    #[test]
+    fn ambiguous_json_arrow_does_not_declare_udf_parameter() {
+        let expr = parse("concat('', doc -> 'key')");
+        let error = UDFValidator::default()
+            .verify_definition_expr(&expr)
+            .unwrap_err();
+        assert!(error.message().contains("doc"));
+    }
+
+    #[test]
+    fn ambiguous_arrow_in_lambda_function_keeps_lambda_scope() {
+        let expr = parse("array_filter(list, x -> x > 2)");
+        let mut validator = UDFValidator {
+            parameters: vec!["list".to_string()],
+            ..Default::default()
+        };
+        validator.verify_definition_expr(&expr).unwrap();
     }
 }

--- a/src/query/sql/src/planner/semantic/aggregating_index_visitor.rs
+++ b/src/query/sql/src/planner/semantic/aggregating_index_visitor.rs
@@ -20,6 +20,7 @@ use databend_common_ast::ast::Expr;
 use databend_common_ast::ast::FunctionCall;
 use databend_common_ast::ast::GroupBy;
 use databend_common_ast::ast::Identifier;
+use databend_common_ast::ast::LambdaArgument;
 use databend_common_ast::ast::Query;
 use databend_common_ast::ast::SelectStmt;
 use databend_common_ast::ast::SelectTarget;
@@ -66,7 +67,7 @@ impl AggregatingIndexRewriter {
                 && SUPPORTED_AGGREGATING_INDEX_FUNCTIONS
                     .contains(&name.name.to_ascii_lowercase().to_lowercase().as_str())
                 && window.is_none()
-                && lambda.is_none() =>
+                && !matches!(lambda, Some(LambdaArgument::Lambda(_))) =>
             {
                 self.agg_func_positions
                     .insert(self.current_position.unwrap());

--- a/src/query/sql/src/planner/semantic/materialized_view_rewriter.rs
+++ b/src/query/sql/src/planner/semantic/materialized_view_rewriter.rs
@@ -482,7 +482,7 @@ impl VisitorMut for AggregateExprRewriter<'_> {
                 if !func.distinct
                     && func.filter.is_none()
                     && func.window.is_none()
-                    && func.lambda.is_none()
+                    && !func.has_explicit_lambda()
                     && func.order_by.is_empty()
                     && func.params.is_empty()
                     && SUPPORTED_AGGREGATING_INDEX_FUNCTIONS

--- a/src/query/sql/src/planner/semantic/type_check/aggregate.rs
+++ b/src/query/sql/src/planner/semantic/type_check/aggregate.rs
@@ -65,7 +65,7 @@ impl<'a> CoreExprArena<'a> {
         func_name: &str,
         func: &'a ASTFunctionCall,
     ) -> Result<Option<CoreExprId>> {
-        if func.lambda.is_some() || !self.aggregate_function_factory.contains(func_name) {
+        if func.has_explicit_lambda() || !self.aggregate_function_factory.contains(func_name) {
             return Ok(None);
         }
 

--- a/src/query/sql/src/planner/semantic/type_check/core_expr.rs
+++ b/src/query/sql/src/planner/semantic/type_check/core_expr.rs
@@ -1040,6 +1040,16 @@ mod tests {
         assert_sql_lowers_to("to_string(doc -> 'key')", |arena, root| {
             assert!(matches!(arena.get(root), CoreExpr::Call { .. }));
         });
+        assert_sql_lowers_to("concat(a, b, doc -> 'key')", |arena, root| {
+            let CoreExpr::Call { args, .. } = arena.get(root) else {
+                panic!("concat should lower as a scalar function");
+            };
+            assert_eq!(args.len(), 3);
+            assert!(matches!(arena.get(args[2]), CoreExpr::Call {
+                func_name: "get",
+                ..
+            }));
+        });
     }
 
     #[test]

--- a/src/query/sql/src/planner/semantic/type_check/core_expr.rs
+++ b/src/query/sql/src/planner/semantic/type_check/core_expr.rs
@@ -998,6 +998,51 @@ mod tests {
     }
 
     #[test]
+    fn lowers_trailing_lambda_through_the_existing_lambda_path() {
+        assert_sql_lowers_to(
+            "json_path_transform(doc, path, value -> value + 1)",
+            |arena, root| {
+                let CoreExpr::LambdaFunction {
+                    args,
+                    lambda_params,
+                    lambda_expr,
+                    ..
+                } = arena.get(root)
+                else {
+                    panic!("json_path_transform should lower as a lambda function");
+                };
+                assert_eq!(args.len(), 2);
+                assert_eq!(lambda_params[0].name, "value");
+                assert!(matches!(arena.get(*lambda_expr), CoreExpr::Call {
+                    func_name: "plus",
+                    ..
+                }));
+            },
+        );
+
+        assert_sql_lowers_to(
+            "json_path_transform(doc, path, value -> value -> 'name')",
+            |arena, root| {
+                let CoreExpr::LambdaFunction { lambda_expr, .. } = arena.get(root) else {
+                    panic!("json_path_transform should lower as a lambda function");
+                };
+                assert!(matches!(arena.get(*lambda_expr), CoreExpr::Call {
+                    func_name: "get",
+                    ..
+                }));
+            },
+        );
+
+        assert_sql_lower_error_contains(
+            "array_transform(arr, (value -> value) + 1)",
+            "must have a lambda expression",
+        );
+        assert_sql_lowers_to("to_string(doc -> 'key')", |arena, root| {
+            assert!(matches!(arena.get(root), CoreExpr::Call { .. }));
+        });
+    }
+
+    #[test]
     fn splits_static_and_runtime_function_names() {
         assert_sql_lowers_to("1 + 2", |arena, root| {
             let CoreExpr::Call { func_name, .. } = arena.get(root) else {

--- a/src/query/sql/src/planner/semantic/type_check/lambda.rs
+++ b/src/query/sql/src/planner/semantic/type_check/lambda.rs
@@ -19,6 +19,7 @@ use databend_common_ast::ast::Expr;
 use databend_common_ast::ast::FunctionCall as ASTFunctionCall;
 use databend_common_ast::ast::Identifier;
 use databend_common_ast::ast::Lambda;
+use databend_common_ast::ast::LambdaArgument;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::ConstantFolder;
@@ -61,31 +62,41 @@ impl<'a> CoreExprArena<'a> {
         func: &'a ASTFunctionCall,
     ) -> Result<Option<CoreExprId>> {
         let uni_case_func_name = Ascii::new(func_name);
-        if func.lambda.is_some() && !GENERAL_LAMBDA_FUNCTIONS.contains(&uni_case_func_name) {
-            return Err(
-                ErrorCode::SemanticError("only lambda functions allowed in lambda syntax")
-                    .set_span(span),
-            );
-        }
-
         let Some(func_name) = GENERAL_LAMBDA_FUNCTIONS
             .iter()
             .cloned()
             .find(|name| *name == uni_case_func_name)
             .map(Ascii::into_inner)
         else {
+            if func.has_explicit_lambda() {
+                return Err(ErrorCode::SemanticError(
+                    "only lambda functions allowed in lambda syntax",
+                )
+                .set_span(span));
+            }
             return Ok(None);
         };
-        let Some(lambda) = func.lambda.as_ref() else {
+        let Some(lambda_arg) = func.lambda.as_ref() else {
             return Err(ErrorCode::SemanticError(format!(
                 "function {func_name} must have a lambda expression",
             ))
             .set_span(span));
         };
 
-        Ok(Some(
-            self.lambda_function(span, func_name, &func.args, lambda)?,
-        ))
+        let (args, lambda) = match lambda_arg {
+            LambdaArgument::Lambda(lambda) => (func.args.as_slice(), lambda),
+            LambdaArgument::Ambiguous(lambda) => {
+                let Some((_, args)) = func.args.split_last() else {
+                    return Err(ErrorCode::SemanticError(format!(
+                        "function {func_name} must have a lambda expression",
+                    ))
+                    .set_span(span));
+                };
+                (args, lambda)
+            }
+        };
+
+        Ok(Some(self.lambda_function(span, func_name, args, lambda)?))
     }
 
     pub(super) fn lambda_function(

--- a/src/query/sql/src/planner/semantic/type_check/scalar_function.rs
+++ b/src/query/sql/src/planner/semantic/type_check/scalar_function.rs
@@ -94,7 +94,6 @@ impl<'a> CoreExprArena<'a> {
             order_by,
             filter,
             window,
-            lambda,
             ..
         } = func;
 
@@ -109,7 +108,7 @@ impl<'a> CoreExprArena<'a> {
             && params.is_empty()
             && order_by.is_empty()
             && window.is_none()
-            && lambda.is_none()
+            && !func.has_explicit_lambda()
         {
             if let Some(expr) = self.lower_rewrite_function(span, func_name, args)? {
                 return Ok(expr);

--- a/src/query/sql/src/planner/semantic/type_check/window.rs
+++ b/src/query/sql/src/planner/semantic/type_check/window.rs
@@ -95,7 +95,7 @@ impl<'a> CoreExprArena<'a> {
         func_name: &str,
         func: &'a ASTFunctionCall,
     ) -> Result<Option<CoreExprId>> {
-        if func.lambda.is_some() {
+        if func.has_explicit_lambda() {
             return Ok(None);
         }
         let func_name = Ascii::new(func_name);

--- a/src/query/sql/tests/it/semantic/type_check/aggregate.rs
+++ b/src/query/sql/tests/it/semantic/type_check/aggregate.rs
@@ -54,6 +54,12 @@ async fn test_type_check_aggregate_rewrites() -> Result<()> {
             sql: "sum(number) FILTER (WHERE flag)",
         },
         SqlTestCase {
+            name: "aggregate_filter_preserves_json_arrow_argument",
+            description: "A JSON-arrow argument before FILTER should remain an ordinary aggregate argument.",
+            setup_sqls: &[],
+            sql: "json_object_agg(text, parse_json(text) -> 'v') FILTER (WHERE flag)",
+        },
+        SqlTestCase {
             name: "count_star_filter_lowers_to_count_if",
             description: "COUNT(*) FILTER should add a constant count argument before the filter predicate.",
             setup_sqls: &[],

--- a/src/query/sql/tests/it/semantic/type_check/aggregate.txt
+++ b/src/query/sql/tests/it/semantic/type_check/aggregate.txt
@@ -54,6 +54,13 @@ status: ok
 scalar: sum(number) FILTER ( WHERE flag )
 type: Int64 NULL
 
+=== aggregate_filter_preserves_json_arrow_argument ===
+description: A JSON-arrow argument before FILTER should remain an ordinary aggregate argument.
+sql: json_object_agg(text, parse_json(text) -> 'v') FILTER (WHERE flag)
+status: ok
+scalar: json_object_agg(text, parse_json(text) -> 'v') FILTER ( WHERE flag )
+type: Variant NULL
+
 === count_star_filter_lowers_to_count_if ===
 description: COUNT(*) FILTER should add a constant count argument before the filter predicate.
 sql: count(*) FILTER (WHERE flag)

--- a/src/query/sql/tests/it/semantic/type_check/lambda.rs
+++ b/src/query/sql/tests/it/semantic/type_check/lambda.rs
@@ -4,8 +4,8 @@ use super::*;
 async fn test_type_check_lambda_functions() -> Result<()> {
     let cases = [
         SqlTestCase {
-            name: "non_lambda_function_rejects_lambda_syntax",
-            description: "Only lambda functions should accept lambda syntax.",
+            name: "non_lambda_function_keeps_ambiguous_arrow_as_json_expression",
+            description: "Non-lambda functions should interpret an ambiguous trailing arrow as a JSON expression.",
             setup_sqls: &[],
             sql: "abs(number, x -> x)",
         },

--- a/src/query/sql/tests/it/semantic/type_check/lambda.txt
+++ b/src/query/sql/tests/it/semantic/type_check/lambda.txt
@@ -1,9 +1,9 @@
-=== non_lambda_function_rejects_lambda_syntax ===
-description: Only lambda functions should accept lambda syntax.
+=== non_lambda_function_keeps_ambiguous_arrow_as_json_expression ===
+description: Non-lambda functions should interpret an ambiguous trailing arrow as a JSON expression.
 sql: abs(number, x -> x)
 status: error
 code: 1065
-message: only lambda functions allowed in lambda syntax
+message: column x doesn't exist
 
 === lambda_function_requires_lambda_expression ===
 description: Lambda functions should reject calls without a lambda expression.

--- a/tests/sqllogictests/suites/base/05_ddl/05_0010_ddl_create_udf.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0010_ddl_create_udf.test
@@ -52,6 +52,9 @@ SELECT with_lambda(arr) from array_int64_table
 statement error 1005
 CREATE FUNCTION with_lambda as (list) -> array_filter(list, x -> y > 2);
 
+statement error 1005
+CREATE FUNCTION ambiguous_json_arrow_udf AS () -> concat('', doc -> 'key');
+
 statement ok
 DROP FUNCTION IF EXISTS with_lambda
 

--- a/tests/sqllogictests/suites/query/functions/02_0000_function_aggregate_mix.test
+++ b/tests/sqllogictests/suites/query/functions/02_0000_function_aggregate_mix.test
@@ -603,9 +603,10 @@ select json_object_agg(b, a), json_object_agg(b, c), json_object_agg(b, d), json
 {"abc":20.00,"de":10.00,"xyz":5.99} {"de":100,"xyz":300} {"abc":{"k":"v"},"de":null,"xyz":[1,2,3]} {"abc":["a","b"],"de":[],"xyz":["z"]} {"abc":"a","de":"a","xyz":"a"}
 
 query T
-select json_object_agg(b, d -> 'k') FILTER (WHERE b = 'abc') from d
+select json_object_agg(k, doc -> 'v') FILTER (WHERE ok)
+from (select 'k' as k, parse_json('{"v":"value"}') as doc, true as ok)
 ----
-{"abc":"v"}
+{"k":"value"}
 
 query TTTTTT
 select array_agg(a), array_agg(b), array_agg(c), array_agg(d), array_agg(e), array_agg('a') from d

--- a/tests/sqllogictests/suites/query/functions/02_0000_function_aggregate_mix.test
+++ b/tests/sqllogictests/suites/query/functions/02_0000_function_aggregate_mix.test
@@ -602,6 +602,11 @@ select json_object_agg(b, a), json_object_agg(b, c), json_object_agg(b, d), json
 ----
 {"abc":20.00,"de":10.00,"xyz":5.99} {"de":100,"xyz":300} {"abc":{"k":"v"},"de":null,"xyz":[1,2,3]} {"abc":["a","b"],"de":[],"xyz":["z"]} {"abc":"a","de":"a","xyz":"a"}
 
+query T
+select json_object_agg(b, d -> 'k') FILTER (WHERE b = 'abc') from d
+----
+{"abc":"v"}
+
 query TTTTTT
 select array_agg(a), array_agg(b), array_agg(c), array_agg(d), array_agg(e), array_agg('a') from d
 ----

--- a/tests/sqllogictests/suites/stage/empty_stage_select_error.test
+++ b/tests/sqllogictests/suites/stage/empty_stage_select_error.test
@@ -11,5 +11,9 @@ query ?
 select * from @empty_stage_select_error
 ----
 
+query T
+select array_transform([1], x -> 1) from @empty_stage_select_error
+----
+
 statement ok
 drop stage empty_stage_select_error;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Remove the function-name whitelist and trailing-lambda special grammar added by #20281
- Keep the parser independent of semantic function classification
- Reinterpret an ambiguous trailing JSON `->` expression only after semantic analysis identifies a registered lambda function
- Preserve the `json_path_transform` type checking, evaluation, JSONPath handling, and SQL behavior from #20281

## Implementation

The parser already represents a multi-argument call such as:

```sql
json_path_transform(doc, path, value -> expression)
```

as ordinary arguments whose final argument is `Expr::JsonOp`. Semantic lambda lowering now recognizes that shape only for functions in `GENERAL_LAMBDA_FUNCTIONS`, extracts the lambda parameters and body, and continues through the existing lambda lowering path.

At least one ordinary argument must precede the ambiguous arrow. Calls such as:

```sql
to_string(doc -> 'key')
concat(a, b, doc -> 'key')
```

therefore remain ordinary JSON extraction expressions. The functions crate returns to a manually maintained lambda registry and no longer needs a runtime dependency on the AST crate.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent analyzed #20281, implemented the parser rollback and semantic lowering adaptation, added regression coverage, ran validation, and drafted this PR description.
- Responsible human: @KKould
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20295)
<!-- Reviewable:end -->
