### PR TITLE
feat(query): add partial evaluation policy

### DIFF
--- a/src/query/expression/src/function.rs
+++ b/src/query/expression/src/function.rs
@@ -179,9 +179,9 @@ pub struct EvalContext<'a> {
     pub num_rows: usize,
 
     pub func_ctx: &'a FunctionContext,
-    /// Validity bitmap of outer nullable column. This is an optimization
-    /// to avoid recording errors on the NULL value which has a corresponding
-    /// default value in nullable's inner column.
+    /// Active rows propagated by nullable and conditional partial evaluation.
+    /// Functions evaluate all rows by default, but expensive functions may opt in to skipping
+    /// inactive rows with `PartialEvalPolicy::SkipInactiveRows`.
     pub validity: Option<Bitmap>,
     pub errors: Option<(MutableBitmap, String)>,
     pub suppress_error: bool,

--- a/src/query/expression/src/function/function_builder.rs
+++ b/src/query/expression/src/function/function_builder.rs
@@ -26,12 +26,15 @@ use super::FunctionSignature;
 use super::ScalarFunction;
 use super::ScalarFunctionDomain;
 use super::function_factory::PassthroughNullableDomain;
+use super::register_vectorize::PartialEvalPolicy;
 use super::register_vectorize::VectorizedFn1;
 use super::register_vectorize::VectorizedFn2;
 use super::register_vectorize::passthrough_nullable_1_arg;
 use super::register_vectorize::passthrough_nullable_2_arg;
 use super::register_vectorize::vectorize_1_arg;
+use super::register_vectorize::vectorize_1_arg_with_policy;
 use super::register_vectorize::vectorize_2_arg;
+use super::register_vectorize::vectorize_2_arg_with_policy;
 use super::register_vectorize::vectorize_with_builder_1_arg;
 use crate::EvalContext;
 use crate::FunctionContext;
@@ -456,7 +459,6 @@ pub struct TypedUnaryFunctionBuilder<I: AccessType, O: AccessType, B: ScalarFunc
     calc_domain: Option<fn(&FunctionContext, &I::Domain) -> FunctionDomain<O>>,
     derive_stat: Option<DeriveStat>,
     passthrough_nullable: bool,
-    is_heavy: bool,
     _marker: PhantomData<fn(I) -> O>,
 }
 
@@ -475,7 +477,6 @@ impl<I: AccessType, O: ReturnType, B: ScalarFunctionCollect> TypedUnaryFunctionB
             calc_domain: None,
             derive_stat: None,
             passthrough_nullable: false,
-            is_heavy: false,
             _marker: PhantomData,
         }
     }
@@ -523,6 +524,12 @@ impl<I: AccessType, O: ReturnType, B: ScalarFunctionCollect> TypedUnaryFunctionB
         self.finish_with(vectorize_1_arg(func))
     }
 
+    pub fn each_row_with_policy<F>(self, policy: PartialEvalPolicy, func: F) -> B
+    where F: Fn(I::ScalarRef<'_>, &mut EvalContext) -> O::Scalar + Send + Sync + Copy + 'static
+    {
+        self.finish_with(vectorize_1_arg_with_policy(policy, func))
+    }
+
     pub fn each_row_throw<F, E>(self, func: F) -> B
     where
         E: fmt::Display + 'static,
@@ -543,12 +550,8 @@ impl<I: AccessType, O: ReturnType, B: ScalarFunctionCollect> TypedUnaryFunctionB
         ))
     }
 
-    pub fn each_row_heavy(
-        mut self,
-        func: fn(I::ScalarRef<'_>, &mut EvalContext) -> O::Scalar,
-    ) -> B {
-        self.is_heavy = true;
-        self.finish_with(vectorize_1_arg(func))
+    pub fn each_row_heavy(self, func: fn(I::ScalarRef<'_>, &mut EvalContext) -> O::Scalar) -> B {
+        self.each_row_with_policy(PartialEvalPolicy::SkipInactiveRows, func)
     }
 
     fn finish_with<F>(self, func: F) -> B
@@ -713,7 +716,6 @@ pub struct TypedBinaryFunctionBuilder<
     calc_domain: Option<fn(&FunctionContext, &I1::Domain, &I2::Domain) -> FunctionDomain<O>>,
     derive_stat: Option<DeriveStat>,
     passthrough_nullable: bool,
-    is_heavy: bool,
     _marker: PhantomData<fn(I1, I2) -> O>,
 }
 
@@ -732,7 +734,6 @@ where
             calc_domain: None,
             derive_stat: None,
             passthrough_nullable: false,
-            is_heavy: false,
             _marker: PhantomData,
         }
     }
