### PR TITLE
feat(query): materialized view support set|unset table option and comment

### DIFF
--- a/src/query/ast/src/ast/statements/materialized_view.rs
+++ b/src/query/ast/src/ast/statements/materialized_view.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
 use std::fmt::Display;
 use std::fmt::Formatter;
 
@@ -26,8 +27,10 @@ use crate::ast::CreateOption;
 use crate::ast::Identifier;
 use crate::ast::Query;
 use crate::ast::ShowLimit;
+use crate::ast::quote::QuotedString;
 use crate::ast::write_comma_separated_list;
 use crate::ast::write_dot_separated_list;
+use crate::ast::write_space_separated_string_map;
 
 #[derive(Debug, Clone, PartialEq, Drive, DriveMut, Walk, WalkMut)]
 pub struct AlterMaterializedViewStmt {
@@ -51,7 +54,7 @@ impl Display for AlterMaterializedViewStmt {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Drive, DriveMut, Walk, WalkMut)]
+#[derive(Debug, Clone, PartialEq, Drive, DriveMut)]
 pub struct CreateMaterializedViewStmt {
     pub create_option: CreateOption,
     pub catalog: Option<Identifier>,
@@ -59,6 +62,8 @@ pub struct CreateMaterializedViewStmt {
     pub view: Identifier,
     pub columns: Vec<Identifier>,
     pub cluster_by: Option<ClusterOption>,
+    pub comment: Option<String>,
+    pub table_options: BTreeMap<String, String>,
     pub query: Box<Query>,
 }
 
@@ -86,6 +91,13 @@ impl Display for CreateMaterializedViewStmt {
         }
         if let Some(cluster_by) = &self.cluster_by {
             write!(f, " {cluster_by}")?;
+        }
+        if let Some(comment) = &self.comment {
+            write!(f, " COMMENT = {}", QuotedString(comment, '\''))?;
+        }
+        if !self.table_options.is_empty() {
+            write!(f, " ")?;
+            write_space_separated_string_map(f, &self.table_options)?;
         }
         write!(f, " AS {}", self.query)
     }

--- a/src/query/ast/src/parser/statement.rs
+++ b/src/query/ast/src/parser/statement.rs
@@ -1639,6 +1639,8 @@ pub fn statement_body(i: Input) -> IResult<Statement> {
             ~ #dot_separated_idents_1_to_3
             ~ ( "(" ~ #comma_separated_list1(ident) ~ ")" )?
             ~ ( CLUSTER ~ ^BY ~ ^#cluster_option )?
+            ~ ( COMMENT ~ ^"=" ~ ^#literal_string )?
+            ~ (#table_option)?
             ~ AS ~ #query
         },
         |(
@@ -1650,6 +1652,8 @@ pub fn statement_body(i: Input) -> IResult<Statement> {
             (catalog, database, view),
             opt_columns,
             opt_cluster_by,
+            opt_comment,
+            opt_table_options,
             _,
             query,
         )| {
@@ -1665,6 +1669,8 @@ pub fn statement_body(i: Input) -> IResult<Statement> {
                         .map(|(_, columns, _)| columns)
                         .unwrap_or_default(),
                     cluster_by: opt_cluster_by.map(|(_, _, cluster_by)| cluster_by),
+                    comment: opt_comment.map(|(_, _, comment)| comment),
+                    table_options: opt_table_options.unwrap_or_default(),
                     query: Box::new(query),
                 },
             ))
@@ -3177,7 +3183,7 @@ AS
                 | #create_table : "`CREATE [OR REPLACE] TABLE [IF NOT EXISTS] [<database>.]<table> [<source>] [<table_options>]`"
                 | #create_dictionary : "`CREATE [OR REPLACE] DICTIONARY [IF NOT EXISTS] <dictionary_name> [(<column>, ...)] PRIMARY KEY [<primary_key>, ...] SOURCE (<source_name> ([<source_options>])) [COMMENT <comment>] `"
                 | #create_view : "`CREATE [OR REPLACE] VIEW [IF NOT EXISTS] [<database>.]<view> [(<column>, ...)] AS SELECT ...`"
-                | #create_materialized_view : "`CREATE [OR REPLACE] MATERIALIZED VIEW [IF NOT EXISTS] [<database>.]<view> [(<column>, ...)] [CLUSTER BY [LINEAR] (...)] AS SELECT ...`"
+                | #create_materialized_view : "`CREATE [OR REPLACE] MATERIALIZED VIEW [IF NOT EXISTS] [<database>.]<view> [(<column>, ...)] [CLUSTER BY [LINEAR] (...)] [COMMENT = '<string_literal>'] AS SELECT ...`"
                 | #create_index: "`CREATE [OR REPLACE] AGGREGATING INDEX [IF NOT EXISTS] <index> AS SELECT ...`"
                 | #create_table_index: "`CREATE [OR REPLACE] <index_type> INDEX [IF NOT EXISTS] <index> ON [<database>.]<table>(<column>, ...)`"
             )
@@ -3265,7 +3271,7 @@ AS
             | #alter_stage : "`ALTER STAGE [IF EXISTS] <name> SET <option> [, ...] | UNSET <option> [, ...]`"
             | #alter_database : "`ALTER DATABASE [IF EXISTS] <action>`"
             | (
-                #alter_materialized_view : "`ALTER MATERIALIZED VIEW [<database>.]<view> {CLUSTER BY (...) | DROP CLUSTER KEY | RECLUSTER [FINAL] [LIMIT <limit>]}`"
+                #alter_materialized_view : "`ALTER MATERIALIZED VIEW [<database>.]<view> {CLUSTER BY (...) | DROP CLUSTER KEY | RECLUSTER [FINAL] [LIMIT <limit>] | SET OPTIONS (...) | UNSET OPTIONS ... | COMMENT = '<string_literal>'}`"
                 | #alter_table : "`ALTER TABLE [<database>.]<table> <action>`"
             )
             | #alter_view : "`ALTER VIEW [<database>.]<view> [(<column>, ...)] AS SELECT ...`"

--- a/src/query/ast/src/visit/statement_table.rs
+++ b/src/query/ast/src/visit/statement_table.rs
@@ -185,6 +185,40 @@ impl WalkMut for CreateTableStmt {
     }
 }
 
+impl Walk for CreateMaterializedViewStmt {
+    fn walk<V: Visitor + ?Sized>(
+        &self,
+        visitor: &mut V,
+    ) -> Result<VisitControl<V::Break>, V::Error> {
+        try_walk!((&self.catalog, &self.database, &self.view).walk(visitor));
+        for column in &self.columns {
+            try_walk!(column.walk(visitor));
+        }
+        if let Some(cluster_by) = &self.cluster_by {
+            try_walk!(cluster_by.walk(visitor));
+        }
+        try_walk!(self.query.walk(visitor));
+        Ok(VisitControl::Continue)
+    }
+}
+
+impl WalkMut for CreateMaterializedViewStmt {
+    fn walk_mut<V: VisitorMut + ?Sized>(
+        &mut self,
+        visitor: &mut V,
+    ) -> Result<VisitControl<V::Break>, V::Error> {
+        try_walk!((&mut self.catalog, &mut self.database, &mut self.view).walk_mut(visitor));
+        for column in &mut self.columns {
+            try_walk!(column.walk_mut(visitor));
+        }
+        if let Some(cluster_by) = &mut self.cluster_by {
+            try_walk!(cluster_by.walk_mut(visitor));
+        }
+        try_walk!(self.query.walk_mut(visitor));
+        Ok(VisitControl::Continue)
+    }
+}
+
 impl Walk for AlterTableAction {
     fn walk<V: Visitor + ?Sized>(
         &self,

--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -1794,10 +1794,22 @@ impl AccessChecker for PrivilegeAccess {
                 }
             }
             Plan::SetOptions(plan) => {
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Alter, false, false).await?
+                match &plan.target {
+                    MaintenanceTarget::Table => self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Alter, false, false).await?,
+                    MaintenanceTarget::MaterializedView { .. } => {
+                        let table = self.ctx.get_table(&plan.catalog, &plan.database, &plan.table).await?;
+                        self.validate_mv_source_access(table.as_ref()).await?
+                    }
+                }
             }
             Plan::UnsetOptions(plan) => {
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Alter, false, false).await?
+                match &plan.target {
+                    MaintenanceTarget::Table => self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Alter, false, false).await?,
+                    MaintenanceTarget::MaterializedView { .. } => {
+                        let table = self.ctx.get_table(&plan.catalog, &plan.database, &plan.table).await?;
+                        self.validate_mv_source_access(table.as_ref()).await?
+                    }
+                }
             }
             Plan::AddTableColumn(plan) => {
                 self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Alter, false, false).await?
