### PR TITLE
feat(query): configure history tables from environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4081,6 +4081,7 @@ dependencies = [
  "log",
  "serde",
  "serde_ignored",
+ "serde_json",
  "serde_with",
  "serfig",
  "temp-env",

--- a/src/query/config/Cargo.toml
+++ b/src/query/config/Cargo.toml
@@ -29,6 +29,7 @@ databend-meta-client = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
 serde_ignored = { workspace = true }
+serde_json = { workspace = true }
 serde_with = { workspace = true }
 serfig = { workspace = true }
 toml = { workspace = true }

--- a/src/query/config/src/config.rs
+++ b/src/query/config/src/config.rs
@@ -18,6 +18,7 @@ use std::env;
 use std::fmt;
 use std::fmt::Debug;
 use std::fmt::Formatter;
+use std::marker::PhantomData;
 use std::str::FromStr;
 
 use clap::ArgAction;
@@ -64,7 +65,11 @@ use databend_common_tracing::StderrConfig as InnerStderrLogConfig;
 use databend_common_tracing::StructLogConfig as InnerStructLogConfig;
 use databend_common_tracing::TracingConfig as InnerTracingConfig;
 use serde::Deserialize;
+use serde::Deserializer;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
+use serde::de::SeqAccess;
+use serde::de::Visitor;
 use serde_with::with_prefix;
 use serfig::collectors::from_env;
 use serfig::collectors::from_file;
@@ -2700,9 +2705,11 @@ pub struct HistoryLogConfig {
     #[serde(rename = "retention_interval")]
     pub log_history_retention_interval: usize,
 
-    /// Specifies which history table to enable
+    /// Specifies which history table to enable.
+    ///
+    /// The `LOG_HISTORY_TABLES` environment variable accepts a JSON array of table configs.
     #[clap(skip)]
-    #[serde(rename = "tables")]
+    #[serde(rename = "tables", deserialize_with = "deserialize_json_string_or_seq")]
     pub log_history_tables: Vec<HistoryLogTableConfig>,
 
     /// Specifies whether enable external storage
@@ -2731,6 +2738,47 @@ pub struct HistoryLogTableConfig {
     /// Whether this history table is invisible for querying.
     /// Default is false.
     pub invisible: bool,
+}
+
+struct JsonStringOrSeqVisitor<T>(PhantomData<T>);
+
+impl<'de, T> Visitor<'de> for JsonStringOrSeqVisitor<T>
+where T: DeserializeOwned
+{
+    type Value = Vec<T>;
+
+    fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+        formatter.write_str("a JSON-encoded array or a native sequence")
+    }
+
+    fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+    where E: serde::de::Error {
+        serde_json::from_str(value).map_err(E::custom)
+    }
+
+    fn visit_string<E>(self, value: String) -> std::result::Result<Self::Value, E>
+    where E: serde::de::Error {
+        self.visit_str(&value)
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> std::result::Result<Self::Value, A::Error>
+    where A: SeqAccess<'de> {
+        let mut configs = Vec::with_capacity(seq.size_hint().unwrap_or_default());
+        while let Some(config) = seq.next_element()? {
+            configs.push(config);
+        }
+        Ok(configs)
+    }
+}
+
+fn deserialize_json_string_or_seq<'de, D, T>(
+    deserializer: D,
+) -> std::result::Result<Vec<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: DeserializeOwned,
+{
+    deserializer.deserialize_any(JsonStringOrSeqVisitor(PhantomData))
 }
 
 impl Default for HistoryLogConfig {
@@ -3783,6 +3831,55 @@ mod test {
                 assert_eq!(cfg.log.tracing.tracing_capture_log_level, "DebuG");
             },
         );
+    }
+
+    #[test]
+    fn test_env_history_tables() {
+        with_vars(
+            vec![
+                (
+                    "LOG_HISTORY_TABLES",
+                    Some(
+                        r#"[{"table_name":"query_history","retention":24,"invisible":true},{"table_name":"lineage_history"}]"#,
+                    ),
+                ),
+                ("CONFIG_FILE", None),
+            ],
+            || {
+                let cfg = Config::default().merge("").unwrap();
+                let default_table = HistoryLogTableConfig::default();
+                assert_eq!(cfg.log.history.log_history_tables, vec![
+                    HistoryLogTableConfig {
+                        table_name: "query_history".to_string(),
+                        retention: 24,
+                        invisible: true,
+                    },
+                    HistoryLogTableConfig {
+                        table_name: "lineage_history".to_string(),
+                        ..default_table
+                    },
+                ]);
+            },
+        );
+    }
+
+    #[test]
+    fn test_history_tables_toml_config_is_unchanged() {
+        let cfg: HistoryLogConfig = toml::from_str(
+            r#"
+                [[tables]]
+                table_name = "lineage_history"
+                retention = 24
+                invisible = true
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(cfg.log_history_tables, vec![HistoryLogTableConfig {
+            table_name: "lineage_history".to_string(),
+            retention: 24,
+            invisible: true,
+        }]);
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

`log.history.tables` is represented as an array of table configuration objects, which works with TOML's `[[log.history.tables]]` syntax but cannot currently be supplied through Databend's scalar environment-variable collector. This makes it impossible to enable `lineage_history` or other history tables in deployments that configure query nodes exclusively with environment variables.

This PR allows the environment variable to carry the complete table configuration as JSON:

```bash
LOG_HISTORY_ON=true
LOG_HISTORY_TABLES='[{"table_name":"query_history","retention":24,"invisible":true},{"table_name":"lineage_history"}]'
```

Omitted JSON fields use the existing `HistoryLogTableConfig` defaults. The structured TOML form remains unchanged.

## Implementation

- Adds a generic JSON-string-or-native-sequence Serde helper for `Vec<T>` configuration fields.
- Parses `LOG_HISTORY_TABLES` as a JSON array with the complete `HistoryLogTableConfig` schema.
- Keeps the existing TOML schema and `HistoryLogTableConfig` conversion unchanged.
- Documents the `LOG_HISTORY_TABLES` format on the configuration field.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Coverage includes the production `Config::merge()` environment path, complete and defaulted JSON table options, and unchanged TOML parsing with explicit retention and visibility.

Validation commands:

```text
cargo fmt --all -- --check
cargo test -p databend-common-config --lib
cargo clippy -p databend-common-config --lib --tests -- -D warnings
git diff --check
```

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent drafted the environment deserialization implementation and unit tests.
- Responsible human: @youngsofun
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20312)
<!-- Reviewable:end -->
