### PR TITLE
chore(query): Add `fuse_virtual_column_build` table function

### DIFF
--- a/src/query/service/src/table_functions/table_function_factory.rs
+++ b/src/query/service/src/table_functions/table_function_factory.rs
@@ -32,6 +32,7 @@ use databend_common_storages_fuse::table_functions::FuseTimeTravelSizeFunc;
 use databend_common_storages_fuse::table_functions::FuseVacuumDropAggregatingIndex;
 use databend_common_storages_fuse::table_functions::FuseVacuumDropInvertedIndex;
 use databend_common_storages_fuse::table_functions::FuseVacuumTemporaryTable;
+use databend_common_storages_fuse::table_functions::FuseVirtualColumnBuildFunc;
 use databend_common_storages_fuse::table_functions::FuseVirtualColumnFunc;
 use databend_common_storages_fuse::table_functions::SetCacheCapacity;
 use databend_common_storages_fuse::table_functions::TableFunctionTemplate;
@@ -239,6 +240,14 @@ impl TableFunctionFactory {
             (
                 next_id(),
                 Arc::new(TableFunctionTemplate::<FuseVirtualColumnFunc>::create),
+            ),
+        );
+
+        creators.insert(
+            "fuse_virtual_column_build".to_string(),
+            (
+                next_id(),
+                Arc::new(TableFunctionTemplate::<FuseVirtualColumnBuildFunc>::create),
             ),
         );
 

--- a/src/query/storages/common/table_meta/src/table/table_compression.rs
+++ b/src/query/storages/common/table_meta/src/table/table_compression.rs
@@ -72,6 +72,24 @@ impl From<TableCompression> for ParquetCompression {
     }
 }
 
