### PR TITLE
fix(query): bound final aggregate finish memory

### DIFF
--- a/src/query/expression/src/aggregate/aggregate_hashtable.rs
+++ b/src/query/expression/src/aggregate/aggregate_hashtable.rs
@@ -90,6 +90,45 @@ impl AggregateHashTable {
         }
     }
 
+    pub fn new_with_partitioned_arenas(
+        group_types: Vec<DataType>,
+        aggrs: Vec<AggregateFunctionRef>,
+        config: HashTableConfig,
+    ) -> Self {
+        // Repartition transfers raw aggregate state addresses between payloads. Separate arenas
+        // are only safe for a final hash table whose partitions will never be repartitioned.
+        assert!(
+            !config.partial_agg,
+            "partition-local aggregate arenas cannot be used by a repartitioning hash table"
+        );
+        let capacity = Self::initial_capacity();
+        let partition_count = 1 << config.initial_radix_bits;
+        let arenas = (0..partition_count)
+            .map(|_| Arc::new(Bump::new()))
+            .collect();
+        Self {
+            direct_append: false,
+            current_radix_bits: config.initial_radix_bits,
+            payload: PartitionedPayload::new_with_start_bit(
+                group_types,
+                aggrs,
+                partition_count,
+                config.partition_start_bit,
+                arenas,
+            ),
+            hash_index: HashIndex::with_capacity(capacity),
+            config,
+            hash_index_resize_count: 0,
+        }
+    }
+
+    pub fn into_payloads(self) -> Vec<Payload> {
+        self.payload
+            .into_bucket_payloads()
+            .map(|(_, payload)| payload)
+            .collect()
+    }
+
     pub fn new_directly(
         group_types: Vec<DataType>,
         aggrs: Vec<AggregateFunctionRef>,

--- a/src/query/expression/src/aggregate/partitioned_payload.rs
+++ b/src/query/expression/src/aggregate/partitioned_payload.rs
@@ -90,6 +90,10 @@ impl PartitionedPayload {
         partition_start_bit: u64,
         arenas: Vec<Arc<Bump>>,
     ) -> Self {
+        assert!(
+            arenas.len() == 1 || arenas.len() == partition_count as usize,
+            "arenas must be shared or match the payload partition count"
+        );
         let states_layout = if !aggrs.is_empty() {
             Some(get_states_layout(&aggrs).unwrap())
         } else {
@@ -97,9 +101,14 @@ impl PartitionedPayload {
         };
 
         let payloads = (0..partition_count)
-            .map(|_| {
+            .map(|partition| {
                 Payload::new(
-                    arenas[0].clone(),
+                    arenas[if arenas.len() == 1 {
+                        0
+                    } else {
+                        partition as usize
+                    }]
+                    .clone(),
                     group_types.clone(),
                     aggrs.clone(),
                     states_layout.clone(),
@@ -206,6 +215,14 @@ impl PartitionedPayload {
             ..
         } = self;
 
+        // Repartition shallow-copies aggregate state addresses. Partition-local arenas would
+        // allow a source arena to be freed while a target partition still points into it.
+        assert_eq!(
+            arenas.len(),
+            1,
+            "partition-local aggregate arenas cannot be repartitioned"
+        );
+
         let mut new_partition_payload = PartitionedPayload::new_with_start_bit(
             group_types,
             aggrs,
@@ -298,6 +315,12 @@ impl PartitionedPayload {
     }
 
     pub fn scatter_into_buckets(self, buckets: usize) -> Vec<PartitionedPayload> {
+        // Scatter also shallow-copies aggregate state addresses, just like repartition.
+        assert_eq!(
+            self.arenas.len(),
+            1,
+            "partition-local aggregate arenas cannot be scattered"
+        );
         let group_types = self.group_types.clone();
         let aggrs = self.aggrs.clone();
         let partition_count = self.partition_count() as u64;

--- a/src/query/expression/src/aggregate/payload.rs
+++ b/src/query/expression/src/aggregate/payload.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use bumpalo::Bump;
 use databend_common_base::runtime::drop_guard;
+use databend_common_exception::Result;
 use log::info;
 use strength_reduce::StrengthReducedU64;
 
@@ -254,6 +255,35 @@ impl Payload {
     #[inline]
     pub fn memory_size(&self) -> usize {
         self.total_rows * self.tuple_size
+    }
+
+    pub fn merge_result(&self, flush_state: &mut PayloadFlushState) -> Result<Option<DataBlock>> {
+        if !self.flush(flush_state) {
+            return Ok(None);
+        }
+
+        let row_count = flush_state.row_count;
+        flush_state.aggregate_results.clear();
+        if let Some(states_layout) = self.row_layout.states_layout.as_ref() {
+            for (aggr, loc) in self
+                .aggrs
+                .iter()
+                .zip(states_layout.states_loc.iter().cloned())
+            {
+                let return_type = aggr.return_type()?;
+                let mut builder = ColumnBuilder::with_capacity(&return_type, row_count * 4);
+                aggr.batch_merge_result(
+                    &flush_state.state_places.as_slice()[0..row_count],
+                    loc,
+                    &mut builder,
+                )?;
+                flush_state.aggregate_results.push(builder.build().into());
+            }
+        }
+
+        let mut entries = flush_state.take_aggregate_results();
+        entries.extend(flush_state.take_group_columns());
+        Ok(Some(DataBlock::new(entries, row_count)))
     }
 
     pub(super) fn commit_transferred_state_offsets(

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/statistics.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/statistics.rs
@@ -60,6 +60,10 @@ impl AggregationStatistics {
         );
     }
 
+    pub fn log_finish_statistics_values(&mut self, output_rows: usize, hash_index_resizes: usize) {
+        self.log_finish(output_rows, hash_index_resizes, None);
+    }
+
     pub fn log_task_finish_statistics(
         &mut self,
         task_id: u64,

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_final.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_final.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::collections::VecDeque;
 use std::mem;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
@@ -25,6 +26,7 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::AggregateHashTable;
 use databend_common_expression::BlockMetaInfoDowncast;
+use databend_common_expression::BlockPartitionStream;
 use databend_common_expression::DataBlock;
 use databend_common_expression::HashTableConfig;
 use databend_common_expression::PayloadFlushState;
@@ -69,6 +71,7 @@ pub struct TransformFinalAggregate {
     output: Arc<OutputPort>,
     input_data: Option<AggregateMeta>,
     channel_data: Option<FinalAggregateTask>,
+    output_data: VecDeque<DataBlock>,
     should_finish: bool,
     tx: Option<Sender<FinalAggregateTask>>,
     rx: Receiver<FinalAggregateTask>,
@@ -123,6 +126,7 @@ impl TransformFinalAggregate {
             output,
             input_data: None,
             channel_data: None,
+            output_data: VecDeque::new(),
             should_finish: false,
             tx: Some(tx),
             rx,
@@ -158,7 +162,7 @@ impl TransformFinalAggregate {
         base_consumed_bits: u64,
         spilled_depth: usize,
     ) -> AggregateHashTable {
-        AggregateHashTable::new(
+        AggregateHashTable::new_with_partitioned_arenas(
             params.group_data_types.clone(),
             params.aggregate_functions.clone(),
             HashTableConfig::default()
@@ -167,7 +171,6 @@ impl TransformFinalAggregate {
                     base_consumed_bits,
                     spilled_depth,
                 )),
-            Arc::new(Bump::new()),
         )
     }
 
@@ -188,7 +191,9 @@ impl TransformFinalAggregate {
     // `base_consumed_bits + spilled_depth * SPILL_BUCKET_BITS`.
     fn ensure_spill_depth(&mut self, spilled_depth: usize) {
         let partition_depth = spilled_depth.min(self.max_partition_depth);
-        if self.current_partition_depth != partition_depth {
+        if !matches!(&self.hashtable, HashTable::AggregateHashTable(_))
+            || self.current_partition_depth != partition_depth
+        {
             self.reset_hashtable(spilled_depth);
         }
     }
@@ -340,45 +345,54 @@ impl TransformFinalAggregate {
             }
 
             self.spilled_occurred = false;
+            let _ = mem::take(&mut self.hashtable);
             return Ok(());
         }
 
-        if let HashTable::AggregateHashTable(mut ht) = mem::take(&mut self.hashtable) {
-            let mut blocks = vec![];
+        if let HashTable::AggregateHashTable(hashtable) = mem::take(&mut self.hashtable) {
+            let output_rows = hashtable.payload.len();
+            let hash_index_resizes = hashtable.hash_index_resize_count();
+            let mut output_stream = BlockPartitionStream::create(
+                self.params.max_block_rows,
+                self.params.max_block_bytes,
+                1,
+            );
             self.flush_state.clear();
 
-            loop {
-                check_interrupt()?;
-                if ht.merge_result(&mut self.flush_state)? {
-                    let mut entries = self.flush_state.take_aggregate_results();
-                    let group_columns = self.flush_state.take_group_columns();
-                    entries.extend_from_slice(&group_columns);
-                    let num_rows = entries[0].len();
-                    blocks.push(DataBlock::new(entries, num_rows));
-                } else {
-                    break;
+            // Consuming the hash table drops its index before result materialization. Each
+            // payload owns its arena, so finishing one partition also releases its states.
+            for payload in hashtable.into_payloads() {
+                loop {
+                    check_interrupt()?;
+                    let Some(block) = payload.merge_result(&mut self.flush_state)? else {
+                        self.flush_state.clear();
+                        break;
+                    };
+
+                    let num_rows = block.num_rows();
+                    let ready = output_stream.partition(vec![0; num_rows], block, true);
+                    self.output_data
+                        .extend(ready.into_iter().map(|(_, block)| block));
                 }
             }
 
-            if !blocks.is_empty() {
-                let concat = DataBlock::concat(&blocks)?;
-                if !concat.is_empty() {
-                    self.output.push_data(Ok(concat));
-                }
+            if let Some(block) = output_stream.finalize_partition(0) {
+                self.output_data.push_back(block);
             }
+
             if let Some(task_id) = task_id {
                 self.statistics.log_task_finish_statistics(
                     task_id,
                     self._id,
                     spilled_depth,
-                    ht.payload.len(),
-                    ht.hash_index_resize_count(),
+                    output_rows,
+                    hash_index_resizes,
                     false,
                 );
             } else {
-                self.statistics.log_finish_statistics(&ht);
+                self.statistics
+                    .log_finish_statistics_values(output_rows, hash_index_resizes);
             }
-            self.reset_hashtable(self.current_partition_depth);
         }
 
         Ok(())
@@ -440,12 +454,18 @@ impl Processor for TransformFinalAggregate {
     fn event(&mut self) -> Result<Event> {
         if self.output.is_finished() {
             let _ = self.tx.take();
+            self.output_data.clear();
             self.input.finish();
             return Ok(Event::Finished);
         }
 
         if !self.output.can_push() {
             self.input.set_not_need_data();
+            return Ok(Event::NeedConsume);
+        }
+
+        if let Some(data_block) = self.output_data.pop_front() {
+            self.output.push_data(Ok(data_block));
             return Ok(Event::NeedConsume);
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Final aggregate result generation collected every flush page and then called `DataBlock::concat`. For high-cardinality aggregation this retained the complete hash table and all result pages while allocating another contiguous copy, causing an OOM in `concat_primitive_types` during `FinalAggregate::finish`.

This PR:

- consumes the final hash table before result generation so the unused hash index is released immediately;
- gives each final payload partition its own arena and releases each payload, its aggregate states, pages, and arena after that partition is emitted;

## Tests

- [ ] Unit Test
- [x] Logic Test (Covered)
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent investigated the OOM path, drafted the final aggregate memory-lifetime changes and regression tests, and prepared this summary; the responsible human directed the partition-arena design and reviewed the final diff
- Responsible human: @dqhl76
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20316)
<!-- Reviewable:end -->
