### PR TITLE
feat(query): add direct lineage neighbor lookup

### DIFF
--- a/src/query/service/src/table_functions/get_lineage/edge_reader.rs
+++ b/src/query/service/src/table_functions/get_lineage/edge_reader.rs
@@ -61,7 +61,7 @@ const LINEAGE_TABLE: &str = "lineage_history";
 const FRONTIER_BATCH_SIZE: usize = 512;
 const FIRST_LINEAGE_SCAN_ID: usize = 1_000;
 
-const EDGE_COLUMNS: &[&str] = &[
+pub(super) const EDGE_COLUMNS: &[&str] = &[
     "updated_on",
     "user_name",
     "query_parameterized_hash",
@@ -352,7 +352,11 @@ impl LineageEdgeReader {
     }
 }
 
-fn build_key_filter(schema: &TableSchema, column: &str, keys: &[String]) -> Result<Filters> {
+pub(super) fn build_key_filter(
+    schema: &TableSchema,
+    column: &str,
+    keys: &[String],
+) -> Result<Filters> {
     let field = schema.field_with_name(column)?;
     let data_type = DataType::from(field.data_type());
     let column_expr = || {
@@ -395,7 +399,7 @@ fn build_key_filter(schema: &TableSchema, column: &str, keys: &[String]) -> Resu
     })
 }
 
-fn decode_edges(
+pub(super) fn decode_edges(
     block: &DataBlock,
     schema: &TableSchema,
     match_column: &str,

--- a/src/query/service/src/table_functions/get_lineage/mod.rs
+++ b/src/query/service/src/table_functions/get_lineage/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod edge_reader;
+mod neighbors;
 mod resolver;
 mod traversal;
 
@@ -49,6 +50,7 @@ use databend_common_pipeline::core::processor::ProcessorPtr;
 use databend_common_pipeline::sources::AsyncSource;
 use databend_common_pipeline::sources::AsyncSourcer;
 use databend_meta_client::types::MetaId;
+pub use neighbors::GetLineageNeighborsTable;
 
 use crate::sessions::TableContext;
 

--- a/src/query/service/src/table_functions/get_lineage/neighbors.rs
+++ b/src/query/service/src/table_functions/get_lineage/neighbors.rs
@@ -1,0 +1,781 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::sync::Arc;
+
+use databend_common_catalog::catalog::CATALOG_DEFAULT;
+use databend_common_catalog::plan::DataSourceInfo;
+use databend_common_catalog::plan::DataSourcePlan;
+use databend_common_catalog::plan::Filters;
+use databend_common_catalog::plan::PartInfo;
+use databend_common_catalog::plan::PartInfoPtr;
+use databend_common_catalog::plan::PartInfoType;
+use databend_common_catalog::plan::PartStatistics;
+use databend_common_catalog::plan::Partitions;
+use databend_common_catalog::plan::Projection;
+use databend_common_catalog::plan::PushDownInfo;
+use databend_common_catalog::table::DistributionLevel;
+use databend_common_catalog::table::Table;
+use databend_common_catalog::table_args::TableArgs;
+use databend_common_catalog::table_args::string_value;
+use databend_common_catalog::table_function::TableFunction;
+use databend_common_exception::ErrorCode;
+use databend_common_exception::Result;
+use databend_common_expression::DataBlock;
+use databend_common_expression::FromData;
+use databend_common_expression::TableDataType;
+use databend_common_expression::TableField;
+use databend_common_expression::TableSchema;
+use databend_common_expression::TableSchemaRefExt;
+use databend_common_expression::type_check::check_function;
+use databend_common_expression::types::StringType;
+use databend_common_expression::types::VariantType;
+use databend_common_functions::BUILTIN_FUNCTIONS;
+use databend_common_meta_app::schema::TableIdent;
+use databend_common_meta_app::schema::TableInfo;
+use databend_common_meta_app::schema::TableMeta;
+use databend_common_pipeline::core::Pipeline;
+use databend_common_pipeline::sources::EmptySource;
+use databend_common_pipeline_transforms::AsyncAccumulatingTransform;
+use databend_common_pipeline_transforms::TransformPipelineHelper;
+use databend_meta_client::types::MetaId;
+use jsonb::parse_value;
+use parking_lot::Mutex;
+
+use super::ObjectDomain;
+use super::edge_reader::EDGE_COLUMNS;
+use super::edge_reader::LineageObjectType;
+use super::edge_reader::RawLineageEdge;
+use super::edge_reader::build_key_filter;
+use super::edge_reader::decode_edges;
+use super::resolver::ObjectResolver;
+use super::resolver::ResolvedObject;
+use super::traversal::normalize_column_name;
+use super::traversal::process_json;
+use super::traversal::resolve_column_ref;
+use super::traversal::same_object;
+use super::traversal::split_column_name;
+use crate::sessions::TableContext;
+
+const GET_LINEAGE_NEIGHBORS_FUNC: &str = "get_lineage_neighbors";
+const GET_LINEAGE_NEIGHBORS_ENGINE: &str = "GET_LINEAGE_NEIGHBORS";
+const HISTORY_DATABASE: &str = "system_history";
+const LINEAGE_TABLE: &str = "lineage_history";
+
+#[derive(Clone, Debug)]
+struct GetLineageNeighborsArgs {
+    object_domain: ObjectDomain,
+    object_name: String,
+}
+
+impl GetLineageNeighborsArgs {
+    fn parse(table_args: &TableArgs) -> Result<Self> {
+        let args = table_args.expect_all_positioned(GET_LINEAGE_NEIGHBORS_FUNC, None)?;
+        if args.len() != 2 {
+            return Err(ErrorCode::BadArguments(format!(
+                "{GET_LINEAGE_NEIGHBORS_FUNC} requires 2 positioned arguments: object_name, object_domain"
+            )));
+        }
+        let object_domain = ObjectDomain::parse(&string_value(&args[1])?)?;
+        Ok(Self {
+            object_domain,
+            object_name: string_value(&args[0])?,
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+struct NeighborRow {
+    direction: &'static str,
+    object_domain: String,
+    catalog: Option<String>,
+    database: Option<String>,
+    object_name: String,
+    column_neighbors: Vec<u8>,
+    process: String,
+}
+
+#[derive(Clone, Debug)]
+struct NeighborStart {
+    object: ResolvedObject,
+    column_name: Option<String>,
+}
+
+pub struct GetLineageNeighborsTable {
+    table_info: TableInfo,
+    table_args: TableArgs,
+    args: GetLineageNeighborsArgs,
+    delegated_tables: Mutex<HashMap<DelegatedTableKey, Arc<dyn Table>>>,
+}
+
+impl GetLineageNeighborsTable {
+    pub fn create(
+        database_name: &str,
+        table_func_name: &str,
+        table_id: MetaId,
+        table_args: TableArgs,
+    ) -> Result<Arc<dyn TableFunction>> {
+        let args = GetLineageNeighborsArgs::parse(&table_args)?;
+        let table_info = TableInfo {
+            ident: TableIdent::new(table_id, 0),
+            desc: format!("'{}'.'{}'", database_name, table_func_name),
+            name: table_func_name.to_string(),
+            meta: TableMeta {
+                schema: Self::schema(),
+                engine: GET_LINEAGE_NEIGHBORS_ENGINE.to_string(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        Ok(Arc::new(Self {
+            table_info,
+            table_args,
+            args,
+            delegated_tables: Mutex::new(HashMap::new()),
+        }))
+    }
+
+    fn schema() -> Arc<TableSchema> {
+        let nullable_string = || TableDataType::Nullable(Box::new(TableDataType::String));
+        TableSchemaRefExt::create(vec![
+            TableField::new("direction", TableDataType::String),
+            TableField::new("object_domain", TableDataType::String),
+            TableField::new("catalog", nullable_string()),
+            TableField::new("database", nullable_string()),
+            TableField::new("object_name", TableDataType::String),
+            TableField::new("column_neighbors", TableDataType::Variant),
+            TableField::new("process", TableDataType::String),
+        ])
+    }
+
+    async fn target_table(&self, ctx: Arc<dyn TableContext>) -> Result<Arc<dyn Table>> {
+        ctx.get_table(CATALOG_DEFAULT, HISTORY_DATABASE, LINEAGE_TABLE)
+            .await
+    }
+
+    async fn resolve_start(
+        &self,
+        ctx: &Arc<dyn TableContext>,
+        resolver: &mut ObjectResolver,
+    ) -> Result<Option<NeighborStart>> {
+        resolve_neighbor_start(ctx, &self.args, resolver).await
+    }
+
+    fn wrap_partitions(
+        table_info: TableInfo,
+        push_downs: PushDownInfo,
+        partitions: Partitions,
+    ) -> Partitions {
+        let is_lazy = partitions.partitions_type() == PartInfoType::LazyLevel;
+        let mut wrapped = Vec::with_capacity(partitions.partitions.len() + 1);
+        wrapped.push(Arc::new(Box::new(LineageNeighborsPart {
+            table_info: Some(table_info),
+            push_downs: Some(push_downs),
+            inner: None,
+            is_lazy,
+        }) as Box<dyn PartInfo>));
+        wrapped.extend(partitions.partitions.into_iter().map(|inner| {
+            Arc::new(Box::new(LineageNeighborsPart {
+                table_info: None,
+                push_downs: None,
+                inner: Some(inner),
+                is_lazy,
+            }) as Box<dyn PartInfo>)
+        }));
+        Partitions::create(partitions.kind, wrapped)
+    }
+
+    fn unwrap_partitions(partitions: &Partitions) -> Result<(TableInfo, PushDownInfo, Partitions)> {
+        let mut table_info = None;
+        let mut push_downs = None;
+        let mut inner = Vec::with_capacity(partitions.partitions.len());
+        for part in &partitions.partitions {
+            let part = part
+                .as_any()
+                .downcast_ref::<LineageNeighborsPart>()
+                .ok_or_else(|| {
+                    ErrorCode::Internal("invalid get_lineage_neighbors partition".to_string())
+                })?;
+            if let Some(info) = &part.table_info {
+                table_info = Some(info.clone());
+            }
+            if let Some(value) = &part.push_downs {
+                push_downs = Some(value.clone());
+            }
+            if let Some(part) = &part.inner {
+                inner.push(part.clone());
+            }
+        }
+        Ok((
+            table_info.ok_or_else(|| {
+                ErrorCode::Internal("missing lineage_history table info".to_string())
+            })?,
+            push_downs.ok_or_else(|| {
+                ErrorCode::Internal("missing lineage_history push downs".to_string())
+            })?,
+            Partitions::create(partitions.kind.clone(), inner),
+        ))
+    }
+
+    fn target_plan(&self, plan: &DataSourcePlan) -> Result<DataSourcePlan> {
+        let (target_info, push_downs, parts) = Self::unwrap_partitions(&plan.parts)?;
+        let target_schema = target_info.meta.schema.clone();
+        let projection = Projection::from_column_names(&target_schema, EDGE_COLUMNS)?;
+        Ok(DataSourcePlan {
+            source_info: DataSourceInfo::TableSource(target_info),
+            output_schema: Arc::new(projection.project_schema(&target_schema)),
+            parts,
+            push_downs: Some(push_downs),
+            // The delegated source is the physical lineage_history table. Keeping the outer
+            // function arguments would make build_table_from_source_plan try to instantiate
+            // `lineage_history` as a table function.
+            tbl_args: None,
+            ..plan.clone()
+        })
+    }
+
+    fn delegated_table_key(
+        ctx: &Arc<dyn TableContext>,
+        plan: &DataSourcePlan,
+    ) -> DelegatedTableKey {
+        DelegatedTableKey {
+            query_id: ctx.get_id(),
+            scan_id: plan.scan_id,
+            table_index: plan.table_index,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Table for GetLineageNeighborsTable {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn get_table_info(&self) -> &TableInfo {
+        &self.table_info
+    }
+
+    fn distribution_level(&self) -> DistributionLevel {
+        // Neighbor selection must see every matching history row before choosing the latest
+        // pattern for each direction/object pair.
+        DistributionLevel::Local
+    }
+
+    #[async_backtrace::framed]
+    async fn read_partitions(
+        &self,
+        ctx: Arc<dyn TableContext>,
+        _push_downs: Option<PushDownInfo>,
+        dry_run: bool,
+    ) -> Result<(PartStatistics, Partitions)> {
+        let target = self.target_table(ctx.clone()).await?;
+        let mut resolver = ObjectResolver::try_create(ctx.clone()).await?;
+        let Some(start) = self.resolve_start(&ctx, &mut resolver).await? else {
+            return Ok((PartStatistics::default(), Partitions::default()));
+        };
+        let schema = target.schema();
+        let projection = Projection::from_column_names(&schema, EDGE_COLUMNS)?;
+        let lookup_keys = start.object.lookup_keys.iter().cloned().collect::<Vec<_>>();
+        let source_filter = build_key_filter(&schema, "source_lineage_key", &lookup_keys)?;
+        let target_filter = build_key_filter(&schema, "target_lineage_key", &lookup_keys)?;
+        let filter = or_filters(source_filter, target_filter)?;
+        let push_downs = PushDownInfo {
+            projection: Some(projection),
+            filters: Some(filter),
+            ..Default::default()
+        };
+        let (statistics, partitions) = target
+            .read_partitions(ctx, Some(push_downs.clone()), dry_run)
+            .await?;
+        Ok((
+            statistics,
+            Self::wrap_partitions(target.get_table_info().clone(), push_downs, partitions),
+        ))
+    }
+
+    fn read_data(
+        &self,
+        ctx: Arc<dyn TableContext>,
+        plan: &DataSourcePlan,
+        pipeline: &mut Pipeline,
+        put_cache: bool,
+    ) -> Result<()> {
+        if plan.parts.is_empty() {
+            pipeline.add_source(EmptySource::create, 1)?;
+            return Ok(());
+        }
+        let target_plan = self.target_plan(plan)?;
+        if target_plan.parts.is_empty() {
+            pipeline.add_source(EmptySource::create, 1)?;
+        } else {
+            let target = self
+                .delegated_tables
+                .lock()
+                .remove(&Self::delegated_table_key(&ctx, &target_plan))
+                .map(Ok)
+                .unwrap_or_else(|| ctx.build_table_from_source_plan(&target_plan))?;
+            ctx.set_partitions(target_plan.parts.clone())?;
+            target.read_data(ctx.clone(), &target_plan, pipeline, put_cache)?;
+        }
+        pipeline.try_resize(1)?;
+        let args = self.args.clone();
+        pipeline.try_add_async_accumulating_transformer(move || {
+            Ok(LineageNeighborsTransform::new(
+                ctx.clone(),
+                args.clone(),
+                target_plan.output_schema.clone(),
+            ))
+        })?;
+        Ok(())
+    }
+
+    fn build_prune_pipeline(
+        &self,
+        ctx: Arc<dyn TableContext>,
+        plan: &DataSourcePlan,
+        source_pipeline: &mut Pipeline,
+        plan_id: u32,
+    ) -> Result<Option<Pipeline>> {
+        if plan.parts.is_empty() {
+            return Ok(None);
+        }
+        let target_plan = self.target_plan(plan)?;
+        let target = ctx.build_table_from_source_plan(&target_plan)?;
+        let prune_pipeline =
+            target.build_prune_pipeline(ctx.clone(), &target_plan, source_pipeline, plan_id)?;
+        if target_plan.parts.partitions_type() == PartInfoType::LazyLevel {
+            self.delegated_tables
+                .lock()
+                .insert(Self::delegated_table_key(&ctx, &target_plan), target);
+        }
+        Ok(prune_pipeline)
+    }
+
+    fn table_args(&self) -> Option<TableArgs> {
+        Some(self.table_args.clone())
+    }
+
+    fn result_can_be_cached(&self) -> bool {
+        false
+    }
+}
+
+impl TableFunction for GetLineageNeighborsTable {
+    fn function_name(&self) -> &str {
+        GET_LINEAGE_NEIGHBORS_FUNC
+    }
+
+    fn as_table<'a>(self: Arc<Self>) -> Arc<dyn Table + 'a>
+    where Self: 'a {
+        self
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct LineageNeighborsPart {
+    table_info: Option<TableInfo>,
+    push_downs: Option<PushDownInfo>,
+    inner: Option<PartInfoPtr>,
+    is_lazy: bool,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct DelegatedTableKey {
+    query_id: String,
+    scan_id: usize,
+    table_index: usize,
+}
+
+#[typetag::serde(name = "lineage_neighbors")]
+impl PartInfo for LineageNeighborsPart {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn equals(&self, info: &Box<dyn PartInfo>) -> bool {
+        info.as_any().downcast_ref::<Self>().is_some_and(|other| {
+            self.table_info.as_ref().map(|info| info.ident)
+                == other.table_info.as_ref().map(|info| info.ident)
+                && self.is_lazy == other.is_lazy
+                && match (&self.inner, &other.inner) {
+                    (Some(left), Some(right)) => left.equals(right),
+                    (None, None) => true,
+                    _ => false,
+                }
+        })
+    }
+
+    fn hash(&self) -> u64 {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        self.table_info
+            .as_ref()
+            .map(|info| info.ident.table_id)
+            .hash(&mut hasher);
+        self.is_lazy.hash(&mut hasher);
+        self.inner
+            .as_ref()
+            .map(|part| part.hash())
+            .hash(&mut hasher);
+        hasher.finish()
+    }
+
+    fn part_type(&self) -> PartInfoType {
+        if self.is_lazy {
+            PartInfoType::LazyLevel
+        } else {
+            PartInfoType::BlockLevel
+        }
+    }
+
+    fn is_reshuffle_header(&self) -> bool {
+        self.table_info.is_some() && self.inner.is_none()
+    }
+}
+
+fn or_filters(left: Filters, right: Filters) -> Result<Filters> {
+    let filter = check_function(
+        None,
+        "or_filters",
+        &[],
+        &[
+            left.filter.as_expr(&BUILTIN_FUNCTIONS),
+            right.filter.as_expr(&BUILTIN_FUNCTIONS),
+        ],
+        &BUILTIN_FUNCTIONS,
+    )?;
+    let inverted_filter = check_function(
+        None,
+        "and_filters",
+        &[],
+        &[
+            left.inverted_filter.as_expr(&BUILTIN_FUNCTIONS),
+            right.inverted_filter.as_expr(&BUILTIN_FUNCTIONS),
+        ],
+        &BUILTIN_FUNCTIONS,
+    )?;
+    Ok(Filters {
+        filter: filter.as_remote_expr(),
+        inverted_filter: inverted_filter.as_remote_expr(),
+    })
+}
+
+struct LineageNeighborsTransform {
+    ctx: Arc<dyn TableContext>,
+    args: GetLineageNeighborsArgs,
+    input_schema: Arc<TableSchema>,
+    resolver: Option<ObjectResolver>,
+    start: Option<NeighborStart>,
+    selected: HashMap<(&'static str, String), (RawLineageEdge, ResolvedObject)>,
+}
+
+impl LineageNeighborsTransform {
+    fn new(
+        ctx: Arc<dyn TableContext>,
+        args: GetLineageNeighborsArgs,
+        input_schema: Arc<TableSchema>,
+    ) -> Self {
+        Self {
+            ctx,
+            args,
+            input_schema,
+            resolver: None,
+            start: None,
+            selected: HashMap::new(),
+        }
+    }
+
+    async fn initialize(&mut self) -> Result<bool> {
+        if self.resolver.is_none() {
+            let mut resolver = ObjectResolver::try_create(self.ctx.clone()).await?;
+            self.start = resolve_neighbor_start(&self.ctx, &self.args, &mut resolver).await?;
+            self.resolver = Some(resolver);
+        }
+        Ok(self.start.is_some())
+    }
+
+    async fn collect_block(&mut self, block: &DataBlock) -> Result<()> {
+        if !self.initialize().await? {
+            return Ok(());
+        }
+        let start = self.start.as_ref().unwrap();
+        let lookup_keys = &start.object.lookup_keys;
+        for direction in ["UPSTREAM", "DOWNSTREAM"] {
+            let match_column = if direction == "UPSTREAM" {
+                "target_lineage_key"
+            } else {
+                "source_lineage_key"
+            };
+            let edges = decode_edges(block, &self.input_schema, match_column, lookup_keys)?;
+            let resolver = self.resolver.as_mut().unwrap();
+            for edge in edges {
+                let Some(source) = resolver.resolve(&edge.source).await? else {
+                    continue;
+                };
+                let Some(target) = resolver.resolve(&edge.target).await? else {
+                    continue;
+                };
+                if same_object(&source, &target) {
+                    continue;
+                }
+                let neighbor = if direction == "UPSTREAM" {
+                    source
+                } else {
+                    target
+                };
+                let key = (direction, canonical_object_key(&neighbor));
+                match self.selected.get_mut(&key) {
+                    Some((current, current_neighbor)) if edge.newer_than(current) => {
+                        *current = edge;
+                        *current_neighbor = neighbor;
+                    }
+                    None => {
+                        self.selected.insert(key, (edge, neighbor));
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn build_block(rows: Vec<NeighborRow>) -> Result<DataBlock> {
+        let mut directions = Vec::with_capacity(rows.len());
+        let mut domains = Vec::with_capacity(rows.len());
+        let mut catalogs = Vec::with_capacity(rows.len());
+        let mut databases = Vec::with_capacity(rows.len());
+        let mut tables = Vec::with_capacity(rows.len());
+        let mut columns = Vec::with_capacity(rows.len());
+        let mut processes = Vec::with_capacity(rows.len());
+        for row in rows {
+            directions.push(row.direction.to_string());
+            domains.push(row.object_domain);
+            catalogs.push(row.catalog);
+            databases.push(row.database);
+            tables.push(row.object_name);
+            columns.push(row.column_neighbors);
+            processes.push(row.process);
+        }
+        Ok(DataBlock::new_from_columns(vec![
+            StringType::from_data(directions),
+            StringType::from_data(domains),
+            StringType::from_opt_data(catalogs),
+            StringType::from_opt_data(databases),
+            StringType::from_data(tables),
+            VariantType::from_data(columns),
+            StringType::from_data(processes),
+        ]))
+    }
+}
+
+#[async_trait::async_trait]
+impl AsyncAccumulatingTransform for LineageNeighborsTransform {
+    const NAME: &'static str = "LineageNeighborsTransform";
+
+    async fn transform(&mut self, data: DataBlock) -> Result<Option<DataBlock>> {
+        self.collect_block(&data).await?;
+        Ok(None)
+    }
+
+    async fn on_finish(&mut self, output: bool) -> Result<Option<DataBlock>> {
+        if !output {
+            return Ok(None);
+        }
+        if !self.initialize().await? {
+            return Ok(Some(Self::build_block(vec![])?));
+        }
+        let start = self.start.as_ref().unwrap();
+        let mut rows = std::mem::take(&mut self.selected)
+            .into_iter()
+            .map(|((direction, _), (edge, neighbor))| {
+                build_neighbor_row(
+                    direction,
+                    edge,
+                    &start.object,
+                    start.column_name.as_deref(),
+                    neighbor,
+                )
+            })
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        rows.sort_by(|left, right| {
+            (
+                left.direction,
+                left.catalog.as_deref().unwrap_or_default(),
+                left.database.as_deref().unwrap_or_default(),
+                left.object_name.as_str(),
+            )
+                .cmp(&(
+                    right.direction,
+                    right.catalog.as_deref().unwrap_or_default(),
+                    right.database.as_deref().unwrap_or_default(),
+                    right.object_name.as_str(),
+                ))
+        });
+        Ok(Some(Self::build_block(rows)?))
+    }
+}
+
+fn canonical_object_key(object: &ResolvedObject) -> String {
+    if object.catalog_type.eq_ignore_ascii_case("DEFAULT")
+        && let Some(id) = object.id
+    {
+        return format!("{}::ID::{id}", object.object_type.as_str());
+    }
+    if object.object_type == LineageObjectType::Stage {
+        return format!("STAGE::NAME::{}", object.name);
+    }
+    format!(
+        "{}::NAME::{}.{}.{}",
+        object.object_type.as_str(),
+        object.catalog,
+        object.database,
+        object.name
+    )
+}
+
+async fn resolve_neighbor_start(
+    ctx: &Arc<dyn TableContext>,
+    args: &GetLineageNeighborsArgs,
+    resolver: &mut ObjectResolver,
+) -> Result<Option<NeighborStart>> {
+    if args.object_domain != ObjectDomain::Column {
+        return Ok(resolver
+            .resolve_start(args.object_domain, &args.object_name)
+            .await?
+            .map(|object| NeighborStart {
+                object,
+                column_name: None,
+            }));
+    }
+
+    let (object_name, column_name) = split_column_name(&args.object_name)?;
+    let Some(object) = resolver
+        .resolve_start(ObjectDomain::Column, &object_name)
+        .await?
+    else {
+        return Ok(None);
+    };
+    let column_name = normalize_column_name(ctx, &column_name)?;
+    let Some((_, column_name)) = object.column_by_name(&column_name) else {
+        return Ok(None);
+    };
+    Ok(Some(NeighborStart {
+        object,
+        column_name: Some(column_name),
+    }))
+}
+
+fn build_neighbor_row(
+    direction: &'static str,
+    edge: RawLineageEdge,
+    current: &ResolvedObject,
+    current_column: Option<&str>,
+    neighbor: ResolvedObject,
+) -> Result<Option<NeighborRow>> {
+    let column_neighbors =
+        build_column_neighbors(direction, &edge, current, &neighbor, current_column);
+    // COLUMN mode filters the map only after the newest object-neighbor pattern has been chosen.
+    // An older pattern must not revive a column mapping removed by the latest event.
+    if current_column.is_some() && column_neighbors.is_empty() {
+        return Ok(None);
+    }
+    let column_neighbors = parse_value(&serde_json::to_vec(&column_neighbors)?)
+        .map(|value| value.to_vec())
+        .map_err(|error| {
+            ErrorCode::Internal(format!(
+                "failed to encode lineage column neighbors: {error}"
+            ))
+        })?;
+    let (catalog, database) = match neighbor.object_type {
+        LineageObjectType::Stage => (None, None),
+        _ => (
+            Some(neighbor.catalog.clone()),
+            Some(neighbor.database.clone()),
+        ),
+    };
+    Ok(Some(NeighborRow {
+        direction,
+        object_domain: neighbor.object_type.as_str().to_string(),
+        catalog,
+        database,
+        object_name: neighbor.name.clone(),
+        column_neighbors,
+        process: process_json(&edge),
+    }))
+}
+
+fn build_column_neighbors(
+    direction: &str,
+    edge: &RawLineageEdge,
+    current: &ResolvedObject,
+    neighbor: &ResolvedObject,
+    current_column: Option<&str>,
+) -> BTreeMap<String, Vec<String>> {
+    let (current_captured, current_kind, neighbor_captured, neighbor_kind, mappings) =
+        if direction == "UPSTREAM" {
+            (
+                &edge.target,
+                edge.target_column_address_kind,
+                &edge.source,
+                edge.source_column_address_kind,
+                &edge.target_to_source_columns,
+            )
+        } else {
+            (
+                &edge.source,
+                edge.source_column_address_kind,
+                &edge.target,
+                edge.target_column_address_kind,
+                &edge.source_to_target_columns,
+            )
+        };
+    let (Some(current_kind), Some(neighbor_kind)) = (current_kind, neighbor_kind) else {
+        return BTreeMap::new();
+    };
+    let mut result = BTreeMap::<String, BTreeSet<String>>::new();
+    for (current_ref, neighbor_refs) in mappings {
+        let Some((_, current_name)) =
+            resolve_column_ref(current_captured, current, current_kind, current_ref)
+        else {
+            continue;
+        };
+        if current_column.is_some_and(|column| column != current_name) {
+            continue;
+        }
+        for neighbor_ref in neighbor_refs {
+            let Some((_, neighbor_name)) =
+                resolve_column_ref(neighbor_captured, neighbor, neighbor_kind, neighbor_ref)
+            else {
+                continue;
+            };
+            result
+                .entry(current_name.clone())
+                .or_default()
+                .insert(neighbor_name);
+        }
+    }
+    result
+        .into_iter()
+        .map(|(column, neighbors)| (column, neighbors.into_iter().collect()))
+        .collect()
+}

--- a/src/query/service/src/table_functions/get_lineage/traversal.rs
+++ b/src/query/service/src/table_functions/get_lineage/traversal.rs
@@ -407,7 +407,7 @@ async fn traverse_columns(
     Ok(rows)
 }
 
-fn resolve_column_ref(
+pub(super) fn resolve_column_ref(
     captured: &CapturedObject,
     object: &ResolvedObject,
     address_kind: AddressKind,
@@ -425,7 +425,7 @@ fn resolve_column_ref(
     }
 }
 
-fn same_object(source: &ResolvedObject, target: &ResolvedObject) -> bool {
+pub(super) fn same_object(source: &ResolvedObject, target: &ResolvedObject) -> bool {
     match (source.id, target.id) {
         (Some(source_id), Some(target_id))
             if source.catalog_type.eq_ignore_ascii_case("DEFAULT")
@@ -460,7 +460,7 @@ fn column_frontier_key(column: &ColumnFrontier) -> (String, String) {
     )
 }
 
-fn process_json(edge: &RawLineageEdge) -> String {
+pub(super) fn process_json(edge: &RawLineageEdge) -> String {
     // Keep embedded JSON timestamps stable across session timezones and self-describing.
     let updated_on = edge.updated_on.map(|timestamp| {
         strtime::format(
@@ -515,7 +515,7 @@ fn sort_rows(rows: &mut [LineageResultRow]) {
     });
 }
 
-fn split_column_name(input: &str) -> Result<(String, String)> {
+pub(super) fn split_column_name(input: &str) -> Result<(String, String)> {
     let input = input.trim();
     let Some(index) = last_unquoted_dot(input) else {
         return Err(ErrorCode::BadArguments(
@@ -532,7 +532,7 @@ fn split_column_name(input: &str) -> Result<(String, String)> {
     Ok((table.to_string(), column.to_string()))
 }
 
-fn normalize_column_name(ctx: &Arc<dyn TableContext>, value: &str) -> Result<String> {
+pub(super) fn normalize_column_name(ctx: &Arc<dyn TableContext>, value: &str) -> Result<String> {
     let settings = ctx.get_settings();
     let resolution = NameResolutionContext::try_from(settings.as_ref())?;
     let dialect = settings.get_sql_dialect().unwrap_or_default();

--- a/src/query/service/src/table_functions/table_function_factory.rs
+++ b/src/query/service/src/table_functions/table_function_factory.rs
@@ -67,6 +67,7 @@ use crate::table_functions::TableFunction;
 use crate::table_functions::async_crash_me::AsyncCrashMeTable;
 use crate::table_functions::copy_history::CopyHistoryTable;
 use crate::table_functions::fuse_vacuum2::FuseVacuum2Table;
+use crate::table_functions::get_lineage::GetLineageNeighborsTable;
 use crate::table_functions::get_lineage::GetLineageTable;
 #[cfg(feature = "storage-stage")]
 use crate::table_functions::infer_schema::InferSchemaTable;
@@ -466,6 +467,10 @@ impl TableFunctionFactory {
         creators.insert(
             "get_lineage".to_string(),
             (next_id(), Arc::new(GetLineageTable::create)),
+        );
+        creators.insert(
+            "get_lineage_neighbors".to_string(),
+            (next_id(), Arc::new(GetLineageNeighborsTable::create)),
         );
 
         TableFunctionFactory {

--- a/tests/logging/history_table/setup_test_data.sh
+++ b/tests/logging/history_table/setup_test_data.sh
@@ -69,7 +69,7 @@ done
 # delay above is sufficient on every CI runner.
 lineage_ready=false
 for _ in {1..30}; do
-  lineage_response=$(execute_query "SELECT count_if(source_database IN ('lineage_history_multi_kind', 'lineage_history_columns', 'lineage_history_views', 'lineage_history_statements') OR target_database IN ('lineage_history_multi_kind', 'lineage_history_columns', 'lineage_history_views', 'lineage_history_statements')) AS captured_edges, count_if(target_database = 'lineage_history_lifecycle') AS lifecycle_edges, count_if(source_catalog = 'lineage_history_iceberg_catalog' AND source_database = 'lineage_db' AND target_database = 'lineage_history_iceberg') AS iceberg_edges, count_if(target_database = 'lineage_history_views' AND target_name IN ('src_view', 'view_dst')) AS view_edges FROM system_history.lineage_history")
+  lineage_response=$(execute_query "SELECT count_if(source_database IN ('lineage_history_multi_kind', 'lineage_history_columns', 'lineage_history_views', 'lineage_history_statements') OR target_database IN ('lineage_history_multi_kind', 'lineage_history_columns', 'lineage_history_views', 'lineage_history_statements')) AS captured_edges, count_if(target_database = 'lineage_history_lifecycle') AS lifecycle_edges, count_if(source_catalog = 'lineage_history_iceberg_catalog' AND source_database = 'lineage_db' AND target_database = 'lineage_history_iceberg') AS iceberg_edges, count_if(target_database = 'lineage_history_views' AND target_name IN ('src_view', 'view_dst')) AS view_edges, count_if(target_database = 'lineage_history_columns' AND target_name = 'pattern_dst') AS pattern_edges FROM system_history.lineage_history")
   if [ "$(echo "$lineage_response" | jq -r '.state')" = "Failed" ]; then
     # The history transform creates its destination table asynchronously. Treat a missing table
     # like any other not-ready state and report the last response if the poll eventually times out.
@@ -80,7 +80,8 @@ for _ in {1..30}; do
   lifecycle_count=$(echo "$lineage_response" | jq -r '.data[0][1] // 0')
   iceberg_count=$(echo "$lineage_response" | jq -r '.data[0][2] // 0')
   view_count=$(echo "$lineage_response" | jq -r '.data[0][3] // 0')
-  if [ "$lineage_count" -ge 16 ] 2>/dev/null && [ "$lifecycle_count" -eq 3 ] 2>/dev/null && [ "$iceberg_count" -ge 1 ] 2>/dev/null && [ "$view_count" -ge 2 ] 2>/dev/null; then
+  pattern_count=$(echo "$lineage_response" | jq -r '.data[0][4] // 0')
+  if [ "$lineage_count" -ge 16 ] 2>/dev/null && [ "$lifecycle_count" -eq 3 ] 2>/dev/null && [ "$iceberg_count" -ge 1 ] 2>/dev/null && [ "$view_count" -ge 2 ] 2>/dev/null && [ "$pattern_count" -eq 2 ] 2>/dev/null; then
     lineage_ready=true
     break
   fi

--- a/tests/logging/history_table/sqllogic/check/01_multi_kind_edges.test
+++ b/tests/logging/history_table/sqllogic/check/01_multi_kind_edges.test
@@ -30,6 +30,38 @@ FROM get_lineage('lineage_history_multi_kind.dst', 'TABLE', 'UPSTREAM', 1)
 ----
 DML
 
+# Neighbors collapse physical patterns for the same direction/object pair to the newest event.
+# The last DML restores the CTAS-shaped mapping, so historical b -> x / a -> y is not unioned in.
+query TTTTTTT
+SELECT direction, object_domain, catalog, database, object_name,
+       column_neighbors['x'][0]::STRING,
+       column_neighbors['y'][0]::STRING
+FROM get_lineage_neighbors('lineage_history_multi_kind.dst', 'TABLE')
+----
+UPSTREAM TABLE default lineage_history_multi_kind src a b
+
+query BB
+WITH neighbor AS (
+  SELECT parse_json(process) AS process
+  FROM get_lineage_neighbors('lineage_history_multi_kind.dst', 'TABLE')
+), history AS (
+  SELECT lineage_kind, query_info
+  FROM system_history.lineage_history
+  WHERE source_database = 'lineage_history_multi_kind'
+    AND source_name = 'src'
+    AND target_database = 'lineage_history_multi_kind'
+    AND target_name = 'dst'
+  QUALIFY row_number() OVER (
+    ORDER BY updated_on DESC, query_info['query_id']::STRING DESC,
+             lineage_kind DESC, column_lineage_hash DESC
+  ) = 1
+)
+SELECT neighbor.process['lineage_kind']::STRING = history.lineage_kind,
+       neighbor.process['query_text']::STRING = history.query_info['query_text']::STRING
+FROM neighbor CROSS JOIN history
+----
+1 1
+
 # Column lineage accumulates every mapping across kinds: dst.x is fed by both src.a (CTAS and the
 # last DML) and src.b (the first DML), deduplicated into one row per distinct source column.
 query ISS rowsort

--- a/tests/logging/history_table/sqllogic/check/02_column_multihop.test
+++ b/tests/logging/history_table/sqllogic/check/02_column_multihop.test
@@ -50,6 +50,63 @@ FROM get_lineage('lineage_history_columns.mid', 'TABLE', 'UPSTREAM', 1)
 ----
 default lineage_history_columns src default lineage_history_columns mid
 
+# A table-level neighbor query returns both directions in one result. Column maps are oriented
+# around the queried object: current mid columns are keys and neighbor columns are values.
+query TTTTTTT rowsort
+SELECT direction, object_domain, catalog, database, object_name,
+       column_neighbors['x'][0]::STRING,
+       column_neighbors['y'][0]::STRING
+FROM get_lineage_neighbors('lineage_history_columns.mid', 'TABLE')
+----
+DOWNSTREAM TABLE default lineage_history_columns dst z NULL
+UPSTREAM TABLE default lineage_history_columns src b a
+
+# Column mode keeps the same one-row-per-neighbor schema, but filters each map to the requested
+# current column. The latest object-neighbor patterns map mid.x upstream to src.b and downstream
+# to dst.z.
+query TTTTTT rowsort
+SELECT direction, object_domain, catalog, database, object_name,
+       to_string(column_neighbors)
+FROM get_lineage_neighbors('lineage_history_columns.mid.x', 'COLUMN')
+----
+DOWNSTREAM TABLE default lineage_history_columns dst {"x":["z"]}
+UPSTREAM TABLE default lineage_history_columns src {"x":["b"]}
+
+query I
+SELECT count(*)
+FROM get_lineage_neighbors('lineage_history_columns.mid.missing', 'COLUMN')
+----
+0
+
+# Select the newest object-neighbor pattern before filtering to the requested column. The older
+# x <- a pattern is still physically retained, but the latest pattern contains only y <- b.
+query T
+SELECT to_string(column_neighbors)
+FROM get_lineage_neighbors('lineage_history_columns.pattern_dst', 'TABLE')
+----
+{"y":["b"]}
+
+query I
+SELECT count(*)
+FROM get_lineage_neighbors('lineage_history_columns.pattern_dst.x', 'COLUMN')
+----
+0
+
+query T
+SELECT to_string(column_neighbors)
+FROM get_lineage_neighbors('lineage_history_columns.pattern_dst.y', 'COLUMN')
+----
+{"y":["b"]}
+
+# The same resolved object is retained once per direction, rather than collapsed across direction.
+query TTIT rowsort
+SELECT direction, object_name, count(*), column_neighbors['a'][0]::STRING
+FROM get_lineage_neighbors('lineage_history_columns.cycle_left', 'TABLE')
+GROUP BY direction, object_name, column_neighbors['a'][0]::STRING
+----
+DOWNSTREAM cycle_right 1 b
+UPSTREAM cycle_right 1 b
+
 # Source and target masking are reported independently for each resolved column endpoint.
 statement ok
 ALTER TABLE lineage_history_columns.src MODIFY COLUMN a SET MASKING POLICY lineage_history_columns_mask

--- a/tests/logging/history_table/sqllogic/check/03_view_boundary.test
+++ b/tests/logging/history_table/sqllogic/check/03_view_boundary.test
@@ -58,6 +58,15 @@ FROM get_lineage('lineage_history_views.src_view', 'VIEW', 'DOWNSTREAM', 1)
 ----
 1 lineage_history_views src_view lineage_history_views view_dst
 
+# Direct neighbors preserve the VIEW domain and orient both column maps around src_view.
+query TTTTTT rowsort
+SELECT direction, object_domain, catalog, database, object_name,
+       to_string(column_neighbors)
+FROM get_lineage_neighbors('lineage_history_views.src_view', 'VIEW')
+----
+DOWNSTREAM TABLE default lineage_history_views view_dst {"p":["q"],"v":["z"]}
+UPSTREAM TABLE default lineage_history_views src {"p":["a"],"v":["a","b"]}
+
 # Column lineage always retains display names. View columns are explicitly NAME-addressed with no
 # schema id, while the CTAS target table column retains both its name and stable id.
 query BB

--- a/tests/logging/history_table/sqllogic/check/04_statement_coverage.test
+++ b/tests/logging/history_table/sqllogic/check/04_statement_coverage.test
@@ -187,6 +187,22 @@ FROM get_lineage('lineage_history_statements_stage', 'STAGE', 'DOWNSTREAM', 1)
 1 NULL NULL lineage_history_statements_stage default lineage_history_statements insert_select_stage_dst
 1 NULL NULL lineage_history_statements_stage default lineage_history_statements insert_stage_dst
 
+# Stage neighbors have no catalog/database or stable file-column mapping.
+query TTTTTT rowsort
+SELECT direction, object_domain, catalog, database, object_name, to_string(column_neighbors)
+FROM get_lineage_neighbors('lineage_history_statements_stage', 'STAGE')
+----
+DOWNSTREAM TABLE default lineage_history_statements copy_dst {}
+DOWNSTREAM TABLE default lineage_history_statements insert_select_stage_dst {}
+DOWNSTREAM TABLE default lineage_history_statements insert_stage_dst {}
+UPSTREAM TABLE default lineage_history_statements src {}
+
+query TTTTTT
+SELECT direction, object_domain, catalog, database, object_name, to_string(column_neighbors)
+FROM get_lineage_neighbors('lineage_history_statements.copy_dst', 'TABLE')
+----
+UPSTREAM STAGE NULL NULL lineage_history_statements_stage {}
+
 query ITSTTT
 SELECT distance, source_object_catalog, source_object_database, source_object_name,
        target_object_database, target_object_name

--- a/tests/logging/history_table/sqllogic/check/05_object_lifecycle.test
+++ b/tests/logging/history_table/sqllogic/check/05_object_lifecycle.test
@@ -18,6 +18,12 @@ FROM get_lineage('lineage_history_lifecycle.dropped_fuse', 'TABLE', 'UPSTREAM', 
 ----
 0
 
+query I
+SELECT count(*)
+FROM get_lineage_neighbors('lineage_history_lifecycle.dropped_fuse', 'TABLE')
+----
+0
+
 # UNDROP restores the same table id, so the retained edge becomes active without a rewrite.
 statement ok
 UNDROP TABLE lineage_history_lifecycle.dropped_fuse
@@ -27,6 +33,12 @@ SELECT distance, source_object_database, source_object_name, target_object_datab
 FROM get_lineage('lineage_history_lifecycle.dropped_fuse', 'TABLE', 'UPSTREAM', 1)
 ----
 1 lineage_history_lifecycle src lineage_history_lifecycle dropped_fuse
+
+query TTTTT
+SELECT direction, object_domain, catalog, database, object_name
+FROM get_lineage_neighbors('lineage_history_lifecycle.dropped_fuse', 'TABLE')
+----
+UPSTREAM TABLE default lineage_history_lifecycle src
 
 # Renaming preserves column ids, so the existing DataMovement edge resolves both current names.
 statement ok

--- a/tests/logging/history_table/sqllogic/check/06_iceberg_catalog.test
+++ b/tests/logging/history_table/sqllogic/check/06_iceberg_catalog.test
@@ -14,6 +14,25 @@ FROM get_lineage('lineage_history_iceberg.dst.a', 'COLUMN', 'UPSTREAM', 1)
 ----
 1 lineage_history_iceberg_catalog lineage_db src a default lineage_history_iceberg dst a
 
+# An external-catalog table can be both the lookup object and the returned neighbor. Its public
+# shape matches a regular TABLE while preserving the external catalog address.
+query TTTTTT
+SELECT direction, object_domain, catalog, database, object_name,
+       to_string(column_neighbors)
+FROM get_lineage_neighbors(
+    'lineage_history_iceberg_catalog.lineage_db.src',
+    'TABLE'
+)
+----
+DOWNSTREAM TABLE default lineage_history_iceberg dst {"a":["a"]}
+
+query TTTTTT
+SELECT direction, object_domain, catalog, database, object_name,
+       to_string(column_neighbors)
+FROM get_lineage_neighbors('lineage_history_iceberg.dst', 'TABLE')
+----
+UPSTREAM TABLE lineage_history_iceberg_catalog lineage_db src {"a":["a"]}
+
 # External catalog ids are not stable across catalog reloads. Both the object and its column data
 # must therefore be name-addressed in the aggregated physical record.
 query IIII

--- a/tests/logging/history_table/sqllogic/setup/02_column_multihop.test
+++ b/tests/logging/history_table/sqllogic/setup/02_column_multihop.test
@@ -27,6 +27,36 @@ statement ok
 CREATE TABLE lineage_history_columns.dst AS
 SELECT x AS z FROM lineage_history_columns.mid
 
+# The same object can be both an upstream and downstream neighbor. Keep this cycle separate from
+# the multi-hop chain above so its traversal assertions remain unambiguous.
+statement ok
+CREATE TABLE lineage_history_columns.cycle_left(a INT)
+
+statement ok
+CREATE TABLE lineage_history_columns.cycle_right(b INT)
+
+statement ok
+INSERT INTO lineage_history_columns.cycle_right SELECT a FROM lineage_history_columns.cycle_left
+
+statement ok
+INSERT INTO lineage_history_columns.cycle_left SELECT b FROM lineage_history_columns.cycle_right
+
+# The latest pattern for this object pair maps only y. Column-neighbor lookup for x must not fall
+# back to the older x pattern retained in history.
+statement ok
+CREATE TABLE lineage_history_columns.pattern_src(a INT, b INT)
+
+statement ok
+CREATE TABLE lineage_history_columns.pattern_dst(x INT, y INT)
+
+statement ok
+INSERT INTO lineage_history_columns.pattern_dst
+SELECT a, 0 FROM lineage_history_columns.pattern_src
+
+statement ok
+INSERT INTO lineage_history_columns.pattern_dst
+SELECT 0, b FROM lineage_history_columns.pattern_src
+
 # Target status is column-specific: only dst.z has a masking policy.
 statement ok
 CREATE MASKING POLICY lineage_history_columns_mask AS (val INT) RETURNS INT -> -1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

`GET_LINEAGE` is designed for recursive traversal. Its nested lineage-history scans are useful for multi-hop SQL queries, but they are unnecessarily complex for the Cloud UI workflow, where each interaction expands only the direct neighbors of one object or column.

This PR adds:

```sql
SELECT *
FROM get_lineage_neighbors('default.db.table', 'TABLE');
```

The table function returns one row per directly connected neighbor object and direction:

- `direction`: `UPSTREAM` or `DOWNSTREAM`, relative to the queried object
- `object_domain`: `TABLE`, `VIEW`, or `STAGE`
- `catalog`, `database`, and `object_name`: the resolved neighbor address
- `column_neighbors`: a current-object-oriented JSON map of directly connected columns
- `process`: the same process JSON exposed by `GET_LINEAGE`

It supports `TABLE`, `VIEW`, `STAGE`, and `COLUMN` inputs. Column mode keeps the same one-row-per-neighbor-object schema and filters `column_neighbors` to the requested current column. For example, querying `A.c` can return neighbor `B` with `{"c":["d","e"]}`.

## Implementation

- Delegates partition discovery and data reads to `system_history.lineage_history`, with projection and source/target lineage-key filter pushdown.
- Runs the underlying Fuse source in the outer query pipeline; it does not create a child `QueryContext`, nested pulling executor, or per-scan runtime.
- Preserves block/lazy partitions and delegates the prune pipeline using the same underlying table instance.
- Reuses the existing object resolver for object validity, rename/id resolution, endpoint type checks, visibility, and Stage resolution.
- Selects the newest valid physical pattern for each `(direction, neighbor object)` and returns at most two rows for the same neighbor, one per direction.
- Resolves persisted column ids/names to current schema names. Object mode returns the selected pattern's complete map; column mode returns only the requested current column's mapping.
- Accumulates only the selected neighbor state rather than materializing all matching history blocks.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Coverage includes:

- upstream and downstream neighbors in one query
- the same object appearing once in each direction
- newest-pattern selection without unioning older column mappings
- current-object-oriented table and column maps
- View neighbors and column mappings
- Stage addresses and empty Stage column mappings
- external-catalog Iceberg neighbors in both directions
- dropped-object filtering and UNDROP reactivation

Validation commands:

```text
cargo fmt --all -- --check
cargo check -p databend-query --lib
cargo clippy -p databend-query --lib -- -D warnings
tests/logging/test-history-tables.sh
```

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent drafted the table function, delegated pipeline integration, and regression tests under the author's direction.
- Responsible human: @youngsofun
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20300)
<!-- Reviewable:end -->
