### PR TITLE
fix(iceberg): refresh expiring table credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5148,6 +5148,7 @@ dependencies = [
 name = "databend-common-storages-iceberg"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "arrow-array 58.1.0",
  "arrow-schema 58.1.0",
  "async-backtrace",
@@ -5179,8 +5180,10 @@ dependencies = [
  "iceberg-catalog-s3tables",
  "log",
  "parquet 58.1.0",
+ "reqwest",
  "serde",
  "serde_json",
+ "tokio",
  "typetag",
  "uuid",
 ]

--- a/src/query/storages/common/cache/src/caches.rs
+++ b/src/query/storages/common/cache/src/caches.rs
@@ -67,7 +67,46 @@ pub type ParquetMetaDataCache = InMemoryLruCache<ParquetMetaData>;
 
 pub type PrunePartitionsCache = InMemoryLruCache<(PartStatistics, Partitions)>;
 
-pub type IcebergTableCache = InMemoryLruCache<(Arc<dyn Table>, AtomicBool, Instant)>;
+pub struct IcebergTableCacheValue {
+    table: Arc<dyn Table>,
+    refreshing: AtomicBool,
+    loaded_at: Instant,
+    credential_refresh_at: Option<Instant>,
+}
+
+impl IcebergTableCacheValue {
+    pub fn new(table: Arc<dyn Table>, credential_refresh_at: Option<Instant>) -> Self {
+        Self {
+            table,
+            refreshing: AtomicBool::new(false),
+            loaded_at: Instant::now(),
+            credential_refresh_at,
+        }
+    }
+
+    pub fn table(&self) -> Arc<dyn Table> {
+        self.table.clone()
+    }
+
+    pub(crate) fn loaded_at(&self) -> Instant {
+        self.loaded_at
+    }
+
+    pub(crate) fn credential_refresh_at(&self) -> Option<Instant> {
+        self.credential_refresh_at
+    }
+
+    pub(crate) fn is_refreshing(&self) -> bool {
+        self.refreshing.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub(crate) fn set_refreshing(&self) {
+        self.refreshing
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+pub type IcebergTableCache = InMemoryLruCache<IcebergTableCacheValue>;
 
 /// In memory object cache of table column array
 pub type ColumnArrayCache = InMemoryLruCache<SizedColumnArray>;
@@ -105,7 +144,7 @@ impl CachedObject<Vec<Arc<BlockMeta>>> for Vec<Arc<BlockMeta>> {
     }
 }
 
-impl CachedObject<(Arc<dyn Table>, AtomicBool, Instant)> for (Arc<dyn Table>, AtomicBool, Instant) {
+impl CachedObject<IcebergTableCacheValue> for IcebergTableCacheValue {
     type Cache = IcebergTableCache;
     fn cache() -> Option<Self::Cache> {
         CacheManager::instance().get_iceberg_table_cache()
@@ -230,10 +269,8 @@ impl From<BlockMeta> for CacheValue<BlockMeta> {
     }
 }
 
-impl From<(Arc<dyn Table>, AtomicBool, Instant)>
-    for CacheValue<(Arc<dyn Table>, AtomicBool, Instant)>
-{
-    fn from(value: (Arc<dyn Table>, AtomicBool, Instant)) -> Self {
+impl From<IcebergTableCacheValue> for CacheValue<IcebergTableCacheValue> {
+    fn from(value: IcebergTableCacheValue) -> Self {
         CacheValue {
             inner: Arc::new(value),
             mem_bytes: 0,

--- a/src/query/storages/common/cache/src/read/cached_ttl_reader.rs
+++ b/src/query/storages/common/cache/src/read/cached_ttl_reader.rs
@@ -13,11 +13,9 @@
 // limitations under the License.
 
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 use std::time::Instant;
 
-use databend_common_catalog::table::Table;
 use databend_common_exception::Result;
 use databend_common_metrics::cache::*;
 
@@ -25,9 +23,13 @@ use super::loader::LoadParams;
 use crate::CacheAccessor;
 use crate::Loader;
 use crate::caches::CacheValue;
+use crate::caches::IcebergTableCacheValue;
 
 pub trait TTLValue {
     fn is_expired(&self, ttl: &Duration) -> bool;
+    fn requires_sync_refresh(&self) -> bool {
+        false
+    }
     fn is_refreshing(&self) -> bool;
     fn set_refreshing(&self);
 }
@@ -53,7 +55,7 @@ where
         }
     }
     /// Load the object at `location`, uses/populates the cache if possible/necessary.
-    /// If the value is expired, it triggers an asynchronous refresh logic and returns the expired data.
+    /// Expired values are refreshed asynchronously unless they require a synchronous refresh.
     #[async_backtrace::framed]
     pub async fn read(&self, params: &LoadParams) -> Result<Arc<V>> {
         match &self.cache {
@@ -63,6 +65,19 @@ where
                 match cache.get(cache_key.as_str()) {
                     Some(item) => {
                         if item.is_expired(&self.ttl) {
+                            if item.requires_sync_refresh() {
+                                let start = Instant::now();
+                                let v = self.loader.load(params).await?;
+                                metrics_inc_cache_miss_load_millisecond(
+                                    start.elapsed().as_millis() as u64,
+                                    cache.name(),
+                                );
+                                return match params.put_cache {
+                                    true => Ok(cache.insert(cache_key, v)),
+                                    false => Ok(Arc::new(v)),
+                                };
+                            }
+
                             // Trigger async refresh logic
                             if !item.is_refreshing() {
                                 item.set_refreshing();
@@ -156,18 +171,21 @@ where
     }
 }
 
-impl TTLValue for (Arc<dyn Table>, AtomicBool, Instant) {
+impl TTLValue for IcebergTableCacheValue {
     fn is_expired(&self, ttl: &Duration) -> bool {
-        Instant::now() > self.2 + *ttl
+        Instant::now() > self.loaded_at() + *ttl || self.requires_sync_refresh()
+    }
+
+    fn requires_sync_refresh(&self) -> bool {
+        self.credential_refresh_at()
+            .is_some_and(|refresh_at| Instant::now() >= refresh_at)
     }
 
     fn is_refreshing(&self) -> bool {
-        // Check the value of the AtomicBool
-        self.1.load(std::sync::atomic::Ordering::Relaxed)
+        self.is_refreshing()
     }
 
     fn set_refreshing(&self) {
-        // Set the AtomicBool to true
-        self.1.store(true, std::sync::atomic::Ordering::Relaxed);
+        self.set_refreshing();
     }
 }

--- a/src/query/storages/iceberg/Cargo.toml
+++ b/src/query/storages/iceberg/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
+anyhow = { workspace = true }
 arrow-array = { workspace = true }
 arrow-schema = { workspace = true }
 async-backtrace = { workspace = true }
@@ -38,8 +39,10 @@ iceberg-catalog-rest = { workspace = true }
 iceberg-catalog-s3tables = { workspace = true }
 log = { workspace = true }
 parquet = { workspace = true }
+reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true }
 typetag = { workspace = true }
 uuid = { workspace = true }
 

--- a/src/query/storages/iceberg/src/cache.rs
+++ b/src/query/storages/iceberg/src/cache.rs
@@ -14,9 +14,6 @@
 
 use std::sync::Arc;
 use std::time::Duration;
-use std::time::Instant;
-use std::time::SystemTime;
-use std::time::UNIX_EPOCH;
 
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -28,14 +25,13 @@ use databend_storages_common_cache::LoadParams;
 use databend_storages_common_cache::Loader;
 
 use crate::IcebergTable;
+use crate::credential::credential_refresh_at;
 
 pub struct LoaderWrapper<T>(T);
 pub type IcebergTableReader = InMemoryCacheTTLReader<
     IcebergTableCacheValue,
     LoaderWrapper<(Arc<dyn iceberg::Catalog>, Arc<CatalogInfo>)>,
 >;
-
-const CREDENTIAL_REFRESH_MARGIN: Duration = Duration::from_secs(300);
 
 pub(crate) const SEP_STR: &str = "\u{001f}";
 
@@ -77,30 +73,6 @@ impl Loader<IcebergTableCacheValue>
     }
 }
 
-fn credential_refresh_at(table: &iceberg::table::Table) -> Option<Instant> {
-    let (_, props, _) = table.file_io().clone().into_builder().into_parts();
-    let expires_at_ms = props
-        .iter()
-        .find(|(key, _)| key.as_str() == "expires-at-ms")
-        .or_else(|| props.iter().find(|(key, _)| key.ends_with("expires-at-ms")))?
-        .1
-        .parse::<u64>()
-        .ok()?;
-
-    credential_refresh_at_from(expires_at_ms, SystemTime::now(), Instant::now())
-}
-
-fn credential_refresh_at_from(
-    expires_at_ms: u64,
-    now_system: SystemTime,
-    now_instant: Instant,
-) -> Option<Instant> {
-    let expires_at = UNIX_EPOCH.checked_add(Duration::from_millis(expires_at_ms))?;
-    let remaining = expires_at.duration_since(now_system).unwrap_or_default();
-    let margin = CREDENTIAL_REFRESH_MARGIN.min(remaining / 10);
-    now_instant.checked_add(remaining.saturating_sub(margin))
-}
-
 pub fn iceberg_table_cache_reader(
     catalog: Arc<dyn iceberg::Catalog>,
     info: Arc<CatalogInfo>,
@@ -129,26 +101,5 @@ mod tests {
     fn test_parse_invalid_table_cache_key() {
         let err = parse_table_cache_key("db1\u{001f}tbl1").unwrap_err();
         assert!(err.message().contains("Invalid iceberg table cache key"));
-    }
-
-    #[test]
-    fn test_credential_refresh_at_uses_safety_margin() {
-        let now_system = UNIX_EPOCH + Duration::from_secs(1_000);
-        let now_instant = Instant::now();
-        let refresh_at = credential_refresh_at_from(4_600_000, now_system, now_instant).unwrap();
-
-        assert_eq!(
-            refresh_at.duration_since(now_instant),
-            Duration::from_secs(3_300)
-        );
-    }
-
-    #[test]
-    fn test_expired_credential_refreshes_immediately() {
-        let now_system = UNIX_EPOCH + Duration::from_secs(2_000);
-        let now_instant = Instant::now();
-        let refresh_at = credential_refresh_at_from(1_000_000, now_system, now_instant).unwrap();
-
-        assert_eq!(refresh_at, now_instant);
     }
 }

--- a/src/query/storages/iceberg/src/cache.rs
+++ b/src/query/storages/iceberg/src/cache.rs
@@ -13,15 +13,16 @@
 // limitations under the License.
 
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 use std::time::Instant;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
-use databend_common_catalog::table::Table;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_meta_app::schema::CatalogInfo;
 use databend_storages_common_cache::CacheManager;
+use databend_storages_common_cache::IcebergTableCacheValue;
 use databend_storages_common_cache::InMemoryCacheTTLReader;
 use databend_storages_common_cache::LoadParams;
 use databend_storages_common_cache::Loader;
@@ -30,9 +31,11 @@ use crate::IcebergTable;
 
 pub struct LoaderWrapper<T>(T);
 pub type IcebergTableReader = InMemoryCacheTTLReader<
-    (Arc<dyn Table>, AtomicBool, Instant),
+    IcebergTableCacheValue,
     LoaderWrapper<(Arc<dyn iceberg::Catalog>, Arc<CatalogInfo>)>,
 >;
+
+const CREDENTIAL_REFRESH_MARGIN: Duration = Duration::from_secs(300);
 
 pub(crate) const SEP_STR: &str = "\u{001f}";
 
@@ -51,11 +54,11 @@ fn parse_table_cache_key(cache_key: &str) -> Result<(&str, &str)> {
 }
 
 #[async_trait::async_trait]
-impl Loader<(Arc<dyn Table>, AtomicBool, Instant)>
+impl Loader<IcebergTableCacheValue>
     for LoaderWrapper<(Arc<dyn iceberg::Catalog>, Arc<CatalogInfo>)>
 {
     #[async_backtrace::framed]
-    async fn load(&self, params: &LoadParams) -> Result<(Arc<dyn Table>, AtomicBool, Instant)> {
+    async fn load(&self, params: &LoadParams) -> Result<IcebergTableCacheValue> {
         let (database_name, table_name) = parse_table_cache_key(&params.location)?;
         let inner = &self.0;
         let iceberg = IcebergTable::try_create_from_iceberg_catalog(
@@ -66,9 +69,36 @@ impl Loader<(Arc<dyn Table>, AtomicBool, Instant)>
         )
         .await?;
 
-        let tbl = Arc::new(iceberg) as Arc<dyn Table>;
-        Ok((tbl, AtomicBool::new(false), Instant::now()))
+        let credential_refresh_at = credential_refresh_at(iceberg.iceberg_table());
+        Ok(IcebergTableCacheValue::new(
+            Arc::new(iceberg),
+            credential_refresh_at,
+        ))
     }
+}
+
+fn credential_refresh_at(table: &iceberg::table::Table) -> Option<Instant> {
+    let (_, props, _) = table.file_io().clone().into_builder().into_parts();
+    let expires_at_ms = props
+        .iter()
+        .find(|(key, _)| key.as_str() == "expires-at-ms")
+        .or_else(|| props.iter().find(|(key, _)| key.ends_with("expires-at-ms")))?
+        .1
+        .parse::<u64>()
+        .ok()?;
+
+    credential_refresh_at_from(expires_at_ms, SystemTime::now(), Instant::now())
+}
+
+fn credential_refresh_at_from(
+    expires_at_ms: u64,
+    now_system: SystemTime,
+    now_instant: Instant,
+) -> Option<Instant> {
+    let expires_at = UNIX_EPOCH.checked_add(Duration::from_millis(expires_at_ms))?;
+    let remaining = expires_at.duration_since(now_system).unwrap_or_default();
+    let margin = CREDENTIAL_REFRESH_MARGIN.min(remaining / 10);
+    now_instant.checked_add(remaining.saturating_sub(margin))
 }
 
 pub fn iceberg_table_cache_reader(
@@ -99,5 +129,26 @@ mod tests {
     fn test_parse_invalid_table_cache_key() {
         let err = parse_table_cache_key("db1\u{001f}tbl1").unwrap_err();
         assert!(err.message().contains("Invalid iceberg table cache key"));
+    }
+
+    #[test]
+    fn test_credential_refresh_at_uses_safety_margin() {
+        let now_system = UNIX_EPOCH + Duration::from_secs(1_000);
+        let now_instant = Instant::now();
+        let refresh_at = credential_refresh_at_from(4_600_000, now_system, now_instant).unwrap();
+
+        assert_eq!(
+            refresh_at.duration_since(now_instant),
+            Duration::from_secs(3_300)
+        );
+    }
+
+    #[test]
+    fn test_expired_credential_refreshes_immediately() {
+        let now_system = UNIX_EPOCH + Duration::from_secs(2_000);
+        let now_instant = Instant::now();
+        let refresh_at = credential_refresh_at_from(1_000_000, now_system, now_instant).unwrap();
+
+        assert_eq!(refresh_at, now_instant);
     }
 }

--- a/src/query/storages/iceberg/src/credential.rs
+++ b/src/query/storages/iceberg/src/credential.rs
@@ -1,0 +1,288 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+use anyhow::anyhow;
+use async_trait::async_trait;
+use chrono::DateTime;
+use chrono::Utc;
+use databend_common_exception::ErrorCode;
+use databend_common_exception::Result;
+use iceberg::TableIdent;
+use iceberg::io::AwsCredential;
+use iceberg::io::AwsCredentialLoad;
+use iceberg::io::CustomAwsCredentialLoader;
+use iceberg::io::FileIOBuilder;
+use reqwest::Client;
+use tokio::sync::Mutex;
+
+const CREDENTIAL_REFRESH_MARGIN: Duration = Duration::from_secs(300);
+const CREDENTIAL_REFRESH_RETRY_INTERVAL: Duration = Duration::from_secs(30);
+
+#[derive(Clone)]
+struct VendedCredential {
+    credential: AwsCredential,
+    refresh_at: Instant,
+    expires_at: Instant,
+}
+
+impl VendedCredential {
+    fn from_table(table: &iceberg::table::Table) -> Option<Self> {
+        let (_, props, _) = table.file_io().clone().into_builder().into_parts();
+        Self::from_props(&props, SystemTime::now(), Instant::now())
+    }
+
+    fn from_props(
+        props: &HashMap<String, String>,
+        now_system: SystemTime,
+        now_instant: Instant,
+    ) -> Option<Self> {
+        let expires_at_ms = property(props, "expires-at-ms")?.parse::<u64>().ok()?;
+        let expires_at_datetime =
+            DateTime::<Utc>::from_timestamp_millis(i64::try_from(expires_at_ms).ok()?)?;
+        let expires_at_system = UNIX_EPOCH.checked_add(Duration::from_millis(expires_at_ms))?;
+        let remaining = expires_at_system
+            .duration_since(now_system)
+            .unwrap_or_default();
+        let margin = CREDENTIAL_REFRESH_MARGIN.min(remaining / 10);
+
+        Some(Self {
+            credential: AwsCredential {
+                access_key_id: props.get("s3.access-key-id")?.clone(),
+                secret_access_key: props.get("s3.secret-access-key")?.clone(),
+                session_token: props.get("s3.session-token").cloned(),
+                expires_in: Some(expires_at_datetime),
+            },
+            refresh_at: now_instant.checked_add(remaining.saturating_sub(margin))?,
+            expires_at: now_instant.checked_add(remaining)?,
+        })
+    }
+}
+
+fn property<'a>(props: &'a HashMap<String, String>, suffix: &str) -> Option<&'a str> {
+    props
+        .get(suffix)
+        .or_else(|| {
+            props
+                .iter()
+                .find(|(key, _)| key.ends_with(suffix))
+                .map(|(_, value)| value)
+        })
+        .map(String::as_str)
+}
+
+#[async_trait]
+trait VendedCredentialProvider: Send + Sync {
+    async fn load(&self) -> anyhow::Result<VendedCredential>;
+}
+
+struct CatalogCredentialProvider {
+    catalog: Arc<dyn iceberg::Catalog>,
+    table_ident: TableIdent,
+}
+
+#[async_trait]
+impl VendedCredentialProvider for CatalogCredentialProvider {
+    async fn load(&self) -> anyhow::Result<VendedCredential> {
+        let table = self
+            .catalog
+            .load_table(&self.table_ident)
+            .await
+            .map_err(|error| anyhow!("failed to refresh Iceberg table credentials: {error:?}"))?;
+        VendedCredential::from_table(&table).ok_or_else(|| {
+            anyhow!("Iceberg load_table response did not contain vended credentials")
+        })
+    }
+}
+
+struct RefreshingAwsCredentialLoader {
+    provider: Arc<dyn VendedCredentialProvider>,
+    current: Mutex<VendedCredential>,
+}
+
+impl RefreshingAwsCredentialLoader {
+    fn new(provider: Arc<dyn VendedCredentialProvider>, current: VendedCredential) -> Self {
+        Self {
+            provider,
+            current: Mutex::new(current),
+        }
+    }
+}
+
+#[async_trait]
+impl AwsCredentialLoad for RefreshingAwsCredentialLoader {
+    async fn load_credential(&self, _client: Client) -> anyhow::Result<Option<AwsCredential>> {
+        let mut current = self.current.lock().await;
+        let now = Instant::now();
+        if now < current.refresh_at {
+            return Ok(Some(current.credential.clone()));
+        }
+
+        match self.provider.load().await {
+            Ok(refreshed) => {
+                let credential = refreshed.credential.clone();
+                *current = refreshed;
+                Ok(Some(credential))
+            }
+            Err(error) if now < current.expires_at => {
+                log::warn!("failed to refresh Iceberg vended credentials early: {error}");
+                current.refresh_at = current
+                    .expires_at
+                    .min(now + CREDENTIAL_REFRESH_RETRY_INTERVAL);
+                Ok(Some(current.credential.clone()))
+            }
+            Err(error) => Err(error),
+        }
+    }
+}
+
+pub(crate) fn credential_refresh_at(table: &iceberg::table::Table) -> Option<Instant> {
+    VendedCredential::from_table(table).map(|credential| credential.refresh_at)
+}
+
+pub(crate) fn with_refreshing_credentials(
+    catalog: Arc<dyn iceberg::Catalog>,
+    table: iceberg::table::Table,
+) -> Result<iceberg::table::Table> {
+    let Some(credential) = VendedCredential::from_table(&table) else {
+        return Ok(table);
+    };
+
+    let table_ident = table.identifier().clone();
+    let provider = Arc::new(CatalogCredentialProvider {
+        catalog,
+        table_ident: table_ident.clone(),
+    });
+    let loader = CustomAwsCredentialLoader::new(Arc::new(RefreshingAwsCredentialLoader::new(
+        provider, credential,
+    )));
+    let (scheme, props, extensions) = table.file_io().clone().into_builder().into_parts();
+    let file_io = FileIOBuilder::new(scheme)
+        .with_props(props)
+        .with_extensions(extensions)
+        .with_extension(loader)
+        .build()
+        .map_err(|error| {
+            ErrorCode::ReadTableDataError(format!(
+                "Rebuild Iceberg table with refreshing credentials failed: {error:?}"
+            ))
+        })?;
+
+    let builder = iceberg::table::Table::builder()
+        .identifier(table_ident)
+        .metadata(table.metadata_ref())
+        .file_io(file_io)
+        .readonly(table.readonly());
+    let builder = match table.metadata_location() {
+        Some(metadata_location) => builder.metadata_location(metadata_location),
+        None => builder,
+    };
+    builder.build().map_err(|error| {
+        ErrorCode::ReadTableDataError(format!(
+            "Rebuild Iceberg table with refreshing credentials failed: {error:?}"
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
+    use super::*;
+
+    struct StaticProvider {
+        calls: AtomicUsize,
+        credential: VendedCredential,
+    }
+
+    #[async_trait]
+    impl VendedCredentialProvider for StaticProvider {
+        async fn load(&self) -> anyhow::Result<VendedCredential> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            Ok(self.credential.clone())
+        }
+    }
+
+    fn test_credential(
+        access_key_id: &str,
+        refresh_at: Instant,
+        expires_at: Instant,
+    ) -> VendedCredential {
+        VendedCredential {
+            credential: AwsCredential {
+                access_key_id: access_key_id.to_string(),
+                secret_access_key: "secret".to_string(),
+                session_token: Some("token".to_string()),
+                expires_in: None,
+            },
+            refresh_at,
+            expires_at,
+        }
+    }
+
+    #[test]
+    fn test_vended_credential_uses_safety_margin() {
+        let now_system = UNIX_EPOCH + Duration::from_secs(1_000);
+        let now_instant = Instant::now();
+        let props = HashMap::from([
+            ("s3.access-key-id".to_string(), "access".to_string()),
+            ("s3.secret-access-key".to_string(), "secret".to_string()),
+            ("s3.session-token".to_string(), "token".to_string()),
+            ("expires-at-ms".to_string(), "4600000".to_string()),
+        ]);
+        let credential = VendedCredential::from_props(&props, now_system, now_instant).unwrap();
+
+        assert_eq!(
+            credential.refresh_at.duration_since(now_instant),
+            Duration::from_secs(3_300)
+        );
+        assert_eq!(
+            credential.expires_at.duration_since(now_instant),
+            Duration::from_secs(3_600)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_loader_refreshes_credentials_during_query() {
+        let now = Instant::now();
+        let provider = Arc::new(StaticProvider {
+            calls: AtomicUsize::new(0),
+            credential: test_credential(
+                "refreshed",
+                now + Duration::from_secs(600),
+                now + Duration::from_secs(900),
+            ),
+        });
+        let loader = RefreshingAwsCredentialLoader::new(
+            provider.clone(),
+            test_credential("expired", now, now),
+        );
+
+        let credential = loader
+            .load_credential(Client::new())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(credential.access_key_id, "refreshed");
+        assert_eq!(provider.calls.load(Ordering::Relaxed), 1);
+    }
+}

--- a/src/query/storages/iceberg/src/database.rs
+++ b/src/query/storages/iceberg/src/database.rs
@@ -110,7 +110,7 @@ impl Database for IcebergDatabase {
         };
         let reader =
             super::cache::iceberg_table_cache_reader(self.ctl.iceberg_catalog(), self.ctl.info());
-        reader.read(&params).await.map(|v| v.0.clone())
+        reader.read(&params).await.map(|v| v.table())
     }
 
     // trigger use will refresh the table meta cache in current databases

--- a/src/query/storages/iceberg/src/lib.rs
+++ b/src/query/storages/iceberg/src/lib.rs
@@ -22,6 +22,7 @@
 mod append;
 pub(crate) mod cache;
 mod catalog;
+mod credential;
 mod database;
 mod iceberg_inspect;
 mod partition;

--- a/src/query/storages/iceberg/src/table.rs
+++ b/src/query/storages/iceberg/src/table.rs
@@ -67,6 +67,7 @@ use iceberg::io::FileIOBuilder;
 use crate::IcebergMutableCatalog;
 use crate::append::IcebergCommitSink;
 use crate::append::IcebergDataFileWriter;
+use crate::credential::with_refreshing_credentials;
 use crate::partition::convert_file_scan_task;
 use crate::predicate::PredicateBuilder;
 use crate::statistics;
@@ -95,13 +96,15 @@ impl IcebergTable {
     pub fn try_create(info: TableInfo) -> Result<Box<dyn Table>> {
         let (table, statistics) = Self::parse_engine_options(&info.meta.engine_options)?;
         let catalog = IcebergMutableCatalog::try_create(info.catalog_info.clone())?;
+        let catalog = catalog.iceberg_catalog();
+        let table = with_refreshing_credentials(catalog.clone(), table)?;
 
         Ok(Box::new(Self {
             info,
             table,
             snapshot_id: None,
             statistics,
-            catalog: catalog.iceberg_catalog(),
+            catalog,
         }))
     }
 
@@ -127,25 +130,23 @@ impl IcebergTable {
         table_name: &str,
     ) -> Result<iceberg::table::Table> {
         let db_ident = iceberg::NamespaceIdent::new(database.to_string());
+        let table_ident = iceberg::TableIdent::new(db_ident, table_name.to_string());
         // here we don't call table_exists to avoid extra network call
-        let table = ctl
-            .load_table(&iceberg::TableIdent::new(db_ident, table_name.to_string()))
-            .await
-            .map_err(|err| {
-                let err_str = format!("{err:?}");
-                if err_str.contains("does not exist")
-                    || err_str.contains("NoSuchTableError")
-                    || err_str.contains("TableNotFound")
-                    || err_str.contains("not found")
-                {
-                    ErrorCode::UnknownTable(format!(
-                        "Iceberg table '{database}.{table_name}' not found: {err_str}"
-                    ))
-                } else {
-                    ErrorCode::ReadTableDataError(format!("Iceberg catalog load failed: {err_str}"))
-                }
-            })?;
-        Ok(table)
+        let table = ctl.load_table(&table_ident).await.map_err(|err| {
+            let err_str = format!("{err:?}");
+            if err_str.contains("does not exist")
+                || err_str.contains("NoSuchTableError")
+                || err_str.contains("TableNotFound")
+                || err_str.contains("not found")
+            {
+                ErrorCode::UnknownTable(format!(
+                    "Iceberg table '{database}.{table_name}' not found: {err_str}"
+                ))
+            } else {
+                ErrorCode::ReadTableDataError(format!("Iceberg catalog load failed: {err_str}"))
+            }
+        })?;
+        with_refreshing_credentials(ctl, table)
     }
 
     pub fn get_schema(table: &iceberg::table::Table) -> Result<TableSchema> {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Respect `expires-at-ms` returned with Iceberg REST table credentials.
- Synchronize `load_table` before cached credentials enter the expiration window instead of returning a stale table.
- Refresh vended AWS credentials from Unity Catalog while a query is running, allowing S3 reads to continue beyond the lifetime of the credentials used to start the query.
- Preserve the existing asynchronous refresh behavior for the normal 10-minute metadata TTL.

## Implementation

- Replace the Iceberg cache tuple with a named `IcebergTableCacheValue` structure.
- Read vended S3 credentials and `expires-at-ms` from the Iceberg `FileIO` properties populated by the REST catalog response.
- Refresh at most five minutes early, using 10% of the remaining credential lifetime for shorter-lived credentials.
- Trigger synchronous table-cache reloads for credential deadlines while retaining stale-while-revalidate for metadata-only expiration.
- Attach a table-specific dynamic AWS credential loader to S3 `FileIO` instances. The loader calls the underlying catalog's `load_table` when credentials approach expiration.
- Reattach the dynamic loader when workers reconstruct Iceberg tables from `engine_options`.
- Single-flight concurrent credential refreshes; if an early refresh fails, continue using credentials that have not expired and retry after 30 seconds.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:

- `cargo test -p databend-common-storages-iceberg --lib`
- `cargo clippy -p databend-common-storages-iceberg --lib -- -D warnings`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## Risk

- Catalogs that do not return vended S3 credentials with `expires-at-ms` keep the existing behavior.
- Dynamic refresh is only installed for tables carrying expiring vended credentials.
- If Unity Catalog is temporarily unavailable during the early refresh window, reads continue with the still-valid credential and retry after 30 seconds. Once the credential has actually expired, the refresh error is returned instead of repeatedly issuing requests with a known-expired token.

## AI assistance

- AI usage: An AI coding agent assisted with root-cause analysis, implementation, tests, validation, and PR drafting.
- Responsible human: @sundy-li
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20303)
<!-- Reviewable:end -->