@@ -1843,7 +1855,13 @@ impl AccessChecker for PrivilegeAccess {
                 }
             }
             Plan::ModifyTableComment(plan) => {
-                self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Alter, false, false).await?
+                match &plan.target {
+                    MaintenanceTarget::Table => self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Alter, false, false).await?,
+                    MaintenanceTarget::MaterializedView { .. } => {
+                        let table = self.ctx.get_table(&plan.catalog, &plan.database, &plan.table).await?;
+                        self.validate_mv_source_access(table.as_ref()).await?
+                    }
+                }
             }
             Plan::ModifyTableConnection(plan) => {
                 self.validate_table_access(&plan.catalog, &plan.database, &plan.table, UserPrivilegeType::Alter, false, false).await?

--- a/src/query/service/src/interpreters/common/table_option_validation.rs
+++ b/src/query/service/src/interpreters/common/table_option_validation.rs
@@ -133,9 +133,38 @@ pub static CREATE_FUSE_OPTIONS: LazyLock<HashSet<&'static str>> = LazyLock::new(
 pub static CREATE_MATERIALIZED_VIEW_OPTIONS: LazyLock<HashSet<&'static str>> =
     LazyLock::new(|| {
         let mut r = HashSet::new();
+        r.insert(FUSE_OPT_KEY_ROW_PER_PAGE);
+        r.insert(FUSE_OPT_KEY_BLOCK_PER_SEGMENT);
+        r.insert(FUSE_OPT_KEY_ROW_PER_BLOCK);
+        r.insert(FUSE_OPT_KEY_BLOCK_IN_MEM_SIZE_THRESHOLD);
+        r.insert(FUSE_OPT_KEY_FILE_SIZE);
+        r.insert(FUSE_OPT_KEY_RECLUSTER_DEPTH);
+        r.insert(FUSE_OPT_KEY_AGGRESSIVE_RECLUSTER);
+        r.insert(FUSE_OPT_KEY_DATA_RETENTION_PERIOD_IN_HOURS);
+        r.insert(FUSE_OPT_KEY_DATA_RETENTION_NUM_SNAPSHOTS_TO_KEEP);
+        r.insert(FUSE_OPT_KEY_ENABLE_AUTO_VACUUM);
+        r.insert(FUSE_OPT_KEY_ENABLE_AUTO_ANALYZE);
+        r.insert(FUSE_OPT_KEY_ENABLE_VIRTUAL_COLUMN);
+        r.insert(FUSE_OPT_KEY_AUTO_COMPACTION_IMPERFECT_BLOCKS_THRESHOLD);
+        r.insert(OPT_KEY_BLOOM_INDEX_COLUMNS);
+        r.insert(OPT_KEY_BLOOM_INDEX_TYPE);
+        r.insert(OPT_KEY_APPROX_DISTINCT_COLUMNS);
+        r.insert(OPT_KEY_TABLE_COMPRESSION);
+        r.insert(OPT_KEY_STORAGE_FORMAT);
+        r.insert(OPT_KEY_WRITE_DISTRIBUTION_MODE);
+        r.insert(OPT_KEY_SEGMENT_FORMAT);
+        r.insert(FUSE_OPT_KEY_ENABLE_PARQUET_DICTIONARY);
+        r.insert(FUSE_OPT_KEY_DATA_PAGE_ROWS);
+        r.insert(FUSE_OPT_KEY_DATA_PAGE_BYTES);
+        r.insert(OPT_KEY_ANALYZE_HISTOGRAM_ALGORITHM);
+        r.insert(OPT_KEY_ANALYZE_HISTOGRAM_KLL_RELATIVE_ERROR);
+        r.insert(OPT_KEY_ANALYZE_FREQUENCY_COLUMNS);
+        r.insert(OPT_KEY_ANALYZE_TOP_N_SIZE);
+        r.insert(OPT_KEY_ANALYZE_COUNT_MIN_SKETCH_ERROR_RATE);
+
+        // Added by the MV binder after user-specified reserved keys are rejected.
         r.insert(OPT_KEY_DATABASE_ID);
         r.insert(OPT_KEY_MATERIALIZED_VIEW_SOURCE_TABLE_ID);
-        r.insert(FUSE_OPT_KEY_AGGRESSIVE_RECLUSTER);
         r
     });
 

--- a/src/query/service/src/interpreters/interpreter_table_modify_comment.rs
+++ b/src/query/service/src/interpreters/interpreter_table_modify_comment.rs
@@ -14,7 +14,6 @@
 
 use std::sync::Arc;
 
-use databend_common_catalog::table::TableExt;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_meta_app::schema::DatabaseType;
@@ -23,6 +22,7 @@ use databend_common_storages_basic::view_table::VIEW_ENGINE;
 use databend_common_storages_stream::stream_table::STREAM_ENGINE;
 
 use crate::interpreters::Interpreter;
+use crate::interpreters::common::check_maintenance_target;
 use crate::interpreters::interpreter_table_add_column::commit_table_meta;
 use crate::pipelines::PipelineBuildResult;
 use crate::sessions::QueryContext;
@@ -60,8 +60,7 @@ impl Interpreter for ModifyTableCommentInterpreter {
             .await
         {
             Ok(table) => {
-                // check mutability
-                table.check_mutable()?;
+                check_maintenance_target(table.as_ref(), &self.plan.target)?;
 
                 let table_info = table.get_table_info();
                 let engine = table.engine();

--- a/src/query/service/src/interpreters/interpreter_table_set_options.rs
+++ b/src/query/service/src/interpreters/interpreter_table_set_options.rs
@@ -24,6 +24,7 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_meta_app::schema::UpsertTableOptionReq;
 use databend_common_pipeline::core::Pipeline;
+use databend_common_sql::plans::MaintenanceTarget;
 use databend_common_sql::plans::SetOptionsPlan;
 use databend_common_storages_factory::Table;
 use databend_common_storages_fuse::FUSE_OPT_KEY_AGGRESSIVE_RECLUSTER;
@@ -47,18 +48,22 @@ use databend_storages_common_table_meta::table::OPT_KEY_ANALYZE_FREQUENCY_COLUMN
 use databend_storages_common_table_meta::table::OPT_KEY_CHANGE_TRACKING;
 use databend_storages_common_table_meta::table::OPT_KEY_CHANGE_TRACKING_BEGIN_VER;
 use databend_storages_common_table_meta::table::OPT_KEY_CLUSTER_TYPE;
+use databend_storages_common_table_meta::table::OPT_KEY_COMMENT;
 use databend_storages_common_table_meta::table::OPT_KEY_DATABASE_ID;
 use databend_storages_common_table_meta::table::OPT_KEY_PARTITION_BY;
 use databend_storages_common_table_meta::table::OPT_KEY_SEGMENT_FORMAT;
 use databend_storages_common_table_meta::table::OPT_KEY_SNAPSHOT_LOCATION;
 use databend_storages_common_table_meta::table::OPT_KEY_STORAGE_FORMAT;
+use databend_storages_common_table_meta::table::OPT_KEY_TABLE_COMPRESSION;
 use databend_storages_common_table_meta::table::OPT_KEY_TEMP_PREFIX;
 use databend_storages_common_table_meta::table::OPT_KEY_WRITE_DISTRIBUTION_MODE;
+use databend_storages_common_table_meta::table::TableCompression;
 use databend_storages_common_table_meta::table::WriteDistributionMode;
 use databend_storages_common_table_meta::table::is_reserved_opt_key;
 use log::error;
 
 use crate::interpreters::Interpreter;
+use crate::interpreters::common::check_maintenance_target;
 use crate::interpreters::common::table_option_validation::analyze_count_min_sketch_error_rate_from_options;
 use crate::interpreters::common::table_option_validation::analyze_top_n_size_from_options;
 use crate::interpreters::common::table_option_validation::is_valid_analyze_count_min_sketch_error_rate;
@@ -127,6 +132,9 @@ impl Interpreter for SetOptionsInterpreter {
         is_valid_analyze_histogram_kll_relative_error(&self.plan.set_options)?;
         is_valid_analyze_top_n_size(&self.plan.set_options)?;
         is_valid_analyze_count_min_sketch_error_rate(&self.plan.set_options)?;
+        if let Some(compression) = self.plan.set_options.get(OPT_KEY_TABLE_COMPRESSION) {
+            let _: TableCompression = compression.as_str().try_into()?;
+        }
 
         // check storage_format
         let error_str = "invalid opt for fuse table in alter table statement";
@@ -190,6 +198,7 @@ impl Interpreter for SetOptionsInterpreter {
         let table = catalog
             .get_table(&self.ctx.get_tenant(), database, table_name)
             .await?;
+        check_maintenance_target(table.as_ref(), &self.plan.target)?;
 
         if let Some(mode) = self.plan.set_options.get(OPT_KEY_WRITE_DISTRIBUTION_MODE) {
             let mode = mode.parse::<WriteDistributionMode>()?;
@@ -205,6 +214,15 @@ impl Interpreter for SetOptionsInterpreter {
         let engine = Engine::from(table.engine());
         for table_option in self.plan.set_options.iter() {
             let key = table_option.0.to_lowercase();
+            if matches!(
+                &self.plan.target,
+                MaintenanceTarget::MaterializedView { .. }
+            ) && key == OPT_KEY_COMMENT
+            {
+                return Err(ErrorCode::TableOptionInvalid(format!(
+                    "table option {key} is invalid for alter materialized view statement; use COMMENT = ... instead",
+                )));
+            }
             if !is_valid_create_opt(&key, &engine) {
                 error!("{}", &error_str);
                 return Err(ErrorCode::TableOptionInvalid(format!(
@@ -231,9 +249,6 @@ impl Interpreter for SetOptionsInterpreter {
                 options_map.insert(OPT_KEY_CHANGE_TRACKING_BEGIN_VER.to_string(), begin_version);
             }
         }
-
-        // check mutability
-        table.check_mutable()?;
 
         // check bloom_index_columns.
         is_valid_bloom_index_columns(&self.plan.set_options, table.schema())?;

--- a/src/query/service/src/interpreters/interpreter_table_show_create.rs
+++ b/src/query/service/src/interpreters/interpreter_table_show_create.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use databend_common_ast::ast::quote::QuotedIdent;
@@ -72,6 +73,15 @@ pub struct ShowCreateQuerySettings {
 impl ShowCreateTableInterpreter {
     pub fn try_create(ctx: Arc<QueryContext>, plan: ShowCreateTablePlan) -> Result<Self> {
         Ok(ShowCreateTableInterpreter { ctx, plan })
+    }
+
+    fn format_table_options(options: &BTreeMap<String, String>) -> String {
+        options
+            .iter()
+            .filter(|(key, _)| !is_internal_opt_key(key))
+            .sorted_by_key(|(key, _)| *key)
+            .map(|(key, value)| format!(" {}={}", key.to_uppercase(), QuotedString(value, '\'')))
+            .join("")
     }
 }
 
@@ -161,7 +171,10 @@ impl ShowCreateTableInterpreter {
             STREAM_ENGINE => Self::show_create_stream_query(catalog, table).await,
             VIEW_ENGINE => Self::show_create_view_query(table, database),
             MATERIALIZED_VIEW_ENGINE => {
-                Self::show_create_materialized_view_query(catalog, tenant, table, database).await
+                Self::show_create_materialized_view_query(
+                    catalog, tenant, table, database, settings,
+                )
+                .await
             }
             _ => match table.options().get(OPT_KEY_STORAGE_PREFIX) {
                 Some(_) => Ok(Self::show_attach_table_query(table, database)),
@@ -370,15 +383,7 @@ impl ShowCreateTableInterpreter {
         }
 
         if !hide_options_in_show_create_table || engine == "ICEBERG" || engine == "DELTA" {
-            let mut opts = table_info.options().iter().collect::<Vec<_>>();
-            opts.sort_by_key(|(k, _)| *k);
-            let s = opts
-                .iter()
-                .filter(|(k, _)| !is_internal_opt_key(k))
-                .map(|(k, v)| format!(" {}='{}'", k.to_uppercase(), v))
-                .collect::<Vec<_>>()
-                .join("");
-            table_create_sql.push_str(&s);
+            table_create_sql.push_str(&Self::format_table_options(table_info.options()));
         }
 
         if engine != "ICEBERG" && engine != "DELTA" {
@@ -419,6 +424,7 @@ impl ShowCreateTableInterpreter {
         tenant: &Tenant,
         table: &dyn Table,
         database: &str,
+        settings: &ShowCreateQuerySettings,
     ) -> Result<String> {
         let name = table.name();
         let definition = get_materialized_view_handler()
@@ -449,6 +455,17 @@ impl ShowCreateTableInterpreter {
 
         if let Some(cluster_key) = table_info.meta.cluster_key_str() {
             create_sql.push_str(&format!(" CLUSTER BY {}", cluster_key));
+        }
+
+        if !table_info.meta.comment.is_empty() {
+            create_sql.push_str(&format!(
+                " COMMENT = {}",
+                QuotedString(&table_info.meta.comment, '\'')
+            ));
+        }
+
+        if !settings.hide_options_in_show_create_table {
+            create_sql.push_str(&Self::format_table_options(table_info.options()));
         }
 
         create_sql.push_str(&format!(" AS {}", definition.original_query));

--- a/src/query/service/src/interpreters/interpreter_table_unset_options.rs
+++ b/src/query/service/src/interpreters/interpreter_table_unset_options.rs
@@ -15,7 +15,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use databend_common_catalog::table::TableExt;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_meta_app::schema::UpsertTableOptionReq;
@@ -23,6 +22,7 @@ use databend_common_sql::plans::UnsetOptionsPlan;
 use databend_meta_client::types::MatchSeq;
 
 use crate::interpreters::Interpreter;
+use crate::interpreters::common::check_maintenance_target;
 use crate::interpreters::common::table_option_validation::UNSET_TABLE_OPTIONS_WHITE_LIST;
 use crate::pipelines::PipelineBuildResult;
 use crate::sessions::QueryContext;
@@ -57,9 +57,7 @@ impl Interpreter for UnsetOptionsInterpreter {
         let table = catalog
             .get_table(&self.ctx.get_tenant(), database, table_name)
             .await?;
-
-        // check mutability
-        table.check_mutable()?;
+        check_maintenance_target(table.as_ref(), &self.plan.target)?;
 
         let table_version = table.get_table_info().ident.seq;
 

--- a/src/query/settings/src/settings_default.rs
+++ b/src/query/settings/src/settings_default.rs
@@ -675,7 +675,7 @@ impl DefaultSettings {
                 }),
                 ("hide_options_in_show_create_table", DefaultSettingValue {
                     value: UserSettingValue::UInt64(1),
-                    desc: "Hides table-relevant information, such as SNAPSHOT_LOCATION and STORAGE_FORMAT, at the end of the result of SHOW TABLE CREATE.",
+                    desc: "Hides table-relevant information, such as SNAPSHOT_LOCATION and STORAGE_FORMAT, at the end of SHOW CREATE TABLE and SHOW CREATE MATERIALIZED VIEW.",
                     mode: SettingMode::Both,
                     scope: SettingScope::Both,
                     range: Some(SettingRange::Numeric(0..=1)),

--- a/src/query/sql/src/planner/binder/ddl/materialized_view.rs
+++ b/src/query/sql/src/planner/binder/ddl/materialized_view.rs
@@ -57,8 +57,13 @@ use databend_meta_client::types::MatchSeq;
 use databend_storages_common_table_meta::table::OPT_KEY_AGGRESSIVE_RECLUSTER;
 use databend_storages_common_table_meta::table::OPT_KEY_CHANGE_TRACKING;
 use databend_storages_common_table_meta::table::OPT_KEY_CHANGE_TRACKING_BEGIN_VER;
+use databend_storages_common_table_meta::table::OPT_KEY_COMMENT;
 use databend_storages_common_table_meta::table::OPT_KEY_DATABASE_ID;
 use databend_storages_common_table_meta::table::OPT_KEY_SNAPSHOT_LOCATION;
+use databend_storages_common_table_meta::table::OPT_KEY_TABLE_COMPRESSION;
+use databend_storages_common_table_meta::table::OPT_KEY_WRITE_DISTRIBUTION_MODE;
+use databend_storages_common_table_meta::table::TableCompression;
+use databend_storages_common_table_meta::table::WriteDistributionMode;
 use databend_storages_common_table_meta::table::is_fuse_engine;
 use log::debug;
 
@@ -84,13 +89,16 @@ use crate::plans::CreateTablePlan;
 use crate::plans::DropMaterializedViewPlan;
 use crate::plans::DropTableClusterKeyPlan;
 use crate::plans::MaintenanceTarget;
+use crate::plans::ModifyTableCommentPlan;
 use crate::plans::Plan;
 use crate::plans::ReclusterPlan;
 use crate::plans::RefreshMaterializedViewPlan;
 use crate::plans::RelOperator;
 use crate::plans::RewriteKind;
 use crate::plans::ScalarExpr;
+use crate::plans::SetOptionsPlan;
 use crate::plans::ShowCreateMaterializedViewPlan;
+use crate::plans::UnsetOptionsPlan;
 
 fn is_supported_materialized_view_source(table: &dyn Table) -> bool {
     !table.is_temp()
@@ -454,6 +462,8 @@ impl Binder {
             view,
             columns,
             cluster_by,
+            comment,
+            table_options,
             query,
         } = stmt;
 
@@ -657,6 +667,24 @@ impl Binder {
         //    Fuse storage; MVDefinition holds the original query, rewritten storage
         //    query, and logical schema (with final projection expressions).
         let mut options = BTreeMap::new();
+        for (key, value) in table_options {
+            self.insert_table_option_with_validation(
+                &mut options,
+                key.to_lowercase(),
+                value.clone(),
+            )?;
+        }
+        if let Some(compression) = options.get(OPT_KEY_TABLE_COMPRESSION) {
+            let _: TableCompression = compression.as_str().try_into()?;
+        }
+        if let Some(mode) = options.get(OPT_KEY_WRITE_DISTRIBUTION_MODE) {
+            let mode = mode.parse::<WriteDistributionMode>()?;
+            if mode == WriteDistributionMode::Hash {
+                return Err(ErrorCode::TableOptionInvalid(format!(
+                    "{OPT_KEY_WRITE_DISTRIBUTION_MODE}='hash' requires PARTITION BY"
+                )));
+            }
+        }
         options.insert(
             OPT_KEY_DATABASE_ID.to_owned(),
             target_database_id.to_string(),
@@ -665,6 +693,11 @@ impl Binder {
             OPT_KEY_MATERIALIZED_VIEW_SOURCE_TABLE_ID.to_owned(),
             source_table_id.to_string(),
         );
+        // CreateTableInterpreter removes this transport option and stores it in TableMeta.comment;
+        // ALTER MATERIALIZED VIEW SET OPTIONS does not accept COMMENT.
+        if let Some(comment) = comment {
+            options.insert(OPT_KEY_COMMENT.to_owned(), comment.clone());
+        }
 
         let mut cluster_key = None;
         if let Some(cluster_opt) = cluster_by {
@@ -806,6 +839,34 @@ impl Binder {
                     limit: limit.map(|value| value as usize),
                     selection: None,
                     is_final: *is_final,
+                })))
+            }
+            AlterTableAction::SetOptions { set_options } => {
+                Ok(Plan::SetOptions(Box::new(SetOptionsPlan {
+                    set_options: set_options.clone(),
+                    catalog,
+                    database,
+                    table,
+                    target: MaintenanceTarget::MaterializedView { table_id },
+                })))
+            }
+            AlterTableAction::UnsetOptions { targets } => {
+                Ok(Plan::UnsetOptions(Box::new(UnsetOptionsPlan {
+                    options: targets.iter().map(|i| i.name.to_lowercase()).collect(),
+                    catalog,
+                    database,
+                    table,
+                    target: MaintenanceTarget::MaterializedView { table_id },
+                })))
+            }
+            AlterTableAction::ModifyTableComment { new_comment } => {
+                Ok(Plan::ModifyTableComment(Box::new(ModifyTableCommentPlan {
+                    if_exists: false,
+                    new_comment: new_comment.to_string(),
+                    catalog,
+                    database,
+                    table,
+                    target: MaintenanceTarget::MaterializedView { table_id },
                 })))
             }
             _ => Err(ErrorCode::SemanticError(format!(

--- a/src/query/sql/src/planner/binder/ddl/table.rs
+++ b/src/query/sql/src/planner/binder/ddl/table.rs
@@ -1269,6 +1269,7 @@ impl Binder {
                     catalog,
                     database,
                     table,
+                    target: MaintenanceTarget::Table,
                 })))
             }
             AlterTableAction::ModifyConnection { new_connection } => Ok(
@@ -1605,6 +1606,7 @@ impl Binder {
                     catalog,
                     database,
                     table,
+                    target: MaintenanceTarget::Table,
                 })))
             }
             AlterTableAction::UnsetOptions { targets } => {
@@ -1613,6 +1615,7 @@ impl Binder {
                     catalog,
                     database,
                     table,
+                    target: MaintenanceTarget::Table,
                 })))
             }
             AlterTableAction::RefreshTableCache => {

--- a/src/query/sql/src/planner/plans/ddl/table.rs
+++ b/src/query/sql/src/planner/plans/ddl/table.rs
@@ -278,6 +278,7 @@ pub struct ModifyTableCommentPlan {
     pub catalog: String,
     pub database: String,
     pub table: String,
+    pub target: MaintenanceTarget,
 }
 
 impl ModifyTableCommentPlan {
@@ -308,6 +309,7 @@ pub struct SetOptionsPlan {
     pub catalog: String,
     pub database: String,
     pub table: String,
+    pub target: MaintenanceTarget,
 }
 
 impl SetOptionsPlan {
@@ -322,6 +324,7 @@ pub struct UnsetOptionsPlan {
     pub catalog: String,
     pub database: String,
     pub table: String,
+    pub target: MaintenanceTarget,
 }
 
 impl UnsetOptionsPlan {

--- a/tests/sqllogictests/suites/ee/05_ee_ddl/05_0017_ddl_materialized_view.test
+++ b/tests/sqllogictests/suites/ee/05_ee_ddl/05_0017_ddl_materialized_view.test
@@ -336,6 +336,133 @@ SHOW CREATE MATERIALIZED VIEW test_mv
 ----
 test_mv CREATE MATERIALIZED VIEW `test_mv_ddl`.`test_mv` (`id`, `val`, `amount`) AS SELECT id, val, amount FROM test_mv_ddl.mv_base_t WHERE id <= 2
 
+# Dedicated MV SET OPTIONS updates Fuse layout options without opening TABLE syntax.
+statement ok
+ALTER MATERIALIZED VIEW test_mv SET OPTIONS (row_per_block = 2)
+
+query B
+SELECT table_option LIKE '%ROW_PER_BLOCK=''2''%'
+FROM system.tables
+WHERE database = 'test_mv_ddl' AND name = 'test_mv'
+----
+1
+
+statement ok
+ALTER MATERIALIZED VIEW test_mv UNSET OPTIONS (row_per_block)
+
+query B
+SELECT table_option LIKE '%ROW_PER_BLOCK=%'
+FROM system.tables
+WHERE database = 'test_mv_ddl' AND name = 'test_mv'
+----
+0
+
+# Physical layout: SET OPTIONS is only metadata until the next write. Refresh should honor
+# row_per_block when materializing storage. MV storage is not subject to ordinary compact-after-write.
+statement ok
+CREATE MATERIALIZED VIEW test_mv_opts AS SELECT id, val, amount FROM mv_base_t WHERE 1 = 1
+
+statement ok
+ALTER MATERIALIZED VIEW test_mv_opts SET OPTIONS (row_per_block = 2)
+
+query B
+SELECT table_option LIKE '%ROW_PER_BLOCK=''2''%'
+FROM system.tables
+WHERE database = 'test_mv_ddl' AND name = 'test_mv_opts'
+----
+1
+
+statement ok
+REFRESH MATERIALIZED VIEW test_mv_opts
+
+# 4 source rows with row_per_block = 2 should land as two full blocks.
+query I
+SELECT row_count FROM fuse_block('test_mv_ddl', 'test_mv_opts') ORDER BY block_location
+----
+2
+2
+
+query I
+SELECT block_count
+FROM fuse_snapshot('test_mv_ddl', 'test_mv_opts')
+ORDER BY timestamp DESC
+LIMIT 1
+----
+2
+
+statement ok
+DROP MATERIALIZED VIEW test_mv_opts
+
+statement error 1301
+ALTER MATERIALIZED VIEW test_mv SET OPTIONS (foo = 1)
+
+statement error 1301
+ALTER MATERIALIZED VIEW test_mv SET OPTIONS (materialized_view_source_table_id = 1)
+
+statement error 1301
+ALTER MATERIALIZED VIEW test_mv SET OPTIONS (row_per_block = 1000001)
+
+statement error 1301
+ALTER MATERIALIZED VIEW test_mv SET OPTIONS (transient = 'T')
+
+query B
+SELECT table_option LIKE '%TRANSIENT%'
+FROM system.tables
+WHERE database = 'test_mv_ddl' AND name = 'test_mv'
+----
+0
+
+# CREATE TABLE and CREATE MATERIALIZED VIEW use the same compression validation. Rejected ALTERs
+# must leave both the source table and the existing MV readable.
+statement error 1075
+ALTER TABLE mv_base_t SET OPTIONS (compression = 'bogus')
+
+statement error 1075
+ALTER MATERIALIZED VIEW test_mv SET OPTIONS (compression = 'bogus')
+
+query I
+SELECT count(*) FROM test_mv
+----
+2
+
+statement error 1301
+ALTER MATERIALIZED VIEW test_mv UNSET OPTIONS (change_tracking)
+
+# COMMENT is a first-class MV clause, not a SET OPTIONS key.
+statement error 1301
+ALTER MATERIALIZED VIEW test_mv SET OPTIONS (comment = 'option comment')
+
+statement ok
+ALTER MATERIALIZED VIEW test_mv COMMENT = 'mv comment'
+
+query TT
+SHOW CREATE MATERIALIZED VIEW test_mv
+----
+test_mv CREATE MATERIALIZED VIEW `test_mv_ddl`.`test_mv` (`id`, `val`, `amount`) COMMENT = 'mv comment' AS SELECT id, val, amount FROM test_mv_ddl.mv_base_t WHERE id <= 2
+
+query T
+SELECT comment FROM system.tables WHERE database = 'test_mv_ddl' AND name = 'test_mv'
+----
+mv comment
+
+statement ok
+ALTER MATERIALIZED VIEW test_mv COMMENT = ''
+
+query TT
+SHOW CREATE MATERIALIZED VIEW test_mv
+----
+test_mv CREATE MATERIALIZED VIEW `test_mv_ddl`.`test_mv` (`id`, `val`, `amount`) AS SELECT id, val, amount FROM test_mv_ddl.mv_base_t WHERE id <= 2
+
+# TABLE syntax stays blocked on materialized views.
+statement error 3905
+ALTER TABLE test_mv SET OPTIONS (row_per_block = 2)
+
+statement error 3905
+ALTER TABLE test_mv UNSET OPTIONS (row_per_block)
+
+statement error 3905
+ALTER TABLE test_mv COMMENT = 'blocked'
+
 # The dedicated syntax rejects ordinary tables and unrelated ALTER actions.
 statement error 1302
 ALTER MATERIALIZED VIEW mv_base_t CLUSTER BY (id)
@@ -363,7 +490,19 @@ statement ok
 ALTER MATERIALIZED VIEW test_mv RECLUSTER LIMIT 1
 
 statement ok
+ALTER MATERIALIZED VIEW test_mv SET OPTIONS (row_per_block = 4)
+
+statement ok
+ALTER MATERIALIZED VIEW test_mv UNSET OPTIONS (row_per_block)
+
+statement ok
+ALTER MATERIALIZED VIEW test_mv COMMENT = 'role comment'
+
+statement ok
 SET ROLE account_admin
+
+statement ok
+ALTER MATERIALIZED VIEW test_mv COMMENT = ''
 
 statement ok
 DROP ROLE mv_maintenance_role
@@ -392,6 +531,104 @@ query TT
 SHOW CREATE MATERIALIZED VIEW test_mv2
 ----
 test_mv2 CREATE MATERIALIZED VIEW `test_mv_ddl`.`test_mv2` (`val`, `cnt`) CLUSTER BY (val) AS SELECT val, COUNT(*) AS cnt FROM test_mv_ddl.mv_base_t WHERE 1 = 1 GROUP BY val
+
+# CREATE MATERIALIZED VIEW COMMENT is stored independently of CLUSTER BY.
+statement ok
+CREATE MATERIALIZED VIEW test_mv_comment COMMENT = 'created comment' AS SELECT id FROM mv_base_t WHERE 1 = 1
+
+query TT
+SHOW CREATE MATERIALIZED VIEW test_mv_comment
+----
+test_mv_comment CREATE MATERIALIZED VIEW `test_mv_ddl`.`test_mv_comment` (`id`) COMMENT = 'created comment' AS SELECT id FROM test_mv_ddl.mv_base_t WHERE 1 = 1
+
+query T
+SELECT comment FROM system.tables WHERE database = 'test_mv_ddl' AND name = 'test_mv_comment'
+----
+created comment
+
+statement ok
+DROP MATERIALIZED VIEW test_mv_comment
+
+# Fuse table options can be specified when the MV is created. SHOW CREATE hides them by default
+# and reconstructs them when hide_options_in_show_create_table is off.
+statement ok
+CREATE MATERIALIZED VIEW test_mv_create_options COMMENT = 'option comment' BLOOM_INDEX_COLUMNS = 'id' ROW_PER_BLOCK = 2 AS SELECT id FROM mv_base_t WHERE 1 = 1
+
+query TT
+SHOW CREATE MATERIALIZED VIEW test_mv_create_options
+----
+test_mv_create_options CREATE MATERIALIZED VIEW `test_mv_ddl`.`test_mv_create_options` (`id`) COMMENT = 'option comment' AS SELECT id FROM test_mv_ddl.mv_base_t WHERE 1 = 1
+
+statement ok
+SET hide_options_in_show_create_table = 0
+
+query TT
+SHOW CREATE MATERIALIZED VIEW test_mv_create_options
+----
+test_mv_create_options CREATE MATERIALIZED VIEW `test_mv_ddl`.`test_mv_create_options` (`id`) COMMENT = 'option comment' BLOOM_INDEX_COLUMNS='id' ROW_PER_BLOCK='2' AS SELECT id FROM test_mv_ddl.mv_base_t WHERE 1 = 1
+
+# SHOW CREATE escapes quotes in string-valued table options.
+statement ok
+CREATE MATERIALIZED VIEW test_mv_quoted_option BLOOM_INDEX_COLUMNS = '`quoted\'column`' AS SELECT id AS `quoted'column` FROM mv_base_t WHERE 1 = 1
+
+query TT
+SHOW CREATE MATERIALIZED VIEW test_mv_quoted_option
+----
+test_mv_quoted_option CREATE MATERIALIZED VIEW `test_mv_ddl`.`test_mv_quoted_option` (`quoted'column`) BLOOM_INDEX_COLUMNS='`quoted\'column`' AS SELECT id AS `quoted'column` FROM test_mv_ddl.mv_base_t WHERE 1 = 1
+
+statement ok
+DROP MATERIALIZED VIEW test_mv_quoted_option
+
+statement ok
+SET hide_options_in_show_create_table = 1
+
+query BB
+SELECT table_option LIKE '%ROW_PER_BLOCK=''2''%', comment = 'option comment'
+FROM system.tables
+WHERE database = 'test_mv_ddl' AND name = 'test_mv_create_options'
+----
+1 1
+
+statement ok
+REFRESH MATERIALIZED VIEW test_mv_create_options
+
+query I
+SELECT row_count FROM fuse_block('test_mv_ddl', 'test_mv_create_options') ORDER BY block_location
+----
+2
+2
+
+statement ok
+DROP MATERIALIZED VIEW test_mv_create_options
+
+statement error 1301
+CREATE MATERIALIZED VIEW test_mv_bad_option ROW_PER_BLOCK = 1000001 AS SELECT id FROM mv_base_t WHERE 1 = 1
+
+statement error 1075
+CREATE MATERIALIZED VIEW test_mv_bad_compression COMPRESSION = 'bogus' AS SELECT id FROM mv_base_t WHERE 1 = 1
+
+statement error 1301
+CREATE MATERIALIZED VIEW test_mv_bad_distribution WRITE_DISTRIBUTION_MODE = 'bogus' AS SELECT id FROM mv_base_t WHERE 1 = 1
+
+statement error 1301
+CREATE MATERIALIZED VIEW test_mv_hash_distribution WRITE_DISTRIBUTION_MODE = 'hash' AS SELECT id FROM mv_base_t WHERE 1 = 1
+
+statement error 1301
+CREATE MATERIALIZED VIEW test_mv_temp_prefix TEMP_PREFIX = 'x' AS SELECT id FROM mv_base_t WHERE 1 = 1
+
+statement error 1301
+CREATE MATERIALIZED VIEW test_mv_transient TRANSIENT = 'T' AS SELECT id FROM mv_base_t WHERE 1 = 1
+
+query I
+SELECT count(*)
+FROM system.tables
+WHERE database = 'test_mv_ddl'
+  AND name IN ('test_mv_bad_compression', 'test_mv_bad_distribution', 'test_mv_hash_distribution', 'test_mv_temp_prefix', 'test_mv_transient')
+----
+0
+
+statement error 1301
+CREATE MATERIALIZED VIEW test_mv_reserved_option MATERIALIZED_VIEW_SOURCE_TABLE_ID = 1 AS SELECT id FROM mv_base_t WHERE 1 = 1
 
 # Aggregate result/state columns cannot be used as MV cluster keys.
 statement error 1081


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Materialized views can now specify supported Fuse storage and layout options, together with a comment, at CREATE time. Dedicated ALTER MATERIALIZED VIEW syntax allows these options and comments to be maintained later. SHOW CREATE MATERIALIZED VIEW follows SHOW CREATE TABLE’s option-hiding and quoting behavior.

###  Changes

```
  CREATE MATERIALIZED VIEW mv
      COMMENT = '...'
      ROW_PER_BLOCK = 2
  AS SELECT ...;

  ALTER MATERIALIZED VIEW mv SET OPTIONS (row_per_block = 4);
  ALTER MATERIALIZED VIEW mv UNSET OPTIONS (row_per_block);
  ALTER MATERIALIZED VIEW mv COMMENT = 'updated';

  SHOW CREATE MATERIALIZED VIEW mv;
```

Only options applicable to materialized-view storage are accepted. Table lifecycle, routing, and ingestion options such as TRANSIENT, TEMP_PREFIX, and CHANGE_TRACKING are rejected.

Existing ALTER TABLE ... SET/UNSET OPTIONS and ALTER TABLE ... COMMENT syntax remains rejected for materialized views.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

<!--
See AI_POLICY.md. Agent-opened PRs are welcome; a responsible human on the author side must own the change.
The responsible human is NOT the reviewer — it is the submitter-side owner who has read the diff,
can explain each change, and will answer questions during review.
Write "None" for AI usage if no AI was involved.
-->

- AI usage: An AI coding agent drafted the implementation and integration tests; I reviewed the final diff and validation results
- Responsible human: @TCeason 
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20306)
<!-- Reviewable:end -->
