### PR TITLE
fix(query): accelerate runtime bloom filter checks

### DIFF
--- a/src/query/catalog/src/sbbf.rs
+++ b/src/query/catalog/src/sbbf.rs
@@ -74,7 +74,18 @@
 //! [bf-formulae]: http://tfk.mit.edu/pdf/bloom.pdf
 
 use core::simd::Simd;
-use core::simd::cmp::SimdPartialEq;
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::__m256i;
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::_mm256_mullo_epi32;
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::_mm256_set1_epi32;
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::_mm256_sllv_epi32;
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::_mm256_srli_epi32;
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::_mm256_testc_si256;
 use std::mem::size_of;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU32;
@@ -141,9 +152,13 @@ impl Block {
 
     /// Returns true when every bit that is set in the result of mask is also set in the block.
     fn check(&self, hash: u32) -> bool {
-        let mask = Self::mask_simd(hash);
-        let block_vec = U32x8::from_array(self.0);
-        (block_vec & mask).simd_ne(U32x8::splat(0)).all()
+        for (slot, salt) in self.0.iter().zip(SALT) {
+            let bit_index = hash.wrapping_mul(salt) >> 27;
+            if slot & (1 << bit_index) == 0 {
+                return false;
+            }
+        }
+        true
     }
 
     #[inline(always)]
@@ -278,9 +293,44 @@ impl Sbbf {
     /// Check a batch of hashes. The callback is triggered for each matching hash index.
     pub fn check_hash_batch<F>(&self, hashes: &[u64], mut on_match: F)
     where F: FnMut(usize) {
+        #[cfg(target_arch = "x86_64")]
+        if std::arch::is_x86_feature_detected!("avx2") {
+            // SAFETY: AVX2 support was checked before entering the target-feature function.
+            unsafe { self.check_hash_batch_avx2(hashes, &mut on_match) };
+            return;
+        }
+
         for (idx, &hash) in hashes.iter().enumerate() {
             let block_index = self.hash_to_block_index(hash);
             if self.0[block_index].check(hash as u32) {
+                on_match(idx);
+            }
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[target_feature(enable = "avx2")]
+    unsafe fn check_hash_batch_avx2<F>(&self, hashes: &[u64], on_match: &mut F)
+    where F: FnMut(usize) {
+        // SAFETY: the pointer covers all eight salt values and read_unaligned handles alignment.
+        let salts = unsafe { SALT.as_ptr().cast::<__m256i>().read_unaligned() };
+        let ones = _mm256_set1_epi32(1);
+
+        for (idx, &hash) in hashes.iter().enumerate() {
+            let block_index = self.hash_to_block_index(hash);
+            let hash = _mm256_set1_epi32(hash as u32 as i32);
+            let bit_indices = _mm256_srli_epi32::<27>(_mm256_mullo_epi32(hash, salts));
+            let mask = _mm256_sllv_epi32(ones, bit_indices);
+            // SAFETY: the pointer covers the complete block and read_unaligned handles alignment.
+            let block = unsafe {
+                self.0[block_index]
+                    .0
+                    .as_ptr()
+                    .cast::<__m256i>()
+                    .read_unaligned()
+            };
+
+            if _mm256_testc_si256(block, mask) != 0 {
                 on_match(idx);
             }
         }
@@ -410,6 +460,13 @@ impl SbbfAtomic {
 mod tests {
     use super::*;
 
+    fn mix_hash(mut value: u64) -> u64 {
+        value = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        value ^ (value >> 31)
+    }
+
     #[test]
     fn test_mask_set_quick_check() {
         for i in 0..1_000_000 {
@@ -444,6 +501,60 @@ mod tests {
         let mut matched = 0;
         sbbf.check_hash_batch(&hashes, |_| matched += 1);
         assert_eq!(matched, hashes.len());
+    }
+
+    #[test]
+    fn test_sbbf_batch_check_matches_scalar() {
+        let inserted = (0..10_000).map(mix_hash).collect::<Vec<_>>();
+        let mut sbbf = Sbbf::new_with_ndv_fpp(inserted.len() as u64, 0.01).unwrap();
+        sbbf.insert_hash_batch(&inserted);
+
+        let probes = (0..100_000)
+            .map(|index| {
+                if index % 4 == 0 {
+                    inserted[index % inserted.len()]
+                } else {
+                    mix_hash((index + 100_000) as u64)
+                }
+            })
+            .collect::<Vec<_>>();
+        let expected = probes
+            .iter()
+            .enumerate()
+            .filter_map(|(index, &hash)| sbbf.check_hash(hash).then_some(index))
+            .collect::<Vec<_>>();
+        let mut actual = Vec::new();
+        sbbf.check_hash_batch(&probes, |index| actual.push(index));
+
+        assert_eq!(actual, expected);
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn test_sbbf_avx2_check_matches_scalar() {
+        if !std::arch::is_x86_feature_detected!("avx2") {
+            return;
+        }
+
+        let mut populated = Block::ZERO;
+        for hash in (0..64).map(mix_hash) {
+            populated.insert(hash as u32);
+        }
+
+        for block in [Block::ZERO, Block([u32::MAX; 8]), populated] {
+            let sbbf = Sbbf(vec![block]);
+            let hashes = (0..100_000).map(mix_hash).collect::<Vec<_>>();
+            let expected = hashes
+                .iter()
+                .enumerate()
+                .filter_map(|(index, &hash)| sbbf.check_hash(hash).then_some(index))
+                .collect::<Vec<_>>();
+            let mut actual = Vec::new();
+            // SAFETY: AVX2 support was checked before calling the target-feature function.
+            unsafe { sbbf.check_hash_batch_avx2(&hashes, &mut |index| actual.push(index)) };
+
+            assert_eq!(actual, expected);
+        }
     }
 
     #[test]

--- a/src/query/storages/fuse/benches/bench.rs
+++ b/src/query/storages/fuse/benches/bench.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![feature(portable_simd)]
+
 fn main() {
     divan::main()
 }
@@ -120,5 +122,372 @@ mod dummy {
         let (_, buffer) = serialize_block(&write_settings, &schema, datablock).unwrap();
 
         (buffer.to_bytes(), schema)
+    }
+}
+
+// Run with the deployment baseline (AVX2 remains runtime-dispatched):
+// RUSTFLAGS='-C target-feature=+sse4.2' \
+//   cargo bench -p databend-common-storages-fuse --bench bench runtime_bloom
+#[divan::bench_group(max_time = 2)]
+mod runtime_bloom {
+    use core::simd::Simd;
+    use core::simd::cmp::SimdPartialEq;
+    use std::sync::Arc;
+
+    use bytes::Bytes;
+    use databend_common_catalog::sbbf::Sbbf;
+    use databend_common_expression::Column;
+    use databend_common_expression::DataBlock;
+    use databend_common_expression::DataSchema;
+    use databend_common_expression::TableDataType;
+    use databend_common_expression::TableField;
+    use databend_common_expression::TableSchema;
+    use databend_common_expression::hash_util::hash_by_method_for_bloom;
+    use databend_common_expression::types::MutableBitmap;
+    use databend_common_expression::types::NumberDataType;
+    use databend_common_expression::types::number::NumberColumn;
+    use databend_common_storages_fuse::FuseStorageFormat;
+    use databend_common_storages_fuse::index::BloomIndexType;
+    use databend_common_storages_fuse::io::WriteSettings;
+    use databend_common_storages_fuse::io::serialize_block;
+    use databend_common_storages_fuse::pruning::ExprBloomFilter;
+    use databend_storages_common_table_meta::table::TableCompression;
+    use divan::black_box;
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+    const REPRESENTATIVE: Scenario = Scenario {
+        rows: 1_048_576,
+        ndv: 65_536,
+        hit_stride: Some(100),
+    };
+    const SALT: [u32; 8] = [
+        0x47b6137b, 0x44974d91, 0x8824ad5b, 0xa2b7289d, 0x705495c7, 0x2df1424b, 0x9efc4947,
+        0x5c6bfb31,
+    ];
+
+    type U32x8 = Simd<u32, 8>;
+
+    #[derive(Clone, Copy, Debug)]
+    enum NumberKind {
+        Int64,
+        UInt64,
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    struct Scenario {
+        rows: usize,
+        ndv: usize,
+        /// One true match every `hit_stride` rows. `None` means no true matches.
+        hit_stride: Option<usize>,
+    }
+
+    struct LookupInput {
+        filter: Sbbf,
+        portable_filter: PortableSbbf,
+        hashes: Vec<u64>,
+    }
+
+    struct ExprInput {
+        filter: Sbbf,
+        portable_filter: PortableSbbf,
+        column: Column,
+    }
+
+    struct ParquetInput {
+        filter: Sbbf,
+        portable_filter: PortableSbbf,
+        parquet: Bytes,
+        data_schema: DataSchema,
+    }
+
+    /// The portable-SIMD lookup implementation used before the optimized batch path.
+    struct PortableSbbf(Vec<[u32; 8]>);
+
+    impl PortableSbbf {
+        fn new(num_blocks: usize, hashes: &[u64]) -> Self {
+            let mut filter = Self(vec![[0; 8]; num_blocks]);
+            for &hash in hashes {
+                let block_index = filter.block_index(hash);
+                let mask = Self::mask(hash as u32).to_array();
+                for (slot, bit) in filter.0[block_index].iter_mut().zip(mask) {
+                    *slot |= bit;
+                }
+            }
+            filter
+        }
+
+        #[inline]
+        fn check_hash(&self, hash: u64) -> bool {
+            let mask = Self::mask(hash as u32);
+            let block = U32x8::from_array(self.0[self.block_index(hash)]);
+            (block & mask).simd_ne(U32x8::splat(0)).all()
+        }
+
+        #[inline]
+        fn block_index(&self, hash: u64) -> usize {
+            (((hash >> 32) * self.0.len() as u64) >> 32) as usize
+        }
+
+        #[inline]
+        fn mask(hash: u32) -> U32x8 {
+            let hash = U32x8::splat(hash);
+            let bit_index = (hash * U32x8::from_array(SALT)) >> U32x8::splat(27);
+            U32x8::splat(1) << bit_index
+        }
+    }
+
+    #[divan::bench(args = [NumberKind::Int64, NumberKind::UInt64])]
+    fn lookup_optimized(bencher: divan::Bencher, kind: NumberKind) {
+        bencher
+            .with_inputs(|| prepare_lookup(kind, REPRESENTATIVE))
+            .bench_refs(|input| {
+                let mut matches = 0;
+                input
+                    .filter
+                    .check_hash_batch(&input.hashes, |_| matches += 1);
+                black_box(matches)
+            });
+    }
+
+    #[divan::bench(args = [NumberKind::Int64, NumberKind::UInt64])]
+    fn lookup_portable_simd(bencher: divan::Bencher, kind: NumberKind) {
+        bencher
+            .with_inputs(|| prepare_lookup(kind, REPRESENTATIVE))
+            .bench_refs(|input| {
+                black_box(
+                    input
+                        .hashes
+                        .iter()
+                        .filter(|&&hash| input.portable_filter.check_hash(hash))
+                        .count(),
+                )
+            });
+    }
+
+    #[divan::bench(args = [NumberKind::Int64, NumberKind::UInt64])]
+    fn hash_and_bloom_optimized(bencher: divan::Bencher, kind: NumberKind) {
+        bencher
+            .with_inputs(|| prepare_expr(kind, REPRESENTATIVE))
+            .bench_refs(|input| {
+                black_box(
+                    ExprBloomFilter::new(&input.filter)
+                        .apply(input.column.clone())
+                        .unwrap(),
+                )
+            });
+    }
+
+    #[divan::bench(args = [NumberKind::Int64, NumberKind::UInt64])]
+    fn hash_and_bloom_portable_simd(bencher: divan::Bencher, kind: NumberKind) {
+        bencher
+            .with_inputs(|| prepare_expr(kind, REPRESENTATIVE))
+            .bench_refs(|input| {
+                black_box(apply_portable(&input.portable_filter, input.column.clone()))
+            });
+    }
+
+    #[divan::bench(args = [NumberKind::Int64, NumberKind::UInt64])]
+    fn parquet_zstd_and_bloom_optimized(bencher: divan::Bencher, kind: NumberKind) {
+        bencher
+            .with_inputs(|| prepare_parquet(kind, REPRESENTATIVE))
+            .bench_refs(|input| {
+                let reader = ParquetRecordBatchReaderBuilder::try_new(input.parquet.clone())
+                    .unwrap()
+                    .with_batch_size(8_192)
+                    .build()
+                    .unwrap();
+                let mut matches = 0;
+                for batch in reader {
+                    let block =
+                        DataBlock::from_record_batch(&input.data_schema, &batch.unwrap()).unwrap();
+                    let bitmap = ExprBloomFilter::new(&input.filter)
+                        .apply(block.get_by_offset(0).to_column())
+                        .unwrap();
+                    matches += bitmap.iter().filter(|matched| *matched).count();
+                }
+                black_box(matches)
+            });
+    }
+
+    #[divan::bench(args = [NumberKind::Int64, NumberKind::UInt64])]
+    fn parquet_zstd_and_bloom_portable_simd(bencher: divan::Bencher, kind: NumberKind) {
+        bencher
+            .with_inputs(|| prepare_parquet(kind, REPRESENTATIVE))
+            .bench_refs(|input| {
+                let reader = ParquetRecordBatchReaderBuilder::try_new(input.parquet.clone())
+                    .unwrap()
+                    .with_batch_size(8_192)
+                    .build()
+                    .unwrap();
+                let mut matches = 0;
+                for batch in reader {
+                    let block =
+                        DataBlock::from_record_batch(&input.data_schema, &batch.unwrap()).unwrap();
+                    let bitmap =
+                        apply_portable(&input.portable_filter, block.get_by_offset(0).to_column());
+                    matches += bitmap.iter().filter(|matched| *matched).count();
+                }
+                black_box(matches)
+            });
+    }
+
+    #[divan::bench(args = [
+        Scenario { rows: 262_144, ndv: 1_024, hit_stride: None },
+        Scenario { rows: 524_288, ndv: 1_048_576, hit_stride: Some(1_000) },
+        Scenario { rows: 1_048_576, ndv: 65_536, hit_stride: Some(10) },
+        Scenario { rows: 1_048_576, ndv: 65_536, hit_stride: Some(1) },
+    ])]
+    fn lookup_scenarios_optimized(bencher: divan::Bencher, scenario: Scenario) {
+        bencher
+            .with_inputs(|| prepare_lookup(NumberKind::Int64, scenario))
+            .bench_refs(|input| {
+                let mut matches = 0;
+                input
+                    .filter
+                    .check_hash_batch(&input.hashes, |_| matches += 1);
+                black_box(matches)
+            });
+    }
+
+    #[divan::bench(args = [
+        Scenario { rows: 262_144, ndv: 1_024, hit_stride: None },
+        Scenario { rows: 524_288, ndv: 1_048_576, hit_stride: Some(1_000) },
+        Scenario { rows: 1_048_576, ndv: 65_536, hit_stride: Some(10) },
+        Scenario { rows: 1_048_576, ndv: 65_536, hit_stride: Some(1) },
+    ])]
+    fn lookup_scenarios_portable_simd(bencher: divan::Bencher, scenario: Scenario) {
+        bencher
+            .with_inputs(|| prepare_lookup(NumberKind::Int64, scenario))
+            .bench_refs(|input| {
+                black_box(
+                    input
+                        .hashes
+                        .iter()
+                        .filter(|&&hash| input.portable_filter.check_hash(hash))
+                        .count(),
+                )
+            });
+    }
+
+    fn prepare_lookup(kind: NumberKind, scenario: Scenario) -> LookupInput {
+        let (filter, portable_filter) = make_filters(kind, scenario.ndv);
+        let column = make_column(kind, &probe_values(scenario));
+        let hashes = make_hashes(column);
+        assert_filters_match(&filter, &portable_filter, &hashes);
+        LookupInput {
+            filter,
+            portable_filter,
+            hashes,
+        }
+    }
+
+    fn prepare_expr(kind: NumberKind, scenario: Scenario) -> ExprInput {
+        let (filter, portable_filter) = make_filters(kind, scenario.ndv);
+        ExprInput {
+            filter,
+            portable_filter,
+            column: make_column(kind, &probe_values(scenario)),
+        }
+    }
+
+    fn prepare_parquet(kind: NumberKind, scenario: Scenario) -> ParquetInput {
+        let (filter, portable_filter) = make_filters(kind, scenario.ndv);
+        let block = DataBlock::new_from_columns(vec![make_column(kind, &probe_values(scenario))]);
+        let schema = Arc::new(TableSchema::new(vec![TableField::new(
+            "value",
+            match kind {
+                NumberKind::Int64 => TableDataType::Number(NumberDataType::Int64),
+                NumberKind::UInt64 => TableDataType::Number(NumberDataType::UInt64),
+            },
+        )]));
+        let data_schema = DataSchema::from(schema.as_ref());
+        let settings = WriteSettings {
+            storage_format: FuseStorageFormat::Parquet,
+            table_compression: TableCompression::Zstd,
+            bloom_index_type: BloomIndexType::default(),
+            block_per_seg: 1_000,
+            enable_parquet_dictionary: false,
+            data_page_rows: None,
+            data_page_bytes: None,
+            col_stats_truncate_lens: std::collections::BTreeMap::new(),
+        };
+        let (_, buffer) = serialize_block(&settings, &schema, block).unwrap();
+        ParquetInput {
+            filter,
+            portable_filter,
+            parquet: buffer.to_bytes(),
+            data_schema,
+        }
+    }
+
+    fn make_filters(kind: NumberKind, ndv: usize) -> (Sbbf, PortableSbbf) {
+        let inserted = (0..ndv)
+            .map(|index| mix_hash(index as u64))
+            .collect::<Vec<_>>();
+        let hashes = make_hashes(make_column(kind, &inserted));
+        let mut filter = Sbbf::new_with_ndv_fpp(ndv as u64, 0.01).unwrap();
+        filter.insert_hash_batch(&hashes);
+        let num_blocks = filter.estimated_memory_size() / std::mem::size_of::<[u32; 8]>();
+        let portable_filter = PortableSbbf::new(num_blocks, &hashes);
+        (filter, portable_filter)
+    }
+
+    fn apply_portable(filter: &PortableSbbf, column: Column) -> MutableBitmap {
+        let hashes = make_hashes(column);
+        let iter = hashes.iter().map(|&hash| filter.check_hash(hash));
+        // SAFETY: iter length equals hashes.len().
+        unsafe { MutableBitmap::from_trusted_len_iter_unchecked(iter) }
+    }
+
+    fn assert_filters_match(filter: &Sbbf, portable_filter: &PortableSbbf, hashes: &[u64]) {
+        let step = (hashes.len() / 1_024).max(1);
+        for &hash in hashes.iter().step_by(step) {
+            assert_eq!(filter.check_hash(hash), portable_filter.check_hash(hash));
+        }
+    }
+
+    fn make_hashes(column: Column) -> Vec<u64> {
+        let num_rows = column.len();
+        let method = DataBlock::choose_hash_method_with_types(&[column.data_type()]).unwrap();
+        let entries = &[column.into()];
+        let group_columns = entries.into();
+        let mut hashes = Vec::with_capacity(num_rows);
+        hash_by_method_for_bloom(&method, group_columns, num_rows, &mut hashes).unwrap();
+        hashes
+    }
+
+    fn make_column(kind: NumberKind, values: &[u64]) -> Column {
+        match kind {
+            NumberKind::Int64 => Column::Number(NumberColumn::Int64(
+                values
+                    .iter()
+                    .map(|value| *value as i64)
+                    .collect::<Vec<_>>()
+                    .into(),
+            )),
+            NumberKind::UInt64 => Column::Number(NumberColumn::UInt64(values.to_vec().into())),
+        }
+    }
+
+    fn probe_values(scenario: Scenario) -> Vec<u64> {
+        (0..scenario.rows)
+            .map(|index| {
+                if scenario
+                    .hit_stride
+                    .is_some_and(|stride| index % stride == 0)
+                {
+                    mix_hash((index % scenario.ndv) as u64)
+                } else {
+                    mix_hash((index + scenario.ndv + scenario.rows) as u64)
+                }
+            })
+            .collect()
+    }
+
+    fn mix_hash(mut value: u64) -> u64 {
+        value = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        value ^ (value >> 31)
     }
 }

--- a/src/query/storages/fuse/src/pruning/expr_bloom_filter.rs
+++ b/src/query/storages/fuse/src/pruning/expr_bloom_filter.rs
@@ -37,8 +37,9 @@ impl<'a> ExprBloomFilter<'a> {
         let group_columns = entries.into();
         let mut hashes = Vec::with_capacity(num_rows);
         hash_by_method_for_bloom(&method, group_columns, num_rows, &mut hashes)?;
-        let iter = hashes.iter().map(|&hash| self.filter.check_hash(hash));
-        // SAFETY: iter length equals hashes.len()
-        Ok(unsafe { MutableBitmap::from_trusted_len_iter_unchecked(iter) })
+        let mut bitmap = MutableBitmap::from_len_zeroed(hashes.len());
+        self.filter
+            .check_hash_batch(&hashes, |index| bitmap.set(index, true));
+        Ok(bitmap)
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Runtime Bloom probes currently build an eight-lane portable-SIMD mask for every hash, even though low-hit probes can usually reject after inspecting only a few bits. Fuse then constructs the result bitmap through a per-value iterator.

This PR:

- changes scalar SBBF checks to reject on the first missing bit
- adds a batch callback API with one runtime AVX2 dispatch per batch on x86_64
- keeps an equivalent scalar fallback when AVX2 is unavailable or the target is not x86_64
- initializes the Fuse bitmap to zero and sets only matching indexes
- leaves SBBF serialization, hashing, FPP, construction, union, and the minimum CPU requirement unchanged

## Reproducible benchmark

The Fuse divan benchmark contains deterministic synthetic inputs and an in-tree copy of the previous portable-SIMD lookup, so reviewers can run before/after comparisons without checking out the parent commit.

```bash
env RUSTFLAGS="-C target-feature=+sse4.2"   cargo bench -p databend-common-storages-fuse --bench bench runtime_bloom
```

It covers Int64 and UInt64, lookup-only, hash plus Bloom, Parquet Zstd decode plus Bloom, multiple row and NDV sizes, and true-hit rates from 0% through 100%.

Representative medians on the current main baseline:

| Path | Portable SIMD reference | Optimized |
| --- | ---: | ---: |
| Lookup only | 33.89 ms | 4.04 ms |
| Hash plus Bloom | 36.67 ms | 6.11 ms |
| Parquet Zstd decode plus hash plus Bloom | about 39.5 ms | about 8.35 ms |

The high-hit scenarios did not show a regression.

Historical deployment profiling showed two Bloom hotspots decreasing by about 39% and 30% in accumulated multi-thread CPU time. Query wall time changed from about 27.19 s to 26.62 s, or about 2.1%. The accumulated processor time is not wall time. The optimized query was still about 17% slower than the comparison release, so this PR addresses only the Bloom-check portion of that gap.

## Validation

- deployment-equivalent benchmark build and run
- release assembly inspection: `vpmulld`, `vpsrld`, `vpsllvd`, and `vptest` are in the batch loop with no per-row call on the loop back-edge

The AVX2 path is tested directly against scalar checks for zero, full, and populated blocks. 

## Tests

- [x] Unit Test
- [ ] Logic Test
- [x] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent adapted the runtime Bloom optimization to current main, added equivalence tests and a reproducible benchmark, ran validation, and drafted this PR description
- Responsible human: @dantengsky
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20323)
<!-- Reviewable:end -->
