### PR TITLE
fix(query): propagate suppressed row errors to is_not_error through nested calls

### DIFF
--- a/src/query/expression/src/evaluator.rs
+++ b/src/query/expression/src/evaluator.rs
@@ -110,21 +110,34 @@ impl<'a> EvaluateOptions<'a> {
 /// error rows and the first error message. Error sets travel upward through
 /// nested calls while suppression is active, so both sibling arguments and
 /// parent calls must accumulate instead of overwrite.
+///
+/// A length-1 source bitmap comes from a scalar subexpression (evaluated in
+/// a one-row block, e.g. a constant cast in `run_simple_cast`); a scalar
+/// error applies to every row, so it is broadcast to `num_rows` instead of
+/// marking only row 0.
 fn merge_eval_errors(
     target: &mut Option<(MutableBitmap, String)>,
     source: Option<(MutableBitmap, String)>,
+    num_rows: usize,
 ) {
-    if let Some((src_valids, src_msg)) = source {
-        match target {
-            Some((valids, _)) => {
-                for (row, valid) in src_valids.iter().enumerate() {
-                    if !valid && row < valids.len() {
-                        valids.set(row, false);
-                    }
+    let Some((src_valids, src_msg)) = source else {
+        return;
+    };
+    if src_valids.len() == 1 && num_rows > 1 {
+        if !src_valids.get(0) {
+            *target = Some((Bitmap::new_constant(false, num_rows).make_mut(), src_msg));
+        }
+        return;
+    }
+    match target {
+        Some((valids, _)) => {
+            for (row, valid) in src_valids.iter().enumerate() {
+                if !valid && row < valids.len() {
+                    valids.set(row, false);
                 }
             }
-            None => *target = Some((src_valids, src_msg)),
         }
+        None => *target = Some((src_valids, src_msg)),
     }
 }
 
@@ -383,12 +396,12 @@ impl<'a> Evaluator<'a> {
         // (is_not_error) observes errors from its whole subtree, not only
         // from its direct children.
         if !child_suppress_error {
-            merge_eval_errors(&mut ctx.errors, child_option.errors.take());
+            merge_eval_errors(&mut ctx.errors, child_option.errors.take(), ctx.num_rows);
         }
 
         if options.suppress_error {
             // inject errors into options, parent will handle it
-            merge_eval_errors(&mut options.errors, ctx.errors.take());
+            merge_eval_errors(&mut options.errors, ctx.errors.take(), ctx.num_rows);
         } else {
             EvalContext::render_error(
                 *span,
@@ -1624,7 +1637,17 @@ impl<'a> Evaluator<'a> {
         let entry = BlockEntry::new(value, || (src_type.clone(), num_rows));
         let block = DataBlock::new(vec![entry], num_rows);
         let evaluator = Evaluator::new(&block, self.func_ctx, self.fn_registry);
-        let result = evaluator.eval_common_call(&call, validity, expr_display, options)?;
+        // The cast may run on a one-row temporary block for scalar values, so
+        // its error bitmap is scoped to that block. Collect it in local
+        // options first, then merge into the shared options with the outer
+        // row count so a scalar error broadcasts to every row.
+        let mut local_options = options.with_suppress_error(options.suppress_error);
+        let result = evaluator.eval_common_call(&call, validity, expr_display, &mut local_options)?;
+        merge_eval_errors(
+            &mut options.errors,
+            local_options.errors.take(),
+            self.data_block.num_rows(),
+        );
         Ok(Some(result))
     }
 
@@ -2564,12 +2587,12 @@ impl<'a> Evaluator<'a> {
                 // function (is_not_error) observes errors from its whole
                 // subtree, not only from its direct children.
                 if !child_suppress_error {
-                    merge_eval_errors(&mut ctx.errors, child_option.errors.take());
+                    merge_eval_errors(&mut ctx.errors, child_option.errors.take(), ctx.num_rows);
                 }
 
                 // inject errors into options, parent will handle it
                 if options.suppress_error {
-                    merge_eval_errors(&mut options.errors, ctx.errors.take());
+                    merge_eval_errors(&mut options.errors, ctx.errors.take(), ctx.num_rows);
                 } else {
                     EvalContext::render_error(
                         *span,

--- a/src/query/expression/src/evaluator.rs
+++ b/src/query/expression/src/evaluator.rs
@@ -1626,28 +1626,71 @@ impl<'a> Evaluator<'a> {
             return Ok(None);
         }
 
-        let num_rows = validity
-            .as_ref()
-            .map(|validity| validity.len())
-            .unwrap_or_else(|| match &value {
-                Value::Scalar(_) => 1,
-                Value::Column(col) => col.len(),
-            });
+        // A scalar cast is evaluated once, and its result (or error) applies
+        // to every row enabled by `validity`. It therefore runs on a one-row
+        // temporary block without the validity mask, and any error is expanded
+        // over the enabled rows when merging below. Passing `validity` through
+        // would size the temporary block to the full outer length, so a scalar
+        // error would be pinned to row 0 of a full-length bitmap — or dropped
+        // when row 0 is not enabled — and the scalar broadcast in
+        // `merge_eval_errors` would not recognize it.
+        let is_scalar = matches!(&value, Value::Scalar(_));
+        if is_scalar {
+            let has_enabled_rows = validity
+                .as_ref()
+                .map(|validity| validity.null_count() < validity.len())
+                .unwrap_or(true);
+            if !has_enabled_rows {
+                // No outer row selected this branch; skip the cast entirely.
+                return Ok(Some(Value::Scalar(Scalar::default_value(dest_type))));
+            }
+        }
+
+        let num_rows = if is_scalar {
+            1
+        } else {
+            validity
+                .as_ref()
+                .map(|validity| validity.len())
+                .unwrap_or_else(|| match &value {
+                    Value::Scalar(_) => unreachable!(),
+                    Value::Column(col) => col.len(),
+                })
+        };
 
         let entry = BlockEntry::new(value, || (src_type.clone(), num_rows));
         let block = DataBlock::new(vec![entry], num_rows);
         let evaluator = Evaluator::new(&block, self.func_ctx, self.fn_registry);
         // The cast may run on a one-row temporary block for scalar values, so
         // its error bitmap is scoped to that block. Collect it in local
-        // options first, then merge into the shared options with the outer
-        // row count so a scalar error broadcasts to every row.
+        // options first, then merge into the shared options, expanding a
+        // scalar error over the rows enabled by `validity` (all rows when
+        // there is no partial selection).
         let mut local_options = options.with_suppress_error(options.suppress_error);
-        let result = evaluator.eval_common_call(&call, validity, expr_display, &mut local_options)?;
-        merge_eval_errors(
-            &mut options.errors,
-            local_options.errors.take(),
-            self.data_block.num_rows(),
-        );
+        let block_validity = if is_scalar { None } else { validity.clone() };
+        let result =
+            evaluator.eval_common_call(&call, block_validity, expr_display, &mut local_options)?;
+        if is_scalar {
+            if let Some((valids, msg)) = local_options.errors.take() {
+                if valids.null_count() > 0 {
+                    let expanded = match &validity {
+                        Some(validity) => validity.not().make_mut(),
+                        None => Bitmap::new_constant(false, self.data_block.num_rows()).make_mut(),
+                    };
+                    merge_eval_errors(
+                        &mut options.errors,
+                        Some((expanded, msg)),
+                        self.data_block.num_rows(),
+                    );
+                }
+            }
+        } else {
+            merge_eval_errors(
+                &mut options.errors,
+                local_options.errors.take(),
+                self.data_block.num_rows(),
+            );
+        }
         Ok(Some(result))
     }
 

--- a/src/query/expression/src/evaluator.rs
+++ b/src/query/expression/src/evaluator.rs
@@ -106,6 +106,28 @@ impl<'a> EvaluateOptions<'a> {
     }
 }
 
+/// Merge a source error set into a target error set, keeping the union of
+/// error rows and the first error message. Error sets travel upward through
+/// nested calls while suppression is active, so both sibling arguments and
+/// parent calls must accumulate instead of overwrite.
+fn merge_eval_errors(
+    target: &mut Option<(MutableBitmap, String)>,
+    source: Option<(MutableBitmap, String)>,
+) {
+    if let Some((src_valids, src_msg)) = source {
+        match target {
+            Some((valids, _)) => {
+                for (row, valid) in src_valids.iter().enumerate() {
+                    if !valid && row < valids.len() {
+                        valids.set(row, false);
+                    }
+                }
+            }
+            None => *target = Some((src_valids, src_msg)),
+        }
+    }
+}
+
 pub struct Evaluator<'a> {
     data_block: &'a DataBlock,
     func_ctx: &'a FunctionContext,
@@ -304,7 +326,11 @@ impl<'a> Evaluator<'a> {
             ..
         } = call;
         let child_suppress_error = function.signature.name == "is_not_error";
-        let mut child_option = options.with_suppress_error(child_suppress_error);
+        // Suppression is sticky downward: once a boundary function opts in
+        // (is_not_error), nested evaluations stay suppressed so row errors
+        // bubble up to the boundary as data instead of raising midway.
+        let mut child_option =
+            options.with_suppress_error(options.suppress_error || child_suppress_error);
         if child_option.strict_eval && call.generics.is_empty() {
             child_option.strict_eval = false;
         }
@@ -352,9 +378,17 @@ impl<'a> Evaluator<'a> {
         let (_, _, eval) = function.eval.as_scalar().unwrap();
         let result = eval.eval(&args, &mut ctx);
 
+        // Non-boundary calls are transparent to suppression: errors from
+        // nested evaluations keep bubbling up so a boundary function
+        // (is_not_error) observes errors from its whole subtree, not only
+        // from its direct children.
+        if !child_suppress_error {
+            merge_eval_errors(&mut ctx.errors, child_option.errors.take());
+        }
+
         if options.suppress_error {
             // inject errors into options, parent will handle it
-            options.errors = ctx.errors.take();
+            merge_eval_errors(&mut options.errors, ctx.errors.take());
         } else {
             EvalContext::render_error(
                 *span,
@@ -2488,7 +2522,11 @@ impl<'a> Evaluator<'a> {
                 ..
             }) => {
                 let child_suppress_error = function.signature.name == "is_not_error";
-                let mut child_option = options.with_suppress_error(child_suppress_error);
+                // Suppression is sticky downward: once a boundary function
+                // opts in (is_not_error), nested evaluations stay suppressed
+                // so row errors bubble up to the boundary as data.
+                let mut child_option =
+                    options.with_suppress_error(options.suppress_error || child_suppress_error);
                 let args = args
                     .iter()
                     .map(|expr| self.get_select_child(expr, &mut child_option))
@@ -2521,9 +2559,17 @@ impl<'a> Evaluator<'a> {
                 let (_, _, eval) = function.eval.as_scalar().unwrap();
                 let result = eval.eval(&args, &mut ctx);
 
+                // Non-boundary calls are transparent to suppression: errors
+                // from nested evaluations keep bubbling up so a boundary
+                // function (is_not_error) observes errors from its whole
+                // subtree, not only from its direct children.
+                if !child_suppress_error {
+                    merge_eval_errors(&mut ctx.errors, child_option.errors.take());
+                }
+
                 // inject errors into options, parent will handle it
                 if options.suppress_error {
-                    options.errors = ctx.errors.take();
+                    merge_eval_errors(&mut options.errors, ctx.errors.take());
                 } else {
                     EvalContext::render_error(
                         *span,

--- a/src/query/expression/src/evaluator.rs
+++ b/src/query/expression/src/evaluator.rs
@@ -141,6 +141,42 @@ fn merge_eval_errors(
     }
 }
 
+/// Expand the error set of an all-scalar evaluation over the rows the
+/// evaluation ran for: the rows enabled by `validity`, or every row when
+/// there is no partial selection.
+///
+/// A scalar evaluation records its error at row 0, which is
+/// indistinguishable from a row-0-only column error; expanding here, where
+/// the scalar-ness of the evaluation is still known, lets `merge_eval_errors`
+/// and `render_error` treat every incoming bitmap as row-aligned. When no
+/// row is enabled the error is dropped: the expression ran for nobody.
+fn expand_scalar_error(
+    errors: &mut Option<(MutableBitmap, String)>,
+    validity: Option<&Bitmap>,
+    num_rows: usize,
+) {
+    let Some((valids, msg)) = errors.take() else {
+        return;
+    };
+    let has_enabled_rows = match validity {
+        Some(validity) => validity.null_count() < validity.len(),
+        None => true,
+    };
+    if !has_enabled_rows {
+        return;
+    }
+    if valids.null_count() == 0 {
+        // No error recorded; keep the (empty) error set.
+        *errors = Some((valids, msg));
+        return;
+    }
+    let expanded = match validity {
+        Some(validity) => validity.not().make_mut(),
+        None => Bitmap::new_constant(false, num_rows).make_mut(),
+    };
+    *errors = Some((expanded, msg));
+}
+
 pub struct Evaluator<'a> {
     data_block: &'a DataBlock,
     func_ctx: &'a FunctionContext,
@@ -378,10 +414,17 @@ impl<'a> Evaluator<'a> {
         } else {
             None
         };
+        // A call whose arguments are all scalars is evaluated once, and an
+        // error it records applies to every row the call runs for. Strip the
+        // validity mask during eval so the error is always recorded — a
+        // scalar reports at row 0, which the validity gate in `set_error`
+        // would otherwise drop whenever row 0 is not enabled — then expand
+        // the recorded error over the enabled rows.
+        let all_scalar = args.iter().all(|arg| matches!(arg, Value::Scalar(_)));
         let mut ctx = EvalContext {
             generics,
             num_rows: self.data_block.num_rows(),
-            validity,
+            validity: if all_scalar { None } else { validity.clone() },
             errors,
             func_ctx: self.func_ctx,
             suppress_error: options.suppress_error,
@@ -390,6 +433,10 @@ impl<'a> Evaluator<'a> {
 
         let (_, _, eval) = function.eval.as_scalar().unwrap();
         let result = eval.eval(&args, &mut ctx);
+
+        if all_scalar {
+            expand_scalar_error(&mut ctx.errors, validity.as_ref(), ctx.num_rows);
+        }
 
         // Non-boundary calls are transparent to suppression: errors from
         // nested evaluations keep bubbling up so a boundary function
@@ -1626,71 +1673,29 @@ impl<'a> Evaluator<'a> {
             return Ok(None);
         }
 
-        // A scalar cast is evaluated once, and its result (or error) applies
-        // to every row enabled by `validity`. It therefore runs on a one-row
-        // temporary block without the validity mask, and any error is expanded
-        // over the enabled rows when merging below. Passing `validity` through
-        // would size the temporary block to the full outer length, so a scalar
-        // error would be pinned to row 0 of a full-length bitmap — or dropped
-        // when row 0 is not enabled — and the scalar broadcast in
-        // `merge_eval_errors` would not recognize it.
-        let is_scalar = matches!(&value, Value::Scalar(_));
-        if is_scalar {
-            let has_enabled_rows = validity
-                .as_ref()
-                .map(|validity| validity.null_count() < validity.len())
-                .unwrap_or(true);
-            if !has_enabled_rows {
-                // No outer row selected this branch; skip the cast entirely.
-                return Ok(Some(Value::Scalar(Scalar::default_value(dest_type))));
-            }
-        }
-
-        let num_rows = if is_scalar {
-            1
-        } else {
-            validity
-                .as_ref()
-                .map(|validity| validity.len())
-                .unwrap_or_else(|| match &value {
-                    Value::Scalar(_) => unreachable!(),
-                    Value::Column(col) => col.len(),
-                })
-        };
+        let num_rows = validity
+            .as_ref()
+            .map(|validity| validity.len())
+            .unwrap_or_else(|| match &value {
+                Value::Scalar(_) => 1,
+                Value::Column(col) => col.len(),
+            });
 
         let entry = BlockEntry::new(value, || (src_type.clone(), num_rows));
         let block = DataBlock::new(vec![entry], num_rows);
         let evaluator = Evaluator::new(&block, self.func_ctx, self.fn_registry);
         // The cast may run on a one-row temporary block for scalar values, so
         // its error bitmap is scoped to that block. Collect it in local
-        // options first, then merge into the shared options, expanding a
-        // scalar error over the rows enabled by `validity` (all rows when
-        // there is no partial selection).
+        // options first, then merge into the shared options with the outer
+        // row count so a scalar error broadcasts to every row.
         let mut local_options = options.with_suppress_error(options.suppress_error);
-        let block_validity = if is_scalar { None } else { validity.clone() };
         let result =
-            evaluator.eval_common_call(&call, block_validity, expr_display, &mut local_options)?;
-        if is_scalar {
-            if let Some((valids, msg)) = local_options.errors.take() {
-                if valids.null_count() > 0 {
-                    let expanded = match &validity {
-                        Some(validity) => validity.not().make_mut(),
-                        None => Bitmap::new_constant(false, self.data_block.num_rows()).make_mut(),
-                    };
-                    merge_eval_errors(
-                        &mut options.errors,
-                        Some((expanded, msg)),
-                        self.data_block.num_rows(),
-                    );
-                }
-            }
-        } else {
-            merge_eval_errors(
-                &mut options.errors,
-                local_options.errors.take(),
-                self.data_block.num_rows(),
-            );
-        }
+            evaluator.eval_common_call(&call, validity, expr_display, &mut local_options)?;
+        merge_eval_errors(
+            &mut options.errors,
+            local_options.errors.take(),
+            self.data_block.num_rows(),
+        );
         Ok(Some(result))
     }
 
@@ -2624,6 +2629,13 @@ impl<'a> Evaluator<'a> {
                 };
                 let (_, _, eval) = function.eval.as_scalar().unwrap();
                 let result = eval.eval(&args, &mut ctx);
+
+                // Same all-scalar rule as `eval_common_call`: an error from a
+                // scalar evaluation applies to every row. This path carries no
+                // branch validity mask, so expand over the whole block.
+                if args.iter().all(|arg| matches!(arg, Value::Scalar(_))) {
+                    expand_scalar_error(&mut ctx.errors, None, ctx.num_rows);
+                }
 
                 // Non-boundary calls are transparent to suppression: errors
                 // from nested evaluations keep bubbling up so a boundary

--- a/src/query/expression/src/filter/selector.rs
+++ b/src/query/expression/src/filter/selector.rs
@@ -487,8 +487,9 @@ impl<'a> Selector<'a> {
                     expr.sql_display(),
                     return_type
                 );
+                let child_suppress_error = function.signature.name == "is_not_error";
                 let mut eval_options = EvaluateOptions::new_for_select(selection)
-                    .with_suppress_error(function.signature.name == "is_not_error");
+                    .with_suppress_error(child_suppress_error);
 
                 let args = args
                     .iter()
@@ -506,7 +507,12 @@ impl<'a> Selector<'a> {
                     generics,
                     num_rows: self.evaluator.data_block().num_rows(),
                     validity: None,
-                    errors: None,
+                    // Boundary functions consume the errors of their subtree.
+                    errors: if child_suppress_error {
+                        eval_options.errors.take()
+                    } else {
+                        None
+                    },
                     func_ctx: self.evaluator.func_ctx(),
                     suppress_error: eval_options.suppress_error,
                     strict_eval: eval_options.strict_eval,

--- a/src/query/functions/tests/it/scalars/control.rs
+++ b/src/query/functions/tests/it/scalars/control.rs
@@ -165,17 +165,40 @@ fn test_is_not_error(file: &mut impl Write) {
     // exactly the rows the branch runs on: the scalar error must be expanded
     // over the branch validity instead of being pinned to (or dropped at)
     // row 0.
-    run_ast(file, "is_not_error(if(denom = 4, cast('x' as int64), 1))", &[(
-        "denom",
-        Int64Type::from_data(vec![2i64, 0, -1, 4]),
-    )]);
-    run_ast(file, "is_not_error(if(denom > 0, cast('x' as int64), 1))", &[(
-        "denom",
-        Int64Type::from_data(vec![2i64, 0, -1, 4]),
-    )]);
+    run_ast(
+        file,
+        "is_not_error(if(denom = 4, cast('x' as int64), 1))",
+        &[("denom", Int64Type::from_data(vec![2i64, 0, -1, 4]))],
+    );
+    run_ast(
+        file,
+        "is_not_error(if(denom > 0, cast('x' as int64), 1))",
+        &[("denom", Int64Type::from_data(vec![2i64, 0, -1, 4]))],
+    );
     // No row selects the branch, so the failing scalar cast never runs and
     // its error must not leak into the result.
-    run_ast(file, "is_not_error(if(denom > 100, cast('x' as int64), 1))", &[(
+    run_ast(
+        file,
+        "is_not_error(if(denom > 100, cast('x' as int64), 1))",
+        &[("denom", Int64Type::from_data(vec![2i64, 0, -1, 4]))],
+    );
+    // Same for a scalar function call (not only casts): the all-scalar eval
+    // must expand its error over the branch validity as well.
+    run_ast(file, "is_not_error(if(denom = 4, 1 % 0, 1))", &[(
+        "denom",
+        Int64Type::from_data(vec![2i64, 0, -1, 4]),
+    )]);
+    // A scalar error invalidates every row when there is no partial
+    // selection, so the modulo error must poison all rows even though only
+    // the division has per-row errors.
+    run_ast(file, "is_not_error((1 / denom) + (1 % 0))", &[(
+        "denom",
+        Int64Type::from_data(vec![2i64, 0, -1, 4]),
+    )]);
+    // The raising path (no is_not_error) must also observe the scalar error:
+    // row 3 executes the branch, so the query must fail instead of silently
+    // returning a garbage value.
+    run_ast(file, "if(denom = 4, 1 % 0, 1)", &[(
         "denom",
         Int64Type::from_data(vec![2i64, 0, -1, 4]),
     )]);
@@ -186,10 +209,7 @@ fn test_is_not_error(file: &mut impl Write) {
         file,
         "is_not_error(if(denom > 100, cast('x' as int64), 1))",
         TestContext {
-            entries: &[(
-                "denom",
-                Int64Type::from_data(vec![2i64, 0, -1, 4]).into(),
-            )],
+            entries: &[("denom", Int64Type::from_data(vec![2i64, 0, -1, 4]).into())],
             input_domains: Some(&[(
                 "denom",
                 Domain::Number(NumberDomain::Int64(SimpleDomain { min: -1, max: 200 })),

--- a/src/query/functions/tests/it/scalars/control.rs
+++ b/src/query/functions/tests/it/scalars/control.rs
@@ -28,6 +28,7 @@ fn test_control() {
 
     test_if(file);
     test_is_not_null(file);
+    test_is_not_error(file);
 }
 
 fn test_if(file: &mut impl Write) {
@@ -135,5 +136,25 @@ fn test_is_not_null(file: &mut impl Write) {
     run_ast(file, "is_not_null(nullable_col)", &[(
         "nullable_col",
         Int64Type::from_data_with_validity(vec![9i64, 10, 11, 12], vec![true, true, false, false]),
+    )]);
+}
+
+fn test_is_not_error(file: &mut impl Write) {
+    run_ast(file, "is_not_error(1 / denom)", &[(
+        "denom",
+        Int64Type::from_data(vec![2i64, 0, -1, 4]),
+    )]);
+    // The throwing expression is nested inside a comparison: the error must
+    // bubble up through the non-boundary `gt` call to reach the boundary.
+    run_ast(file, "is_not_error((1 / denom) > 0)", &[(
+        "denom",
+        Int64Type::from_data(vec![2i64, 0, -1, 4]),
+    )]);
+    // A scalar subexpression that errors invalidates every row: the constant
+    // cast is evaluated in a one-row block, and its error bitmap must
+    // broadcast to all rows when merged with the column error set.
+    run_ast(file, "is_not_error((1 / denom) + cast('x' as int64))", &[(
+        "denom",
+        Int64Type::from_data(vec![2i64, 0, -1, 4]),
     )]);
 }

--- a/src/query/functions/tests/it/scalars/control.rs
+++ b/src/query/functions/tests/it/scalars/control.rs
@@ -15,11 +15,15 @@
 use std::io::Write;
 
 use databend_common_expression::Column;
+use databend_common_expression::Domain;
 use databend_common_expression::FromData;
+use databend_common_expression::FunctionContext;
 use databend_common_expression::types::*;
 use goldenfile::Mint;
 
+use super::TestContext;
 use super::run_ast;
+use super::run_ast_with_context;
 
 #[test]
 fn test_control() {
@@ -157,4 +161,41 @@ fn test_is_not_error(file: &mut impl Write) {
         "denom",
         Int64Type::from_data(vec![2i64, 0, -1, 4]),
     )]);
+    // A scalar cast inside a partially selected `if` branch invalidates
+    // exactly the rows the branch runs on: the scalar error must be expanded
+    // over the branch validity instead of being pinned to (or dropped at)
+    // row 0.
+    run_ast(file, "is_not_error(if(denom = 4, cast('x' as int64), 1))", &[(
+        "denom",
+        Int64Type::from_data(vec![2i64, 0, -1, 4]),
+    )]);
+    run_ast(file, "is_not_error(if(denom > 0, cast('x' as int64), 1))", &[(
+        "denom",
+        Int64Type::from_data(vec![2i64, 0, -1, 4]),
+    )]);
+    // No row selects the branch, so the failing scalar cast never runs and
+    // its error must not leak into the result.
+    run_ast(file, "is_not_error(if(denom > 100, cast('x' as int64), 1))", &[(
+        "denom",
+        Int64Type::from_data(vec![2i64, 0, -1, 4]),
+    )]);
+    // Same shape with an input domain wider than the concrete values, so the
+    // optimizer cannot prove the branch dead: at runtime no row selects the
+    // branch, and the failing scalar cast must stay silent.
+    run_ast_with_context(
+        file,
+        "is_not_error(if(denom > 100, cast('x' as int64), 1))",
+        TestContext {
+            entries: &[(
+                "denom",
+                Int64Type::from_data(vec![2i64, 0, -1, 4]).into(),
+            )],
+            input_domains: Some(&[(
+                "denom",
+                Domain::Number(NumberDomain::Int64(SimpleDomain { min: -1, max: 200 })),
+            )]),
+            func_ctx: FunctionContext::default(),
+            strict_eval: true,
+        },
+    );
 }

--- a/src/query/functions/tests/it/scalars/testdata/control.txt
+++ b/src/query/functions/tests/it/scalars/testdata/control.txt
@@ -335,3 +335,73 @@ evaluation (internal):
 +--------------+-----------------------------------------------------------------------------------+
 
 
+ast            : is_not_error(1 / denom)
+raw expr       : is_not_error(divide(1, denom::Int64))
+checked expr   : is_not_error<T0=Float64><T0>(divide<UInt8, Int64>(1_u8, denom))
+evaluation:
++--------+----------+---------+
+|        | denom    | Output  |
++--------+----------+---------+
+| Type   | Int64    | Boolean |
+| Domain | {-1..=4} | Unknown |
+| Row 0  | 2        | true    |
+| Row 1  | 0        | false   |
+| Row 2  | -1       | true    |
+| Row 3  | 4        | true    |
++--------+----------+---------+
+evaluation (internal):
++--------+------------------------------+
+| Column | Data                         |
++--------+------------------------------+
+| denom  | Column(Int64([2, 0, -1, 4])) |
+| Output | Boolean([0b____1101])        |
++--------+------------------------------+
+
+
+ast            : is_not_error((1 / denom) > 0)
+raw expr       : is_not_error(gt(divide(1, denom::Int64), 0))
+checked expr   : is_not_error<T0=Boolean><T0>(gt<Float64, Float64>(divide<UInt8, Int64>(1_u8, denom), CAST<UInt8>(0_u8 AS Float64)))
+optimized expr : is_not_error<T0=Boolean><T0>(gt<Float64, Float64>(divide<UInt8, Int64>(1_u8, denom), 0_f64))
+evaluation:
++--------+----------+---------+
+|        | denom    | Output  |
++--------+----------+---------+
+| Type   | Int64    | Boolean |
+| Domain | {-1..=4} | Unknown |
+| Row 0  | 2        | true    |
+| Row 1  | 0        | false   |
+| Row 2  | -1       | true    |
+| Row 3  | 4        | true    |
++--------+----------+---------+
+evaluation (internal):
++--------+------------------------------+
+| Column | Data                         |
++--------+------------------------------+
+| denom  | Column(Int64([2, 0, -1, 4])) |
+| Output | Boolean([0b____1101])        |
++--------+------------------------------+
+
+
+ast            : is_not_error((1 / denom) + cast('x' as int64))
+raw expr       : is_not_error(plus(divide(1, denom::Int64), CAST('x' AS Int64)))
+checked expr   : is_not_error<T0=Float64><T0>(plus<Float64, Int64>(divide<UInt8, Int64>(1_u8, denom), CAST<String>("x" AS Int64)))
+evaluation:
++--------+----------+---------+
+|        | denom    | Output  |
++--------+----------+---------+
+| Type   | Int64    | Boolean |
+| Domain | {-1..=4} | Unknown |
+| Row 0  | 2        | false   |
+| Row 1  | 0        | false   |
+| Row 2  | -1       | false   |
+| Row 3  | 4        | false   |
++--------+----------+---------+
+evaluation (internal):
++--------+------------------------------+
+| Column | Data                         |
++--------+------------------------------+
+| denom  | Column(Int64([2, 0, -1, 4])) |
+| Output | Boolean([0b____0000])        |
++--------+------------------------------+
+
+

--- a/src/query/functions/tests/it/scalars/testdata/control.txt
+++ b/src/query/functions/tests/it/scalars/testdata/control.txt
@@ -462,6 +462,60 @@ output domain  : {TRUE}
 output         : true
 
 
+ast            : is_not_error(if(denom = 4, 1 % 0, 1))
+raw expr       : is_not_error(if(eq(denom::Int64, 4), modulo(1, 0), 1))
+checked expr   : is_not_error<T0=UInt8><T0>(if<T0=UInt8><Boolean NULL, T0, T0>(CAST<Boolean>(eq<Int64, Int64>(denom, 4_i64) AS Boolean NULL), modulo<UInt8, UInt8>(1_u8, 0_u8), 1_u8))
+evaluation:
++--------+----------+---------+
+|        | denom    | Output  |
++--------+----------+---------+
+| Type   | Int64    | Boolean |
+| Domain | {-1..=4} | Unknown |
+| Row 0  | 2        | true    |
+| Row 1  | 0        | true    |
+| Row 2  | -1       | true    |
+| Row 3  | 4        | false   |
++--------+----------+---------+
+evaluation (internal):
++--------+------------------------------+
+| Column | Data                         |
++--------+------------------------------+
+| denom  | Column(Int64([2, 0, -1, 4])) |
+| Output | Boolean([0b____0111])        |
++--------+------------------------------+
+
+
+ast            : is_not_error((1 / denom) + (1 % 0))
+raw expr       : is_not_error(plus(divide(1, denom::Int64), modulo(1, 0)))
+checked expr   : is_not_error<T0=Float64><T0>(plus<Float64, UInt8>(divide<UInt8, Int64>(1_u8, denom), modulo<UInt8, UInt8>(1_u8, 0_u8)))
+evaluation:
++--------+----------+---------+
+|        | denom    | Output  |
++--------+----------+---------+
+| Type   | Int64    | Boolean |
+| Domain | {-1..=4} | Unknown |
+| Row 0  | 2        | false   |
+| Row 1  | 0        | false   |
+| Row 2  | -1       | false   |
+| Row 3  | 4        | false   |
++--------+----------+---------+
+evaluation (internal):
++--------+------------------------------+
+| Column | Data                         |
++--------+------------------------------+
+| denom  | Column(Int64([2, 0, -1, 4])) |
+| Output | Boolean([0b____0000])        |
++--------+------------------------------+
+
+
+error: 
+  --> SQL:1:17
+  |
+1 | if(denom = 4, 1 % 0, 1)
+  |                 ^ Division by zero while evaluating function `modulo(1, 0)` in expr `1 % 0`, during run expr: `if(CAST(denom = 4 AS Boolean NULL), 1 % 0, 1)`
+
+
+
 ast            : is_not_error(if(denom > 100, cast('x' as int64), 1))
 raw expr       : is_not_error(if(gt(denom::Int64, 100), CAST('x' AS Int64), 1))
 checked expr   : is_not_error<T0=Int64><T0>(if<T0=Int64><Boolean NULL, T0, T0>(CAST<Boolean>(gt<Int64, Int64>(denom, CAST<UInt8>(100_u8 AS Int64)) AS Boolean NULL), CAST<String>("x" AS Int64), CAST<UInt8>(1_u8 AS Int64)))

--- a/src/query/functions/tests/it/scalars/testdata/control.txt
+++ b/src/query/functions/tests/it/scalars/testdata/control.txt
@@ -405,3 +405,69 @@ evaluation (internal):
 +--------+------------------------------+
 
 
+ast            : is_not_error(if(denom = 4, cast('x' as int64), 1))
+raw expr       : is_not_error(if(eq(denom::Int64, 4), CAST('x' AS Int64), 1))
+checked expr   : is_not_error<T0=Int64><T0>(if<T0=Int64><Boolean NULL, T0, T0>(CAST<Boolean>(eq<Int64, Int64>(denom, 4_i64) AS Boolean NULL), CAST<String>("x" AS Int64), CAST<UInt8>(1_u8 AS Int64)))
+optimized expr : is_not_error<T0=Int64><T0>(if<T0=Int64><Boolean NULL, T0, T0>(CAST<Boolean>(eq<Int64, Int64>(denom, 4_i64) AS Boolean NULL), CAST<String>("x" AS Int64), 1_i64))
+evaluation:
++--------+----------+---------+
+|        | denom    | Output  |
++--------+----------+---------+
+| Type   | Int64    | Boolean |
+| Domain | {-1..=4} | Unknown |
+| Row 0  | 2        | true    |
+| Row 1  | 0        | true    |
+| Row 2  | -1       | true    |
+| Row 3  | 4        | false   |
++--------+----------+---------+
+evaluation (internal):
++--------+------------------------------+
+| Column | Data                         |
++--------+------------------------------+
+| denom  | Column(Int64([2, 0, -1, 4])) |
+| Output | Boolean([0b____0111])        |
++--------+------------------------------+
+
+
+ast            : is_not_error(if(denom > 0, cast('x' as int64), 1))
+raw expr       : is_not_error(if(gt(denom::Int64, 0), CAST('x' AS Int64), 1))
+checked expr   : is_not_error<T0=Int64><T0>(if<T0=Int64><Boolean NULL, T0, T0>(CAST<Boolean>(gt<Int64, Int64>(denom, CAST<UInt8>(0_u8 AS Int64)) AS Boolean NULL), CAST<String>("x" AS Int64), CAST<UInt8>(1_u8 AS Int64)))
+optimized expr : is_not_error<T0=Int64><T0>(if<T0=Int64><Boolean NULL, T0, T0>(CAST<Boolean>(gt<Int64, Int64>(denom, 0_i64) AS Boolean NULL), CAST<String>("x" AS Int64), 1_i64))
+evaluation:
++--------+----------+---------+
+|        | denom    | Output  |
++--------+----------+---------+
+| Type   | Int64    | Boolean |
+| Domain | {-1..=4} | Unknown |
+| Row 0  | 2        | false   |
+| Row 1  | 0        | true    |
+| Row 2  | -1       | true    |
+| Row 3  | 4        | false   |
++--------+----------+---------+
+evaluation (internal):
++--------+------------------------------+
+| Column | Data                         |
++--------+------------------------------+
+| denom  | Column(Int64([2, 0, -1, 4])) |
+| Output | Boolean([0b____0110])        |
++--------+------------------------------+
+
+
+ast            : is_not_error(if(denom > 100, cast('x' as int64), 1))
+raw expr       : is_not_error(if(gt(denom::Int64, 100), CAST('x' AS Int64), 1))
+checked expr   : is_not_error<T0=Int64><T0>(if<T0=Int64><Boolean NULL, T0, T0>(CAST<Boolean>(gt<Int64, Int64>(denom, CAST<UInt8>(100_u8 AS Int64)) AS Boolean NULL), CAST<String>("x" AS Int64), CAST<UInt8>(1_u8 AS Int64)))
+optimized expr : true
+output type    : Boolean
+output domain  : {TRUE}
+output         : true
+
+
+ast            : is_not_error(if(denom > 100, cast('x' as int64), 1))
+raw expr       : is_not_error(if(gt(denom::Int64, 100), CAST('x' AS Int64), 1))
+checked expr   : is_not_error<T0=Int64><T0>(if<T0=Int64><Boolean NULL, T0, T0>(CAST<Boolean>(gt<Int64, Int64>(denom, CAST<UInt8>(100_u8 AS Int64)) AS Boolean NULL), CAST<String>("x" AS Int64), CAST<UInt8>(1_u8 AS Int64)))
+optimized expr : is_not_error<T0=Int64><T0>(if<T0=Int64><Boolean NULL, T0, T0>(CAST<Boolean>(gt<Int64, Int64>(denom, 100_i64) AS Boolean NULL), CAST<String>("x" AS Int64), 1_i64))
+output type    : Boolean
+output domain  : Unknown
+output         : true
+
+

--- a/tests/sqllogictests/suites/query/functions/02_0072_error.test
+++ b/tests/sqllogictests/suites/query/functions/02_0072_error.test
@@ -7,3 +7,18 @@ query ?
 select error_or(from_base64('aak') ,  from_base64('aaj'),  from_base64('MzQz'));
 ----
 333433
+
+# is_not_error as a filter predicate: rows whose argument evaluation fails
+# are removed (1/(number-1) throws for number = 1).
+query I
+select number from numbers(3) where is_not_error(1 / (number - 1)) order by number
+----
+0
+2
+
+# Errors nested inside the argument expression must also be observed.
+query I
+select number from numbers(3) where is_not_error((1 / (number - 1)) > 0) order by number
+----
+0
+2

--- a/tests/sqllogictests/suites/query/functions/02_0072_error.test
+++ b/tests/sqllogictests/suites/query/functions/02_0072_error.test
@@ -43,3 +43,17 @@ select error_or(1 / (number - 1), 42) from numbers(3) order by number
 -1
 42
 1
+
+# A scalar subexpression that errors invalidates every row: the constant
+# cast fails for the whole expression, so its (one-row) error bitmap must
+# broadcast to all rows when merged with the column error set.
+query I
+select number from numbers(3) where is_not_error((1 / (number - 1)) + cast('x' as int))
+----
+
+query B
+select is_not_error((1 / (number - 1)) + cast('x' as int)) from numbers(3) order by number
+----
+0
+0
+0

--- a/tests/sqllogictests/suites/query/functions/02_0072_error.test
+++ b/tests/sqllogictests/suites/query/functions/02_0072_error.test
@@ -33,16 +33,16 @@ select number from numbers(3) where is_error((1 / (number - 1)) > 0)
 query B
 select is_error((1 / 0) > 0)
 ----
-true
+1
 
 # error_or rewrites to if(is_not_error(a), a, ...): nested errors must not
 # raise midway and must skip the erroring argument.
 query ?
 select error_or(1 / (number - 1), 42) from numbers(3) order by number
 ----
--1
-42
-1
+-1.0
+42.0
+1.0
 
 # A scalar subexpression that errors invalidates every row: the constant
 # cast fails for the whole expression, so its (one-row) error bitmap must
@@ -91,3 +91,22 @@ select is_not_error(if(number > 100, cast('x' as int), 1)) from numbers(4) order
 1
 1
 1
+
+# Same for a scalar function call (not only casts): the modulo error must
+# invalidate exactly the branch rows.
+query B
+select is_not_error(if(number = 3, 1 % 0, 1)) from numbers(4) order by number
+----
+1
+1
+1
+0
+
+# Without partial selection, a scalar error invalidates every row when mixed
+# with per-row column errors, not only row 0.
+query B
+select is_not_error((1 / (number - 1)) + (1 % 0)) from numbers(3) order by number
+----
+0
+0
+0

--- a/tests/sqllogictests/suites/query/functions/02_0072_error.test
+++ b/tests/sqllogictests/suites/query/functions/02_0072_error.test
@@ -22,3 +22,24 @@ select number from numbers(3) where is_not_error((1 / (number - 1)) > 0) order b
 ----
 0
 2
+
+# is_error is rewritten to not(is_not_error(x)) at type-check time, so it
+# observes nested errors as well, in projection and filter position.
+query I
+select number from numbers(3) where is_error((1 / (number - 1)) > 0)
+----
+1
+
+query B
+select is_error((1 / 0) > 0)
+----
+true
+
+# error_or rewrites to if(is_not_error(a), a, ...): nested errors must not
+# raise midway and must skip the erroring argument.
+query ?
+select error_or(1 / (number - 1), 42) from numbers(3) order by number
+----
+-1
+42
+1

--- a/tests/sqllogictests/suites/query/functions/02_0072_error.test
+++ b/tests/sqllogictests/suites/query/functions/02_0072_error.test
@@ -57,3 +57,37 @@ select is_not_error((1 / (number - 1)) + cast('x' as int)) from numbers(3) order
 0
 0
 0
+
+# A failing scalar cast inside a partially selected if branch invalidates
+# exactly the rows the branch runs on: the scalar error must be expanded
+# over the branch validity, not pinned to (or dropped at) row 0.
+
+# Only number = 3 selects the branch; row 0 is not selected, so the scalar
+# error must not be dropped.
+query B
+select is_not_error(if(number = 3, cast('x' as int), 1)) from numbers(4) order by number
+----
+1
+1
+1
+0
+
+# number = 0 and number = 2 select the branch; both must be flagged, not
+# only row 0.
+query B
+select is_not_error(if(number % 2 = 0, cast('x' as int), 1)) from numbers(4) order by number
+----
+0
+1
+0
+1
+
+# No row selects the branch: the failing scalar cast never runs, so nothing
+# is an error.
+query B
+select is_not_error(if(number > 100, cast('x' as int), 1)) from numbers(4) order by number
+----
+1
+1
+1
+1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- `is_not_error` only suppressed errors from its **direct** child expression; errors from deeper nesting either raised midway or were silently dropped before reaching the function.
- In the filter execution path (`Selector`), `WHERE is_not_error(f(x))` discarded the collected errors entirely and returned constant `true`, letting every row through.
- A scalar error broadcast relied on a length-1 error bitmap, which breaks for any all-scalar call (constant cast, `1 % 0`, ...) evaluated under a partial selection mask: the error was dropped when row 0 was not selected, or pinned to row 0 of a full-length bitmap when it was. On the raising path (no `is_not_error`), the same drop produced a **silent wrong result** — e.g. `if(denom = 4, 1 % 0, 1)` succeeded instead of failing with division by zero.
- This PR makes suppressed row errors accumulate along the evaluation tree so `is_not_error` observes errors from its whole subtree in both projection and filter paths, and expands scalar errors over exactly the rows the evaluation ran for.

## Changes

Four gaps in the `suppress_error` machinery (`src/query/expression/src/evaluator.rs`, `src/query/expression/src/filter/selector.rs`):

1. **Not sticky downward**: a non-boundary call (e.g. `gt`) created its child options with `suppress_error=false`, so `is_not_error((1/(x-1)) > 0)` raised midway instead of returning `false` for the error rows. Now `options.suppress_error || child_suppress_error`.
2. **Dropped on the way up**: a non-boundary parent overwrote `options.errors` with its own (empty) error set after eval, and a later error-free sibling argument wiped an earlier sibling's recorded errors. Now non-boundary calls forward their subtree's errors upward, and injection merges (union of error rows, first message wins) instead of overwriting — see `merge_eval_errors`.
3. **Selector path**: `process_expr` hardcoded `errors: None` when invoking a top-level `is_not_error` predicate, so the function's `ctx.errors.take()` always saw "no errors" and returned `Scalar(true)`. The collected subtree errors are now fed into the boundary function's `EvalContext`.
4. **Scalar errors vs. partial selection** (`expand_scalar_error`): an all-scalar call is evaluated once, but records its error at row 0 of a block-length bitmap — where the validity gate in `set_error` drops it whenever row 0 is not enabled, and where the length-1 broadcast heuristic cannot recognize it as scalar. `eval_common_call` now strips the validity mask while evaluating an all-scalar call (so the error is always recorded) and expands it over exactly the rows the call ran for: the enabled rows under partial selection, or all rows otherwise; the error is dropped when no row is enabled (a dead branch must not fail). The selector path (`get_select_child`, which never carries a mask) gets the symmetric expand-to-all-rows handling. `merge_eval_errors` stays validity-agnostic: every bitmap that reaches it is now row-aligned.

## Behavior change

`WHERE is_not_error(f(x))` now actually filters out rows where `f(x)` errored; previously it passed all rows. A failing scalar subexpression inside an `if`/`CASE` branch now invalidates (or raises for) exactly the rows that execute the branch.

## Behavior comparison (verified locally against builds of `main` and this branch)

| Query | `main` | This PR |
|-------|--------|---------|
| `select is_error(1/0)` (direct child) | `true` ✓ | `true` ✓ (unchanged) |
| `select is_error((1/0) > 0)` (nested) | **ERROR: divided by zero** | `true` |
| `select number from numbers(3) where is_not_error(1 / (number - 1))` (filter path) | **0, 1, 2 (all rows pass)** | 0, 2 |
| `select number from numbers(3) where is_error((1 / (number - 1)) > 0)` | **ERROR: divided by zero** | 1 |
| `... where is_not_error((1 / (number - 1)) + cast('x' as int))` (scalar error) | **0, 2** (only row 0 + column-error rows caught) | (empty) |
| `select is_not_error((1 / (number - 1)) + cast('x' as int)) from numbers(3)` | **false, false, true** | false, false, false |
| `select error_or(1 / (number - 1), 42) from numbers(3)` | ERROR: divided by zero | -1, 42, 1 |
| `select is_not_error(if(number = 3, cast('x' as int), 1)) from numbers(4)` | **true, true, true, true** (scalar error dropped: row 0 not branch-selected) | true, true, true, **false** |
| `select is_not_error(if(number % 2 = 0, cast('x' as int), 1)) from numbers(4)` | **false, true, true, true** (only row 0 marked) | false, true, **false**, true |
| `select is_not_error(if(number = 3, 1 % 0, 1)) from numbers(4)` (scalar function) | **true, true, true, true** | true, true, true, **false** |
| `select is_not_error((1 / (number - 1)) + (1 % 0)) from numbers(3)` (scalar + column errors) | **false, false, true, true** | false, false, false, false |
| `select if(number = 3, 1 % 0, 1) from numbers(4)` (raising path) | **silent wrong result** | ERROR: Division by zero |
| `select is_not_error(if(number > 100, cast('x' as int), 1)) from numbers(4)` (dead branch) | true, true, true, true | true, true, true, true (unchanged) |

In short: on `main`, nested errors either raised midway or were silently dropped; in the filter path the predicate degraded to constant `true`; and a scalar error only marked row 0 — or vanished — under partial branch selection. With this PR, errors from the whole subtree reach `is_not_error`/`is_error` in both projection and filter paths, and scalar errors apply to exactly the rows that evaluate them.

## Tests

- [x] Unit Test
- [x] Logic Test

Added sqllogictest cases in `02_0072_error.test` for `is_not_error` as a filter predicate, with the erroring expression as a direct argument and nested inside a comparison. Also covered `is_error` and `error_or`, which rewrite through `is_not_error` at type-check time (`is_error(x)` -> `not(is_not_error(x))`, `error_or(a, ...)` -> `if(is_not_error(a), a, ...)`), in both projection and filter position, plus scalar casts and scalar function calls inside partially selected `if` branches (branch selected on a non-zero row only, on multiple rows, and on no rows) and a mixed scalar-error/column-error case.

Added golden cases in `control.rs` (`test_is_not_error`) for the same scenarios, including the raising path (must fail instead of silently returning a garbage value) and a runtime zero-selected-rows case with a widened input domain so the optimizer cannot prove the branch dead.

Validated locally:
- `cargo test -p databend-common-expression` (89 + 72 passed)
- `cargo test -p databend-common-functions --test it` (132 passed)
- `databend-sqllogictests --handlers mysql --run 'tests/sqllogictests/suites/query/functions/02_0072_error.test'` (26 passed)
- `databend-sqllogictests --handlers mysql --run_dir functions` (only pre-existing platform float-formatting failures in `02_0060_function_geo_h3.test`, unrelated to this change)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## AI assistance

- AI usage: An AI coding agent found the root cause, drafted the implementation and tests; I reviewed the full diff before submission
- Responsible human: @junli1026
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20305)
<!-- Reviewable:end -->
