### PR TITLE
fix(query): track common hashtable allocator memory

### DIFF
--- a/src/common/base/src/mem_allocator/mod.rs
+++ b/src/common/base/src/mem_allocator/mod.rs
@@ -25,6 +25,13 @@ pub use global::TrackingGlobalAllocator;
 pub use jemalloc::JEAllocator;
 pub use std_::StdAllocator;
 
+/// The default allocator wrapped with Databend's memory accounting.
+///
+/// Use this for allocator-aware containers that bypass Rust's global
+/// allocator. Ordinary containers such as `Vec` are already tracked by the
+/// query binary's global allocator.
+pub type TrackingAllocator = tracker::MetaTrackerAllocator<DefaultAllocator>;
+
 mod default;
 #[cfg(feature = "memory-profiling")]
 mod profiling;

--- a/src/common/hashtable/src/hashtable.rs
+++ b/src/common/hashtable/src/hashtable.rs
@@ -17,7 +17,7 @@ use std::intrinsics::unlikely;
 use std::iter::TrustedLen;
 use std::mem::MaybeUninit;
 
-use databend_common_base::mem_allocator::DefaultAllocator;
+use databend_common_base::mem_allocator::TrackingAllocator;
 
 use super::container::HeapContainer;
 use super::table0::Entry;
@@ -29,7 +29,7 @@ use super::traits::Keyable;
 use super::utils::ZeroEntry;
 use crate::FastHash;
 
-pub struct Hashtable<K, V, A = DefaultAllocator>
+pub struct Hashtable<K, V, A = TrackingAllocator>
 where
     K: Keyable,
     A: Allocator + Clone,

--- a/src/common/hashtable/src/lookup_hashtable.rs
+++ b/src/common/hashtable/src/lookup_hashtable.rs
@@ -17,7 +17,7 @@ use std::iter::TrustedLen;
 use std::mem;
 use std::mem::MaybeUninit;
 
-use databend_common_base::mem_allocator::DefaultAllocator;
+use databend_common_base::mem_allocator::TrackingAllocator;
 
 use crate::HashtableLike;
 use crate::table0::Entry;
@@ -26,7 +26,7 @@ pub struct LookupHashtable<
     K: Sized,
     const CAPACITY: usize,
     V,
-    A: Allocator + Clone = DefaultAllocator,
+    A: Allocator + Clone = TrackingAllocator,
 > {
     flags: Box<[bool; CAPACITY], A>,
     data: Box<[Entry<K, V>; CAPACITY], A>,

--- a/src/common/hashtable/src/short_string_hashtable.rs
+++ b/src/common/hashtable/src/short_string_hashtable.rs
@@ -21,7 +21,7 @@ use std::ptr::NonNull;
 use std::sync::Arc;
 
 use bumpalo::Bump;
-use databend_common_base::mem_allocator::DefaultAllocator;
+use databend_common_base::mem_allocator::TrackingAllocator;
 
 use super::container::HeapContainer;
 use super::table0::Entry;
@@ -39,7 +39,7 @@ use crate::table_empty::TableEmptyIterMut;
 use crate::table0::Table0Iter;
 use crate::table0::Table0IterMut;
 
-pub struct ShortStringHashtable<K, V, A = DefaultAllocator>
+pub struct ShortStringHashtable<K, V, A = TrackingAllocator>
 where
     K: UnsizedKeyable + ?Sized,
     A: Allocator + Clone,

--- a/src/common/hashtable/src/stack_hashtable.rs
+++ b/src/common/hashtable/src/stack_hashtable.rs
@@ -16,7 +16,7 @@ use std::alloc::Allocator;
 use std::intrinsics::unlikely;
 use std::mem::MaybeUninit;
 
-use databend_common_base::mem_allocator::DefaultAllocator;
+use databend_common_base::mem_allocator::TrackingAllocator;
 
 use super::container::StackContainer;
 use super::table0::Entry;
@@ -25,7 +25,7 @@ use super::table0::Table0Iter;
 use super::traits::Keyable;
 use super::utils::ZeroEntry;
 
-pub struct StackHashtable<K, V, const N: usize = 16, A = DefaultAllocator>
+pub struct StackHashtable<K, V, const N: usize = 16, A = TrackingAllocator>
 where
     K: Keyable,
     A: Allocator + Clone,

--- a/src/common/hashtable/src/string_hashtable.rs
+++ b/src/common/hashtable/src/string_hashtable.rs
@@ -19,7 +19,7 @@ use std::mem::MaybeUninit;
 use std::sync::Arc;
 
 use bumpalo::Bump;
-use databend_common_base::mem_allocator::DefaultAllocator;
+use databend_common_base::mem_allocator::TrackingAllocator;
 
 use super::container::HeapContainer;
 use super::table0::Entry;
@@ -38,7 +38,7 @@ use crate::table0::Table0IterMut;
 /// Simple unsized hashtable is used for storing unsized keys in arena. It can be worked with HashMethodSerializer.
 /// Different from `ShortStringHashTable`, it doesn't use adaptive sub hashtable to store key values via key size.
 /// It can be considered as a minimal hashtable implementation of ShortStringHashTable
-pub struct StringHashtable<K, V, A = DefaultAllocator>
+pub struct StringHashtable<K, V, A = TrackingAllocator>
 where
     K: UnsizedKeyable + ?Sized,
     A: Allocator + Clone,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Allocator-aware containers bypass Rust global allocator accounting when they invoke `DefaultAllocator` directly. The common hashtable defaults therefore allocated memory without updating the active query `MemStat`.



This PR:

- Adds a shared `TrackingAllocator` alias that wraps `DefaultAllocator` with `MetaTrackerAllocator`
- Uses it as the default allocator for `Hashtable`, `StackHashtable`, `ShortStringHashtable`, `StringHashtable`, and `LookupHashtable`
- Preserves the existing explicit allocator type parameter for callers that intentionally provide a custom allocator

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:

- `cargo test -p databend-common-hashtable --test it` (4 passed)
- `cargo fmt --all -- --check`
- `git diff --check upstream/main...HEAD`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent investigated the allocator bypass, drafted the scoped allocator-default fix, and assisted with validation and the PR summary
- Responsible human: @dqhl76
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20321)
<!-- Reviewable:end -->