@@ -781,12 +782,20 @@ where
         self.finish_with(vectorize_2_arg(func))
     }
 
+    pub fn each_row_with_policy<F>(self, policy: PartialEvalPolicy, func: F) -> B
+    where F: Fn(I1::ScalarRef<'_>, I2::ScalarRef<'_>, &mut EvalContext) -> O::Scalar
+            + Send
+            + Sync
+            + Copy
+            + 'static {
+        self.finish_with(vectorize_2_arg_with_policy(policy, func))
+    }
+
     pub fn each_row_heavy(
-        mut self,
+        self,
         func: fn(I1::ScalarRef<'_>, I2::ScalarRef<'_>, &mut EvalContext) -> O::Scalar,
     ) -> B {
-        self.is_heavy = true;
-        self.finish_with(vectorize_2_arg(func))
+        self.each_row_with_policy(PartialEvalPolicy::SkipInactiveRows, func)
     }
 
     fn finish_with<F>(self, func: F) -> B

--- a/src/query/expression/src/function/register.rs
+++ b/src/query/expression/src/function/register.rs
@@ -43,12 +43,29 @@ impl FunctionRegistry {
             + Send
             + Sync,
     {
+        self.register_1_arg_with_policy(name, calc_domain, PartialEvalPolicy::EvaluateAll, func);
+    }
+
+    pub fn register_1_arg_with_policy<I1: ArgType, O: ArgType, G>(
+        &mut self,
+        name: &str,
+        calc_domain: fn(&FunctionContext, &I1::Domain) -> FunctionDomain<O>,
+        policy: PartialEvalPolicy,
+        func: G,
+    ) where
+        G: Fn(I1::ScalarRef<'_>, &mut EvalContext) -> O::Scalar
+            + 'static
+            + Clone
+            + Copy
+            + Send
+            + Sync,
+    {
         self.scalar_builder(name)
             .function()
             .typed_1_arg::<I1, O>()
             .passthrough_nullable()
             .calc_domain(calc_domain)
-            .each_row(func)
+            .each_row_with_policy(policy, func)
             .register();
     }
 
@@ -65,12 +82,29 @@ impl FunctionRegistry {
             + Send
             + Sync,
     {
+        self.register_2_arg_with_policy(name, calc_domain, PartialEvalPolicy::EvaluateAll, func);
+    }
+
+    pub fn register_2_arg_with_policy<I1: ArgType, I2: ArgType, O: ArgType, G>(
+        &mut self,
+        name: &str,
+        calc_domain: fn(&FunctionContext, &I1::Domain, &I2::Domain) -> FunctionDomain<O>,
+        policy: PartialEvalPolicy,
+        func: G,
+    ) where
+        G: Fn(I1::ScalarRef<'_>, I2::ScalarRef<'_>, &mut EvalContext) -> O::Scalar
+            + 'static
+            + Clone
+            + Copy
+            + Send
+            + Sync,
+    {
         self.scalar_builder(name)
             .function()
             .typed_2_arg::<I1, I2, O>()
             .passthrough_nullable()
             .calc_domain(calc_domain)
-            .each_row(func)
+            .each_row_with_policy(policy, func)
             .register();
     }
 

--- a/src/query/expression/src/function/register_vectorize.rs
+++ b/src/query/expression/src/function/register_vectorize.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use databend_common_column::bitmap::Bitmap;
+
 use crate::EvalContext;
 use crate::types::nullable::NullableColumn;
 use crate::types::*;
@@ -33,19 +35,74 @@ pub trait VectorizedFn4<I1, I2, I3, I4, O: AccessType> = Fn(Value<I1>, Value<I2>
     + Send
     + Sync;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum PartialEvalPolicy {
+    /// Evaluate every row regardless of `EvalContext::validity`.
+    #[default]
+    EvaluateAll,
+    /// Skip rows excluded by `EvalContext::validity` and write the output type's default payload.
+    /// This is only valid when inactive payloads and skipped function calls are unobservable.
+    SkipInactiveRows,
+}
+
+impl PartialEvalPolicy {
+    /// Return a sparse active-row bitmap when row-level evaluation can be skipped.
+    pub fn active_rows(self, ctx: &EvalContext) -> Option<Bitmap> {
+        match self {
+            PartialEvalPolicy::EvaluateAll => None,
+            PartialEvalPolicy::SkipInactiveRows if ctx.num_rows == 0 => Some(Bitmap::new()),
+            PartialEvalPolicy::SkipInactiveRows => ctx
+                .validity
+                .as_ref()
+                .filter(|validity| validity.null_count() > 0)
+                .cloned(),
+        }
+    }
+}
+
 pub fn vectorize_1_arg<I1: AccessType, O: ReturnType>(
+    func: impl Fn(I1::ScalarRef<'_>, &mut EvalContext) -> O::Scalar + Copy + Send + Sync,
+) -> impl VectorizedFn1<I1, O> {
+    vectorize_1_arg_with_policy(PartialEvalPolicy::EvaluateAll, func)
+}
+
+pub fn vectorize_1_arg_with_policy<I1: AccessType, O: ReturnType>(
+    policy: PartialEvalPolicy,
     func: impl Fn(I1::ScalarRef<'_>, &mut EvalContext) -> O::Scalar + Copy + Send + Sync,
 ) -> impl VectorizedFn1<I1, O> {
     move |arg1, ctx| match arg1 {
         Value::Scalar(arg1) => {
-            let result = func(I1::to_scalar_ref(&arg1), ctx);
-            Value::Scalar(result)
+            let active_rows = policy.active_rows(ctx);
+            if active_rows
+                .as_ref()
+                .is_some_and(|validity| validity.null_count() == validity.len())
+            {
+                let mut builder = O::create_builder(1, ctx.generics);
+                O::push_default(&mut builder);
+                Value::Scalar(O::build_scalar(builder))
+            } else {
+                let result = func(I1::to_scalar_ref(&arg1), ctx);
+                Value::Scalar(result)
+            }
         }
         Value::Column(arg1) => {
-            let generics = ctx.generics.to_vec();
-            let iter = I1::iter_column(&arg1).map(|arg1| func(arg1, ctx));
-            let col = O::column_from_iter(iter, &generics);
-            Value::Column(col)
+            let Some(active_rows) = policy.active_rows(ctx) else {
+                let generics = ctx.generics.to_vec();
+                let iter = I1::iter_column(&arg1).map(|arg1| func(arg1, ctx));
+                let col = O::column_from_iter(iter, &generics);
+                return Value::Column(col);
+            };
+
+            let mut builder = O::create_builder(ctx.num_rows, ctx.generics);
+            for (index, arg1) in I1::iter_column(&arg1).enumerate() {
+                if active_rows.get_bit(index) {
+                    let result = func(arg1, ctx);
+                    O::push_item(&mut builder, O::to_scalar_ref(&result));
+                } else {
+                    O::push_default(&mut builder);
+                }
+            }
+            Value::Column(O::build_column(builder))
         }
     }
 }
@@ -56,36 +113,103 @@ pub fn vectorize_2_arg<I1: AccessType, I2: AccessType, O: ReturnType>(
     + Send
     + Sync,
 ) -> impl VectorizedFn2<I1, I2, O> {
+    vectorize_2_arg_with_policy(PartialEvalPolicy::EvaluateAll, func)
+}
+
+pub fn vectorize_2_arg_with_policy<I1: AccessType, I2: AccessType, O: ReturnType>(
+    policy: PartialEvalPolicy,
+    func: impl Fn(I1::ScalarRef<'_>, I2::ScalarRef<'_>, &mut EvalContext) -> O::Scalar
+    + Copy
+    + Send
+    + Sync,
+) -> impl VectorizedFn2<I1, I2, O> {
     move |arg1, arg2, ctx| match (arg1, arg2) {
         (Value::Scalar(arg1), Value::Scalar(arg2)) => {
-            let result = func(I1::to_scalar_ref(&arg1), I2::to_scalar_ref(&arg2), ctx);
-            Value::Scalar(result)
+            let active_rows = policy.active_rows(ctx);
+            if active_rows
+                .as_ref()
+                .is_some_and(|validity| validity.null_count() == validity.len())
+            {
+                let mut builder = O::create_builder(1, ctx.generics);
+                O::push_default(&mut builder);
+                Value::Scalar(O::build_scalar(builder))
+            } else {
+                let result = func(I1::to_scalar_ref(&arg1), I2::to_scalar_ref(&arg2), ctx);
+                Value::Scalar(result)
+            }
         }
         (Value::Scalar(arg1), Value::Column(arg2)) => {
+            let active_rows = policy.active_rows(ctx);
             let generics = ctx.generics.to_vec();
-            let iter = I2::iter_column(&arg2).map(|arg2| {
-                let arg1 = I1::to_scalar_ref(&arg1);
-                func(arg1, arg2, ctx)
-            });
-            let col = O::column_from_iter(iter, &generics);
-            Value::Column(col)
+            if let Some(active_rows) = active_rows {
+                let mut builder = O::create_builder(ctx.num_rows, &generics);
+                for (index, arg2) in I2::iter_column(&arg2).enumerate() {
+                    if active_rows.get_bit(index) {
+                        let arg1 = I1::to_scalar_ref(&arg1);
+                        let result = func(arg1, arg2, ctx);
+                        O::push_item(&mut builder, O::to_scalar_ref(&result));
+                    } else {
+                        O::push_default(&mut builder);
+                    }
+                }
+                Value::Column(O::build_column(builder))
+            } else {
+                let iter = I2::iter_column(&arg2).map(|arg2| {
+                    let arg1 = I1::to_scalar_ref(&arg1);
+                    func(arg1, arg2, ctx)
+                });
+                let col = O::column_from_iter(iter, &generics);
+                Value::Column(col)
+            }
         }
         (Value::Column(arg1), Value::Scalar(arg2)) => {
+            let active_rows = policy.active_rows(ctx);
             let generics = ctx.generics.to_vec();
-            let iter = I1::iter_column(&arg1).map(|arg1| {
-                let arg2 = I2::to_scalar_ref(&arg2);
-                func(arg1, arg2, ctx)
-            });
-            let col = O::column_from_iter(iter, &generics);
-            Value::Column(col)
+            if let Some(active_rows) = active_rows {
+                let mut builder = O::create_builder(ctx.num_rows, &generics);
+                for (index, arg1) in I1::iter_column(&arg1).enumerate() {
+                    if active_rows.get_bit(index) {
+                        let arg2 = I2::to_scalar_ref(&arg2);
+                        let result = func(arg1, arg2, ctx);
+                        O::push_item(&mut builder, O::to_scalar_ref(&result));
+                    } else {
+                        O::push_default(&mut builder);
+                    }
+                }
+                Value::Column(O::build_column(builder))
+            } else {
+                let iter = I1::iter_column(&arg1).map(|arg1| {
+                    let arg2 = I2::to_scalar_ref(&arg2);
+                    func(arg1, arg2, ctx)
+                });
+                let col = O::column_from_iter(iter, &generics);
+                Value::Column(col)
+            }
         }
         (Value::Column(arg1), Value::Column(arg2)) => {
+            let active_rows = policy.active_rows(ctx);
             let generics = ctx.generics.to_vec();
-            let iter = I1::iter_column(&arg1)
-                .zip(I2::iter_column(&arg2))
-                .map(|(arg1, arg2)| func(arg1, arg2, ctx));
-            let col = O::column_from_iter(iter, &generics);
-            Value::Column(col)
+            if let Some(active_rows) = active_rows {
+                let mut builder = O::create_builder(ctx.num_rows, &generics);
+                for (index, (arg1, arg2)) in I1::iter_column(&arg1)
+                    .zip(I2::iter_column(&arg2))
+                    .enumerate()
+                {
+                    if active_rows.get_bit(index) {
+                        let result = func(arg1, arg2, ctx);
+                        O::push_item(&mut builder, O::to_scalar_ref(&result));
+                    } else {
+                        O::push_default(&mut builder);
+                    }
+                }
+                Value::Column(O::build_column(builder))
+            } else {
+                let iter = I1::iter_column(&arg1)
+                    .zip(I2::iter_column(&arg2))
+                    .map(|(arg1, arg2)| func(arg1, arg2, ctx));
+                let col = O::column_from_iter(iter, &generics);
+                Value::Column(col)
+            }
         }
     }
 }
@@ -464,5 +588,118 @@ pub fn combine_nullable_2_arg<I1: AccessType, I2: AccessType, O: ReturnType>(
             }
             _ => Value::Scalar(None),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
+    use super::*;
+    use crate::FunctionContext;
+
+    fn eval_context<'a>(func_ctx: &'a FunctionContext, validity: Bitmap) -> EvalContext<'a> {
+        EvalContext {
+            generics: &[],
+            num_rows: validity.len(),
+            func_ctx,
+            validity: Some(validity),
+            errors: None,
+            suppress_error: false,
+            strict_eval: false,
+        }
+    }
+
+    fn assert_boolean_column(value: Value<BooleanType>, expected: &[bool]) {
+        let Value::Column(column) = value else {
+            unreachable!()
+        };
+        assert_eq!(column.iter().collect::<Vec<_>>(), expected);
+    }
+
+    #[test]
+    fn test_partial_eval_policy_controls_row_evaluation() {
+        let calls = AtomicUsize::new(0);
+        let func = |value: bool, _ctx: &mut EvalContext| {
+            calls.fetch_add(1, Ordering::Relaxed);
+            !value
+        };
+        let func_ctx = FunctionContext::default();
+        let input = Value::<BooleanType>::Column(Bitmap::new_constant(false, 4));
+
+        let mut evaluate_all_ctx =
+            eval_context(&func_ctx, Bitmap::from_iter([true, false, true, false]));
+        let evaluate_all = vectorize_1_arg_with_policy::<BooleanType, BooleanType>(
+            PartialEvalPolicy::EvaluateAll,
+            func,
+        )(input.clone(), &mut evaluate_all_ctx);
+        assert_boolean_column(evaluate_all, &[true, true, true, true]);
+        assert_eq!(calls.load(Ordering::Relaxed), 4);
+
+        calls.store(0, Ordering::Relaxed);
+        let mut skip_inactive_ctx =
+            eval_context(&func_ctx, Bitmap::from_iter([true, false, true, false]));
+        let skip_inactive = vectorize_1_arg_with_policy::<BooleanType, BooleanType>(
+            PartialEvalPolicy::SkipInactiveRows,
+            func,
+        )(input, &mut skip_inactive_ctx);
+        assert_boolean_column(skip_inactive, &[true, false, true, false]);
+        assert_eq!(calls.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn test_skip_inactive_rows_for_binary_function() {
+        let func_ctx = FunctionContext::default();
+        let validity = Bitmap::from_iter([true, false, true, false]);
+        let column = || Value::<BooleanType>::Column(Bitmap::new_constant(false, 4));
+        let scalar = || Value::<BooleanType>::Scalar(false);
+
+        let calls = AtomicUsize::new(0);
+        let mut ctx = eval_context(&func_ctx, validity.clone());
+        let result = vectorize_2_arg_with_policy::<BooleanType, BooleanType, BooleanType>(
+            PartialEvalPolicy::SkipInactiveRows,
+            |_, _, _| {
+                calls.fetch_add(1, Ordering::Relaxed);
+                true
+            },
+        )(column(), scalar(), &mut ctx);
+        assert_boolean_column(result, &[true, false, true, false]);
+        assert_eq!(calls.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn test_partial_eval_policy_handles_scalar_inputs() {
+        let calls = AtomicUsize::new(0);
+        let func = |value: bool, _ctx: &mut EvalContext| {
+            calls.fetch_add(1, Ordering::Relaxed);
+            !value
+        };
+        let func_ctx = FunctionContext::default();
+        let vectorized = vectorize_1_arg_with_policy::<BooleanType, BooleanType>(
+            PartialEvalPolicy::SkipInactiveRows,
+            func,
+        );
+
+        let mut partially_active_ctx =
+            eval_context(&func_ctx, Bitmap::from_iter([false, true, false]));
+        let partially_active = vectorized(
+            Value::<BooleanType>::Scalar(false),
+            &mut partially_active_ctx,
+        );
+        assert_eq!(partially_active, Value::Scalar(true));
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+
+        calls.store(0, Ordering::Relaxed);
+        let mut inactive_ctx = eval_context(&func_ctx, Bitmap::new_constant(false, 3));
+        let inactive = vectorized(Value::<BooleanType>::Scalar(false), &mut inactive_ctx);
+        assert_eq!(inactive, Value::Scalar(false));
+        assert_eq!(calls.load(Ordering::Relaxed), 0);
+
+        let mut empty_ctx = eval_context(&func_ctx, Bitmap::new());
+        empty_ctx.validity = None;
+        let empty = vectorized(Value::<BooleanType>::Scalar(false), &mut empty_ctx);
+        assert_eq!(empty, Value::Scalar(false));
+        assert_eq!(calls.load(Ordering::Relaxed), 0);
     }
 }

--- a/src/query/functions/src/scalars/comparison.rs
+++ b/src/query/functions/src/scalars/comparison.rs
@@ -29,6 +29,7 @@ use databend_common_expression::FunctionFactory;
 use databend_common_expression::FunctionRegistry;
 use databend_common_expression::FunctionSignature;
 use databend_common_expression::LikePattern;
+use databend_common_expression::PartialEvalPolicy;
 use databend_common_expression::Scalar;
 use databend_common_expression::ScalarRef;
 use databend_common_expression::SimpleDomainCmp;
@@ -1908,12 +1909,9 @@ fn register_like(registry: &mut FunctionRegistry) {
             FunctionDomain::Full
         },
         |arg1, arg2, ctx| {
-            vectorize_like(|str, pattern_type| pattern_type.compare(str))(
-                arg1,
-                arg2,
-                Value::Scalar("".to_string()),
-                ctx,
-            )
+            vectorize_like(PartialEvalPolicy::SkipInactiveRows, |str, pattern_type| {
+                pattern_type.compare(str)
+            })(arg1, arg2, Value::Scalar("".to_string()), ctx)
         },
     );
 
@@ -1934,7 +1932,10 @@ fn register_like(registry: &mut FunctionRegistry) {
             FunctionDomain::Full
         },
         |arg1, arg2, arg3, ctx| {
-            vectorize_like(|str, pattern_type| pattern_type.compare(str))(
+            vectorize_like(
+                PartialEvalPolicy::SkipInactiveRows,
+                |str, pattern_type| pattern_type.compare(str),
+            )(
                 arg1,
                 arg2,
                 arg3,
@@ -2073,6 +2074,7 @@ fn variant_like_requires_traversal(pattern: &[u8], pattern_type: &LikePattern) -
 }
 
 fn vectorize_like(
+    policy: PartialEvalPolicy,
     func: impl Fn(&[u8], &LikePattern) -> bool + Copy,
 ) -> impl Fn(
     Value<StringType>,
@@ -2085,8 +2087,15 @@ fn vectorize_like(
         let Value::Scalar(escape) = arg3 else {
             unreachable!()
         };
+        let active_rows = policy.active_rows(ctx);
         match (arg1, arg2) {
             (Value::Scalar(arg1), Value::Scalar(arg2)) => {
+                if active_rows
+                    .as_ref()
+                    .is_some_and(|validity| validity.null_count() == validity.len())
+                {
+                    return Value::Scalar(false);
+                }
                 let pattern = convert_escape_pattern(&escape, arg2);
                 let pattern_type = generate_like_pattern(pattern.as_bytes(), 1);
                 Value::Scalar(func(arg1.as_bytes(), &pattern_type))
@@ -2097,11 +2106,7 @@ fn vectorize_like(
                 let pattern = convert_escape_pattern(&escape, arg2);
                 let pattern_type =
                     generate_like_pattern(pattern.as_bytes(), arg1.total_bytes_len());
-                let sparse_validity = ctx
-                    .validity
-                    .as_ref()
-                    .filter(|validity| validity.null_count() > 0);
-                if let Some(validity) = sparse_validity {
+                if let Some(validity) = active_rows.as_ref() {
                     if let LikePattern::SurroundByPercent(searcher) = pattern_type {
                         for (index, arg1) in arg1_iter.enumerate() {
                             builder.push(
@@ -2131,12 +2136,9 @@ fn vectorize_like(
             (Value::Scalar(arg1), Value::Column(arg2)) => {
                 let arg2_iter = StringType::iter_column(&arg2);
                 let mut builder = MutableBitmap::with_capacity(arg2.len());
-                let sparse_validity = ctx
-                    .validity
-                    .as_ref()
-                    .filter(|validity| validity.null_count() > 0);
                 for (index, arg2) in arg2_iter.enumerate() {
-                    if sparse_validity
+                    if active_rows
+                        .as_ref()
                         .map(|validity| !validity.get_bit(index))
                         .unwrap_or(false)
                     {
@@ -2153,12 +2155,9 @@ fn vectorize_like(
                 let arg1_iter = StringType::iter_column(&arg1);
                 let arg2_iter = StringType::iter_column(&arg2);
                 let mut builder = MutableBitmap::with_capacity(arg2.len());
-                let sparse_validity = ctx
-                    .validity
-                    .as_ref()
-                    .filter(|validity| validity.null_count() > 0);
                 for (index, (arg1, arg2)) in arg1_iter.zip(arg2_iter).enumerate() {
-                    if sparse_validity
+                    if active_rows
+                        .as_ref()
                         .map(|validity| !validity.get_bit(index))
                         .unwrap_or(false)
                     {
@@ -2265,7 +2264,9 @@ fn like_any_fn(args: &[Value<AnyType>], ctx: &mut EvalContext) -> Value<AnyType>
         .unwrap_or(Value::Scalar("".to_string()));
 
     let result = if let Ok(value) = arg.try_downcast::<StringType>() {
-        let like = vectorize_like(|str, pattern_type| pattern_type.compare(str));
+        let like = vectorize_like(PartialEvalPolicy::SkipInactiveRows, |str, pattern_type| {
+            pattern_type.compare(str)
+        });
         patterns
             .iter()
             .map(|pattern| {
@@ -2592,7 +2593,7 @@ mod tests {
     #[test]
     fn test_vectorized_like_skips_rows_excluded_by_validity() {
         let calls = AtomicUsize::new(0);
-        let like = vectorize_like(|value, pattern| {
+        let like = vectorize_like(PartialEvalPolicy::SkipInactiveRows, |value, pattern| {
             calls.fetch_add(1, AtomicOrdering::Relaxed);
             pattern.compare(value)
         });
@@ -2651,7 +2652,7 @@ mod tests {
     #[test]
     fn test_vectorized_like_keeps_dense_and_surround_paths() {
         let calls = AtomicUsize::new(0);
-        let like = vectorize_like(|value, pattern| {
+        let like = vectorize_like(PartialEvalPolicy::SkipInactiveRows, |value, pattern| {
             calls.fetch_add(1, AtomicOrdering::Relaxed);
             pattern.compare(value)
         });
@@ -2698,7 +2699,7 @@ mod tests {
         ) {
             let values = rows.iter().map(|(value, _)| value.as_str()).collect::<Vec<_>>();
             let validity = rows.iter().map(|(_, valid)| *valid).collect::<Vec<_>>();
-            let like = vectorize_like(|value, pattern| pattern.compare(value));
+            let like = vectorize_like(PartialEvalPolicy::SkipInactiveRows, |value, pattern| pattern.compare(value));
             let func_ctx = FunctionContext::default();
             let mut dense_ctx = EvalContext {
                 generics: &[],


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Introduce an explicit `PartialEvalPolicy` for scalar vectorization so expensive functions can opt in to skipping rows excluded by partial evaluation without changing the default behavior of existing functions.

This builds on the inactive-row LIKE optimization merged in #20211.

## Implementation

- Add `PartialEvalPolicy::EvaluateAll` as the default behavior.
- Add `PartialEvalPolicy::SkipInactiveRows` for functions whose inactive payloads and skipped calls are unobservable.
- Add policy-aware unary and binary vectorizers and registration helpers.
- Make the existing `each_row_heavy` builder methods use `SkipInactiveRows` instead of setting an unused flag.
- Migrate string `LIKE` and `LIKE_ANY` from their local validity checks to the shared policy.
- Evaluate scalar inputs once when at least one row is active, and skip them only when no rows are active.
- Preserve the existing dense path when validity is absent or all true.

## Risks

- `SkipInactiveRows` is opt-in because it is only valid for pure functions whose inactive output payload and skipped errors or side effects are unobservable.
- Existing registrations continue to use `EvaluateAll`; this PR only migrates the LIKE implementation already covered by #20211.
- No SQL-visible behavior is intended to change.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validated with:

- `cargo test -p databend-common-expression --lib`
- `cargo test -p databend-common-functions --lib vectorized_like -- --nocapture`
- `cargo test -p databend-common-functions --test it test_comparison -- --nocapture`
- `cargo clippy -p databend-common-expression -p databend-common-functions --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent assisted with codebase exploration, implementation, focused tests, and local validation; I reviewed the final diff
- Responsible human: @sundy-li
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20318)
<!-- Reviewable:end -->
