### PR TITLE
feat(query): extend runtime filters to single-column probe expressions

### DIFF
--- a/src/query/catalog/src/runtime_filter_info.rs
+++ b/src/query/catalog/src/runtime_filter_info.rs
@@ -407,7 +407,6 @@ pub struct RuntimeFilterEntry {
 
 #[derive(Clone)]
 pub struct RuntimeFilterBloom {
-    pub column_name: String,
     pub filter: RuntimeBloomFilter,
 }
 

--- a/src/query/catalog/src/table_context/runtime_filter.rs
+++ b/src/query/catalog/src/table_context/runtime_filter.rs
@@ -51,7 +51,10 @@ pub trait TableContextRuntimeFilter: Send + Sync {
 
     fn get_runtime_filters(&self, id: usize) -> Vec<RuntimeFilterEntry>;
 
-    fn get_bloom_runtime_filter_with_id(&self, id: usize) -> Vec<(String, RuntimeBloomFilter)>;
+    fn get_bloom_runtime_filter_with_id(
+        &self,
+        id: usize,
+    ) -> Vec<(Expr<String>, RuntimeBloomFilter)>;
 
     fn get_inlist_runtime_filter_with_id(&self, id: usize) -> Vec<Expr<String>>;
 

--- a/src/query/service/src/physical_plans/physical_hash_join.rs
+++ b/src/query/service/src/physical_plans/physical_hash_join.rs
@@ -49,6 +49,9 @@ use tokio::sync::Barrier;
 
 use super::PhysicalPlanCast;
 use super::runtime_filter::PhysicalRuntimeFilters;
+use super::runtime_filter::RuntimeFilterProbeKey;
+use super::runtime_filter::canonical_equivalence_connector;
+use super::runtime_filter::resolve_runtime_filter_probe_expr;
 use crate::physical_plans::Exchange;
 use crate::physical_plans::PhysicalPlanBuilder;
 use crate::physical_plans::explain::PlanStatsInfo;
@@ -77,7 +80,7 @@ type JoinConditionsResult = (
     Vec<RemoteExpr>,
     Vec<RemoteExpr>,
     Vec<bool>,
-    Vec<Option<(RemoteExpr<String>, usize, usize, Symbol, bool)>>,
+    Vec<Option<RuntimeFilterProbeKey<RemoteExpr<String>>>>,
     Vec<((usize, bool), usize)>,
     Vec<Option<IndexType>>,
 );
@@ -88,14 +91,7 @@ type ProjectionsResult = (
     Option<(usize, HashMap<Symbol, usize>)>,
 );
 
-/// Type alias for runtime filter expression result
-/// Contains: (Expr, scan_id, table_index, column_idx)
-type RuntimeFilterExpr = Option<(
-    databend_common_expression::Expr<String>,
-    usize,
-    usize,
-    Symbol,
-)>;
+type RuntimeFilterExpr = Option<RuntimeFilterProbeKey<databend_common_expression::Expr<String>>>;
 
 type MergedFieldsResult = (
     Vec<DataField>,
@@ -713,66 +709,24 @@ impl PhysicalPlanBuilder {
     /// * `left_condition` - The left side condition
     ///
     /// # Returns
-    /// * `Result<Option<(databend_common_expression::Expr<String>, usize, usize)>>` - Runtime filter expression, scan ID, and table index
+    /// The typed probe key and its scan/column metadata, if the expression
+    /// references exactly one physical base column.
     fn prepare_runtime_filter_expr(
         &self,
         left_condition: &ScalarExpr,
     ) -> Result<RuntimeFilterExpr> {
-        // Runtime filter only supports columns in base tables
-        if left_condition.used_columns().iter().all(|idx| {
-            matches!(
-                self.metadata.read().column(*idx),
-                ColumnEntry::BaseTableColumn(_)
-            )
-        }) {
-            if let Some(column_idx) = left_condition.used_columns().iter().next() {
-                // Safe to unwrap because we have checked the column is a base table column
-                let table_index = self
-                    .metadata
-                    .read()
-                    .column(*column_idx)
-                    .table_index()
-                    .unwrap();
-                let scan_id = self
-                    .metadata
-                    .read()
-                    .base_column_scan_id(*column_idx)
-                    .unwrap();
-
-                let metadata = self.metadata.read();
-                return Ok(Some((
-                    left_condition
-                        .as_raw_expr()
-                        .type_check(&*metadata)?
-                        .project_column_ref(|col| {
-                            // Use the physical column name from the table schema
-                            // (looked up by column_id) rather than the binding's
-                            // context name, which can be an alias that collides
-                            // with another column in the same table.
-                            let entry = metadata.column(col.index);
-                            if let ColumnEntry::BaseTableColumn(base_col) = entry {
-                                if base_col.path_indices.is_none() {
-                                    let table = metadata.table(base_col.table_index);
-                                    let schema = table.table().schema_with_stream();
-                                    if let Ok(field) = schema.field_of_column_id(base_col.column_id)
-                                    {
-                                        return Ok(field.name().clone());
-                                    }
-                                }
-                                // For nested/path columns, or when schema lookup
-                                // fails, use the stable metadata-level column name.
-                                return Ok(base_col.column_name.clone());
-                            }
-                            Ok(col.column_name.clone())
-                        })?,
-                    scan_id,
-                    table_index,
-                    *column_idx,
-                )));
-            }
-        }
-
-        Ok(None)
+        let Some(probe) = resolve_runtime_filter_probe_expr(&self.metadata, left_condition)? else {
+            return Ok(None);
+        };
+        let is_connector =
+            canonical_equivalence_connector(probe.probe_key.as_remote_expr()).is_ok();
+        Ok(Some(RuntimeFilterProbeKey {
+            probe_key: probe.probe_key,
+            scan_id: probe.scan_id,
+            column_idx: probe.column_idx,
+            is_connector,
+            is_null_equal: false,
+        }))
     }
 
     /// Handles inner join column optimization
@@ -925,20 +879,22 @@ impl PhysicalPlanBuilder {
 
             // Process runtime filter expressions
             let left_expr_for_runtime_filter = left_expr_for_runtime_filter
-                .map(|(expr, scan_id, table_index, column_idx)| {
-                    check_cast(expr.span(), false, expr, &common_ty, &BUILTIN_FUNCTIONS).map(
-                        |casted_expr| {
-                            (
-                                casted_expr,
-                                scan_id,
-                                table_index,
-                                column_idx,
-                                condition.is_null_equal,
-                            )
-                        },
-                    )
+                .map(|probe| {
+                    probe.try_map_probe_key(|probe_key| {
+                        check_cast(
+                            probe_key.span(),
+                            false,
+                            probe_key,
+                            &common_ty,
+                            &BUILTIN_FUNCTIONS,
+                        )
+                    })
                 })
                 .transpose()?;
+            let left_expr_for_runtime_filter = left_expr_for_runtime_filter.map(|mut probe| {
+                probe.is_null_equal = condition.is_null_equal;
+                probe
+            });
 
             // Fold constants
             let (left_expr, _) =
@@ -946,33 +902,20 @@ impl PhysicalPlanBuilder {
             let (right_expr, _) =
                 ConstantFolder::fold(&right_expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
 
-            let left_expr_for_runtime_filter = left_expr_for_runtime_filter.map(
-                |(expr, scan_id, table_index, column_idx, is_null_equal)| {
-                    (
-                        ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS).0,
-                        scan_id,
-                        table_index,
-                        column_idx,
-                        is_null_equal,
-                    )
-                },
-            );
+            let left_expr_for_runtime_filter = left_expr_for_runtime_filter.map(|probe| {
+                probe.map_probe_key(|probe_key| {
+                    ConstantFolder::fold(&probe_key, &self.func_ctx, &BUILTIN_FUNCTIONS).0
+                })
+            });
 
             // Add to result collections
             left_join_conditions.push(left_expr.as_remote_expr());
             right_join_conditions.push(right_expr.as_remote_expr());
             is_null_equal.push(condition.is_null_equal);
-            left_join_conditions_rt.push(left_expr_for_runtime_filter.map(
-                |(expr, scan_id, table_index, column_idx, is_null_equal)| {
-                    (
-                        expr.as_remote_expr(),
-                        scan_id,
-                        table_index,
-                        column_idx,
-                        is_null_equal,
-                    )
-                },
-            ));
+            left_join_conditions_rt.push(
+                left_expr_for_runtime_filter
+                    .map(|probe| probe.map_probe_key(|probe_key| probe_key.as_remote_expr())),
+            );
             build_table_indexes.push(build_table_index);
         }
 

--- a/src/query/service/src/physical_plans/runtime_filter/builder.rs
+++ b/src/query/service/src/physical_plans/runtime_filter/builder.rs
@@ -16,14 +16,20 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use databend_common_exception::Result;
+use databend_common_expression::Domain;
+use databend_common_expression::Expr;
+use databend_common_expression::FunctionContext;
+use databend_common_expression::FunctionDomain;
+use databend_common_expression::FunctionEval;
 use databend_common_expression::RemoteExpr;
+use databend_common_expression::conversion::classify_conversion;
+use databend_common_expression::conversion::common_super_type_with_conversion;
+use databend_common_expression::type_check::check_cast;
 use databend_common_expression::types::DataType;
 use databend_common_functions::BUILTIN_FUNCTIONS;
-use databend_common_sql::ColumnEntry;
 use databend_common_sql::IndexType;
 use databend_common_sql::MetadataRef;
 use databend_common_sql::Symbol;
-use databend_common_sql::TypeCheck;
 use databend_common_sql::optimizer::ir::SExpr;
 use databend_common_sql::plans::Exchange;
 use databend_common_sql::plans::Join;
@@ -34,11 +40,10 @@ use databend_common_sql::plans::ScalarExpr;
 
 use super::types::PhysicalRuntimeFilter;
 use super::types::PhysicalRuntimeFilters;
+use super::types::RuntimeFilterProbeKey;
+use super::types::canonical_equivalence_connector;
+use super::types::resolve_runtime_filter_probe_expr;
 use crate::sessions::TableContext;
-
-/// Type alias for probe keys with runtime filter information
-/// Contains: (RemoteExpr, scan_id, table_index, column_idx, is_null_equal)
-type ProbeKeysWithRuntimeFilter = Vec<Option<(RemoteExpr<String>, usize, usize, Symbol, bool)>>;
 
 /// Check if a data type is supported for bloom filter
 ///
@@ -72,8 +77,8 @@ pub fn supported_join_type_for_runtime_filter(join_type: &JoinType) -> bool {
 
 /// Build runtime filters for a join operation
 ///
-/// This is the legacy method that creates one runtime filter per probe key.
-/// For equivalence class propagation, use the enhanced version in physical_hash_join.rs
+/// Creates one runtime filter per eligible probe key and propagates it to
+/// equality-safe connector columns and their attached expression leaves.
 ///
 /// # Arguments
 /// * `ctx` - Table context
@@ -81,7 +86,7 @@ pub fn supported_join_type_for_runtime_filter(join_type: &JoinType) -> bool {
 /// * `join` - Join plan
 /// * `s_expr` - SExpr for the join
 /// * `build_keys` - Build side keys
-/// * `probe_keys` - Probe side keys with scan_id, table_index, and column_idx
+/// * `probe_keys` - Probe keys with their scan, source column, connector, and null-equality metadata
 ///
 /// # Returns
 /// Collection of runtime filters to be applied
@@ -91,7 +96,7 @@ pub async fn build_runtime_filter(
     join: &Join,
     s_expr: &SExpr,
     build_keys: &[RemoteExpr],
-    probe_keys: ProbeKeysWithRuntimeFilter,
+    probe_keys: Vec<Option<RuntimeFilterProbeKey<RemoteExpr<String>>>>,
     build_table_indexes: Vec<Option<IndexType>>,
 ) -> Result<PhysicalRuntimeFilters> {
     if !ctx.get_settings().get_enable_join_runtime_filter()? {
@@ -117,42 +122,39 @@ pub async fn build_runtime_filter(
     }
 
     let mut filters = Vec::new();
+    let func_ctx = ctx.get_function_context()?;
 
     let probe_side = s_expr.probe_side_child();
 
     // Process each probe key that has runtime filter information
-    for (
-        build_key,
-        probe_key,
-        scan_id,
-        _table_index,
-        column_idx,
-        is_null_equal,
-        build_table_index,
-    ) in build_keys
+    for (build_key, probe, build_table_index) in build_keys
         .iter()
         .zip(probe_keys.into_iter())
         .zip(build_table_indexes.into_iter())
-        .filter_map(|((b, p), table_idx)| {
-            p.map(|(p, scan_id, table_index, column_idx, is_null_equal)| {
-                (
-                    b,
-                    p,
-                    scan_id,
-                    table_index,
-                    column_idx,
-                    is_null_equal,
-                    table_idx,
-                )
-            })
+        .filter_map(|((build_key, probe), table_index)| {
+            probe.map(|probe| (build_key, probe, table_index))
         })
     {
-        if !supported_probe_key_for_runtime_filter(&probe_key) {
+        let RuntimeFilterProbeKey {
+            probe_key,
+            scan_id,
+            column_idx,
+            is_connector,
+            is_null_equal,
+        } = probe;
+        if !supported_probe_key_for_runtime_filter(&probe_key, &func_ctx) {
             continue;
         }
 
-        let probe_targets =
-            find_probe_targets(metadata, probe_side, &probe_key, scan_id, column_idx)?;
+        let probe_targets = find_probe_targets(
+            metadata,
+            probe_side,
+            probe_key,
+            scan_id,
+            column_idx,
+            is_connector,
+            &func_ctx,
+        )?;
 
         let build_table_rows =
             get_build_table_rows(ctx.clone(), metadata, build_table_index).await?;
@@ -208,26 +210,87 @@ async fn get_build_table_rows(
 fn find_probe_targets(
     metadata: &MetadataRef,
     s_expr: &SExpr,
-    probe_key: &RemoteExpr<String>,
+    probe_key: RemoteExpr<String>,
     probe_scan_id: usize,
     probe_key_col_idx: Symbol,
+    probe_key_is_connector: bool,
+    func_ctx: &FunctionContext,
+) -> Result<Vec<(RemoteExpr<String>, usize)>> {
+    // A value-changing expression is a leaf in the equivalence graph. Its
+    // underlying column is not equivalent to the expression result, so the
+    // root expression can only be installed on its own scan.
+    if !probe_key_is_connector {
+        return Ok(vec![(probe_key, probe_scan_id)]);
+    }
+
+    let mut relations = Vec::new();
+    for cond in collect_equi_conditions(s_expr)? {
+        if let (Some(left), Some(right)) = (
+            scalar_to_probe_target(metadata, &cond.left, func_ctx)?,
+            scalar_to_probe_target(metadata, &cond.right, func_ctx)?,
+        ) {
+            relations.push((left, right));
+        }
+    }
+
+    propagate_probe_targets(
+        probe_key,
+        probe_scan_id,
+        probe_key_col_idx,
+        relations,
+        func_ctx,
+    )
+}
+
+fn propagate_probe_targets(
+    probe_key: RemoteExpr<String>,
+    probe_scan_id: usize,
+    probe_key_col_idx: Symbol,
+    relations: Vec<(ProbeTarget, ProbeTarget)>,
+    func_ctx: &FunctionContext,
 ) -> Result<Vec<(RemoteExpr<String>, usize)>> {
     let mut uf = UnionFind::new();
     let mut column_to_remote: HashMap<Symbol, (RemoteExpr<String>, usize)> = HashMap::new();
-    column_to_remote.insert(probe_key_col_idx, (probe_key.clone(), probe_scan_id));
+    let mut leaf_targets: HashMap<Symbol, Vec<(RemoteExpr<String>, usize)>> = HashMap::new();
+    let target_type = probe_key.as_expr(&BUILTIN_FUNCTIONS).data_type().clone();
+    column_to_remote.insert(probe_key_col_idx, (probe_key, probe_scan_id));
 
-    let equi_conditions = collect_equi_conditions(s_expr)?;
-    for cond in equi_conditions {
-        if let (
-            Some((left_remote, left_scan_id, left_idx)),
-            Some((right_remote, right_scan_id, right_idx)),
-        ) = (
-            scalar_to_remote_expr(metadata, &cond.left)?,
-            scalar_to_remote_expr(metadata, &cond.right)?,
-        ) {
-            uf.union(left_idx, right_idx);
-            column_to_remote.insert(left_idx, (left_remote, left_scan_id));
-            column_to_remote.insert(right_idx, (right_remote, right_scan_id));
+    for (left, right) in relations {
+        let left_type = left
+            .remote_expr
+            .as_expr(&BUILTIN_FUNCTIONS)
+            .data_type()
+            .clone();
+        let right_type = right
+            .remote_expr
+            .as_expr(&BUILTIN_FUNCTIONS)
+            .data_type()
+            .clone();
+        if !common_super_type_with_conversion(left_type, right_type)
+            .is_some_and(|conversion| conversion.is_safe_for_equality_inference())
+        {
+            continue;
+        }
+
+        match (left.is_connector, right.is_connector) {
+            (true, true) => {
+                uf.union(left.column_idx, right.column_idx);
+                column_to_remote
+                    .entry(left.column_idx)
+                    .or_insert((left.remote_expr, left.scan_id));
+                column_to_remote
+                    .entry(right.column_idx)
+                    .or_insert((right.remote_expr, right.scan_id));
+            }
+            (true, false) => leaf_targets
+                .entry(left.column_idx)
+                .or_default()
+                .push((right.remote_expr, right.scan_id)),
+            (false, true) => leaf_targets
+                .entry(right.column_idx)
+                .or_default()
+                .push((left.remote_expr, left.scan_id)),
+            (false, false) => {}
         }
     }
 
@@ -236,7 +299,19 @@ fn find_probe_targets(
     let mut result = Vec::new();
     for idx in equiv_class {
         if let Some((remote_expr, scan_id)) = column_to_remote.get(&idx) {
-            result.push((remote_expr.clone(), *scan_id));
+            if let Some(remote_expr) = normalize_probe_target(remote_expr, &target_type, func_ctx)?
+            {
+                push_unique_target(&mut result, remote_expr, *scan_id);
+            }
+        }
+        if let Some(targets) = leaf_targets.get(&idx) {
+            for (remote_expr, scan_id) in targets {
+                if let Some(remote_expr) =
+                    normalize_probe_target(remote_expr, &target_type, func_ctx)?
+                {
+                    push_unique_target(&mut result, remote_expr, *scan_id);
+                }
+            }
         }
     }
 
@@ -259,67 +334,107 @@ fn collect_equi_conditions(s_expr: &SExpr) -> Result<Vec<JoinEquiCondition>> {
     Ok(conditions)
 }
 
-fn scalar_to_remote_expr(
+struct ProbeTarget {
+    remote_expr: RemoteExpr<String>,
+    scan_id: usize,
+    column_idx: Symbol,
+    is_connector: bool,
+}
+
+fn scalar_to_probe_target(
     metadata: &MetadataRef,
     scalar: &ScalarExpr,
-) -> Result<Option<(RemoteExpr<String>, usize, Symbol)>> {
-    let used_columns = scalar.used_columns();
-    if used_columns.len() != 1 {
-        return Ok(None);
-    }
-
-    let column_idx = *used_columns.iter().next().unwrap();
-    if !matches!(
-        metadata.read().column(column_idx),
-        ColumnEntry::BaseTableColumn(_)
-    ) {
-        return Ok(None);
-    }
-
-    let Some(scan_id) = metadata.read().base_column_scan_id(column_idx) else {
+    func_ctx: &FunctionContext,
+) -> Result<Option<ProbeTarget>> {
+    let Some(probe) = resolve_runtime_filter_probe_expr(metadata, scalar)? else {
         return Ok(None);
     };
+    let remote_expr = probe.probe_key.as_remote_expr();
 
-    let remote_expr = {
-        let md = metadata.read();
-        scalar
-            .as_raw_expr()
-            .type_check(&*md)?
-            .project_column_ref(|col| {
-                let entry = md.column(col.index);
-                if let ColumnEntry::BaseTableColumn(base_col) = entry {
-                    if base_col.path_indices.is_none() {
-                        let table = md.table(base_col.table_index);
-                        let schema = table.table().schema_with_stream();
-                        if let Ok(field) = schema.field_of_column_id(base_col.column_id) {
-                            return Ok(field.name().clone());
-                        }
-                    }
-                    return Ok(base_col.column_name.clone());
-                }
-                Ok(col.column_name.clone())
-            })?
-            .as_remote_expr()
-    };
-
-    if supported_probe_key_for_runtime_filter(&remote_expr) {
-        return Ok(Some((remote_expr, scan_id, column_idx)));
+    if supported_probe_key_for_runtime_filter(&remote_expr, func_ctx) {
+        let (remote_expr, is_connector) = match canonical_equivalence_connector(remote_expr) {
+            Ok(connector) => (connector, true),
+            Err(leaf) => (leaf, false),
+        };
+        return Ok(Some(ProbeTarget {
+            remote_expr,
+            scan_id: probe.scan_id,
+            column_idx: probe.column_idx,
+            is_connector,
+        }));
     }
 
     Ok(None)
 }
 
-fn supported_probe_key_for_runtime_filter(probe_key: &RemoteExpr<String>) -> bool {
-    match probe_key {
-        RemoteExpr::ColumnRef { .. } => true,
-        // Support simple cast that only changes nullability, e.g. CAST(col AS Nullable(T)).
-        RemoteExpr::Cast {
-            expr, dest_type, ..
-        } => matches!(
-            expr.as_ref(),
-            RemoteExpr::ColumnRef { data_type, .. } if &dest_type.remove_nullable() == data_type
-        ),
-        _ => false,
+fn supported_probe_key_for_runtime_filter(
+    probe_key: &RemoteExpr<String>,
+    func_ctx: &FunctionContext,
+) -> bool {
+    let expr = probe_key.as_expr(&BUILTIN_FUNCTIONS);
+    expr.column_refs().len() == 1
+        && expr.is_deterministic(&BUILTIN_FUNCTIONS)
+        && safe_expression_domain(&expr, func_ctx).is_some()
+}
+
+fn safe_expression_domain(expr: &Expr<String>, func_ctx: &FunctionContext) -> Option<Domain> {
+    match expr {
+        Expr::Constant(constant) => Some(constant.scalar.as_ref().domain(&constant.data_type)),
+        Expr::ColumnRef(column) => Some(Domain::full(&column.data_type)),
+        Expr::Cast(cast) => {
+            safe_expression_domain(&cast.expr, func_ctx)?;
+            if !cast.is_try
+                && !classify_conversion(cast.expr.data_type(), &cast.dest_type)
+                    .is_lossless_injective()
+            {
+                return None;
+            }
+            Some(Domain::full(&cast.dest_type))
+        }
+        Expr::FunctionCall(call) => {
+            let domains = call
+                .args
+                .iter()
+                .map(|arg| safe_expression_domain(arg, func_ctx))
+                .collect::<Option<Vec<_>>>()?;
+            let FunctionEval::Scalar { calc_domain, .. } = &call.function.eval else {
+                return None;
+            };
+            match calc_domain.domain_eval(func_ctx, &domains) {
+                FunctionDomain::MayThrow => None,
+                FunctionDomain::Full => Some(Domain::full(&call.return_type)),
+                FunctionDomain::Domain(domain) => Some(domain),
+            }
+        }
+        Expr::LambdaFunctionCall(_) => None,
+    }
+}
+
+fn normalize_probe_target(
+    target: &RemoteExpr<String>,
+    target_type: &DataType,
+    func_ctx: &FunctionContext,
+) -> Result<Option<RemoteExpr<String>>> {
+    let expr = target.as_expr(&BUILTIN_FUNCTIONS);
+    if !classify_conversion(expr.data_type(), target_type).is_lossless_injective() {
+        return Ok(None);
+    }
+    let expr = check_cast(expr.span(), false, expr, target_type, &BUILTIN_FUNCTIONS)?;
+    let expr =
+        databend_common_expression::ConstantFolder::fold(&expr, func_ctx, &BUILTIN_FUNCTIONS).0;
+    Ok(Some(expr.as_remote_expr()))
+}
+
+fn push_unique_target(
+    targets: &mut Vec<(RemoteExpr<String>, usize)>,
+    expr: RemoteExpr<String>,
+    scan_id: usize,
+) {
+    if !targets
+        .iter()
+        .any(|(target, target_scan_id)| target == &expr && *target_scan_id == scan_id)
+    {
+        targets.push((expr, scan_id));
     }
 }
 
@@ -363,5 +478,277 @@ impl UnionFind {
             .into_iter()
             .filter(|&k| self.find(k) == root)
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_expression::ColumnRef;
+    use databend_common_expression::Constant;
+    use databend_common_expression::Expr;
+    use databend_common_expression::FunctionContext;
+    use databend_common_expression::LambdaFunctionCall;
+    use databend_common_expression::RemoteExpr;
+    use databend_common_expression::Scalar;
+    use databend_common_expression::type_check::check_cast;
+    use databend_common_expression::type_check::check_function;
+    use databend_common_expression::types::DataType;
+    use databend_common_expression::types::NumberDataType;
+    use databend_common_expression::types::NumberScalar;
+    use databend_common_functions::BUILTIN_FUNCTIONS;
+    use databend_common_sql::Symbol;
+
+    use super::ProbeTarget;
+    use super::canonical_equivalence_connector;
+    use super::propagate_probe_targets;
+    use super::supported_probe_key_for_runtime_filter;
+
+    fn column(name: &str, data_type: DataType) -> Expr<String> {
+        Expr::ColumnRef(ColumnRef {
+            span: None,
+            id: name.to_string(),
+            data_type,
+            display_name: name.to_string(),
+        })
+    }
+
+    fn int32(value: i32) -> Expr<String> {
+        Expr::Constant(Constant {
+            span: None,
+            scalar: Scalar::Number(NumberScalar::Int32(value)),
+            data_type: DataType::Number(NumberDataType::Int32),
+        })
+    }
+
+    fn string(value: &str) -> Expr<String> {
+        Expr::Constant(Constant {
+            span: None,
+            scalar: Scalar::String(value.to_string()),
+            data_type: DataType::String,
+        })
+    }
+
+    fn supported(expr: Expr<String>) -> bool {
+        supported_probe_key_for_runtime_filter(&expr.as_remote_expr(), &FunctionContext::default())
+    }
+
+    fn target(
+        remote_expr: databend_common_expression::RemoteExpr<String>,
+        scan_id: usize,
+        column_idx: usize,
+        is_connector: bool,
+    ) -> ProbeTarget {
+        ProbeTarget {
+            remote_expr,
+            scan_id,
+            column_idx: Symbol::new(column_idx),
+            is_connector,
+        }
+    }
+
+    #[test]
+    fn test_safe_single_column_probe_expressions() {
+        let int16 = DataType::Number(NumberDataType::Int16);
+        let int32_type = DataType::Number(NumberDataType::Int32);
+        let int64 = DataType::Number(NumberDataType::Int64);
+
+        let widened = check_cast(
+            None,
+            false,
+            column("a", int16),
+            &int32_type,
+            &BUILTIN_FUNCTIONS,
+        )
+        .unwrap();
+        let nested = check_cast(None, false, widened, &int64, &BUILTIN_FUNCTIONS).unwrap();
+        assert!(supported(nested));
+
+        let plus = check_function(
+            None,
+            "plus",
+            &[],
+            &[column("a", int32_type.clone()), int32(10)],
+            &BUILTIN_FUNCTIONS,
+        )
+        .unwrap();
+        assert!(supported(plus));
+
+        let repeated_column = check_function(
+            None,
+            "plus",
+            &[],
+            &[
+                column("a", int32_type.clone()),
+                column("a", int32_type.clone()),
+            ],
+            &BUILTIN_FUNCTIONS,
+        )
+        .unwrap();
+        assert!(supported(repeated_column));
+
+        let replace = check_function(
+            None,
+            "replace",
+            &[],
+            &[column("s", DataType::String), string("a"), string("b")],
+            &BUILTIN_FUNCTIONS,
+        )
+        .unwrap();
+        assert!(supported(replace));
+
+        let try_cast = check_cast(
+            None,
+            true,
+            column("s", DataType::String),
+            &int64,
+            &BUILTIN_FUNCTIONS,
+        )
+        .unwrap();
+        assert!(supported(try_cast));
+    }
+
+    #[test]
+    fn test_unsafe_probe_expressions_are_rejected() {
+        let int32_type = DataType::Number(NumberDataType::Int32);
+        let int64 = DataType::Number(NumberDataType::Int64);
+
+        let value_dependent_cast = check_cast(
+            None,
+            false,
+            column("s", DataType::String),
+            &int64,
+            &BUILTIN_FUNCTIONS,
+        )
+        .unwrap();
+        assert!(!supported(value_dependent_cast));
+
+        let multiple_columns = check_function(
+            None,
+            "plus",
+            &[],
+            &[
+                column("a", int32_type.clone()),
+                column("b", int32_type.clone()),
+            ],
+            &BUILTIN_FUNCTIONS,
+        )
+        .unwrap();
+        assert!(!supported(multiple_columns));
+
+        let may_throw = check_function(
+            None,
+            "divide",
+            &[],
+            &[column("a", int32_type), int32(1)],
+            &BUILTIN_FUNCTIONS,
+        )
+        .unwrap();
+        assert!(!supported(may_throw));
+
+        let nondeterministic = check_function(
+            None,
+            "rand",
+            &[],
+            &[column("a", DataType::Number(NumberDataType::UInt64))],
+            &BUILTIN_FUNCTIONS,
+        )
+        .unwrap();
+        assert!(!supported(nondeterministic));
+
+        let srf = check_function(
+            None,
+            "generate_series",
+            &[],
+            &[
+                column("a", DataType::Number(NumberDataType::Int64)),
+                int32(10),
+            ],
+            &BUILTIN_FUNCTIONS,
+        )
+        .unwrap();
+        assert!(!supported(srf));
+
+        let lambda = Expr::LambdaFunctionCall(LambdaFunctionCall {
+            span: None,
+            name: "test_lambda".to_string(),
+            args: vec![column("a", DataType::Number(NumberDataType::Int64))],
+            lambda_expr: Box::new(RemoteExpr::Constant {
+                span: None,
+                scalar: Scalar::Number(NumberScalar::Int32(1)),
+                data_type: DataType::Number(NumberDataType::Int32),
+            }),
+            lambda_display: "x -> 1".to_string(),
+            return_type: DataType::Number(NumberDataType::Int64),
+        });
+        assert!(!supported(lambda));
+    }
+
+    #[test]
+    fn test_nullable_wrapper_of_expression_is_leaf() {
+        let int32_type = DataType::Number(NumberDataType::Int32);
+        let int64 = DataType::Number(NumberDataType::Int64);
+        let nullable_int64 = DataType::Nullable(Box::new(int64.clone()));
+
+        let direct_column = column("connector", int64);
+        let direct_nullable_cast = check_cast(
+            None,
+            false,
+            direct_column,
+            &nullable_int64,
+            &BUILTIN_FUNCTIONS,
+        )
+        .unwrap();
+        assert!(canonical_equivalence_connector(direct_nullable_cast.as_remote_expr()).is_ok());
+
+        let plus = check_function(
+            None,
+            "plus",
+            &[],
+            &[column("a", int32_type), int32(10)],
+            &BUILTIN_FUNCTIONS,
+        )
+        .unwrap();
+        let wrapped = check_cast(None, false, plus, &nullable_int64, &BUILTIN_FUNCTIONS).unwrap();
+        assert!(canonical_equivalence_connector(wrapped.as_remote_expr()).is_err());
+    }
+
+    #[test]
+    fn test_connector_to_leaf_propagation_keeps_expression_as_leaf() {
+        let int32_type = DataType::Number(NumberDataType::Int32);
+        let int64 = DataType::Number(NumberDataType::Int64);
+        let root = column("root", int64.clone()).as_remote_expr();
+        let connector = column("connector", int64).as_remote_expr();
+        let leaf = check_function(
+            None,
+            "plus",
+            &[],
+            &[column("a", int32_type.clone()), int32(10)],
+            &BUILTIN_FUNCTIONS,
+        )
+        .unwrap()
+        .as_remote_expr();
+        let raw_leaf_column = column("a", int32_type).as_remote_expr();
+
+        let targets = propagate_probe_targets(
+            root.clone(),
+            0,
+            Symbol::new(0),
+            vec![
+                (
+                    target(root.clone(), 0, 0, true),
+                    target(connector.clone(), 1, 1, true),
+                ),
+                (
+                    target(connector, 1, 1, true),
+                    target(leaf.clone(), 2, 2, false),
+                ),
+            ],
+            &FunctionContext::default(),
+        )
+        .unwrap();
+
+        assert!(targets.contains(&(root, 0)));
+        assert!(targets.contains(&(leaf, 2)));
+        assert!(!targets.contains(&(raw_leaf_column, 2)));
     }
 }

--- a/src/query/service/src/physical_plans/runtime_filter/types.rs
+++ b/src/query/service/src/physical_plans/runtime_filter/types.rs
@@ -12,7 +12,130 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use databend_common_exception::Result;
+use databend_common_expression::Expr;
 use databend_common_expression::RemoteExpr;
+use databend_common_sql::ColumnEntry;
+use databend_common_sql::MetadataRef;
+use databend_common_sql::Symbol;
+use databend_common_sql::TypeCheck;
+use databend_common_sql::plans::ScalarExpr;
+
+pub(crate) struct ResolvedRuntimeFilterProbeExpr {
+    pub probe_key: Expr<String>,
+    pub scan_id: usize,
+    pub column_idx: Symbol,
+}
+
+pub(crate) fn resolve_runtime_filter_probe_expr(
+    metadata: &MetadataRef,
+    scalar: &ScalarExpr,
+) -> Result<Option<ResolvedRuntimeFilterProbeExpr>> {
+    let used_columns = scalar.used_columns();
+    if used_columns.len() != 1 {
+        return Ok(None);
+    }
+
+    let column_idx = *used_columns.iter().next().unwrap();
+    if !matches!(
+        metadata.read().column(column_idx),
+        ColumnEntry::BaseTableColumn(_)
+    ) {
+        return Ok(None);
+    }
+    let Some(scan_id) = metadata.read().base_column_scan_id(column_idx) else {
+        return Ok(None);
+    };
+
+    let metadata = metadata.read();
+    let probe_key = scalar
+        .as_raw_expr()
+        .type_check(&*metadata)?
+        .project_column_ref(|column| {
+            let entry = metadata.column(column.index);
+            if let ColumnEntry::BaseTableColumn(base_column) = entry {
+                if base_column.path_indices.is_none() {
+                    let table = metadata.table(base_column.table_index);
+                    let schema = table.table().schema_with_stream();
+                    if let Ok(field) = schema.field_of_column_id(base_column.column_id) {
+                        return Ok(field.name().clone());
+                    }
+                }
+                return Ok(base_column.column_name.clone());
+            }
+            Ok(column.column_name.clone())
+        })?;
+
+    Ok(Some(ResolvedRuntimeFilterProbeExpr {
+        probe_key,
+        scan_id,
+        column_idx,
+    }))
+}
+
+/// Probe-side information retained while a join condition is converted into a
+/// physical runtime filter.
+pub(crate) struct RuntimeFilterProbeKey<T> {
+    pub probe_key: T,
+    pub scan_id: usize,
+    pub column_idx: Symbol,
+    pub is_connector: bool,
+    pub is_null_equal: bool,
+}
+
+impl<T> RuntimeFilterProbeKey<T> {
+    pub fn map_probe_key<U>(self, map: impl FnOnce(T) -> U) -> RuntimeFilterProbeKey<U> {
+        RuntimeFilterProbeKey {
+            probe_key: map(self.probe_key),
+            scan_id: self.scan_id,
+            column_idx: self.column_idx,
+            is_connector: self.is_connector,
+            is_null_equal: self.is_null_equal,
+        }
+    }
+
+    pub fn try_map_probe_key<U, E>(
+        self,
+        map: impl FnOnce(T) -> Result<U, E>,
+    ) -> Result<RuntimeFilterProbeKey<U>, E> {
+        Ok(RuntimeFilterProbeKey {
+            probe_key: map(self.probe_key)?,
+            scan_id: self.scan_id,
+            column_idx: self.column_idx,
+            is_connector: self.is_connector,
+            is_null_equal: self.is_null_equal,
+        })
+    }
+}
+
+/// Only a direct column, optionally wrapped in a nullability-only cast, can
+/// connect equivalence classes. Every value-changing expression is a leaf.
+pub(crate) fn canonical_equivalence_connector(
+    probe_key: RemoteExpr<String>,
+) -> std::result::Result<RemoteExpr<String>, RemoteExpr<String>> {
+    match probe_key {
+        probe_key @ RemoteExpr::ColumnRef { .. } => Ok(probe_key),
+        RemoteExpr::Cast {
+            expr,
+            dest_type,
+            is_try: false,
+            span,
+        } => match expr.as_ref() {
+            RemoteExpr::ColumnRef { data_type, .. }
+                if dest_type.remove_nullable() == *data_type =>
+            {
+                Ok(*expr)
+            }
+            _ => Err(RemoteExpr::Cast {
+                span,
+                is_try: false,
+                expr,
+                dest_type,
+            }),
+        },
+        probe_key => Err(probe_key),
+    }
+}
 
 /// Collection of runtime filters for a join operation
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, Default)]
@@ -37,7 +160,8 @@ pub struct PhysicalRuntimeFilter {
 
     /// List of (probe_key, scan_id) pairs that this filter should be applied to
     /// A single filter is built once and then pushed down to multiple scans
-    /// All probe targets in this list are in the same equivalence class
+    /// Targets are equality-safe connector members or complete expression
+    /// leaves attached to one of those members.
     pub probe_targets: Vec<(RemoteExpr<String>, usize)>,
 
     pub build_table_rows: Option<u64>,

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/convert.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/convert.rs
@@ -24,13 +24,11 @@ use databend_common_catalog::sbbf::SbbfAtomic;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::Column;
-use databend_common_expression::ColumnRef;
 use databend_common_expression::Constant;
 use databend_common_expression::Domain;
 use databend_common_expression::Expr;
-use databend_common_expression::RawExpr;
 use databend_common_expression::Scalar;
-use databend_common_expression::type_check;
+use databend_common_expression::type_check::check_function;
 use databend_common_expression::types::DataType;
 use databend_common_expression::types::NumberDomain;
 use databend_common_expression::types::NumberScalar;
@@ -80,7 +78,7 @@ pub async fn build_runtime_filter_infos(
             };
             let bloom = if bloom_enabled {
                 if let Some(ref bloom) = packet.bloom {
-                    Some(build_bloom_filter(bloom.clone(), probe_key, max_threads, desc.id).await?)
+                    Some(build_bloom_filter(bloom.clone(), max_threads, desc.id).await?)
                 } else {
                     None
                 }
@@ -130,42 +128,31 @@ fn build_inlist_filter(inlist: Column, probe_key: &Expr<String>) -> Result<(Expr
             0,
         ));
     }
-    let probe_key = resolve_probe_column_ref(probe_key);
-
-    let probe_data_type = probe_key.data_type.clone();
-    let raw_probe_key = RawExpr::ColumnRef {
-        span: probe_key.span,
-        id: probe_key.id.to_string(),
-        data_type: probe_key.data_type.clone(),
-        display_name: probe_key.display_name.clone(),
-    };
-
-    let eq_exprs: Vec<RawExpr<String>> = inlist
+    let probe_data_type = probe_key.data_type().clone();
+    let eq_exprs = inlist
         .iter()
-        .map(|scalar_ref| RawExpr::FunctionCall {
-            span: None,
-            name: "eq".to_string(),
-            params: vec![],
-            args: vec![raw_probe_key.clone(), RawExpr::Constant {
+        .map(|scalar_ref| {
+            let value = Expr::Constant(Constant {
                 span: None,
                 scalar: scalar_ref.to_owned(),
-                data_type: Some(probe_data_type.clone()),
-            }],
+                data_type: probe_data_type.clone(),
+            });
+            check_function(
+                probe_key.span(),
+                "eq",
+                &[],
+                &[probe_key.clone(), value],
+                &BUILTIN_FUNCTIONS,
+            )
         })
-        .collect();
+        .collect::<Result<Vec<_>>>()?;
 
-    let or_filters_expr = if eq_exprs.len() == 1 {
+    let expr = if eq_exprs.len() == 1 {
         eq_exprs[0].clone()
     } else {
-        RawExpr::FunctionCall {
-            span: None,
-            name: "or_filters".to_string(),
-            params: vec![],
-            args: eq_exprs,
-        }
+        check_function(None, "or_filters", &[], &eq_exprs, &BUILTIN_FUNCTIONS)?
     };
 
-    let expr = type_check::check(&or_filters_expr, &BUILTIN_FUNCTIONS)?;
     Ok((expr, inlist_value_count))
 }
 
@@ -254,12 +241,9 @@ fn build_min_max_filter(
 
 async fn build_bloom_filter(
     bloom: Vec<u64>,
-    probe_key: &Expr<String>,
     max_threads: usize,
     filter_id: usize,
 ) -> Result<RuntimeFilterBloom> {
-    let probe_column = resolve_probe_column_ref(probe_key);
-    let column_name = probe_column.id.to_string();
     let total_items = bloom.len();
 
     if total_items < 3_000_000 {
@@ -267,7 +251,6 @@ async fn build_bloom_filter(
             .map_err(|e| ErrorCode::Internal(e.to_string()))?;
         filter.insert_hash_batch(&bloom);
         return Ok(RuntimeFilterBloom {
-            column_name,
             filter: Arc::new(filter),
         });
     }
@@ -284,21 +267,8 @@ async fn build_bloom_filter(
     );
 
     Ok(RuntimeFilterBloom {
-        column_name,
         filter: Arc::new(filter),
     })
-}
-
-fn resolve_probe_column_ref(probe_key: &Expr<String>) -> &ColumnRef<String> {
-    match probe_key {
-        Expr::ColumnRef(col) => col,
-        // Support simple cast that only changes nullability, e.g. CAST(col AS Nullable(T))
-        Expr::Cast(cast) => match cast.expr.as_ref() {
-            Expr::ColumnRef(col) => col,
-            _ => unreachable!(),
-        },
-        _ => unreachable!(),
-    }
 }
 
 #[cfg(test)]
@@ -309,15 +279,24 @@ mod tests {
     use databend_common_expression::ColumnRef;
     use databend_common_expression::Constant;
     use databend_common_expression::ConstantFolder;
+    use databend_common_expression::DataBlock;
     use databend_common_expression::Domain;
+    use databend_common_expression::Evaluator;
     use databend_common_expression::Expr;
+    use databend_common_expression::FromData;
     use databend_common_expression::FunctionContext;
     use databend_common_expression::Scalar;
+    use databend_common_expression::type_check::check_function;
+    use databend_common_expression::types::AccessType;
+    use databend_common_expression::types::BooleanType;
     use databend_common_expression::types::DataType;
+    use databend_common_expression::types::Int32Type;
     use databend_common_expression::types::NumberDataType;
+    use databend_common_expression::types::NumberScalar;
     use databend_common_functions::BUILTIN_FUNCTIONS;
 
     use super::build_inlist_filter;
+    use super::build_min_max_filter;
     use super::build_runtime_filter_infos;
     use crate::pipelines::processors::transforms::hash_join::desc::RuntimeFilterDesc;
     use crate::pipelines::processors::transforms::hash_join::runtime_filter::packet::JoinRuntimeFilterPacket;
@@ -451,6 +430,58 @@ mod tests {
             _ => {
                 panic!("Expected constant false, got: {:?}", folded_expr_false);
             }
+        }
+    }
+
+    #[test]
+    fn test_runtime_filters_evaluate_full_probe_expression() {
+        let int32_type = DataType::Number(NumberDataType::Int32);
+        let probe_column = Expr::ColumnRef(ColumnRef {
+            span: None,
+            id: "a".to_string(),
+            data_type: int32_type.clone(),
+            display_name: "a".to_string(),
+        });
+        let ten = Expr::Constant(Constant {
+            span: None,
+            scalar: Scalar::Number(NumberScalar::Int32(10)),
+            data_type: int32_type.clone(),
+        });
+        let probe_expr =
+            check_function(None, "plus", &[], &[probe_column, ten], &BUILTIN_FUNCTIONS).unwrap();
+
+        let mut inlist_builder = ColumnBuilder::with_capacity(probe_expr.data_type(), 1);
+        inlist_builder.push(Scalar::Number(11i64.into()).as_ref());
+        let (inlist, _) = build_inlist_filter(inlist_builder.build(), &probe_expr).unwrap();
+
+        let build_key = Expr::ColumnRef(ColumnRef {
+            span: None,
+            id: 0,
+            data_type: probe_expr.data_type().clone(),
+            display_name: "build_key".to_string(),
+        });
+        let min_max = build_min_max_filter(
+            SerializableDomain {
+                min: Scalar::Number(11i64.into()),
+                max: Scalar::Number(11i64.into()),
+            },
+            &probe_expr,
+            &build_key,
+        )
+        .unwrap();
+
+        let block = DataBlock::new_from_columns(vec![Int32Type::from_data(vec![1, 2])]);
+        let func_ctx = FunctionContext::default();
+        for filter in [inlist, min_max] {
+            let filter = filter
+                .project_column_ref(|name| if name == "a" { Ok(0) } else { unreachable!() })
+                .unwrap();
+            let result = Evaluator::new(&block, &func_ctx, &BUILTIN_FUNCTIONS)
+                .run(&filter)
+                .unwrap()
+                .convert_to_full_column(filter.data_type(), block.num_rows());
+            let bitmap = BooleanType::try_downcast_column(&result).unwrap();
+            assert_eq!(bitmap.iter().collect::<Vec<_>>(), vec![true, false]);
         }
     }
 

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/util.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/util.rs
@@ -13,15 +13,15 @@
 // limitations under the License.
 
 use databend_common_exception::Result;
+use databend_common_expression::Constant;
 use databend_common_expression::DataField;
 use databend_common_expression::DataSchemaRef;
 use databend_common_expression::DataSchemaRefExt;
 use databend_common_expression::Expr;
-use databend_common_expression::RawExpr;
 use databend_common_expression::Scalar;
 pub use databend_common_expression::hash_util::hash_by_method;
 pub use databend_common_expression::hash_util::hash_by_method_for_bloom;
-use databend_common_expression::type_check;
+use databend_common_expression::type_check::check_function;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 
 pub(crate) fn build_schema_wrap_nullable(build_schema: &DataSchemaRef) -> DataSchemaRef {
@@ -51,51 +51,30 @@ pub(crate) fn min_max_filter(
     max: Scalar,
     probe_key: &Expr<String>,
 ) -> Result<Expr<String>> {
-    let probe_key = match probe_key {
-        Expr::ColumnRef(col) => col,
-        // Support simple cast that only changes nullability, e.g. CAST(col AS Nullable(T))
-        Expr::Cast(cast) => match cast.expr.as_ref() {
-            Expr::ColumnRef(col) => col,
-            _ => unreachable!(),
-        },
-        _ => unreachable!(),
-    };
-    let raw_probe_key = RawExpr::ColumnRef {
-        span: probe_key.span,
-        id: probe_key.id.to_string(),
-        data_type: probe_key.data_type.clone(),
-        display_name: probe_key.display_name.clone(),
-    };
-    let min = RawExpr::Constant {
+    let bound_type = probe_key.data_type().remove_nullable();
+    let min = Expr::Constant(Constant {
         span: None,
         scalar: min,
-        data_type: None,
-    };
-    let max = RawExpr::Constant {
+        data_type: bound_type.clone(),
+    });
+    let max = Expr::Constant(Constant {
         span: None,
         scalar: max,
-        data_type: None,
-    };
-    // Make gte and lte function
-    let gte_func = RawExpr::FunctionCall {
-        span: None,
-        name: "gte".to_string(),
-        params: vec![],
-        args: vec![raw_probe_key.clone(), min],
-    };
-    let lte_func = RawExpr::FunctionCall {
-        span: None,
-        name: "lte".to_string(),
-        params: vec![],
-        args: vec![raw_probe_key, max],
-    };
-    // Make and_filters function
-    let and_filters_func = RawExpr::FunctionCall {
-        span: None,
-        name: "and_filters".to_string(),
-        params: vec![],
-        args: vec![gte_func, lte_func],
-    };
-    let expr = type_check::check(&and_filters_func, &BUILTIN_FUNCTIONS)?;
-    Ok(expr)
+        data_type: bound_type,
+    });
+    let gte = check_function(
+        probe_key.span(),
+        "gte",
+        &[],
+        &[probe_key.clone(), min],
+        &BUILTIN_FUNCTIONS,
+    )?;
+    let lte = check_function(
+        probe_key.span(),
+        "lte",
+        &[],
+        &[probe_key.clone(), max],
+        &BUILTIN_FUNCTIONS,
+    )?;
+    check_function(None, "and_filters", &[], &[gte, lte], &BUILTIN_FUNCTIONS)
 }

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -755,7 +755,6 @@ impl QueryContext {
         struct FilterLogEntry {
             filter_id: usize,
             probe_expr: String,
-            bloom_column: Option<String>,
             has_bloom: bool,
             has_inlist: bool,
             has_min_max: bool,
@@ -780,7 +779,6 @@ impl QueryContext {
                 .map(|entry| FilterLogEntry {
                     filter_id: entry.id,
                     probe_expr: entry.probe_expr.sql_display(),
-                    bloom_column: entry.bloom.as_ref().map(|bloom| bloom.column_name.clone()),
                     has_bloom: entry.bloom.is_some(),
                     has_inlist: entry.inlist.is_some(),
                     has_min_max: entry.min_max.is_some(),
@@ -812,7 +810,6 @@ impl QueryContext {
                 let FilterLogEntry {
                     filter_id,
                     probe_expr,
-                    bloom_column,
                     has_bloom,
                     has_inlist,
                     has_min_max,
@@ -850,10 +847,6 @@ impl QueryContext {
                             .unwrap_or_else(|| "unknown".to_string())
                     )),
                 ];
-
-                if let Some(column) = bloom_column {
-                    detail_children.push(FormatTreeNode::new(format!("bloom column: {}", column)));
-                }
 
                 if has_bloom {
                     detail_children.push(FormatTreeNode::new(format!(

--- a/src/query/service/src/sessions/query_ctx/state.rs
+++ b/src/query/service/src/sessions/query_ctx/state.rs
@@ -247,7 +247,10 @@ impl TableContextRuntimeFilter for QueryContext {
         self.shared.runtime_filter_state.get_runtime_filters(id)
     }
 
-    fn get_bloom_runtime_filter_with_id(&self, id: IndexType) -> Vec<(String, RuntimeBloomFilter)> {
+    fn get_bloom_runtime_filter_with_id(
+        &self,
+        id: IndexType,
+    ) -> Vec<(Expr<String>, RuntimeBloomFilter)> {
         self.shared
             .runtime_filter_state
             .get_bloom_runtime_filter_with_id(id)

--- a/src/query/service/src/sessions/runtime_filter_state.rs
+++ b/src/query/service/src/sessions/runtime_filter_state.rs
@@ -96,10 +96,13 @@ impl RuntimeFilterState {
             .unwrap_or_default()
     }
 
-    pub fn get_bloom_runtime_filter_with_id(&self, id: usize) -> Vec<(String, RuntimeBloomFilter)> {
+    pub fn get_bloom_runtime_filter_with_id(
+        &self,
+        id: usize,
+    ) -> Vec<(Expr<String>, RuntimeBloomFilter)> {
         self.get_runtime_filters(id)
             .into_iter()
-            .filter_map(|entry| entry.bloom.map(|bloom| (bloom.column_name, bloom.filter)))
+            .filter_map(|entry| entry.bloom.map(|bloom| (entry.probe_expr, bloom.filter)))
             .collect()
     }
 

--- a/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
+++ b/src/query/service/tests/it/sql/exec/get_table_bind_test.rs
@@ -1073,7 +1073,10 @@ impl TableContextRuntimeFilter for CtxDelegation {
         HashMap::new()
     }
 
-    fn get_bloom_runtime_filter_with_id(&self, _id: usize) -> Vec<(String, RuntimeBloomFilter)> {
+    fn get_bloom_runtime_filter_with_id(
+        &self,
+        _id: usize,
+    ) -> Vec<(Expr<String>, RuntimeBloomFilter)> {
         todo!()
     }
 

--- a/src/query/service/tests/it/storages/fuse/operations/commit.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/commit.rs
@@ -901,7 +901,10 @@ impl TableContextRuntimeFilter for CtxDelegation {
         HashMap::new()
     }
 
-    fn get_bloom_runtime_filter_with_id(&self, _id: usize) -> Vec<(String, RuntimeBloomFilter)> {
+    fn get_bloom_runtime_filter_with_id(
+        &self,
+        _id: usize,
+    ) -> Vec<(Expr<String>, RuntimeBloomFilter)> {
         todo!()
     }
 

--- a/src/query/service/tests/it/storages/fuse/operations/prewhere.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/prewhere.rs
@@ -24,6 +24,7 @@ use databend_common_catalog::runtime_filter_info::RuntimeFilterInfo;
 use databend_common_catalog::runtime_filter_info::RuntimeFilterStats;
 use databend_common_catalog::sbbf::Sbbf;
 use databend_common_exception::Result;
+use databend_common_expression::Column;
 use databend_common_expression::ColumnId;
 use databend_common_expression::ColumnRef;
 use databend_common_expression::Constant;
@@ -40,6 +41,7 @@ use databend_common_expression::type_check::check_function;
 use databend_common_expression::types::AccessType;
 use databend_common_expression::types::DataType;
 use databend_common_expression::types::Int32Type;
+use databend_common_expression::types::Int64Type;
 use databend_common_expression::types::NumberDataType;
 use databend_common_expression::types::NumberScalar;
 use databend_common_functions::BUILTIN_FUNCTIONS;
@@ -84,6 +86,7 @@ async fn run_prewhere_test_with_threshold(
         part,
         num_rows,
         scan_id,
+        runtime_filter_stats,
     } = prepare_prewhere_data().await?;
     let _ = _fixture;
 
@@ -104,6 +107,13 @@ async fn run_prewhere_test_with_threshold(
     // Use the new unified API that handles all states internally
     let (data_block, row_selection, bitmap_selection) =
         read_state.deserialize_and_filter(column_chunks.clone(), &part)?;
+
+    // Static prewhere leaves one row, and both Bloom filters match it. A zero
+    // filtered-row count proves Bloom was not evaluated on the four rows that
+    // prewhere had already rejected.
+    for stats in runtime_filter_stats {
+        assert_eq!(stats.snapshot().bloom_rows_filtered, 0);
+    }
 
     // Verify the final data_block (all columns in order: x, y, z, d, e)
     // The new API internally handles all filter stages (prewhere + runtime filters)
@@ -167,8 +177,7 @@ async fn run_prewhere_test_with_threshold(
     Ok(())
 }
 
-fn create_bloom_filter_for_int32(values: &[i32]) -> Sbbf {
-    let column = Int32Type::from_data(values.to_vec());
+fn create_bloom_filter(column: Column) -> Sbbf {
     let data_type = column.data_type();
     let num_rows = column.len();
     let method =
@@ -178,7 +187,7 @@ fn create_bloom_filter_for_int32(values: &[i32]) -> Sbbf {
     let mut hashes = Vec::with_capacity(num_rows);
     hash_by_method_for_bloom(&method, group_columns, num_rows, &mut hashes).unwrap();
 
-    let mut filter = Sbbf::new_with_ndv_fpp(values.len() as u64, 0.01).unwrap();
+    let mut filter = Sbbf::new_with_ndv_fpp(num_rows as u64, 0.01).unwrap();
     filter.insert_hash_batch(&hashes);
     filter
 }
@@ -192,6 +201,7 @@ struct PrewhereTestSetup {
     part: FuseBlockPartInfo,
     num_rows: usize,
     scan_id: usize,
+    runtime_filter_stats: Vec<Arc<RuntimeFilterStats>>,
 }
 
 async fn prepare_prewhere_data() -> Result<PrewhereTestSetup> {
@@ -339,47 +349,57 @@ async fn prepare_prewhere_data() -> Result<PrewhereTestSetup> {
         block_meta_index: None,
     };
 
-    let bloom_y = create_bloom_filter_for_int32(&[30]);
-    let bloom_d = create_bloom_filter_for_int32(&[3000]);
+    let bloom_y_plus_ten = create_bloom_filter(Int64Type::from_data(vec![40]));
+    let bloom_d = create_bloom_filter(Int32Type::from_data(vec![3000]));
+    let probe_y = Expr::ColumnRef(ColumnRef {
+        span: None,
+        id: "y".to_string(),
+        data_type: DataType::Number(NumberDataType::Int32),
+        display_name: "y".to_string(),
+    });
+    let ten = Expr::Constant(Constant {
+        span: None,
+        scalar: Scalar::Number(NumberScalar::Int32(10)),
+        data_type: DataType::Number(NumberDataType::Int32),
+    });
+    let probe_y_plus_ten = check_function(None, "plus", &[], &[probe_y, ten], &BUILTIN_FUNCTIONS)?;
+    let probe_d = Expr::ColumnRef(ColumnRef {
+        span: None,
+        id: "d".to_string(),
+        data_type: DataType::Number(NumberDataType::Int32),
+        display_name: "d".to_string(),
+    });
 
     let scan_id = 999;
+    let bloom_y_stats = Arc::new(RuntimeFilterStats::default());
+    let bloom_d_stats = Arc::new(RuntimeFilterStats::default());
     let mut filters = HashMap::new();
     filters.insert(scan_id, RuntimeFilterInfo {
         filters: vec![
             RuntimeFilterEntry {
                 id: 0,
-                probe_expr: Expr::Constant(Constant {
-                    span: None,
-                    scalar: Scalar::Null,
-                    data_type: DataType::Null,
-                }),
+                probe_expr: probe_y_plus_ten,
                 bloom: Some(RuntimeFilterBloom {
-                    column_name: "y".to_string(),
-                    filter: Arc::new(bloom_y),
+                    filter: Arc::new(bloom_y_plus_ten),
                 }),
                 inlist: None,
                 inlist_value_count: 0,
                 min_max: None,
-                stats: Arc::new(RuntimeFilterStats::default()),
+                stats: bloom_y_stats.clone(),
                 build_rows: 1,
                 build_table_rows: None,
                 enabled: true,
             },
             RuntimeFilterEntry {
                 id: 1,
-                probe_expr: Expr::Constant(Constant {
-                    span: None,
-                    scalar: Scalar::Null,
-                    data_type: DataType::Null,
-                }),
+                probe_expr: probe_d,
                 bloom: Some(RuntimeFilterBloom {
-                    column_name: "d".to_string(),
                     filter: Arc::new(bloom_d),
                 }),
                 inlist: None,
                 inlist_value_count: 0,
                 min_max: None,
-                stats: Arc::new(RuntimeFilterStats::default()),
+                stats: bloom_d_stats.clone(),
                 build_rows: 1,
                 build_table_rows: None,
                 enabled: true,
@@ -397,6 +417,7 @@ async fn prepare_prewhere_data() -> Result<PrewhereTestSetup> {
         part,
         num_rows,
         scan_id,
+        runtime_filter_stats: vec![bloom_y_stats, bloom_d_stats],
     })
 }
 

--- a/src/query/sql/test-support/data/results/tpcds/materialized_cte_ref_stats_after_dphyp_physical.txt
+++ b/src/query/sql/test-support/data/results/tpcds/materialized_cte_ref_stats_after_dphyp_physical.txt
@@ -382,7 +382,7 @@ Exchange
     │                                               │       │       ├── keys is null equal: [false]
     │                                               │       │       ├── filters: []
     │                                               │       │       ├── build join filters(distributed):
-    │                                               │       │       │   └── filter id:2, build key:item.i_item_sk (#317), probe targets:[catalog_sales.cs_item_sk (#58)@scan2, catalog_returns.cr_item_sk (#79)@scan3], filter type:bloom,inlist,min_max
+    │                                               │       │       │   └── filter id:2, build key:item.i_item_sk (#317), probe targets:[cs_ui.cs_item_sk (#58)@scan2, catalog_returns.cr_item_sk (#79)@scan3], filter type:bloom,inlist,min_max
     │                                               │       │       ├── estimated rows: 18150.03
     │                                               │       │       ├── Exchange(Build)
     │                                               │       │       │   ├── output columns: [item.i_item_sk (#317), item.i_product_name (#338)]

--- a/src/query/sql/test-support/src/lite_context.rs
+++ b/src/query/sql/test-support/src/lite_context.rs
@@ -2058,7 +2058,10 @@ impl TableContextRuntimeFilter for LiteTableContext {
         vec![]
     }
 
-    fn get_bloom_runtime_filter_with_id(&self, _id: usize) -> Vec<(String, RuntimeBloomFilter)> {
+    fn get_bloom_runtime_filter_with_id(
+        &self,
+        _id: usize,
+    ) -> Vec<(Expr<String>, RuntimeBloomFilter)> {
         vec![]
     }
 

--- a/src/query/storages/fuse/src/operations/read/read_state.rs
+++ b/src/query/storages/fuse/src/operations/read/read_state.rs
@@ -225,7 +225,9 @@ impl ReadState {
         // the static prewhere predicate. Expand their bitmap back to the
         // original row positions before combining it with prewhere.
         let runtime_filter_bitmap = if self.runtime_filters.is_empty() {
-            None
+            // Preserve the profile entry emitted before expression probes were
+            // supported, even when there is no Bloom filter to evaluate.
+            self.runtime_filter(&preread_block, part.nums_rows)?
         } else if let Some(filter_bitmap) = &filter_bitmap {
             let filter_bitmap: Bitmap = filter_bitmap.clone().into();
             let filtered_block = preread_block.clone().filter_with_bitmap(&filter_bitmap)?;

--- a/src/query/storages/fuse/src/operations/read/read_state.rs
+++ b/src/query/storages/fuse/src/operations/read/read_state.rs
@@ -46,7 +46,7 @@ use crate::pruning::ExprBloomFilter;
 
 #[derive(Clone)]
 pub struct BloomRuntimeFilterRef {
-    pub column_index: FieldIndex,
+    pub probe_expr: Expr<FieldIndex>,
     pub filter: RuntimeBloomFilter,
     pub stats: Arc<RuntimeFilterStats>,
 }
@@ -77,18 +77,27 @@ impl ReadState {
             prewhere_info.is_some() && prewhere_selectivity_threshold == 0;
         let original_schema = block_reader.original_schema.as_ref();
 
-        let runtime_filter_entries = ctx.get_runtime_filters(scan_id);
-        let runtime_filter_column_names: Vec<_> = runtime_filter_entries
-            .iter()
-            .filter_map(|entry| {
-                let column_name = entry.bloom.as_ref().map(|bloom| &bloom.column_name)?;
-                if original_schema.index_of(column_name).is_ok() {
-                    Some(column_name)
-                } else {
-                    None
-                }
+        let runtime_filter_entries: Vec<_> = ctx
+            .get_runtime_filters(scan_id)
+            .into_iter()
+            .filter(|entry| {
+                entry.bloom.is_some()
+                    && entry
+                        .probe_expr
+                        .column_refs()
+                        .keys()
+                        .all(|name| runtime_filter_column_is_projectable(original_schema, name))
             })
             .collect();
+        let mut runtime_filter_column_names = Vec::new();
+        for entry in &runtime_filter_entries {
+            for name in entry.probe_expr.column_refs().into_keys() {
+                if !runtime_filter_column_names.contains(&name) {
+                    runtime_filter_column_names.push(name);
+                }
+            }
+        }
+        let runtime_filter_column_names: Vec<_> = runtime_filter_column_names.iter().collect();
 
         let mut preread_projection =
             Projection::from_column_names(original_schema, &runtime_filter_column_names)?;
@@ -116,9 +125,12 @@ impl ReadState {
             .into_iter()
             .filter_map(|entry| {
                 let bloom = entry.bloom?;
-                let column_index = prewhere_schema.index_of(bloom.column_name.as_str()).ok()?;
+                let probe_expr = entry
+                    .probe_expr
+                    .project_column_ref(|name| prewhere_schema.index_of(name))
+                    .ok()?;
                 Some(BloomRuntimeFilterRef {
-                    column_index,
+                    probe_expr,
                     filter: bloom.filter,
                     stats: entry.stats,
                 })
@@ -165,14 +177,22 @@ impl ReadState {
     pub fn runtime_filter(
         &self,
         block: &DataBlock,
-        _num_rows: usize,
+        num_rows: usize,
     ) -> Result<Option<MutableBitmap>> {
         let bloom_start = Instant::now();
 
         let mut bitmaps = vec![];
+        let evaluator = Evaluator::new(block, &self.func_ctx, &BUILTIN_FUNCTIONS);
         for runtime_filter in &self.runtime_filters {
-            let probe_column = block.get_by_offset(runtime_filter.column_index).to_column();
+            let filter_start = Instant::now();
+            let probe_column = evaluator
+                .run(&runtime_filter.probe_expr)?
+                .convert_to_full_column(runtime_filter.probe_expr.data_type(), num_rows);
             let bitmap = ExprBloomFilter::new(&runtime_filter.filter).apply(probe_column)?;
+            runtime_filter.stats.record_bloom(
+                filter_start.elapsed().as_nanos() as u64,
+                bitmap.null_count() as u64,
+            );
             bitmaps.push(bitmap);
         }
 
@@ -201,7 +221,19 @@ impl ReadState {
             .deserialize_part(part, pre_columns_chunks, None)?;
 
         let filter_bitmap = self.filter(&preread_block, part.nums_rows)?;
-        let runtime_filter_bitmap = self.runtime_filter(&preread_block, part.nums_rows)?;
+        // Expensive probe expressions are evaluated only for rows surviving
+        // the static prewhere predicate. Expand their bitmap back to the
+        // original row positions before combining it with prewhere.
+        let runtime_filter_bitmap = if self.runtime_filters.is_empty() {
+            None
+        } else if let Some(filter_bitmap) = &filter_bitmap {
+            let filter_bitmap: Bitmap = filter_bitmap.clone().into();
+            let filtered_block = preread_block.clone().filter_with_bitmap(&filter_bitmap)?;
+            self.runtime_filter(&filtered_block, filtered_block.num_rows())?
+                .map(|runtime_bitmap| expand_runtime_filter_bitmap(&filter_bitmap, &runtime_bitmap))
+        } else {
+            self.runtime_filter(&preread_block, part.nums_rows)?
+        };
 
         let bitmap_selection: Option<Bitmap> = match (filter_bitmap, runtime_filter_bitmap) {
             (Some(filter_bitmap), Some(runtime_filter_bitmap)) => {
@@ -267,6 +299,31 @@ impl ReadState {
     }
 }
 
+fn runtime_filter_column_is_projectable(
+    schema: &databend_common_expression::TableSchema,
+    name: &str,
+) -> bool {
+    Projection::from_column_names(schema, &[name]).is_ok()
+}
+
+fn expand_runtime_filter_bitmap(
+    prewhere_bitmap: &Bitmap,
+    runtime_filter_bitmap: &MutableBitmap,
+) -> MutableBitmap {
+    let mut runtime_filter_bits = runtime_filter_bitmap.iter();
+    let mut expanded = MutableBitmap::with_capacity(prewhere_bitmap.len());
+    for survives_prewhere in prewhere_bitmap.iter() {
+        expanded.push(
+            survives_prewhere
+                && runtime_filter_bits
+                    .next()
+                    .expect("runtime filter bitmap must match surviving rows"),
+        );
+    }
+    debug_assert!(runtime_filter_bits.next().is_none());
+    expanded
+}
+
 fn should_push_down_row_selection(row_selection: &RowSelection, threshold: u64) -> bool {
     let total_rows = row_selection.bitmap.len();
     if threshold == 0 || total_rows == 0 {
@@ -278,7 +335,13 @@ fn should_push_down_row_selection(row_selection: &RowSelection, threshold: u64) 
 
 #[cfg(test)]
 mod tests {
+    use databend_common_expression::ColumnRef;
+    use databend_common_expression::TableDataType;
+    use databend_common_expression::TableField;
+    use databend_common_expression::TableSchema;
+    use databend_common_expression::types::DataType;
     use databend_common_expression::types::MutableBitmap;
+    use databend_common_expression::types::NumberDataType;
 
     use super::*;
 
@@ -306,5 +369,46 @@ mod tests {
         let sparse_selection = RowSelection::from(&sparse_bitmap);
 
         assert!(!should_push_down_row_selection(&sparse_selection, 0));
+    }
+
+    #[test]
+    fn test_expand_runtime_filter_bitmap_after_prewhere() {
+        let prewhere: Bitmap = [false, true, true, false, true].into_iter().collect();
+        let runtime_filter: MutableBitmap = [true, false, true].into_iter().collect();
+
+        let expanded = expand_runtime_filter_bitmap(&prewhere, &runtime_filter);
+        assert_eq!(expanded.iter().collect::<Vec<_>>(), vec![
+            false, true, false, false, true
+        ]);
+    }
+
+    #[test]
+    fn test_nested_runtime_filter_column_is_projectable() {
+        let schema = TableSchema::new(vec![TableField::new("payload", TableDataType::Tuple {
+            fields_name: vec!["value".to_string()],
+            fields_type: vec![TableDataType::Number(NumberDataType::Int64)],
+        })]);
+        assert!(schema.index_of("payload:value").is_err());
+        assert!(runtime_filter_column_is_projectable(
+            &schema,
+            "payload:value"
+        ));
+
+        let projection = Projection::from_column_names(&schema, &["payload:value"]).unwrap();
+        let projected_schema = projection.project_schema(&schema);
+        let projected_schema: DataSchema = (&projected_schema).into();
+        let probe_expr = Expr::ColumnRef(ColumnRef {
+            span: None,
+            id: "payload:value".to_string(),
+            data_type: DataType::Number(NumberDataType::Int64),
+            display_name: "payload:value".to_string(),
+        });
+        let projected_expr = probe_expr
+            .project_column_ref(|name| projected_schema.index_of(name))
+            .unwrap();
+        assert_eq!(
+            projected_expr.column_refs().into_keys().collect::<Vec<_>>(),
+            vec![0]
+        );
     }
 }

--- a/src/query/storages/fuse/src/pruning/expr_runtime_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/expr_runtime_pruner.rs
@@ -506,6 +506,57 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn test_runtime_stats_pruner_folds_full_probe_expression() -> Result<()> {
+        let schema = test_schema();
+        let stats = Arc::new(RuntimeFilterStats::default());
+        let pruner = RuntimeStatsPruner::new(FunctionContext::default(), schema.clone(), vec![
+            RuntimeFilterExpr {
+                filter_id: 0,
+                kind: RuntimeFilterExprKind::MinMax,
+                inlist_value_count: 0,
+                // The block domain is y=[10,40], so y+10=[20,50] cannot
+                // intersect the runtime-filter range [51,60].
+                expr: min_max_expr_plus("y", 10, 51, 60)?,
+                stats: stats.clone(),
+            },
+        ]);
+        let part = make_part(&schema, None, 0, 10, 40);
+        let part = FuseBlockPartInfo::from_part(&part)?;
+
+        assert!(pruner.should_prune_part(part));
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_runtime_inlist_complex_expression_keeps_bloom_index() -> Result<()> {
+        init_test_globals()?;
+        let schema = test_schema();
+        let block = DataBlock::new_from_columns(vec![Int32Type::from_data(vec![10, 20, 30, 40])]);
+        let operator = opendal::Operator::via_iter(opendal::Scheme::Memory, [])?;
+        let (index_location, index_size) = write_bloom_index(&operator, &schema, &block).await?;
+        let part = make_part(&schema, index_location, index_size, 10, 40);
+        let pruner = ExprRuntimePruner::new(
+            FunctionContext::default(),
+            schema,
+            operator,
+            test_read_settings(),
+            1,
+            vec![RuntimeFilterExpr {
+                filter_id: 0,
+                kind: RuntimeFilterExprKind::Inlist,
+                inlist_value_count: 1,
+                expr: inlist_expr_plus("y", 10, 25)?,
+                stats: Arc::new(RuntimeFilterStats::default()),
+            }],
+        );
+
+        // The static Bloom index stores y, not y+10. It cannot safely answer
+        // this expression and must conservatively keep the block.
+        assert!(!pruner.prune(&part).await?);
+        Ok(())
+    }
+
     fn test_schema() -> TableSchemaRef {
         Arc::new(TableSchema::new(vec![TableField::new(
             "y",
@@ -600,6 +651,54 @@ mod tests {
 
         let gte = check_function(None, "gte", &[], &[column.clone(), min], &BUILTIN_FUNCTIONS)?;
         let lte = check_function(None, "lte", &[], &[column, max], &BUILTIN_FUNCTIONS)?;
+        check_function(None, "and_filters", &[], &[gte, lte], &BUILTIN_FUNCTIONS)
+    }
+
+    fn plus_expr(column_name: &str, value: i32) -> Result<Expr<String>> {
+        let column = Expr::ColumnRef(ColumnRef {
+            span: None,
+            id: column_name.to_string(),
+            data_type: DataType::Number(NumberDataType::Int32),
+            display_name: column_name.to_string(),
+        });
+        let value = Expr::Constant(Constant {
+            span: None,
+            scalar: Scalar::Number(NumberScalar::Int32(value)),
+            data_type: DataType::Number(NumberDataType::Int32),
+        });
+        check_function(None, "plus", &[], &[column, value], &BUILTIN_FUNCTIONS)
+    }
+
+    fn inlist_expr_plus(column_name: &str, add: i32, value: i64) -> Result<Expr<String>> {
+        let probe_expr = plus_expr(column_name, add)?;
+        let value = Expr::Constant(Constant {
+            span: None,
+            scalar: Scalar::Number(NumberScalar::Int64(value)),
+            data_type: DataType::Number(NumberDataType::Int64),
+        });
+        check_function(None, "eq", &[], &[probe_expr, value], &BUILTIN_FUNCTIONS)
+    }
+
+    fn min_max_expr_plus(column_name: &str, add: i32, min: i64, max: i64) -> Result<Expr<String>> {
+        let probe_expr = plus_expr(column_name, add)?;
+        let min = Expr::Constant(Constant {
+            span: None,
+            scalar: Scalar::Number(NumberScalar::Int64(min)),
+            data_type: DataType::Number(NumberDataType::Int64),
+        });
+        let max = Expr::Constant(Constant {
+            span: None,
+            scalar: Scalar::Number(NumberScalar::Int64(max)),
+            data_type: DataType::Number(NumberDataType::Int64),
+        });
+        let gte = check_function(
+            None,
+            "gte",
+            &[],
+            &[probe_expr.clone(), min],
+            &BUILTIN_FUNCTIONS,
+        )?;
+        let lte = check_function(None, "lte", &[], &[probe_expr, max], &BUILTIN_FUNCTIONS)?;
         check_function(None, "and_filters", &[], &[gte, lte], &BUILTIN_FUNCTIONS)
     }
 

--- a/tests/sqllogictests/suites/mode/cluster/merge_into_non_equal_distributed.test
+++ b/tests/sqllogictests/suites/mode/cluster/merge_into_non_equal_distributed.test
@@ -259,6 +259,8 @@ CommitSink
                     ├── probe keys: [CAST(t1.a (#1) AS Decimal(38, 5) NULL)]
                     ├── keys is null equal: [false]
                     ├── filters: []
+                    ├── build join filters(distributed):
+                    │   └── filter id:0, build key:CAST(t2.a (#0) AS Decimal(38, 5) NULL), probe targets:[CAST(t1.a (#1) AS Decimal(38, 5) NULL)@scan1], filter type:inlist
                     ├── estimated rows: 0.00
                     ├── Exchange(Build)
                     │   ├── output columns: [stage._$1 (#0)]

--- a/tests/sqllogictests/suites/mode/cluster/merge_into_non_equal_distributed.test
+++ b/tests/sqllogictests/suites/mode/cluster/merge_into_non_equal_distributed.test
@@ -288,6 +288,7 @@ CommitSink
                             ├── partitions scanned: 1
                             ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
                             ├── push downs: [filters: [], limit: NONE]
+                            ├── apply join filters: [#0]
                             └── estimated rows: 2.00
 
 query II

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain_virtual_column.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain_virtual_column.test
@@ -569,8 +569,8 @@ EvalScalar
                 ├── keys is null equal: [false, false, false]
                 ├── filters: []
                 ├── build join filters:
-                │   ├── filter id:2, build key:a.entity_id (#0), probe targets:[a.entity_id (#5)@scan1, c.entity_id (#10)@scan2], filter type:bloom,inlist,min_max
-                │   └── filter id:3, build key:a.source_id (#1), probe targets:[a.source_id (#6)@scan1, c.source_id (#11)@scan2], filter type:bloom,inlist,min_max
+                │   ├── filter id:2, build key:a.entity_id (#0), probe targets:[p.entity_id (#5)@scan1, c.entity_id (#10)@scan2], filter type:bloom,inlist,min_max
+                │   └── filter id:3, build key:a.source_id (#1), probe targets:[p.source_id (#6)@scan1, c.source_id (#11)@scan2], filter type:bloom,inlist,min_max
                 ├── estimated rows: 0.20
                 ├── Filter(Build)
                 │   ├── output columns: [a.entity_id (#0), a.source_id (#1), a.content_object['event_date'] (#16), a.metadata_object['type'] (#18), a.content_object['category_a'] (#19), a.content_object['category_b'] (#20)]

--- a/tests/sqllogictests/suites/mode/standalone/explain/join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join.test
@@ -64,7 +64,8 @@ HashJoin
 ├── keys is null equal: [false, false]
 ├── filters: []
 ├── build join filters:
-│   └── filter id:0, build key:t.number (#0), probe targets:[t1.number (#1)@scan1], filter type:bloom,inlist,min_max
+│   ├── filter id:0, build key:t.number (#0), probe targets:[t1.number (#1)@scan1], filter type:bloom,inlist,min_max
+│   └── filter id:1, build key:t.number (#0), probe targets:[t1.number (#1) + 1@scan1], filter type:bloom,inlist,min_max
 ├── estimated rows: 1.00
 ├── TableScan(Build)
 │   ├── table: default.default.t
@@ -87,7 +88,7 @@ HashJoin
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [t1.number (#1) = t1.number (#1) + 1], limit: NONE]
-    ├── apply join filters: [#0]
+    ├── apply join filters: [#0, #1]
     └── estimated rows: 2.00
 
 query T
@@ -849,6 +850,8 @@ EvalScalar
     ├── probe keys: [replace(t1.ext (#1), '33', '44')]
     ├── keys is null equal: [false]
     ├── filters: []
+    ├── build join filters:
+    │   └── filter id:0, build key:t6.wms_id (#4), probe targets:[replace(t1.ext (#1), '33', '44')@scan0], filter type:bloom,inlist,min_max
     ├── estimated rows: 0.00
     ├── TableScan(Build)
     │   ├── table: default.default.t2
@@ -869,6 +872,7 @@ EvalScalar
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(substr(replace(t1.ext (#1), '33', '44'), 1) = 'R006')], limit: NONE]
+        ├── apply join filters: [#0]
         └── estimated rows: 0.00
 
 query T
@@ -885,6 +889,8 @@ EvalScalar
     ├── probe keys: [replace(t1.ext (#1), '33', '44')]
     ├── keys is null equal: [false]
     ├── filters: []
+    ├── build join filters:
+    │   └── filter id:0, build key:t6.wms_id (#4), probe targets:[replace(t1.ext (#1), '33', '44')@scan0], filter type:bloom,inlist,min_max
     ├── estimated rows: 0.00
     ├── TableScan(Build)
     │   ├── table: default.default.t2
@@ -905,6 +911,7 @@ EvalScalar
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(replace(t1.ext (#1), '33', '44') = 'R006')], limit: NONE]
+        ├── apply join filters: [#0]
         └── estimated rows: 0.00
 
 query T
@@ -921,6 +928,8 @@ EvalScalar
     ├── probe keys: [replace(t1.ext (#1), '33', '44')]
     ├── keys is null equal: [false]
     ├── filters: []
+    ├── build join filters:
+    │   └── filter id:0, build key:t6.wms_id (#4), probe targets:[replace(t1.ext (#1), '33', '44')@scan0], filter type:bloom,inlist,min_max
     ├── estimated rows: 0.00
     ├── TableScan(Build)
     │   ├── table: default.default.t2
@@ -941,6 +950,7 @@ EvalScalar
         ├── partitions total: 0
         ├── partitions scanned: 0
         ├── push downs: [filters: [is_true(replace(substr(t1.ext (#1), 1), '33', '44') = 'R006')], limit: NONE]
+        ├── apply join filters: [#0]
         └── estimated rows: 0.00
 
 statement ok
@@ -1066,6 +1076,8 @@ HashJoin
 ├── probe keys: [CAST(t1.a (#0) AS Decimal(38, 5) NULL)]
 ├── keys is null equal: [false]
 ├── filters: []
+├── build join filters:
+│   └── filter id:0, build key:CAST(t3.a (#1) AS Decimal(38, 5) NULL), probe targets:[CAST(t1.a (#0) AS Decimal(38, 5) NULL)@scan0], filter type:inlist
 ├── estimated rows: 12.00
 ├── TableScan(Build)
 │   ├── table: default.default.t3
@@ -1088,6 +1100,7 @@ HashJoin
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
+    ├── apply join filters: [#0]
     └── estimated rows: 4.00
 
 query T

--- a/tests/sqllogictests/suites/mode/standalone/explain/runtime_filter_cast.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/runtime_filter_cast.test
@@ -175,3 +175,225 @@ drop table rf_cast_probe_nullable;
 
 statement ok
 drop table rf_cast_build_nn;
+
+statement ok
+drop table if exists rf_expr_probe;
+
+statement ok
+drop table if exists rf_expr_build;
+
+statement ok
+drop table if exists rf_expr_connector;
+
+statement ok
+drop table if exists rf_expr_equiv;
+
+statement ok
+create table rf_expr_probe (a Int not null);
+
+statement ok
+create table rf_expr_build (id BigInt not null);
+
+statement ok
+create table rf_expr_connector (id BigInt not null);
+
+statement ok
+create table rf_expr_equiv (c Int not null);
+
+statement ok
+insert into rf_expr_probe values (1), (2), (3);
+
+statement ok
+insert into rf_expr_build values (11), (13);
+
+statement ok
+insert into rf_expr_connector values (11), (12), (13);
+
+statement ok
+insert into rf_expr_equiv values (1);
+
+# Bloom must hash the Int64 result of `a + 10`, not the underlying Int32 column.
+statement ok
+set inlist_runtime_filter_threshold = 0;
+
+statement ok
+set min_max_runtime_filter_threshold = 0;
+
+statement ok
+set bloom_runtime_filter_threshold = 1000;
+
+query I
+SELECT count(*)
+FROM rf_expr_probe p
+JOIN rf_expr_build b ON p.a + 10 = b.id;
+----
+2
+
+# A nullable-only wrapper does not turn its value-changing argument into an
+# equivalence connector. Propagating the build value 11 to e.c=1 would wrongly
+# prune the only matching row.
+statement ok
+set min_max_runtime_filter_threshold = 0;
+
+statement ok
+set bloom_runtime_filter_threshold = 0;
+
+statement ok
+set inlist_runtime_filter_threshold = 1000;
+
+statement ok
+set disable_join_reorder = 1;
+
+query I
+SELECT count(*)
+FROM rf_expr_probe p
+JOIN rf_expr_equiv e ON p.a = e.c
+JOIN rf_expr_build b ON CAST(p.a + 10 AS Nullable(BigInt)) = b.id;
+----
+1
+
+# In-list must compare build values with the complete probe expression.
+statement ok
+set bloom_runtime_filter_threshold = 0;
+
+statement ok
+set inlist_runtime_filter_threshold = 1000;
+
+query I
+SELECT count(*)
+FROM rf_expr_probe p
+JOIN rf_expr_build b ON p.a + 10 = b.id;
+----
+2
+
+# Min-max must use the same complete expression.
+statement ok
+set inlist_runtime_filter_threshold = 0;
+
+statement ok
+set min_max_runtime_filter_threshold = 1000;
+
+query I
+SELECT count(*)
+FROM rf_expr_probe p
+JOIN rf_expr_build b ON p.a + 10 = b.id;
+----
+2
+
+query T
+EXPLAIN SELECT *
+FROM rf_expr_probe p
+JOIN rf_expr_build b ON p.a + 10 = b.id;
+----
+HashJoin
+├── output columns: [p.a (#0), b.id (#1)]
+├── join type: INNER
+├── build keys: [b.id (#1)]
+├── probe keys: [p.a (#0) + 10]
+├── keys is null equal: [false]
+├── filters: []
+├── build join filters:
+│   └── filter id:0, build key:b.id (#1), probe targets:[p.a (#0) + 10@scan0], filter type:bloom,inlist,min_max
+├── estimated rows: 6.00
+├── TableScan(Build)
+│   ├── table: default.default.rf_expr_build
+│   ├── scan id: 1
+│   ├── output columns: [id (#1)]
+│   ├── read rows: 2
+│   ├── read size: < 1 KiB
+│   ├── partitions total: 1
+│   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 2.00
+└── TableScan(Probe)
+    ├── table: default.default.rf_expr_probe
+    ├── scan id: 0
+    ├── output columns: [a (#0)]
+    ├── read rows: 3
+    ├── read size: < 1 KiB
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── push downs: [filters: [], limit: NONE]
+    ├── apply join filters: [#0]
+    └── estimated rows: 3.00
+
+# A value-changing root expression stays on its own scan even when the probe
+# subtree contains an equivalent connector.
+
+query T
+EXPLAIN SELECT *
+FROM rf_expr_probe p
+JOIN rf_expr_connector c ON p.a + 10 = c.id
+JOIN rf_expr_build b ON c.id = b.id;
+----
+HashJoin
+├── output columns: [p.a (#0), c.id (#1), b.id (#2)]
+├── join type: INNER
+├── build keys: [b.id (#2)]
+├── probe keys: [p.a (#0) + 10]
+├── keys is null equal: [false]
+├── filters: []
+├── build join filters:
+│   └── filter id:1, build key:b.id (#2), probe targets:[p.a (#0) + 10@scan0], filter type:bloom,inlist,min_max
+├── estimated rows: 18.00
+├── TableScan(Build)
+│   ├── table: default.default.rf_expr_build
+│   ├── scan id: 2
+│   ├── output columns: [id (#2)]
+│   ├── read rows: 2
+│   ├── read size: < 1 KiB
+│   ├── partitions total: 1
+│   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 2.00
+└── HashJoin(Probe)
+    ├── output columns: [p.a (#0), c.id (#1)]
+    ├── join type: INNER
+    ├── build keys: [c.id (#1)]
+    ├── probe keys: [p.a (#0) + 10]
+    ├── keys is null equal: [false]
+    ├── filters: []
+    ├── build join filters:
+    │   └── filter id:0, build key:c.id (#1), probe targets:[p.a (#0) + 10@scan0], filter type:bloom,inlist,min_max
+    ├── estimated rows: 9.00
+    ├── TableScan(Build)
+    │   ├── table: default.default.rf_expr_connector
+    │   ├── scan id: 1
+    │   ├── output columns: [id (#1)]
+    │   ├── read rows: 3
+    │   ├── read size: < 1 KiB
+    │   ├── partitions total: 1
+    │   ├── partitions scanned: 1
+    │   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    │   ├── push downs: [filters: [], limit: NONE]
+    │   └── estimated rows: 3.00
+    └── TableScan(Probe)
+        ├── table: default.default.rf_expr_probe
+        ├── scan id: 0
+        ├── output columns: [a (#0)]
+        ├── read rows: 3
+        ├── read size: < 1 KiB
+        ├── partitions total: 1
+        ├── partitions scanned: 1
+        ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+        ├── push downs: [filters: [], limit: NONE]
+        ├── apply join filters: [#1, #0]
+        └── estimated rows: 3.00
+
+statement ok
+unset disable_join_reorder;
+
+statement ok
+drop table rf_expr_probe;
+
+statement ok
+drop table rf_expr_build;
+
+statement ok
+drop table rf_expr_connector;
+
+statement ok
+drop table rf_expr_equiv;

--- a/tests/sqllogictests/suites/mode/standalone/explain/runtime_filter_cast.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/runtime_filter_cast.test
@@ -397,3 +397,174 @@ drop table rf_expr_connector;
 
 statement ok
 drop table rf_expr_equiv;
+
+statement ok
+drop table if exists rf_nested_cast_probe;
+
+statement ok
+drop table if exists rf_nested_cast_build;
+
+statement ok
+create table rf_nested_cast_probe (a SmallInt not null);
+
+statement ok
+create table rf_nested_cast_build (id BigInt not null);
+
+statement ok
+insert into rf_nested_cast_probe values (1), (2), (3), (4);
+
+statement ok
+insert into rf_nested_cast_build values (1), (3), (5);
+
+# A nested lossless widening cast is retained as the complete Bloom probe key.
+statement ok
+set inlist_runtime_filter_threshold = 0;
+
+statement ok
+set min_max_runtime_filter_threshold = 0;
+
+statement ok
+set bloom_runtime_filter_threshold = 1000;
+
+statement ok
+set join_runtime_filter_selectivity_threshold = 101;
+
+query I
+SELECT count(*)
+FROM rf_nested_cast_probe p
+JOIN rf_nested_cast_build b
+    ON CAST(CAST(p.a AS Int) AS BigInt) = b.id;
+----
+2
+
+query T
+EXPLAIN SELECT *
+FROM rf_nested_cast_probe p
+JOIN rf_nested_cast_build b
+    ON CAST(CAST(p.a AS Int) AS BigInt) = b.id;
+----
+HashJoin
+├── output columns: [p.a (#0), b.id (#1)]
+├── join type: INNER
+├── build keys: [b.id (#1)]
+├── probe keys: [CAST(CAST(p.a (#0) AS Int32) AS Int64)]
+├── keys is null equal: [false]
+├── filters: []
+├── build join filters:
+│   └── filter id:0, build key:b.id (#1), probe targets:[CAST(CAST(p.a (#0) AS Int32) AS Int64)@scan0], filter type:bloom,inlist,min_max
+├── estimated rows: 12.00
+├── TableScan(Build)
+│   ├── table: default.default.rf_nested_cast_build
+│   ├── scan id: 1
+│   ├── output columns: [id (#1)]
+│   ├── read rows: 3
+│   ├── read size: < 1 KiB
+│   ├── partitions total: 1
+│   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 3.00
+└── TableScan(Probe)
+    ├── table: default.default.rf_nested_cast_probe
+    ├── scan id: 0
+    ├── output columns: [a (#0)]
+    ├── read rows: 4
+    ├── read size: < 1 KiB
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── push downs: [filters: [], limit: NONE]
+    ├── apply join filters: [#0]
+    └── estimated rows: 4.00
+
+statement ok
+drop table rf_nested_cast_probe;
+
+statement ok
+drop table rf_nested_cast_build;
+
+statement ok
+drop table if exists rf_try_cast_probe;
+
+statement ok
+drop table if exists rf_try_cast_build;
+
+statement ok
+create table rf_try_cast_probe (s String not null);
+
+statement ok
+create table rf_try_cast_build (id BigInt not null);
+
+statement ok
+insert into rf_try_cast_probe values ('11'), ('invalid'), ('13'), ('14');
+
+statement ok
+insert into rf_try_cast_build values (11), (13);
+
+# TRY_CAST must hash its Nullable(Int64) result rather than the underlying
+# String column; the invalid input becomes NULL and is safely rejected.
+statement ok
+set inlist_runtime_filter_threshold = 0;
+
+statement ok
+set min_max_runtime_filter_threshold = 0;
+
+statement ok
+set bloom_runtime_filter_threshold = 1000;
+
+statement ok
+set join_runtime_filter_selectivity_threshold = 101;
+
+query I
+SELECT count(*)
+FROM rf_try_cast_probe p
+JOIN rf_try_cast_build b
+    ON TRY_CAST(p.s AS BigInt) = b.id;
+----
+2
+
+query T
+EXPLAIN SELECT *
+FROM rf_try_cast_probe p
+JOIN rf_try_cast_build b
+    ON TRY_CAST(p.s AS BigInt) = b.id;
+----
+HashJoin
+├── output columns: [p.s (#0), b.id (#1)]
+├── join type: INNER
+├── build keys: [CAST(b.id (#1) AS Int64 NULL)]
+├── probe keys: [TRY_CAST(p.s (#0) AS Int64 NULL)]
+├── keys is null equal: [false]
+├── filters: []
+├── build join filters:
+│   └── filter id:0, build key:CAST(b.id (#1) AS Int64 NULL), probe targets:[TRY_CAST(p.s (#0) AS Int64 NULL)@scan0], filter type:bloom,inlist,min_max
+├── estimated rows: 8.00
+├── TableScan(Build)
+│   ├── table: default.default.rf_try_cast_build
+│   ├── scan id: 1
+│   ├── output columns: [id (#1)]
+│   ├── read rows: 2
+│   ├── read size: < 1 KiB
+│   ├── partitions total: 1
+│   ├── partitions scanned: 1
+│   ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+│   ├── push downs: [filters: [], limit: NONE]
+│   └── estimated rows: 2.00
+└── TableScan(Probe)
+    ├── table: default.default.rf_try_cast_probe
+    ├── scan id: 0
+    ├── output columns: [s (#0)]
+    ├── read rows: 4
+    ├── read size: < 1 KiB
+    ├── partitions total: 1
+    ├── partitions scanned: 1
+    ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
+    ├── push downs: [filters: [], limit: NONE]
+    ├── apply join filters: [#0]
+    └── estimated rows: 4.00
+
+statement ok
+drop table rf_try_cast_probe;
+
+statement ok
+drop table rf_try_cast_build;

--- a/tests/sqllogictests/suites/query/join/runtime_filter.test
+++ b/tests/sqllogictests/suites/query/join/runtime_filter.test
@@ -117,14 +117,24 @@ statement ok
 create table rf_expr_probe_t3(a bigint);
 
 statement ok
-insert into rf_expr_probe_t1 values (3), (5);
+insert into rf_expr_probe_t1 values (3), (5), (11);
 
 statement ok
 insert into rf_expr_probe_t2 values (1, 2), (2, 3);
 
 statement ok
-insert into rf_expr_probe_t3 values (3);
+insert into rf_expr_probe_t3 values (3), (11);
 
+# A single-column expression is a leaf probe target of the connector t1.a.
+query I
+select count(*)
+from rf_expr_probe_t1 t1
+join rf_expr_probe_t2 t2 on t1.a = cast(t2.x + 10 as bigint)
+join rf_expr_probe_t3 t3 on t1.a = t3.a;
+----
+1
+
+# Multiple physical columns remain unsupported as a runtime-filter target.
 query I
 select count(*)
 from rf_expr_probe_t1 t1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Extend runtime filter probe keys from direct columns and nullable casts to safe single-column expressions across planning, pruning, and execution.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent implemented the planner, runtime-filter execution, Fuse scan, and regression-test changes and assisted with iterative review.
- Responsible human: @SkyFan2002
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20301)
<!-- Reviewable:end -->
