### PR TITLE
fix(query): avoid oversized row output buffer allocations

### DIFF
--- a/src/query/formats/src/output_format/csv.rs
+++ b/src/query/formats/src/output_format/csv.rs
@@ -69,7 +69,7 @@ impl CSVOutputFormat {
 impl OutputFormat for CSVOutputFormat {
     fn serialize_block(&mut self, block: &DataBlock) -> Result<Vec<u8>> {
         let rows_size = block.num_rows();
-        let mut buf = Vec::with_capacity(block.memory_size());
+        let mut buf = Vec::with_capacity(block.estimate_block_size(block.num_columns()));
 
         let fd = self.field_delimiter;
         let rd = &self.record_delimiter;

--- a/src/query/formats/src/output_format/mod.rs
+++ b/src/query/formats/src/output_format/mod.rs
@@ -208,3 +208,45 @@ mod test_utils {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use databend_common_exception::Result;
+    use databend_common_expression::FromData;
+    use databend_common_expression::TableDataType;
+    use databend_common_expression::TableField;
+    use databend_common_expression::types::StringType;
+
+    use super::test_utils::gen_schema_and_block;
+    use super::test_utils::get_output_format_clickhouse;
+
+    #[test]
+    fn test_sliced_string_output_does_not_preallocate_parent_buffer_size() -> Result<()> {
+        const PARENT_ROWS: usize = 4096;
+        const VALUE_LEN: usize = 1024;
+
+        let value = "x".repeat(VALUE_LEN);
+        let (schema, parent) =
+            gen_schema_and_block(vec![TableField::new("c1", TableDataType::String)], vec![
+                StringType::from_data(vec![value; PARENT_ROWS]),
+            ]);
+        let block = parent.slice(0..2);
+        let retained_size = block.memory_size();
+        let visible_size = block.estimate_block_size(block.num_columns());
+
+        assert!(retained_size > visible_size * 1000);
+
+        for format in ["ndjson", "csv", "tsv"] {
+            let mut output_format = get_output_format_clickhouse(format, schema.clone())?;
+            let output = output_format.serialize_block(&block)?;
+
+            assert!(
+                output.capacity() < retained_size / 8,
+                "{format} output capacity {} retained the sliced parent buffer size {retained_size}",
+                output.capacity()
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/src/query/formats/src/output_format/ndjson.rs
+++ b/src/query/formats/src/output_format/ndjson.rs
@@ -57,7 +57,7 @@ impl<const STRINGS: bool, const COMPACT: bool> OutputFormat
     fn serialize_block(&mut self, block: &DataBlock) -> Result<Vec<u8>> {
         let rows_size = block.num_rows();
 
-        let mut buf = Vec::with_capacity(block.memory_size());
+        let mut buf = Vec::with_capacity(block.estimate_block_size(block.num_columns()));
         let field_names: Vec<_> = self
             .schema
             .fields()

--- a/src/query/formats/src/output_format/tsv.rs
+++ b/src/query/formats/src/output_format/tsv.rs
@@ -66,7 +66,7 @@ impl TEXTOutputFormat {
 impl OutputFormat for TEXTOutputFormat {
     fn serialize_block(&mut self, block: &DataBlock) -> Result<Vec<u8>> {
         let rows_size = block.num_rows();
-        let mut buf = Vec::with_capacity(block.memory_size());
+        let mut buf = Vec::with_capacity(block.estimate_block_size(block.num_columns()));
 
         let fd = self.field_delimiter;
         let rd = &self.record_delimiter;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Avoid preallocating row-format output buffers from retained parent column buffers
- Base CSV, TSV, and NDJSON output capacity on the visible data in each block slice
- Add regression coverage for sliced string columns with shared backing buffers

## Implementation

Row-based unload serialization processes large blocks in smaller slices. String slices can retain shared backing buffers from their parent block, so `DataBlock::memory_size()` may be much larger than the data visible in a slice. Using that value as the initial output capacity causes each serialized slice to reserve capacity for unrelated parent data.

Use `DataBlock::estimate_block_size()` for the initial capacity instead. This API estimates the visible data written by the block, including repeated constant values and nullable columns. The estimate does not need to include output-format escaping or delimiters exactly because the vector can grow when necessary.

The existing `DataBlock::memory_size()` behavior remains unchanged for memory-accounting callers.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Added a unit regression that creates a small slice sharing a much larger string backing buffer and verifies that NDJSON, CSV, and TSV output capacity no longer scales with the retained parent buffer.

Validation:

- `cargo test -p databend-common-formats`
- `cargo clippy -p databend-common-formats --all-targets -- -D warnings`
- `cargo fmt --check`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent investigated the row-format allocation path, drafted the implementation and regression test, and prepared the PR summary
- Responsible human: @dqhl76
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20325)
<!-- Reviewable:end -->
