### PR TITLE
fix(fuse): recheck runtime TopN during block reads

### DIFF
--- a/src/query/storages/fuse/src/operations/read/read_data_transform.rs
+++ b/src/query/storages/fuse/src/operations/read/read_data_transform.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use databend_common_catalog::plan::PartInfoPtr;
+use databend_common_catalog::runtime_filter_info::RuntimeScanFilters;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -30,6 +31,7 @@ use databend_common_pipeline_transforms::processors::AsyncTransformer;
 use databend_common_sql::IndexType;
 
 use super::read_block_context::ReadBlockContext;
+use crate::FuseBlockPartInfo;
 use crate::io::BlockReader;
 use crate::operations::read::block_partition_meta::BlockPartitionMeta;
 use crate::operations::read::data_source_with_meta::DataSourceWithMeta;
@@ -43,6 +45,7 @@ pub struct ReadDataTransform {
     table_schema: Arc<TableSchema>,
     scan_id: IndexType,
     context: Arc<dyn TableContext>,
+    runtime_scan_filters: RuntimeScanFilters,
 }
 
 impl ReadDataTransform {
@@ -57,6 +60,7 @@ impl ReadDataTransform {
         output: Arc<OutputPort>,
     ) -> Result<ProcessorPtr> {
         let func_ctx = ctx.get_function_context()?;
+        let runtime_scan_filters = ctx.get_runtime_scan_filters(scan_id);
         Ok(ProcessorPtr::create(AsyncTransformer::create(
             input,
             output,
@@ -67,6 +71,7 @@ impl ReadDataTransform {
                 table_schema,
                 scan_id,
                 context: ctx,
+                runtime_scan_filters,
             },
         )))
     }
@@ -96,29 +101,67 @@ impl ReadDataTransform {
 
     async fn read_parts(&self, parts: Vec<PartInfoPtr>) -> Result<DataBlock> {
         let mut read_tasks = Vec::with_capacity(parts.len());
-        let mut parts_to_read = Vec::with_capacity(parts.len());
         let expr_runtime_pruner = self.create_runtime_pruners()?;
 
         for part in parts {
+            if !self.runtime_scan_filters.is_empty() {
+                let part_info = FuseBlockPartInfo::from_part(&part)?;
+                if self
+                    .runtime_scan_filters
+                    .should_prune(part_info.columns_stat.as_ref())
+                {
+                    continue;
+                }
+            }
+
             if expr_runtime_pruner.prune(&part).await? {
                 continue;
             }
 
-            parts_to_read.push(part.clone());
+            let filters = self.runtime_scan_filters.clone();
             let read_block_context = self.read_block_context.clone();
-
             read_tasks.push(async move {
                 databend_common_base::runtime::spawn(async move {
-                    read_block_context.read_data(part).await
+                    if filters.is_empty() {
+                        let source = read_block_context.read_data(part.clone()).await?;
+                        return Ok::<_, ErrorCode>(Some((part, source)));
+                    }
+
+                    let read = read_block_context.read_data(part.clone());
+                    tokio::pin!(read);
+                    loop {
+                        // Subscribe before checking so a boundary update cannot be missed.
+                        let rechecks = filters.recheck_notified();
+                        debug_assert!(!rechecks.is_empty());
+                        let part_info = FuseBlockPartInfo::from_part(&part)?;
+                        if filters.should_prune(part_info.columns_stat.as_ref()) {
+                            return Ok::<_, ErrorCode>(None);
+                        }
+
+                        tokio::select! {
+                            result = &mut read => {
+                                let source = result?;
+                                return Ok::<_, ErrorCode>(Some((part, source)));
+                            }
+                            _ = futures::future::select_all(rechecks) => {}
+                        }
+                    }
                 })
-                .await
-                .unwrap()
+                .await?
             });
+        }
+
+        let completed_reads = futures::future::try_join_all(read_tasks).await?;
+        let mut parts_to_read = Vec::with_capacity(completed_reads.len());
+        let mut sources = Vec::with_capacity(completed_reads.len());
+        for (part, source) in completed_reads.into_iter().flatten() {
+            parts_to_read.push(part);
+            sources.push(source);
         }
 
         Ok(DataBlock::empty_with_meta(DataSourceWithMeta::create(
             parts_to_read,
-            futures::future::try_join_all(read_tasks).await?,
+            sources,
         )))
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Runtime TopN orders promising Fuse block partitions first, but the block reader did
not consume runtime scan-filter updates. A TopN boundary that tightened after a
block read was scheduled therefore could not prune that block or stop its I/O.

This PR makes `ReadDataTransform`:

- check runtime scan filters against block statistics before scheduling I/O;
- subscribe to filter updates while each block read is in flight;
- recheck the block whenever the boundary tightens and cancel the read when the
  block becomes prunable;
- keep only completed, non-pruned `(part, source)` pairs in the output metadata;
- preserve the existing fast path when no runtime scan filter is registered.

The implementation is independent of granule/page-index reads and only changes
the existing block-level reader.

## Implementation

The scheduling and recheck flow stays inline in `read_parts`. Before I/O, each
part is checked against the current runtime scan filters. Each spawned task then
pins its `read_data` future and races it against
`RuntimeScanFilters::recheck_notified()`. It subscribes before evaluating
`should_prune()`, so a boundary update between arming the notification and
checking the current boundary cannot be missed. When a part becomes prunable,
the task returns `None`, which drops the read future; only completed reads are
included in the emitted `DataSourceWithMeta`.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

No new timing-based test is added in this isolated patch. Existing coverage
exercises runtime scan-filter notification/pruning semantics and end-to-end TopN
correctness over a multi-block Fuse table.

Validation performed:

- `cargo test -p databend-common-storages-fuse --lib` — 111 passed
- `cargo test -p databend-query --test it sql::top_n -- --nocapture` — 6 passed
- `cargo clippy -p databend-common-storages-fuse --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

## Risk

The change only skips or cancels reads when an existing runtime scan filter
proves the whole block can be pruned from its column statistics. Blocks without
usable statistics are retained. There are no configuration, storage-format,
migration, or compatibility changes.

## AI assistance

- AI usage: An AI coding agent investigated the missing block-read repruning path, adapted and simplified the runtime-filter recheck and cancellation logic for the existing reader, ran local validation, and drafted this PR description.
- Responsible human: @zhang2014
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20309)
<!-- Reviewable:end -->
