### PR TITLE
fix(query): disable refresh in tenant tables API

### DIFF
--- a/src/query/service/src/servers/admin/v1/tenant_tables.rs
+++ b/src/query/service/src/servers/admin/v1/tenant_tables.rs
@@ -57,7 +57,9 @@ pub struct TenantTableInfo {
 }
 
 async fn load_tenant_tables(tenant: &Tenant) -> Result<TenantTablesResponse> {
-    let catalog = CatalogManager::instance().get_default_catalog(Default::default())?;
+    let catalog = CatalogManager::instance()
+        .get_default_catalog(Default::default())?
+        .disable_table_info_refresh()?;
 
     let databases = catalog.list_databases(tenant).await?;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Stop the tenant tables admin API from refreshing table metadata while listing tables.
- Keep metadata-only table listing available when a materialized view or attached table cannot refresh its storage metadata.
- Match the existing behavior of the HTTP catalog metadata endpoints, which already use `disable_table_info_refresh()`.

`catalog.list_tables()` constructs every table in a database. Before this change, a refresh failure for one table caused the whole database to be skipped by the admin API, so ordinary source tables disappeared from the response as well.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - The handler depends on the global `CatalogManager` and has no injectable catalog test seam. The focused change follows the established HTTP catalog endpoint pattern.

Validation performed:

- `cargo fmt --all -- --check`
- `cargo check -p databend-query --message-format short`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent traced the tenant table listing path, compared it with the HTTP catalog endpoints, drafted the one-line behavioral fix, ran validation, and prepared this PR.
- Responsible human: @sundy-li
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20319)
<!-- Reviewable:end -->