+impl TryFrom<ParquetCompression> for meta::Compression {
+    type Error = ErrorCode;
+
+    fn try_from(value: ParquetCompression) -> Result<Self, Self::Error> {
+        match value {
+            ParquetCompression::UNCOMPRESSED => Ok(meta::Compression::None),
+            ParquetCompression::SNAPPY => Ok(meta::Compression::Snappy),
+            ParquetCompression::GZIP(_) => Ok(meta::Compression::Gzip),
+            ParquetCompression::LZ4 => Ok(meta::Compression::Lz4),
+            ParquetCompression::ZSTD(_) => Ok(meta::Compression::Zstd),
+            ParquetCompression::LZ4_RAW => Ok(meta::Compression::Lz4Raw),
+            compression => Err(ErrorCode::UnknownCompressionType(format!(
+                "unsupported parquet compression: {compression:?}"
+            ))),
+        }
+    }
+}
+
 impl From<meta::Compression> for ParquetCompression {
     fn from(value: meta::Compression) -> Self {
         match value {

--- a/src/query/storages/fuse/src/io/write/virtual_column_builder.rs
+++ b/src/query/storages/fuse/src/io/write/virtual_column_builder.rs
@@ -71,6 +71,7 @@ use jsonb::TimestampTz as JsonbTimestampTz;
 use jsonb::Value as JsonbValue;
 use jsonb::keypath::KeyPath as JsonbKeyPath;
 use jsonb::keypath::KeyPaths as JsonbKeyPaths;
+use log::info;
 use parquet::file::metadata::KeyValue;
 use parquet::file::metadata::ParquetMetaData;
 use siphasher::sip128::Hasher128;
@@ -680,8 +681,17 @@ impl VirtualColumnBuilder {
 
         let total_rows = self.total_rows;
         self.total_rows = 0;
+        let extracted_path_count = virtual_paths.iter().map(HashMap::len).sum::<usize>();
+        let extracted_value_count = virtual_values.iter().map(Vec::len).sum::<usize>();
 
-        if total_rows == 0 || virtual_values.iter().all(|vals| vals.is_empty()) {
+        if total_rows == 0 || extracted_value_count == 0 {
+            info!(
+                "No virtual column data generated for block {}: rows={}, variant_fields={}, extracted_paths={}",
+                location.0,
+                total_rows,
+                self.variant_fields.len(),
+                extracted_path_count
+            );
             let draft_virtual_block_meta = DraftVirtualBlockMeta {
                 virtual_column_metas: vec![],
                 virtual_column_size: 0,
@@ -956,6 +966,14 @@ impl VirtualColumnBuilder {
         let virtual_column_location =
             TableMetaLocationGenerator::gen_virtual_block_location(&location.0);
 
+        info!(
+            "Generated virtual column data for block {}: virtual_columns={}, extracted_paths={}, rows={}, bytes={}",
+            location.0,
+            virtual_block_schema.num_fields(),
+            extracted_path_count,
+            total_rows,
+            data_size
+        );
         let draft_virtual_block_meta = DraftVirtualBlockMeta {
             virtual_column_metas: draft_virtual_column_metas,
             virtual_column_size: data_size,

--- a/src/query/storages/fuse/src/operations/virtual_column.rs
+++ b/src/query/storages/fuse/src/operations/virtual_column.rs
@@ -136,6 +136,11 @@ pub async fn prepare_refresh_virtual_column(
         ));
     }
     let virtual_column_builder = VirtualColumnBuilder::try_create(source_schema)?;
+    info!(
+        "Preparing virtual column refresh for table_id={} with {} variant source fields",
+        fuse_table.get_id(),
+        field_indices.len()
+    );
 
     let projection = Projection::Columns(field_indices);
     let block_reader = fuse_table.create_block_reader(ctx.clone(), projection, false)?;
@@ -770,8 +775,9 @@ async fn build_virtual_columns(
                     );
                 } else {
                     info!(
-                        "No virtual column data produced for block {}",
-                        task.block_location
+                        "No virtual column data produced for block {} (rows={}); no sidecar file will be written",
+                        task.block_location,
+                        block.num_rows()
                     );
                 }
 

--- a/src/query/storages/fuse/src/table_functions/fuse_virtual_column.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_virtual_column.rs
@@ -40,6 +40,7 @@ use databend_storages_common_index::VirtualColumnSharedDataType;
 use databend_storages_common_table_meta::meta::TableSnapshot;
 use databend_storages_common_table_meta::meta::column_oriented_segment::AbstractBlockMeta;
 use databend_storages_common_table_meta::meta::column_oriented_segment::AbstractSegment;
+use log::warn;
 
 use crate::FuseTable;
 use crate::io::SegmentsIO;
@@ -81,6 +82,13 @@ impl TableMetaFunc for FuseVirtualColumn {
                 "bytes_compressed",
                 TableDataType::Number(NumberDataType::UInt64).wrap_nullable(),
             ),
+            TableField::new(
+                "source_column_id",
+                TableDataType::Number(NumberDataType::UInt32),
+            ),
+            TableField::new("source_column_name", TableDataType::String),
+            TableField::new("storage_kind", TableDataType::String),
+            TableField::new("num_values", TableDataType::Number(NumberDataType::UInt64)),
         ])
     }
 
@@ -123,6 +131,10 @@ impl FuseVirtualColumn {
         let mut column_id = vec![];
         let mut block_offset = vec![];
         let mut bytes_compressed = vec![];
+        let mut source_column_id = vec![];
+        let mut source_column_name = StringColumnBuilder::with_capacity(len);
+        let mut storage_kind = StringColumnBuilder::with_capacity(len);
+        let mut num_values = vec![];
 
         let schema = tbl.schema();
         let segments_io = SegmentsIO::create(ctx.clone(), tbl.operator.clone(), schema.clone());
@@ -145,10 +157,20 @@ impl FuseVirtualColumn {
                         continue;
                     };
                     let location = block_meta.virtual_location.0;
-                    let Ok(virtual_meta) =
-                        load_virtual_column_file_meta(tbl.operator.clone(), &location).await
-                    else {
-                        continue;
+                    let virtual_meta = match load_virtual_column_file_meta(
+                        tbl.operator.clone(),
+                        &location,
+                    )
+                    .await
+                    {
+                        Ok(meta) => meta,
+                        Err(error) => {
+                            warn!(
+                                "Failed to load virtual column metadata from {}: {}",
+                                location, error
+                            );
+                            continue;
+                        }
                     };
                     let entries =
                         collect_virtual_column_entries(&virtual_meta, &source_column_names);
@@ -165,6 +187,10 @@ impl FuseVirtualColumn {
 
                         block_offset.push(entry.offset);
                         bytes_compressed.push(entry.len);
+                        source_column_id.push(entry.source_column_id);
+                        source_column_name.put_and_commit(&entry.source_column_name);
+                        storage_kind.put_and_commit(entry.storage_kind);
+                        num_values.push(entry.num_values);
 
                         num_rows += 1;
 
@@ -189,20 +215,27 @@ impl FuseVirtualColumn {
                 UInt32Type::from_opt_data(column_id).into(),
                 UInt64Type::from_opt_data(block_offset).into(),
                 UInt64Type::from_opt_data(bytes_compressed).into(),
+                UInt32Type::from_data(source_column_id).into(),
+                Column::String(source_column_name.build()).into(),
+                Column::String(storage_kind.build()).into(),
+                UInt64Type::from_data(num_values).into(),
             ],
             num_rows,
         ))
     }
 }
 
-struct VirtualColumnEntry {
-    shared_paths: Option<String>,
-    column_name: String,
-    column_type: String,
-    column_id: Option<u32>,
-    offset: Option<u64>,
-    len: Option<u64>,
-    num_values: u64,
+pub(crate) struct VirtualColumnEntry {
+    pub(crate) source_column_id: u32,
+    pub(crate) source_column_name: String,
+    pub(crate) storage_kind: &'static str,
+    pub(crate) shared_paths: Option<String>,
+    pub(crate) column_name: String,
+    pub(crate) column_type: String,
+    pub(crate) column_id: Option<u32>,
+    pub(crate) offset: Option<u64>,
+    pub(crate) len: Option<u64>,
+    pub(crate) num_values: u64,
 }
 
 struct SharedPathBucket {
@@ -210,7 +243,7 @@ struct SharedPathBucket {
     paths: Vec<String>,
 }
 
-fn collect_virtual_column_entries(
+pub(crate) fn collect_virtual_column_entries(
     virtual_meta: &VirtualColumnFileMeta,
     source_column_names: &HashMap<u32, String>,
 ) -> Vec<VirtualColumnEntry> {
@@ -242,6 +275,7 @@ fn collect_virtual_column_entries(
             .and_then(|typed_metas| typed_metas.get(&data_type));
         if let Some((key_meta, value_meta)) = metas {
             push_shared_entries(
+                source_column_id,
                 &bucket.source_column_name,
                 data_type,
                 &bucket.paths,
@@ -274,6 +308,7 @@ fn shared_column_name(source_name: &str, data_type: VirtualColumnSharedDataType)
 }
 
 fn push_shared_entries(
+    source_column_id: u32,
     source_column_name: &str,
     data_type: VirtualColumnSharedDataType,
     paths: &[String],
@@ -282,8 +317,12 @@ fn push_shared_entries(
     entries: &mut Vec<VirtualColumnEntry>,
 ) {
     let column_name = shared_column_name(source_column_name, data_type);
+    let shared_paths = paths.join(", ");
     entries.push(VirtualColumnEntry {
-        shared_paths: Some(format_shared_paths(paths)),
+        source_column_id,
+        source_column_name: source_column_name.to_string(),
+        storage_kind: "shared_key",
+        shared_paths: Some(shared_paths),
         column_name: format!("{column_name}.entries.key"),
         column_type: key_meta.data_type.to_string(),
         column_id: Some(key_meta.column_id),
@@ -292,6 +331,9 @@ fn push_shared_entries(
         num_values: key_meta.meta.num_values,
     });
     entries.push(VirtualColumnEntry {
+        source_column_id,
+        source_column_name: source_column_name.to_string(),
+        storage_kind: "shared_value",
         shared_paths: None,
         column_name: format!("{column_name}.entries.value"),
         column_type: value_meta.data_type.to_string(),
@@ -319,10 +361,6 @@ fn push_shared_path(
         .push(virtual_path);
 }
 
-fn format_shared_paths(paths: &[String]) -> String {
-    paths.join(", ")
-}
-
 fn collect_virtual_column_leaves(
     virtual_meta: &VirtualColumnFileMeta,
     source_column_id: u32,
@@ -338,6 +376,9 @@ fn collect_virtual_column_leaves(
             VirtualColumnNameIndex::Column(leaf_index) => {
                 if let Some(meta) = virtual_meta.column_metas.get(*leaf_index as usize) {
                     entries.push(VirtualColumnEntry {
+                        source_column_id,
+                        source_column_name: source_column_name.to_string(),
+                        storage_kind: "direct",
                         shared_paths: None,
                         column_name: format!("{}{}", source_column_name, virtual_path),
                         column_type: meta.data_type.to_string(),
@@ -393,7 +434,7 @@ fn collect_virtual_column_leaves(
     }
 }
 
-fn build_source_column_name_map(schema: &TableSchema) -> HashMap<u32, String> {
+pub(crate) fn build_source_column_name_map(schema: &TableSchema) -> HashMap<u32, String> {
     schema
         .fields()
         .iter()

--- a/src/query/storages/fuse/src/table_functions/fuse_virtual_column_build.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_virtual_column_build.rs
@@ -192,21 +192,20 @@ async fn read_block_location(
         )));
     }
 
-    let physical_schema = Arc::new(table.schema().remove_virtual_computed_fields());
-    let parquet_leaf_columns = parquet_meta.file_metadata().schema_descr().num_columns();
-    let table_leaf_columns = physical_schema.to_leaf_column_ids().len();
-    if parquet_leaf_columns != table_leaf_columns {
-        return Err(ErrorCode::ParquetFileInvalid(format!(
-            "Fuse block {} has {} parquet leaf columns, but table {}.{} currently has {}; the supplied table schema does not match this block",
-            block_location,
-            parquet_leaf_columns,
-            table.get_table_info().desc,
-            table.name(),
-            table_leaf_columns
-        )));
-    }
+    let physical_schema = Arc::new(table.schema_with_stream().remove_virtual_computed_fields());
     let column_metas = column_parquet_metas(&parquet_meta, &physical_schema)?;
     let row_group = &parquet_meta.row_groups()[0];
+    let compression = row_group
+        .columns()
+        .first()
+        .ok_or_else(|| {
+            ErrorCode::ParquetFileInvalid(format!(
+                "Fuse block {} has no parquet columns",
+                block_location
+            ))
+        })?
+        .compression()
+        .try_into()?;
     let reader = table.create_block_reader(ctx.clone(), projection, false)?;
     let settings = ReadSettings::from_ctx(ctx)?;
     let data = reader
@@ -216,7 +215,7 @@ async fn read_block_location(
         location: block_location.to_string(),
         row_count: row_group.num_rows() as u64,
         col_metas: column_metas,
-        compression: table.get_write_settings().table_compression.into(),
+        compression,
         block_size: 0,
     };
     reader.deserialize_chunks_with_meta(&meta, &table.storage_format, data)

--- a/src/query/storages/fuse/src/table_functions/fuse_virtual_column_build.rs
+++ b/src/query/storages/fuse/src/table_functions/fuse_virtual_column_build.rs
@@ -1,0 +1,272 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use databend_common_catalog::catalog_kind::CATALOG_DEFAULT;
+use databend_common_catalog::plan::DataSourcePlan;
+use databend_common_catalog::plan::Projection;
+use databend_common_catalog::table::Table;
+use databend_common_catalog::table_args::TableArgs;
+use databend_common_catalog::table_args::string_value;
+use databend_common_catalog::table_context::TableContext;
+use databend_common_exception::ErrorCode;
+use databend_common_exception::Result;
+use databend_common_expression::Column;
+use databend_common_expression::ComputedExpr;
+use databend_common_expression::DataBlock;
+use databend_common_expression::FromData;
+use databend_common_expression::TableDataType;
+use databend_common_expression::TableField;
+use databend_common_expression::TableSchema;
+use databend_common_expression::TableSchemaRef;
+use databend_common_expression::TableSchemaRefExt;
+use databend_common_expression::types::NumberDataType;
+use databend_common_expression::types::StringType;
+use databend_common_expression::types::UInt32Type;
+use databend_common_expression::types::UInt64Type;
+use databend_common_expression::types::string::StringColumnBuilder;
+use databend_common_storage::read_metadata_async;
+use databend_storages_common_index::VirtualColumnFileMeta;
+use databend_storages_common_io::ReadSettings;
+use databend_storages_common_table_meta::meta::column_oriented_segment::BlockReadInfo;
+use parquet::file::metadata::ParquetMetaDataReader;
+
+use crate::FuseTable;
+use crate::io::VirtualColumnBuilder;
+use crate::operations::column_parquet_metas;
+use crate::table_functions::SimpleArgFunc;
+use crate::table_functions::SimpleArgFuncTemplate;
+use crate::table_functions::fuse_virtual_column::build_source_column_name_map;
+use crate::table_functions::fuse_virtual_column::collect_virtual_column_entries;
+use crate::table_functions::string_literal;
+
+pub struct FuseVirtualColumnBuildArgs {
+    database_name: String,
+    table_name: String,
+    block_location: String,
+}
+
+impl TryFrom<(&str, TableArgs)> for FuseVirtualColumnBuildArgs {
+    type Error = ErrorCode;
+
+    fn try_from(
+        (func_name, table_args): (&str, TableArgs),
+    ) -> std::result::Result<Self, Self::Error> {
+        let args = table_args.expect_all_positioned(func_name, Some(3))?;
+        Ok(Self {
+            database_name: string_value(&args[0])?,
+            table_name: string_value(&args[1])?,
+            block_location: string_value(&args[2])?,
+        })
+    }
+}
+
+impl From<&FuseVirtualColumnBuildArgs> for TableArgs {
+    fn from(args: &FuseVirtualColumnBuildArgs) -> Self {
+        TableArgs::new_positioned(vec![
+            string_literal(&args.database_name),
+            string_literal(&args.table_name),
+            string_literal(&args.block_location),
+        ])
+    }
+}
+
+pub type FuseVirtualColumnBuildFunc = SimpleArgFuncTemplate<FuseVirtualColumnBuild>;
+pub struct FuseVirtualColumnBuild;
+
+#[async_trait::async_trait]
+impl SimpleArgFunc for FuseVirtualColumnBuild {
+    type Args = FuseVirtualColumnBuildArgs;
+
+    fn schema() -> TableSchemaRef {
+        TableSchemaRefExt::create(vec![
+            TableField::new("block_location", TableDataType::String),
+            TableField::new(
+                "source_column_id",
+                TableDataType::Number(NumberDataType::UInt32),
+            ),
+            TableField::new("source_column_name", TableDataType::String),
+            TableField::new("storage_kind", TableDataType::String),
+            TableField::new("shared_paths", TableDataType::String.wrap_nullable()),
+            TableField::new("column_name", TableDataType::String),
+            TableField::new("column_type", TableDataType::String),
+            TableField::new(
+                "column_id",
+                TableDataType::Number(NumberDataType::UInt32).wrap_nullable(),
+            ),
+            TableField::new("num_values", TableDataType::Number(NumberDataType::UInt64)),
+            TableField::new(
+                "block_offset",
+                TableDataType::Number(NumberDataType::UInt64).wrap_nullable(),
+            ),
+            TableField::new(
+                "bytes_compressed",
+                TableDataType::Number(NumberDataType::UInt64).wrap_nullable(),
+            ),
+        ])
+    }
+
+    async fn apply(
+        ctx: &Arc<dyn TableContext>,
+        args: &Self::Args,
+        _plan: &DataSourcePlan,
+    ) -> Result<DataBlock> {
+        let table = ctx
+            .get_catalog(CATALOG_DEFAULT)
+            .await?
+            .get_table(&ctx.get_tenant(), &args.database_name, &args.table_name)
+            .await?;
+        let table = FuseTable::try_from_table(table.as_ref())?;
+        let (source_schema, projection) = variant_projection(table)?;
+        let block = read_block_location(ctx, table, &args.block_location, projection).await?;
+
+        let mut builder = VirtualColumnBuilder::try_create(source_schema)?;
+        builder.add_block(&block)?;
+        let state = builder.finalize(
+            &table.get_write_settings(),
+            &(args.block_location.clone(), 0),
+        )?;
+        if state.data.is_empty() {
+            return Ok(DataBlock::empty_with_schema(&Self::schema().into()));
+        }
+
+        let bytes = state.data.to_bytes();
+        let parquet_meta = ParquetMetaDataReader::new().parse_and_finish(&bytes)?;
+        let virtual_meta = VirtualColumnFileMeta::try_from(parquet_meta)?;
+        let source_names = build_source_column_name_map(table.schema().as_ref());
+        let entries = collect_virtual_column_entries(&virtual_meta, &source_names);
+        Ok(entries_to_block(&args.block_location, entries))
+    }
+}
+
+fn variant_projection(table: &FuseTable) -> Result<(TableSchemaRef, Projection)> {
+    let schema = table.schema();
+    let mut fields = Vec::new();
+    let mut indices = Vec::new();
+    for (index, field) in schema.fields().iter().enumerate() {
+        if field.data_type().remove_nullable() == TableDataType::Variant
+            && !matches!(field.computed_expr(), Some(ComputedExpr::Virtual(_)))
+        {
+            fields.push(field.clone());
+            indices.push(index);
+        }
+    }
+    if fields.is_empty() {
+        return Err(ErrorCode::VirtualColumnError(
+            "Virtual column only supports tables with Variant fields",
+        ));
+    }
+    let source_schema = Arc::new(TableSchema {
+        fields,
+        ..schema.as_ref().clone()
+    });
+    Ok((source_schema, Projection::Columns(indices)))
+}
+
+async fn read_block_location(
+    ctx: &Arc<dyn TableContext>,
+    table: &FuseTable,
+    block_location: &str,
+    projection: Projection,
+) -> Result<DataBlock> {
+    // Read the parquet footer directly from the user-provided location. This deliberately does
+    // not consult snapshots or segments, so orphaned and historical blocks can also be inspected.
+    let parquet_meta = read_metadata_async(block_location, &table.operator, None).await?;
+    if parquet_meta.num_row_groups() != 1 {
+        return Err(ErrorCode::ParquetFileInvalid(format!(
+            "invalid Fuse block {}, expected one row group but got {}",
+            block_location,
+            parquet_meta.num_row_groups()
+        )));
+    }
+
+    let physical_schema = Arc::new(table.schema().remove_virtual_computed_fields());
+    let parquet_leaf_columns = parquet_meta.file_metadata().schema_descr().num_columns();
+    let table_leaf_columns = physical_schema.to_leaf_column_ids().len();
+    if parquet_leaf_columns != table_leaf_columns {
+        return Err(ErrorCode::ParquetFileInvalid(format!(
+            "Fuse block {} has {} parquet leaf columns, but table {}.{} currently has {}; the supplied table schema does not match this block",
+            block_location,
+            parquet_leaf_columns,
+            table.get_table_info().desc,
+            table.name(),
+            table_leaf_columns
+        )));
+    }
+    let column_metas = column_parquet_metas(&parquet_meta, &physical_schema)?;
+    let row_group = &parquet_meta.row_groups()[0];
+    let reader = table.create_block_reader(ctx.clone(), projection, false)?;
+    let settings = ReadSettings::from_ctx(ctx)?;
+    let data = reader
+        .read_columns_data_by_merge_io(&settings, block_location, &column_metas, &None)
+        .await?;
+    let meta = BlockReadInfo {
+        location: block_location.to_string(),
+        row_count: row_group.num_rows() as u64,
+        col_metas: column_metas,
+        compression: table.get_write_settings().table_compression.into(),
+        block_size: 0,
+    };
+    reader.deserialize_chunks_with_meta(&meta, &table.storage_format, data)
+}
+
+fn entries_to_block(
+    block_location_value: &str,
+    entries: Vec<super::fuse_virtual_column::VirtualColumnEntry>,
+) -> DataBlock {
+    let len = entries.len();
+    let mut block_location = StringColumnBuilder::with_capacity(len);
+    let mut source_column_ids = Vec::with_capacity(len);
+    let mut source_column_names = StringColumnBuilder::with_capacity(len);
+    let mut storage_kinds = StringColumnBuilder::with_capacity(len);
+    let mut shared_paths = Vec::with_capacity(len);
+    let mut column_names = StringColumnBuilder::with_capacity(len);
+    let mut column_types = StringColumnBuilder::with_capacity(len);
+    let mut column_ids = Vec::with_capacity(len);
+    let mut num_values = Vec::with_capacity(len);
+    let mut offsets = Vec::with_capacity(len);
+    let mut compressed_bytes = Vec::with_capacity(len);
+
+    for entry in entries {
+        block_location.put_and_commit(block_location_value);
+        source_column_ids.push(entry.source_column_id);
+        source_column_names.put_and_commit(&entry.source_column_name);
+        storage_kinds.put_and_commit(entry.storage_kind);
+        shared_paths.push(entry.shared_paths);
+        column_names.put_and_commit(&entry.column_name);
+        column_types.put_and_commit(&entry.column_type);
+        column_ids.push(entry.column_id);
+        num_values.push(entry.num_values);
+        offsets.push(entry.offset);
+        compressed_bytes.push(entry.len);
+    }
+
+    DataBlock::new(
+        vec![
+            Column::String(block_location.build()).into(),
+            UInt32Type::from_data(source_column_ids).into(),
+            Column::String(source_column_names.build()).into(),
+            Column::String(storage_kinds.build()).into(),
+            StringType::from_opt_data(shared_paths).into(),
+            Column::String(column_names.build()).into(),
+            Column::String(column_types.build()).into(),
+            UInt32Type::from_opt_data(column_ids).into(),
+            UInt64Type::from_data(num_values).into(),
+            UInt64Type::from_opt_data(offsets).into(),
+            UInt64Type::from_opt_data(compressed_bytes).into(),
+        ],
+        len,
+    )
+}

--- a/src/query/storages/fuse/src/table_functions/mod.rs
+++ b/src/query/storages/fuse/src/table_functions/mod.rs
@@ -31,6 +31,7 @@ mod fuse_vacuum_drop_aggregating_index;
 mod fuse_vacuum_drop_inverted_index;
 mod fuse_vacuum_temporary_table;
 mod fuse_virtual_column;
+mod fuse_virtual_column_build;
 mod set_cache_capacity;
 
 pub use clustering_information::ClusteringInformationFunc;
@@ -60,4 +61,5 @@ pub use fuse_vacuum_drop_inverted_index::FuseVacuumDropInvertedIndex;
 pub use fuse_vacuum_temporary_table::FuseVacuumTemporaryTable;
 pub use fuse_vacuum_temporary_table::vacuum_inactive_temp_tables;
 pub use fuse_virtual_column::FuseVirtualColumnFunc;
+pub use fuse_virtual_column_build::FuseVirtualColumnBuildFunc;
 pub use set_cache_capacity::SetCacheCapacity;

--- a/tests/sqllogictests/suites/base/06_show/06_0014_show_table_functions.test
+++ b/tests/sqllogictests/suites/base/06_show/06_0014_show_table_functions.test
@@ -25,6 +25,7 @@ fuse_vacuum_drop_aggregating_index
 fuse_vacuum_drop_inverted_index
 fuse_vacuum_temporary_table
 fuse_virtual_column
+fuse_virtual_column_build
 
 query T
 SHOW TABLE_FUNCTIONS LIKE 'fuse%' LIMIT 1

--- a/tests/sqllogictests/suites/query/virtual_column.test
+++ b/tests/sqllogictests/suites/query/virtual_column.test
@@ -154,6 +154,13 @@ select virtual_block_size, row_count, column_name, column_type, column_id, block
 839 3 val['b'] UInt64 NULL 1 44 40
 839 3 val['c'] String NULL 2 84 40
 
+query ITTI
+select source_column_id, source_column_name, storage_kind, num_values from fuse_virtual_column('test_virtual_column', 't2')
+----
+1 val direct 3
+1 val direct 3
+1 val direct 3
+
 query IIIIII
 select block_count, row_count, bytes_uncompressed, bytes_compressed, index_size, virtual_block_count from fuse_segment('test_virtual_column', 't2')
 ----


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR introduces the `fuse_virtual_column_build` table function for diagnosing virtual column generation on a specific Fuse block. The function reads the block directly from the provided `block_location`, runs `VirtualColumnBuilder`, and returns the virtual columns that can be generated. It does not depend on the current snapshot or existing virtual column files.

It also adds a few INFO logs to `VirtualColumnBuilder` to help identify whether virtual column data was generated and how many virtual columns were produced.

Usage

```sql
SELECT * FROM fuse_virtual_column_build('db_name', 'table_name', 'block_location');
```

The block location can be obtained from:

```sql
SELECT block_location FROM fuse_block('db_name', 'table_name');
```

The result includes information such as the source column, generated column name and type, storage kind, shared paths, value count, offset, and compressed size.

If the function returns rows, the block can generate virtual column data. If it returns no rows, no virtual columns can be extracted from that block.

Example

```sql
CREATE TABLE test (
    id INT,
    data VARIANT
) ENGINE = FUSE;

INSERT INTO test VALUES
    (1, '{"user":{"name":"Alice","age":20},"create":"3/06"}'),
    (2, '{"user":{"name":"Andy","age":30}}'),
    (3, '{"user":{"name":"Bob","age":35}}'),
    (4, '{"user":{"name":"Tom","age":40}}');

select block_location from fuse_block('default', 'test');
╭────────────────────────────────────────────────────────╮
│                     block_location                     │
│                         String                         │
├────────────────────────────────────────────────────────┤
│ 1/4324/_b/h019ffb6eb2a67de594d2def1f3b48eec_v2.parquet │
╰────────────────────────────────────────────────────────╯

select storage_kind, shared_paths, column_name, column_type, column_id from fuse_virtual_column_build('default', 'test', '1/4324/_b/h019ffb6eb2a67de594d2def1f3b48eec_v2.parquet');
╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ storage_kind │   shared_paths   │                        column_name                       │ column_type │     column_id    │
│    String    │ Nullable(String) │                          String                          │    String   │ Nullable(UInt32) │
├──────────────┼──────────────────┼──────────────────────────────────────────────────────────┼─────────────┼──────────────────┤
│ direct       │ NULL             │ data['user']['age']                                      │ UInt64 NULL │                0 │
│ direct       │ NULL             │ data['user']['name']                                     │ String NULL │                1 │
│ shared_key   │ ['create']       │ data.__shared_string_virtual_column_data__.entries.key   │ UInt32      │                2 │
│ shared_value │ NULL             │ data.__shared_string_virtual_column_data__.entries.value │ String      │                3 │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```




- fixes: #[Link the issue here]

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): add table function for debug

## AI assistance

<!--
See AI_POLICY.md. Agent-opened PRs are welcome; a responsible human on the author side must own the change.
The responsible human is NOT the reviewer — it is the submitter-side owner who has read the diff,
can explain each change, and will answer questions during review.
Write "None" for AI usage if no AI was involved.
-->

- AI usage: An AI coding agent assisted with implementation
- Responsible human: @b41sh
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20299)
<!-- Reviewable:end -->
