### PR TITLE
refactor(query): clarify get lineage object output

### DIFF
--- a/src/query/service/src/table_functions/get_lineage/mod.rs
+++ b/src/query/service/src/table_functions/get_lineage/mod.rs
@@ -146,14 +146,19 @@ impl GetLineageArgs {
 
 #[derive(Clone, Debug)]
 struct LineageResultRow {
-    distance: i32,
-    source_object_domain: Option<String>,
+    source_object_catalog: Option<String>,
+    source_object_database: Option<String>,
     source_object_name: Option<String>,
+    source_object_domain: Option<String>,
     source_column_name: Option<String>,
-    target_object_domain: Option<String>,
+    source_status: String,
+    target_object_catalog: Option<String>,
+    target_object_database: Option<String>,
     target_object_name: Option<String>,
+    target_object_domain: Option<String>,
     target_column_name: Option<String>,
     target_status: String,
+    distance: i32,
     process: Option<String>,
 }
 
@@ -192,17 +197,22 @@ impl GetLineageTable {
     fn schema() -> Arc<TableSchema> {
         let nullable_string = || TableDataType::Nullable(Box::new(TableDataType::String));
         TableSchemaRefExt::create(vec![
+            TableField::new("source_object_catalog", nullable_string()),
+            TableField::new("source_object_database", nullable_string()),
+            TableField::new("source_object_name", nullable_string()),
+            TableField::new("source_object_domain", nullable_string()),
+            TableField::new("source_column_name", nullable_string()),
+            TableField::new("source_status", TableDataType::String),
+            TableField::new("target_object_catalog", nullable_string()),
+            TableField::new("target_object_database", nullable_string()),
+            TableField::new("target_object_name", nullable_string()),
+            TableField::new("target_object_domain", nullable_string()),
+            TableField::new("target_column_name", nullable_string()),
+            TableField::new("target_status", TableDataType::String),
             TableField::new(
                 "distance",
                 TableDataType::Number(databend_common_expression::types::NumberDataType::Int32),
             ),
-            TableField::new("source_object_domain", nullable_string()),
-            TableField::new("source_object_name", nullable_string()),
-            TableField::new("source_column_name", nullable_string()),
-            TableField::new("target_object_domain", nullable_string()),
-            TableField::new("target_object_name", nullable_string()),
-            TableField::new("target_column_name", nullable_string()),
-            TableField::new("target_status", TableDataType::String),
             TableField::new("process", nullable_string()),
         ])
     }
@@ -291,37 +301,52 @@ impl GetLineageSource {
             return DataBlock::empty_with_schema(&self.schema);
         }
 
-        let mut distances = Vec::with_capacity(rows.len());
-        let mut source_domains = Vec::with_capacity(rows.len());
+        let mut source_catalogs = Vec::with_capacity(rows.len());
+        let mut source_databases = Vec::with_capacity(rows.len());
         let mut source_names = Vec::with_capacity(rows.len());
+        let mut source_domains = Vec::with_capacity(rows.len());
         let mut source_columns = Vec::with_capacity(rows.len());
-        let mut target_domains = Vec::with_capacity(rows.len());
+        let mut source_statuses = Vec::with_capacity(rows.len());
+        let mut target_catalogs = Vec::with_capacity(rows.len());
+        let mut target_databases = Vec::with_capacity(rows.len());
         let mut target_names = Vec::with_capacity(rows.len());
+        let mut target_domains = Vec::with_capacity(rows.len());
         let mut target_columns = Vec::with_capacity(rows.len());
         let mut target_statuses = Vec::with_capacity(rows.len());
+        let mut distances = Vec::with_capacity(rows.len());
         let mut processes = Vec::with_capacity(rows.len());
 
         for row in rows {
-            distances.push(row.distance);
-            source_domains.push(row.source_object_domain);
+            source_catalogs.push(row.source_object_catalog);
+            source_databases.push(row.source_object_database);
             source_names.push(row.source_object_name);
+            source_domains.push(row.source_object_domain);
             source_columns.push(row.source_column_name);
-            target_domains.push(row.target_object_domain);
+            source_statuses.push(row.source_status);
+            target_catalogs.push(row.target_object_catalog);
+            target_databases.push(row.target_object_database);
             target_names.push(row.target_object_name);
+            target_domains.push(row.target_object_domain);
             target_columns.push(row.target_column_name);
             target_statuses.push(row.target_status);
+            distances.push(row.distance);
             processes.push(row.process);
         }
 
         DataBlock::new_from_columns(vec![
-            Int32Type::from_data(distances),
-            StringType::from_opt_data(source_domains),
+            StringType::from_opt_data(source_catalogs),
+            StringType::from_opt_data(source_databases),
             StringType::from_opt_data(source_names),
+            StringType::from_opt_data(source_domains),
             StringType::from_opt_data(source_columns),
-            StringType::from_opt_data(target_domains),
+            StringType::from_data(source_statuses),
+            StringType::from_opt_data(target_catalogs),
+            StringType::from_opt_data(target_databases),
             StringType::from_opt_data(target_names),
+            StringType::from_opt_data(target_domains),
             StringType::from_opt_data(target_columns),
             StringType::from_data(target_statuses),
+            Int32Type::from_data(distances),
             StringType::from_opt_data(processes),
         ])
     }

--- a/src/query/service/src/table_functions/get_lineage/resolver.rs
+++ b/src/query/service/src/table_functions/get_lineage/resolver.rs
@@ -59,10 +59,14 @@ pub(super) struct ResolvedObject {
 }
 
 impl ResolvedObject {
-    pub(super) fn qualified_name(&self) -> String {
+    pub(super) fn output_address(&self) -> (Option<String>, Option<String>, Option<String>) {
         match self.object_type {
-            LineageObjectType::Stage => self.name.clone(),
-            _ => format!("{}.{}.{}", self.catalog, self.database, self.name),
+            LineageObjectType::Stage => (None, None, Some(self.name.clone())),
+            _ => (
+                Some(self.catalog.clone()),
+                Some(self.database.clone()),
+                Some(self.name.clone()),
+            ),
         }
     }
 

--- a/src/query/service/src/table_functions/get_lineage/traversal.rs
+++ b/src/query/service/src/table_functions/get_lineage/traversal.rs
@@ -59,6 +59,7 @@ struct TraversedColumnEdge {
     edge: RawLineageEdge,
     source: ResolvedObject,
     source_column: String,
+    source_masked: bool,
     target: ResolvedObject,
     target_column: String,
     target_masked: bool,
@@ -155,16 +156,27 @@ async fn traverse_objects(
 
     let mut rows = results
         .into_values()
-        .map(|result| LineageResultRow {
-            distance: i32::from(result.distance),
-            source_object_domain: Some(result.source.object_type.as_str().to_string()),
-            source_object_name: Some(result.source.qualified_name()),
-            source_column_name: None,
-            target_object_domain: Some(result.target.object_type.as_str().to_string()),
-            target_object_name: Some(result.target.qualified_name()),
-            target_column_name: None,
-            target_status: "ACTIVE".to_string(),
-            process: Some(process_json(&result.edge)),
+        .map(|result| {
+            let (source_object_catalog, source_object_database, source_object_name) =
+                result.source.output_address();
+            let (target_object_catalog, target_object_database, target_object_name) =
+                result.target.output_address();
+            LineageResultRow {
+                source_object_catalog,
+                source_object_database,
+                source_object_name,
+                source_object_domain: Some(result.source.object_type.as_str().to_string()),
+                source_column_name: None,
+                source_status: "ACTIVE".to_string(),
+                target_object_catalog,
+                target_object_database,
+                target_object_name,
+                target_object_domain: Some(result.target.object_type.as_str().to_string()),
+                target_column_name: None,
+                target_status: "ACTIVE".to_string(),
+                distance: i32::from(result.distance),
+                process: Some(process_json(&result.edge)),
+            }
         })
         .collect::<Vec<_>>();
     sort_rows(&mut rows);
@@ -286,11 +298,15 @@ async fn traverse_columns(
                             (current_column.column_name.clone(), next_name.clone())
                         }
                     };
-                    let target_masked = match args.direction {
-                        QueryDirection::Upstream => {
-                            target.is_column_masked(&current_column.column_id)
-                        }
-                        QueryDirection::Downstream => target.is_column_masked(&next_id),
+                    let (source_masked, target_masked) = match args.direction {
+                        QueryDirection::Upstream => (
+                            source.is_column_masked(&next_id),
+                            target.is_column_masked(&current_column.column_id),
+                        ),
+                        QueryDirection::Downstream => (
+                            source.is_column_masked(&current_column.column_id),
+                            target.is_column_masked(&next_id),
+                        ),
                     };
                     let key = (
                         source.object_key.clone(),
@@ -305,6 +321,7 @@ async fn traverse_columns(
                         source_column,
                         target: target.clone(),
                         target_column,
+                        source_masked,
                         target_masked,
                     };
                     match level_edges.get_mut(&key) {
@@ -363,16 +380,27 @@ async fn traverse_columns(
 
     let mut rows = results
         .into_values()
-        .map(|result| LineageResultRow {
-            distance: i32::from(result.distance),
-            source_object_domain: Some(result.source.object_type.as_str().to_string()),
-            source_object_name: Some(result.source.qualified_name()),
-            source_column_name: Some(result.source_column),
-            target_object_domain: Some(result.target.object_type.as_str().to_string()),
-            target_object_name: Some(result.target.qualified_name()),
-            target_column_name: Some(result.target_column),
-            target_status: target_status(result.target_masked).to_string(),
-            process: Some(process_json(&result.edge)),
+        .map(|result| {
+            let (source_object_catalog, source_object_database, source_object_name) =
+                result.source.output_address();
+            let (target_object_catalog, target_object_database, target_object_name) =
+                result.target.output_address();
+            LineageResultRow {
+                source_object_catalog,
+                source_object_database,
+                source_object_name,
+                source_object_domain: Some(result.source.object_type.as_str().to_string()),
+                source_column_name: Some(result.source_column),
+                source_status: target_status(result.source_masked).to_string(),
+                target_object_catalog,
+                target_object_database,
+                target_object_name,
+                target_object_domain: Some(result.target.object_type.as_str().to_string()),
+                target_column_name: Some(result.target_column),
+                target_status: target_status(result.target_masked).to_string(),
+                distance: i32::from(result.distance),
+                process: Some(process_json(&result.edge)),
+            }
         })
         .collect::<Vec<_>>();
     sort_rows(&mut rows);
@@ -464,15 +492,23 @@ fn sort_rows(rows: &mut [LineageResultRow]) {
     rows.sort_by(|left, right| {
         (
             left.distance,
+            left.source_object_catalog.as_deref().unwrap_or_default(),
+            left.source_object_database.as_deref().unwrap_or_default(),
             left.source_object_name.as_deref().unwrap_or_default(),
             left.source_column_name.as_deref().unwrap_or_default(),
+            left.target_object_catalog.as_deref().unwrap_or_default(),
+            left.target_object_database.as_deref().unwrap_or_default(),
             left.target_object_name.as_deref().unwrap_or_default(),
             left.target_column_name.as_deref().unwrap_or_default(),
         )
             .cmp(&(
                 right.distance,
+                right.source_object_catalog.as_deref().unwrap_or_default(),
+                right.source_object_database.as_deref().unwrap_or_default(),
                 right.source_object_name.as_deref().unwrap_or_default(),
                 right.source_column_name.as_deref().unwrap_or_default(),
+                right.target_object_catalog.as_deref().unwrap_or_default(),
+                right.target_object_database.as_deref().unwrap_or_default(),
                 right.target_object_name.as_deref().unwrap_or_default(),
                 right.target_column_name.as_deref().unwrap_or_default(),
             ))

--- a/tests/logging/history_table/sqllogic/check/01_multi_kind_edges.test
+++ b/tests/logging/history_table/sqllogic/check/01_multi_kind_edges.test
@@ -17,11 +17,11 @@ CTAS 1 1
 DML 2 2
 
 # GET_LINEAGE collapses every retained record for the pair into a single object edge.
-query ITT
-SELECT distance, source_object_name, target_object_name
+query ITTTT
+SELECT distance, source_object_database, source_object_name, target_object_database, target_object_name
 FROM get_lineage('lineage_history_multi_kind.dst', 'TABLE', 'UPSTREAM', 1)
 ----
-1 default.lineage_history_multi_kind.src default.lineage_history_multi_kind.dst
+1 lineage_history_multi_kind src lineage_history_multi_kind dst
 
 # The collapsed edge carries the process of the newest statement, which is the last DML.
 query T

--- a/tests/logging/history_table/sqllogic/check/02_column_multihop.test
+++ b/tests/logging/history_table/sqllogic/check/02_column_multihop.test
@@ -1,28 +1,31 @@
 # Column patterns and multi-hop traversal correspond to setup/02_column_multihop.test.
 
-query ITTTT rowsort
-SELECT distance, source_object_name, source_column_name, target_object_name, target_column_name
+query ITTTTTT rowsort
+SELECT distance, source_object_database, source_object_name, source_column_name,
+       target_object_database, target_object_name, target_column_name
 FROM get_lineage('lineage_history_columns.mid.x', 'COLUMN', 'UPSTREAM', 1)
 ----
-1 default.lineage_history_columns.src a default.lineage_history_columns.mid x
-1 default.lineage_history_columns.src b default.lineage_history_columns.mid x
+1 lineage_history_columns src a lineage_history_columns mid x
+1 lineage_history_columns src b lineage_history_columns mid x
 
-query ITTTT rowsort
-SELECT distance, source_object_name, source_column_name, target_object_name, target_column_name
+query ITTTTTT rowsort
+SELECT distance, source_object_database, source_object_name, source_column_name,
+       target_object_database, target_object_name, target_column_name
 FROM get_lineage('lineage_history_columns.dst.z', 'COLUMN', 'UPSTREAM', 2)
 ----
-1 default.lineage_history_columns.mid x default.lineage_history_columns.dst z
-2 default.lineage_history_columns.src a default.lineage_history_columns.mid x
-2 default.lineage_history_columns.src b default.lineage_history_columns.mid x
+1 lineage_history_columns mid x lineage_history_columns dst z
+2 lineage_history_columns src a lineage_history_columns mid x
+2 lineage_history_columns src b lineage_history_columns mid x
 
 # Masking applies to a concrete target column, not to the whole object or traversal path.
-query ITTTTT rowsort
-SELECT distance, source_object_name, source_column_name, target_object_name, target_column_name, target_status
+query ITTTTTTTT rowsort
+SELECT distance, source_object_database, source_object_name, source_column_name, source_status,
+       target_object_database, target_object_name, target_column_name, target_status
 FROM get_lineage('lineage_history_columns.dst.z', 'COLUMN', 'UPSTREAM', 2)
 ----
-1 default.lineage_history_columns.mid x default.lineage_history_columns.dst z MASKED
-2 default.lineage_history_columns.src a default.lineage_history_columns.mid x ACTIVE
-2 default.lineage_history_columns.src b default.lineage_history_columns.mid x ACTIVE
+1 lineage_history_columns mid x ACTIVE lineage_history_columns dst z MASKED
+2 lineage_history_columns src a ACTIVE lineage_history_columns mid x ACTIVE
+2 lineage_history_columns src b ACTIVE lineage_history_columns mid x ACTIVE
 
 query T
 SELECT target_status
@@ -30,13 +33,36 @@ FROM get_lineage('lineage_history_columns.dst', 'TABLE', 'UPSTREAM', 1)
 ----
 ACTIVE
 
-query ITTTT rowsort
-SELECT distance, source_object_name, source_column_name, target_object_name, target_column_name
+query ITTTTTT rowsort
+SELECT distance, source_object_database, source_object_name, source_column_name,
+       target_object_database, target_object_name, target_column_name
 FROM get_lineage('lineage_history_columns.src.a', 'COLUMN', 'DOWNSTREAM', 2)
 ----
-1 default.lineage_history_columns.src a default.lineage_history_columns.mid x
-1 default.lineage_history_columns.src a default.lineage_history_columns.mid y
-2 default.lineage_history_columns.mid x default.lineage_history_columns.dst z
+1 lineage_history_columns src a lineage_history_columns mid x
+1 lineage_history_columns src a lineage_history_columns mid y
+2 lineage_history_columns mid x lineage_history_columns dst z
+
+# Object identity is returned as separate catalog, database, and name columns.
+query TTTTTT
+SELECT source_object_catalog, source_object_database, source_object_name,
+       target_object_catalog, target_object_database, target_object_name
+FROM get_lineage('lineage_history_columns.mid', 'TABLE', 'UPSTREAM', 1)
+----
+default lineage_history_columns src default lineage_history_columns mid
+
+# Source and target masking are reported independently for each resolved column endpoint.
+statement ok
+ALTER TABLE lineage_history_columns.src MODIFY COLUMN a SET MASKING POLICY lineage_history_columns_mask
+
+query TT
+SELECT source_status, target_status
+FROM get_lineage('lineage_history_columns.src.a', 'COLUMN', 'DOWNSTREAM', 1)
+WHERE target_column_name = 'x'
+----
+MASKED ACTIVE
+
+statement ok
+ALTER TABLE lineage_history_columns.src MODIFY COLUMN a UNSET MASKING POLICY
 
 statement ok
 ALTER TABLE lineage_history_columns.dst MODIFY COLUMN z UNSET MASKING POLICY

--- a/tests/logging/history_table/sqllogic/check/03_view_boundary.test
+++ b/tests/logging/history_table/sqllogic/check/03_view_boundary.test
@@ -2,38 +2,41 @@
 
 # The derived column z traces back through the view to both base columns. The view is a distinct
 # hop: distance 1 stops at the view, distance 2 reaches the base table.
-query ITTTT rowsort
-SELECT distance, source_object_name, source_column_name, target_object_name, target_column_name
+query ITTTTTT rowsort
+SELECT distance, source_object_database, source_object_name, source_column_name,
+       target_object_database, target_object_name, target_column_name
 FROM get_lineage('lineage_history_views.view_dst.z', 'COLUMN', 'UPSTREAM', 2)
 ----
-1 default.lineage_history_views.src_view v default.lineage_history_views.view_dst z
-2 default.lineage_history_views.src a default.lineage_history_views.src_view v
-2 default.lineage_history_views.src b default.lineage_history_views.src_view v
+1 lineage_history_views src_view v lineage_history_views view_dst z
+2 lineage_history_views src a lineage_history_views src_view v
+2 lineage_history_views src b lineage_history_views src_view v
 
 # The passthrough column q keeps a single-source mapping across the same view boundary.
-query ITTTT rowsort
-SELECT distance, source_object_name, source_column_name, target_object_name, target_column_name
+query ITTTTTT rowsort
+SELECT distance, source_object_database, source_object_name, source_column_name,
+       target_object_database, target_object_name, target_column_name
 FROM get_lineage('lineage_history_views.view_dst.q', 'COLUMN', 'UPSTREAM', 2)
 ----
-1 default.lineage_history_views.src_view p default.lineage_history_views.view_dst q
-2 default.lineage_history_views.src a default.lineage_history_views.src_view p
+1 lineage_history_views src_view p lineage_history_views view_dst q
+2 lineage_history_views src a lineage_history_views src_view p
 
 # Object traversal exposes both hops with their object domains. The middle object is a VIEW while
 # the endpoints are TABLE objects, so the view is not collapsed into a base-table edge.
-query ITTTTT rowsort
-SELECT distance, source_object_domain, source_object_name, target_object_domain, target_object_name,
+query ITTTTTTT rowsort
+SELECT distance, source_object_domain, source_object_database, source_object_name,
+       target_object_domain, target_object_database, target_object_name,
        parse_json(process)['lineage_kind']::STRING
 FROM get_lineage('lineage_history_views.view_dst', 'TABLE', 'UPSTREAM', 2)
 ----
-1 VIEW default.lineage_history_views.src_view TABLE default.lineage_history_views.view_dst CTAS
-2 TABLE default.lineage_history_views.src VIEW default.lineage_history_views.src_view CREATE_VIEW
+1 VIEW lineage_history_views src_view TABLE lineage_history_views view_dst CTAS
+2 TABLE lineage_history_views src VIEW lineage_history_views src_view CREATE_VIEW
 
 # Starting from the view object in the VIEW domain resolves the view itself and both directions.
-query ITT rowsort
-SELECT distance, source_object_name, target_object_name
+query ITTTT rowsort
+SELECT distance, source_object_database, source_object_name, target_object_database, target_object_name
 FROM get_lineage('lineage_history_views.src_view', 'VIEW', 'UPSTREAM', 1)
 ----
-1 default.lineage_history_views.src default.lineage_history_views.src_view
+1 lineage_history_views src lineage_history_views src_view
 
 # CREATE VIEW has no execution pipeline data movement, so its latest process snapshot reports
 # zero query-level scan/write rows while still carrying a non-negative duration.
@@ -49,11 +52,11 @@ FROM result
 ----
 1 1 1
 
-query ITT rowsort
-SELECT distance, source_object_name, target_object_name
+query ITTTT rowsort
+SELECT distance, source_object_database, source_object_name, target_object_database, target_object_name
 FROM get_lineage('lineage_history_views.src_view', 'VIEW', 'DOWNSTREAM', 1)
 ----
-1 default.lineage_history_views.src_view default.lineage_history_views.view_dst
+1 lineage_history_views src_view lineage_history_views view_dst
 
 # Column lineage always retains display names. View columns are explicitly NAME-addressed with no
 # schema id, while the CTAS target table column retains both its name and stable id.
@@ -85,14 +88,15 @@ WHERE target_database = 'lineage_history_views'
 
 # Downstream from a base column crosses the view and continues to the final table column, proving
 # the boundary is transparent in the forward direction too.
-query ITTTT rowsort
-SELECT distance, source_object_name, source_column_name, target_object_name, target_column_name
+query ITTTTTT rowsort
+SELECT distance, source_object_database, source_object_name, source_column_name,
+       target_object_database, target_object_name, target_column_name
 FROM get_lineage('lineage_history_views.src.a', 'COLUMN', 'DOWNSTREAM', 2)
 ----
-1 default.lineage_history_views.src a default.lineage_history_views.src_view p
-1 default.lineage_history_views.src a default.lineage_history_views.src_view v
-2 default.lineage_history_views.src_view p default.lineage_history_views.view_dst q
-2 default.lineage_history_views.src_view v default.lineage_history_views.view_dst z
+1 lineage_history_views src a lineage_history_views src_view p
+1 lineage_history_views src a lineage_history_views src_view v
+2 lineage_history_views src_view p lineage_history_views view_dst q
+2 lineage_history_views src_view v lineage_history_views view_dst z
 
 statement ok
 DROP DATABASE lineage_history_views

--- a/tests/logging/history_table/sqllogic/check/04_statement_coverage.test
+++ b/tests/logging/history_table/sqllogic/check/04_statement_coverage.test
@@ -1,10 +1,10 @@
 # Statement coverage corresponds to setup/04_statement_coverage.test.
 
-query ITT
-SELECT distance, source_object_name, target_object_name
+query ITTTT
+SELECT distance, source_object_database, source_object_name, target_object_database, target_object_name
 FROM get_lineage('lineage_history_statements.self_insert_dst', 'TABLE', 'UPSTREAM', 1)
 ----
-1 default.lineage_history_statements.src default.lineage_history_statements.self_insert_dst
+1 lineage_history_statements src lineage_history_statements self_insert_dst
 
 query ISS
 SELECT distance, source_column_name, target_column_name
@@ -20,11 +20,11 @@ WHERE target_database = 'lineage_history_statements'
 ----
 0
 
-query ITT
-SELECT distance, source_object_name, target_object_name
+query ITTTT
+SELECT distance, source_object_database, source_object_name, target_object_database, target_object_name
 FROM get_lineage('lineage_history_statements.insert_dst', 'TABLE', 'UPSTREAM', 1)
 ----
-1 default.lineage_history_statements.src default.lineage_history_statements.insert_dst
+1 lineage_history_statements src lineage_history_statements insert_dst
 
 query I
 SELECT count(*)
@@ -93,30 +93,30 @@ FROM result CROSS JOIN history
 ----
 1
 
-query ITT
-SELECT distance, source_object_name, target_object_name
+query ITTTT
+SELECT distance, source_object_database, source_object_name, target_object_database, target_object_name
 FROM get_lineage('lineage_history_statements.multi_a', 'TABLE', 'UPSTREAM', 1)
 ----
-1 default.lineage_history_statements.src default.lineage_history_statements.multi_a
+1 lineage_history_statements src lineage_history_statements multi_a
 
-query ITT
-SELECT distance, source_object_name, target_object_name
+query ITTTT
+SELECT distance, source_object_database, source_object_name, target_object_database, target_object_name
 FROM get_lineage('lineage_history_statements.multi_b', 'TABLE', 'UPSTREAM', 1)
 ----
-1 default.lineage_history_statements.src default.lineage_history_statements.multi_b
+1 lineage_history_statements src lineage_history_statements multi_b
 
-query ITT
-SELECT distance, source_object_name, target_object_name
+query ITTTT
+SELECT distance, source_object_database, source_object_name, target_object_database, target_object_name
 FROM get_lineage('lineage_history_statements.replace_dst', 'TABLE', 'UPSTREAM', 1)
 ----
-1 default.lineage_history_statements.src default.lineage_history_statements.replace_dst
+1 lineage_history_statements src lineage_history_statements replace_dst
 
 # MERGE INTO records a single DML edge for the src -> merge_dst pair.
-query ITT
-SELECT distance, source_object_name, target_object_name
+query ITTTT
+SELECT distance, source_object_database, source_object_name, target_object_database, target_object_name
 FROM get_lineage('lineage_history_statements.merge_dst', 'TABLE', 'UPSTREAM', 1)
 ----
-1 default.lineage_history_statements.src default.lineage_history_statements.merge_dst
+1 lineage_history_statements src lineage_history_statements merge_dst
 
 query T
 SELECT parse_json(process)['lineage_kind']::STRING
@@ -146,11 +146,11 @@ FROM get_lineage('lineage_history_statements.merge_dst.n', 'COLUMN', 'UPSTREAM',
 1 c n
 
 # Stream data lineage passes through to the backing table.
-query ITT
-SELECT distance, source_object_name, target_object_name
+query ITTTT
+SELECT distance, source_object_database, source_object_name, target_object_database, target_object_name
 FROM get_lineage('lineage_history_statements.stream_dst', 'TABLE', 'UPSTREAM', 1)
 ----
-1 default.lineage_history_statements.stream_src default.lineage_history_statements.stream_dst
+1 lineage_history_statements stream_src lineage_history_statements stream_dst
 
 query ISS
 SELECT distance, source_column_name, target_column_name
@@ -169,34 +169,37 @@ WHERE source_database = 'lineage_history_statements'
 ----
 0
 
-query ITT
-SELECT distance, source_object_name, target_object_name
+query ITSTTT
+SELECT distance, source_object_catalog, source_object_database, source_object_name,
+       target_object_database, target_object_name
 FROM get_lineage('lineage_history_statements.copy_dst', 'TABLE', 'UPSTREAM', 2)
 ORDER BY distance, source_object_name, target_object_name
 ----
-1 lineage_history_statements_stage default.lineage_history_statements.copy_dst
-2 default.lineage_history_statements.src lineage_history_statements_stage
+1 NULL NULL lineage_history_statements_stage lineage_history_statements copy_dst
+2 default lineage_history_statements src NULL lineage_history_statements_stage
 
-query ITT
-SELECT distance, source_object_name, target_object_name
+query ITTSTTT rowsort
+SELECT distance, source_object_catalog, source_object_database, source_object_name,
+       target_object_catalog, target_object_database, target_object_name
 FROM get_lineage('lineage_history_statements_stage', 'STAGE', 'DOWNSTREAM', 1)
-ORDER BY target_object_name
 ----
-1 lineage_history_statements_stage default.lineage_history_statements.copy_dst
-1 lineage_history_statements_stage default.lineage_history_statements.insert_select_stage_dst
-1 lineage_history_statements_stage default.lineage_history_statements.insert_stage_dst
+1 NULL NULL lineage_history_statements_stage default lineage_history_statements copy_dst
+1 NULL NULL lineage_history_statements_stage default lineage_history_statements insert_select_stage_dst
+1 NULL NULL lineage_history_statements_stage default lineage_history_statements insert_stage_dst
 
-query ITT
-SELECT distance, source_object_name, target_object_name
+query ITSTTT
+SELECT distance, source_object_catalog, source_object_database, source_object_name,
+       target_object_database, target_object_name
 FROM get_lineage('lineage_history_statements.insert_select_stage_dst', 'TABLE', 'UPSTREAM', 1)
 ----
-1 lineage_history_statements_stage default.lineage_history_statements.insert_select_stage_dst
+1 NULL NULL lineage_history_statements_stage lineage_history_statements insert_select_stage_dst
 
-query ITT
-SELECT distance, source_object_name, target_object_name
+query ITSTTT
+SELECT distance, source_object_catalog, source_object_database, source_object_name,
+       target_object_database, target_object_name
 FROM get_lineage('lineage_history_statements.insert_stage_dst', 'TABLE', 'UPSTREAM', 1)
 ----
-1 lineage_history_statements_stage default.lineage_history_statements.insert_stage_dst
+1 NULL NULL lineage_history_statements_stage lineage_history_statements insert_stage_dst
 
 # Stage file fields are not stable columns, so Stage-to-table edges stay object-only.
 query I

--- a/tests/logging/history_table/sqllogic/check/05_object_lifecycle.test
+++ b/tests/logging/history_table/sqllogic/check/05_object_lifecycle.test
@@ -22,11 +22,11 @@ FROM get_lineage('lineage_history_lifecycle.dropped_fuse', 'TABLE', 'UPSTREAM', 
 statement ok
 UNDROP TABLE lineage_history_lifecycle.dropped_fuse
 
-query ITT
-SELECT distance, source_object_name, target_object_name
+query ITTTT
+SELECT distance, source_object_database, source_object_name, target_object_database, target_object_name
 FROM get_lineage('lineage_history_lifecycle.dropped_fuse', 'TABLE', 'UPSTREAM', 1)
 ----
-1 default.lineage_history_lifecycle.src default.lineage_history_lifecycle.dropped_fuse
+1 lineage_history_lifecycle src lineage_history_lifecycle dropped_fuse
 
 # Renaming preserves column ids, so the existing DataMovement edge resolves both current names.
 statement ok
@@ -35,8 +35,9 @@ ALTER TABLE lineage_history_lifecycle.renamed_column_src RENAME COLUMN a TO rena
 statement ok
 ALTER TABLE lineage_history_lifecycle.renamed_column_dst RENAME COLUMN a TO renamed_a
 
-query ITTTT
-SELECT distance, source_object_name, source_column_name, target_object_name, target_column_name
+query ITTTTTT
+SELECT distance, source_object_database, source_object_name, source_column_name,
+       target_object_database, target_object_name, target_column_name
 FROM get_lineage(
     'lineage_history_lifecycle.renamed_column_dst.renamed_a',
     'COLUMN',
@@ -44,7 +45,7 @@ FROM get_lineage(
     1
 )
 ----
-1 default.lineage_history_lifecycle.renamed_column_src renamed_a default.lineage_history_lifecycle.renamed_column_dst renamed_a
+1 lineage_history_lifecycle renamed_column_src renamed_a lineage_history_lifecycle renamed_column_dst renamed_a
 
 # Dropping and adding the same name allocates a new column id. The object edge remains valid, but
 # the old column mapping must not attach itself to the replacement column.
@@ -54,8 +55,8 @@ ALTER TABLE lineage_history_lifecycle.replaced_column_src DROP COLUMN a
 statement ok
 ALTER TABLE lineage_history_lifecycle.replaced_column_src ADD COLUMN a INT
 
-query ITT
-SELECT distance, source_object_name, target_object_name
+query ITTTT
+SELECT distance, source_object_database, source_object_name, target_object_database, target_object_name
 FROM get_lineage(
     'lineage_history_lifecycle.replaced_column_dst',
     'TABLE',
@@ -63,7 +64,7 @@ FROM get_lineage(
     1
 )
 ----
-1 default.lineage_history_lifecycle.replaced_column_src default.lineage_history_lifecycle.replaced_column_dst
+1 lineage_history_lifecycle replaced_column_src lineage_history_lifecycle replaced_column_dst
 
 query I
 SELECT count(*)

--- a/tests/logging/history_table/sqllogic/check/06_iceberg_catalog.test
+++ b/tests/logging/history_table/sqllogic/check/06_iceberg_catalog.test
@@ -1,16 +1,18 @@
 # Iceberg lineage corresponds to setup/06_iceberg_catalog.test.
 
-query ITT
-SELECT distance, source_object_name, target_object_name
+query ITTTTTT
+SELECT distance, source_object_catalog, source_object_database, source_object_name,
+       target_object_catalog, target_object_database, target_object_name
 FROM get_lineage('lineage_history_iceberg.dst', 'TABLE', 'UPSTREAM', 1)
 ----
-1 lineage_history_iceberg_catalog.lineage_db.src default.lineage_history_iceberg.dst
+1 lineage_history_iceberg_catalog lineage_db src default lineage_history_iceberg dst
 
-query ITTTT
-SELECT distance, source_object_name, source_column_name, target_object_name, target_column_name
+query ITTTTTTTT
+SELECT distance, source_object_catalog, source_object_database, source_object_name, source_column_name,
+       target_object_catalog, target_object_database, target_object_name, target_column_name
 FROM get_lineage('lineage_history_iceberg.dst.a', 'COLUMN', 'UPSTREAM', 1)
 ----
-1 lineage_history_iceberg_catalog.lineage_db.src a default.lineage_history_iceberg.dst a
+1 lineage_history_iceberg_catalog lineage_db src a default lineage_history_iceberg dst a
 
 # External catalog ids are not stable across catalog reloads. Both the object and its column data
 # must therefore be name-addressed in the aggregated physical record.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

`GET_LINEAGE` previously returned each object as one dotted `catalog.database.name` string. That display is ambiguous when identifiers themselves contain dots or require quoting, and it makes consumers parse a presentation value to access address components.

This change returns catalog, database, and object name in separate source/target columns. Stage endpoints expose their stage name while leaving catalog and database null. It also adds `source_status`, symmetric with the existing target status, so column masking state is available for both endpoints.

The lineage log, history-table schema, traversal inputs, and process JSON remain unchanged.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Updated lineage history sqllogic coverage for table, view, multi-hop column, stage, object lifecycle, and external catalog output. It also verifies source and target column masking status independently.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent drafted the patch; I reviewed and added logic tests
- Responsible human: @youngsofun
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20296)
<!-- Reviewable:end -->
