### PR TITLE
fix(stage): improve Parquet unload compatibility with older readers

### DIFF
--- a/.github/actions/test_stateful_cluster_linux/action.yml
+++ b/.github/actions/test_stateful_cluster_linux/action.yml
@@ -18,3 +18,11 @@ runs:
     - name: Run nox test
       shell: bash
       run: nox -f tests/nox/noxfile.py -s test_suites -- suites/
+
+    - uses: actions/setup-python@v6
+      with:
+        python-version: "3.9"
+
+    - name: Run PyArrow compatibility tests
+      shell: bash
+      run: nox -f tests/nox/noxfile.py -s pyarrow_compat

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5314,6 +5314,7 @@ dependencies = [
  "async-backtrace",
  "async-trait",
  "bstr",
+ "bytes",
  "chrono",
  "csv-core",
  "databend-common-ast",

--- a/src/query/storages/stage/Cargo.toml
+++ b/src/query/storages/stage/Cargo.toml
@@ -66,5 +66,8 @@ uuid = { workspace = true }
 [lints]
 workspace = true
 
+[dev-dependencies]
+bytes = { workspace = true }
+
 [package.metadata.cargo-machete]
 ignored = ["match-template", "lance-encoding"]

--- a/src/query/storages/stage/src/append/parquet_file/writer_processor.rs
+++ b/src/query/storages/stage/src/append/parquet_file/writer_processor.rs
@@ -15,7 +15,10 @@
 use std::mem;
 use std::sync::Arc;
 
+use arrow_array::RecordBatch;
+use arrow_array::RecordBatchOptions;
 use arrow_schema::DataType;
+use arrow_schema::FieldRef;
 use arrow_schema::Schema;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -27,14 +30,16 @@ use databend_common_pipeline::core::OutputPort;
 use databend_common_pipeline::core::ProcessorPtr;
 use databend_storages_common_stage::CopyIntoLocationInfo;
 use opendal::Operator;
+use parquet::arrow::ARROW_SCHEMA_META_KEY;
 use parquet::arrow::ArrowWriter;
+use parquet::arrow::arrow_writer::ArrowWriterOptions;
+use parquet::arrow::encode_arrow_schema;
 use parquet::basic::Compression;
-use parquet::basic::Encoding;
 use parquet::basic::ZstdLevel;
+use parquet::file::metadata::KeyValue;
 use parquet::file::properties::EnabledStatistics;
 use parquet::file::properties::WriterProperties;
 use parquet::file::properties::WriterVersion;
-use parquet::schema::types::ColumnPath;
 
 use crate::append::column_based::file_writer::ColumnarFileEncoder;
 use crate::append::column_based::file_writer::ColumnarFileWriter;
@@ -53,42 +58,167 @@ const MAX_BUFFER_SIZE: usize = 64 * 1024 * 1024;
 // this is number of rows, not size
 const MAX_ROW_GROUP_SIZE: usize = 1024 * 1024;
 
+/// Return an Arrow schema with canonical names for Parquet map entries.
+///
+/// Some older Arrow implementations look up map children by name. The arrays are
+/// reused without copying; only their schema is reattached with field-name matching
+/// disabled before writing.
+fn parquet_compatible_schema(schema: &Schema) -> Schema {
+    let fields = schema
+        .fields()
+        .iter()
+        .map(parquet_compatible_field)
+        .collect::<Vec<_>>();
+    Schema::new_with_metadata(fields, schema.metadata().clone())
+}
+
+fn parquet_compatible_field(field: &FieldRef) -> FieldRef {
+    Arc::new(
+        field
+            .as_ref()
+            .clone()
+            .with_data_type(parquet_compatible_data_type(field.data_type())),
+    )
+}
+
+fn parquet_compatible_map_field(field: &FieldRef) -> FieldRef {
+    let field = parquet_compatible_field(field);
+    let DataType::Struct(fields) = field.data_type() else {
+        return field;
+    };
+    if fields.len() != 2 {
+        return field;
+    }
+
+    let key = Arc::new(fields[0].as_ref().clone().with_name("key"));
+    let value = Arc::new(fields[1].as_ref().clone().with_name("value"));
+    Arc::new(
+        field
+            .as_ref()
+            .clone()
+            .with_data_type(DataType::Struct(vec![key, value].into())),
+    )
+}
+
+fn parquet_compatible_data_type(data_type: &DataType) -> DataType {
+    match data_type {
+        DataType::List(field) => DataType::List(parquet_compatible_field(field)),
+        DataType::ListView(field) => DataType::ListView(parquet_compatible_field(field)),
+        DataType::FixedSizeList(field, size) => {
+            DataType::FixedSizeList(parquet_compatible_field(field), *size)
+        }
+        DataType::LargeList(field) => DataType::LargeList(parquet_compatible_field(field)),
+        DataType::LargeListView(field) => DataType::LargeListView(parquet_compatible_field(field)),
+        DataType::Struct(fields) => DataType::Struct(
+            fields
+                .iter()
+                .map(parquet_compatible_field)
+                .collect::<Vec<_>>()
+                .into(),
+        ),
+        DataType::Dictionary(key, value) => DataType::Dictionary(
+            Box::new(parquet_compatible_data_type(key)),
+            Box::new(parquet_compatible_data_type(value)),
+        ),
+        DataType::Map(field, sorted) => DataType::Map(parquet_compatible_map_field(field), *sorted),
+        _ => data_type.clone(),
+    }
+}
+
+/// Return an Arrow schema that can be decoded by older Arrow implementations.
+///
+/// This schema is only embedded in the Parquet footer as an `ARROW:schema` hint. The
+/// writer schema and arrays still use their original data types. Every conversion below
+/// must therefore have the same Parquet representation as the writer type.
+fn legacy_compatible_schema(schema: &Schema) -> Schema {
+    let schema = parquet_compatible_schema(schema);
+    let fields = schema
+        .fields()
+        .iter()
+        .map(legacy_compatible_field)
+        .collect::<Vec<_>>();
+    Schema::new_with_metadata(fields, schema.metadata().clone())
+}
+
+fn legacy_compatible_field(field: &FieldRef) -> FieldRef {
+    Arc::new(
+        field
+            .as_ref()
+            .clone()
+            .with_data_type(legacy_compatible_data_type(field.data_type())),
+    )
+}
+
+fn legacy_compatible_data_type(data_type: &DataType) -> DataType {
+    match data_type {
+        DataType::BinaryView => DataType::Binary,
+        DataType::Utf8View => DataType::Utf8,
+        DataType::List(field) => DataType::List(legacy_compatible_field(field)),
+        DataType::ListView(field) => DataType::List(legacy_compatible_field(field)),
+        DataType::FixedSizeList(field, size) => {
+            DataType::FixedSizeList(legacy_compatible_field(field), *size)
+        }
+        DataType::LargeList(field) => DataType::LargeList(legacy_compatible_field(field)),
+        DataType::LargeListView(field) => DataType::LargeList(legacy_compatible_field(field)),
+        DataType::Struct(fields) => DataType::Struct(
+            fields
+                .iter()
+                .map(legacy_compatible_field)
+                .collect::<Vec<_>>()
+                .into(),
+        ),
+        DataType::Dictionary(key, value) => DataType::Dictionary(
+            Box::new(legacy_compatible_data_type(key)),
+            Box::new(legacy_compatible_data_type(value)),
+        ),
+        DataType::Decimal32(precision, scale) | DataType::Decimal64(precision, scale) => {
+            DataType::Decimal128(*precision, *scale)
+        }
+        DataType::Map(field, sorted) => DataType::Map(legacy_compatible_field(field), *sorted),
+        _ => data_type.clone(),
+    }
+}
+
 fn create_writer(
     arrow_schema: Arc<Schema>,
     target_file_size: Option<usize>,
     compression: Compression,
     create_by: String,
 ) -> Result<ArrowWriter<Vec<u8>>> {
-    let mut builder = WriterProperties::builder()
-        .set_writer_version(WriterVersion::PARQUET_2_0)
+    let metadata_schema = legacy_compatible_schema(&arrow_schema);
+    let metadata = KeyValue {
+        key: ARROW_SCHEMA_META_KEY.to_string(),
+        value: Some(encode_arrow_schema(&metadata_schema)),
+    };
+
+    let props = WriterProperties::builder()
+        // COPY INTO LOCATION is an interoperability boundary. Keep its output readable by
+        // older Parquet implementations.
+        .set_writer_version(WriterVersion::PARQUET_1_0)
         .set_compression(compression)
         .set_created_by(create_by)
         .set_max_row_group_row_count(Some(MAX_ROW_GROUP_SIZE))
         .set_statistics_enabled(EnabledStatistics::Chunk)
-        .set_dictionary_enabled(true)
-        .set_bloom_filter_enabled(false);
+        // RLE_DICTIONARY was added in Parquet 2.0 even though arrow-rs may use it with
+        // WriterVersion::PARQUET_1_0. Disable dictionaries to keep value encodings at 1.0.
+        .set_dictionary_enabled(false)
+        .set_bloom_filter_enabled(false)
+        .set_key_value_metadata(Some(vec![metadata]))
+        .build();
 
-    // Set the encoding of the decimal column to `PLAIN` to avoid
-    // compatibility issues caused by encoding as `Delta_Byte_Array`.
-    for field in arrow_schema.fields() {
-        if matches!(
-            field.data_type(),
-            DataType::Decimal128(_, _) | DataType::Decimal256(_, _)
-        ) {
-            let column = ColumnPath::from(field.name().clone());
-            builder = builder.set_column_encoding(column, Encoding::PLAIN);
-        }
-    }
-
-    let props = builder.build();
     let buf_size = match target_file_size {
         Some(n) if n < MAX_BUFFER_SIZE => n,
         _ => MAX_BUFFER_SIZE,
     };
-    Ok(ArrowWriter::try_new(
+    let options = ArrowWriterOptions::new()
+        .with_properties(props)
+        // `ARROW:schema` above intentionally describes storage-equivalent legacy types.
+        // Do not let ArrowWriter replace it with the original modern schema.
+        .with_skip_arrow_metadata(true);
+    Ok(ArrowWriter::try_new_with_options(
         Vec::with_capacity(buf_size),
         arrow_schema,
-        Some(props),
+        options,
     )?)
 }
 
@@ -99,7 +229,7 @@ impl ParquetEncoder {
         target_file_size: Option<usize>,
         create_by: String,
     ) -> Result<Self> {
-        let arrow_schema = Arc::new(Schema::from(schema.as_ref()));
+        let arrow_schema = Arc::new(parquet_compatible_schema(&Schema::from(schema.as_ref())));
         let compression = info.stage.file_format_params.compression();
         let compression = match &compression {
             StageFileCompression::Zstd => Compression::ZSTD(ZstdLevel::default()),
@@ -143,6 +273,12 @@ impl ColumnarFileEncoder for ParquetEncoder {
 
     fn write(&mut self, block: DataBlock, schema: &TableSchemaRef) -> Result<()> {
         let batch = block.to_record_batch(schema)?;
+        let options = RecordBatchOptions::new().with_match_field_names(false);
+        let batch = RecordBatch::try_new_with_options(
+            self.arrow_schema.clone(),
+            batch.columns().to_vec(),
+            &options,
+        )?;
         self.writer.write(&batch)?;
         Ok(())
     }
@@ -185,5 +321,248 @@ impl ParquetFileWriter {
             target_file_size,
             encoder,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use arrow_array::Array;
+    use arrow_array::ArrayRef;
+    use arrow_array::BooleanArray;
+    use arrow_array::Decimal64Array;
+    use arrow_array::Decimal128Array;
+    use arrow_array::MapArray;
+    use arrow_array::StringArray;
+    use arrow_array::StringViewArray;
+    use arrow_schema::Field;
+    use bytes::Bytes;
+    use parquet::arrow::arrow_reader::ArrowReaderOptions;
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+    use parquet::basic::Encoding;
+    use parquet::column::page::Page;
+    use parquet::file::reader::FileReader;
+    use parquet::file::serialized_reader::SerializedFileReader;
+
+    use super::*;
+
+    #[test]
+    fn test_legacy_compatible_schema_recursively_downgrades_storage_equivalent_types() {
+        let field_metadata = HashMap::from([("extension".to_string(), "value".to_string())]);
+        let nested = Field::new(
+            "item",
+            DataType::Struct(
+                vec![
+                    Field::new("string", DataType::Utf8View, true),
+                    Field::new("binary", DataType::BinaryView, true),
+                    Field::new("decimal", DataType::Decimal64(18, 3), true),
+                    Field::new("wide_decimal", DataType::Decimal256(50, 4), true),
+                ]
+                .into(),
+            ),
+            true,
+        )
+        .with_metadata(field_metadata.clone());
+        let schema_metadata = HashMap::from([("schema".to_string(), "metadata".to_string())]);
+        let schema = Schema::new_with_metadata(
+            vec![
+                Field::new("list", DataType::ListView(Arc::new(nested)), true),
+                Field::new(
+                    "large_list",
+                    DataType::LargeListView(Arc::new(Field::new(
+                        "item",
+                        DataType::Decimal32(9, 2),
+                        false,
+                    ))),
+                    false,
+                ),
+                Field::new(
+                    "map",
+                    DataType::Map(
+                        Arc::new(Field::new(
+                            "entries",
+                            DataType::Struct(
+                                vec![
+                                    Field::new("1", DataType::Utf8View, false),
+                                    Field::new("2", DataType::Decimal64(18, 2), true),
+                                ]
+                                .into(),
+                            ),
+                            false,
+                        )),
+                        false,
+                    ),
+                    false,
+                ),
+            ],
+            schema_metadata.clone(),
+        );
+
+        let compatible = legacy_compatible_schema(&schema);
+        assert_eq!(compatible.metadata(), &schema_metadata);
+
+        let DataType::List(item) = compatible.field(0).data_type() else {
+            panic!("ListView must be downgraded to List");
+        };
+        assert_eq!(item.metadata(), &field_metadata);
+        let DataType::Struct(fields) = item.data_type() else {
+            panic!("nested struct must be preserved");
+        };
+        assert_eq!(fields[0].data_type(), &DataType::Utf8);
+        assert_eq!(fields[1].data_type(), &DataType::Binary);
+        assert_eq!(fields[2].data_type(), &DataType::Decimal128(18, 3));
+        assert_eq!(fields[3].data_type(), &DataType::Decimal256(50, 4));
+
+        let DataType::LargeList(item) = compatible.field(1).data_type() else {
+            panic!("LargeListView must be downgraded to LargeList");
+        };
+        assert_eq!(item.data_type(), &DataType::Decimal128(9, 2));
+
+        let DataType::Map(entries, false) = compatible.field(2).data_type() else {
+            panic!("map must be preserved");
+        };
+        let DataType::Struct(fields) = entries.data_type() else {
+            panic!("map entries must remain a struct");
+        };
+        assert_eq!(fields[0].name(), "key");
+        assert_eq!(fields[0].data_type(), &DataType::Utf8);
+        assert_eq!(fields[1].name(), "value");
+        assert_eq!(fields[1].data_type(), &DataType::Decimal128(18, 2));
+    }
+
+    #[test]
+    fn test_parquet_unload_uses_legacy_writer_and_compatible_schema() {
+        let map = MapArray::new_from_strings(
+            ["first", "second"].into_iter(),
+            &StringArray::from(vec!["one", "two"]),
+            &[0, 1, 2],
+        )
+        .unwrap();
+        let original_schema = Arc::new(Schema::new(vec![
+            Field::new("bool", DataType::Boolean, false),
+            Field::new("string", DataType::Utf8View, false),
+            Field::new("decimal", DataType::Decimal64(10, 2), false),
+            Field::new("map", map.data_type().clone(), false),
+        ]));
+        let writer_schema = Arc::new(parquet_compatible_schema(&original_schema));
+        let expected_metadata_schema = legacy_compatible_schema(&writer_schema);
+        let batch = RecordBatch::try_new(original_schema.clone(), vec![
+            Arc::new(BooleanArray::from(vec![true, false])) as ArrayRef,
+            Arc::new(StringViewArray::from(vec!["alpha", "beta"])) as ArrayRef,
+            Arc::new(
+                Decimal64Array::from(vec![1234_i64, -5678_i64])
+                    .with_precision_and_scale(10, 2)
+                    .unwrap(),
+            ) as ArrayRef,
+            Arc::new(map) as ArrayRef,
+        ])
+        .unwrap();
+        let options = RecordBatchOptions::new().with_match_field_names(false);
+        let batch = RecordBatch::try_new_with_options(
+            writer_schema.clone(),
+            batch.columns().to_vec(),
+            &options,
+        )
+        .unwrap();
+
+        let mut writer = create_writer(
+            writer_schema,
+            None,
+            Compression::UNCOMPRESSED,
+            "test".to_string(),
+        )
+        .unwrap();
+        writer.write(&batch).unwrap();
+        writer.finish().unwrap();
+        let parquet_data = Bytes::copy_from_slice(writer.inner());
+
+        let builder = ParquetRecordBatchReaderBuilder::try_new(parquet_data.clone()).unwrap();
+        assert_eq!(builder.metadata().file_metadata().version(), 1);
+        let kvs = builder
+            .metadata()
+            .file_metadata()
+            .key_value_metadata()
+            .expect("ARROW:schema must be present");
+        let arrow_schema_metadata = kvs
+            .iter()
+            .filter(|kv| kv.key == ARROW_SCHEMA_META_KEY)
+            .collect::<Vec<_>>();
+        assert_eq!(arrow_schema_metadata.len(), 1);
+        assert_eq!(
+            arrow_schema_metadata[0].value.as_deref(),
+            Some(encode_arrow_schema(&expected_metadata_schema).as_str())
+        );
+
+        // Column chunk encodings also include RLE for definition/repetition levels. Inspect
+        // every page to ensure values use only Parquet 1.0 PLAIN encoding and Data Page V1.
+        let file_reader = SerializedFileReader::new(parquet_data.clone()).unwrap();
+        let row_group = file_reader.get_row_group(0).unwrap();
+        for column_index in 0..builder.metadata().row_group(0).columns().len() {
+            let mut pages = row_group.get_column_page_reader(column_index).unwrap();
+            let mut data_page_count = 0;
+            while let Some(page) = pages.get_next_page().unwrap() {
+                match page {
+                    Page::DataPage { encoding, .. } => {
+                        data_page_count += 1;
+                        assert_eq!(encoding, Encoding::PLAIN);
+                    }
+                    Page::DataPageV2 { .. } => panic!("legacy unload must use Data Page V1"),
+                    Page::DictionaryPage { .. } => {
+                        panic!("legacy unload must not use dictionary encoding")
+                    }
+                }
+            }
+            assert!(data_page_count > 0);
+        }
+        for column in builder.metadata().row_group(0).columns() {
+            for encoding in column.encodings() {
+                assert!(matches!(encoding, Encoding::PLAIN | Encoding::RLE));
+            }
+        }
+
+        assert_eq!(builder.schema().as_ref(), &expected_metadata_schema);
+        let mut reader = builder.build().unwrap();
+        let output = reader.next().unwrap().unwrap();
+        let strings = output
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(strings.value(0), "alpha");
+        assert_eq!(strings.value(1), "beta");
+        let decimals = output
+            .column(2)
+            .as_any()
+            .downcast_ref::<Decimal128Array>()
+            .unwrap();
+        assert_eq!(decimals.value(0), 1234_i128);
+        assert_eq!(decimals.value(1), -5678_i128);
+        let maps = output
+            .column(3)
+            .as_any()
+            .downcast_ref::<MapArray>()
+            .unwrap();
+        let (key, value) = maps.entries_fields();
+        assert_eq!(key.name(), "key");
+        assert_eq!(value.name(), "value");
+
+        let options = ArrowReaderOptions::new().with_skip_arrow_metadata(true);
+        let builder =
+            ParquetRecordBatchReaderBuilder::try_new_with_options(parquet_data, options).unwrap();
+        assert_eq!(builder.schema().field(1).data_type(), &DataType::Utf8);
+        assert_eq!(
+            builder.schema().field(2).data_type(),
+            &DataType::Decimal128(10, 2)
+        );
+        let mut reader = builder.build().unwrap();
+        let output = reader.next().unwrap().unwrap();
+        let decimals = output
+            .column(2)
+            .as_any()
+            .downcast_ref::<Decimal128Array>()
+            .unwrap();
+        assert_eq!(decimals.value(0), 1234_i128);
+        assert_eq!(decimals.value(1), -5678_i128);
     }
 }

--- a/tests/nox/noxfile.py
+++ b/tests/nox/noxfile.py
@@ -1,5 +1,6 @@
 import json
 import os
+import platform
 import shutil
 import tarfile
 import tempfile
@@ -15,6 +16,14 @@ PYTHON_DRIVER_PINNED = ["0.33.6"]
 PYTHON_DRIVER = ["latest", *PYTHON_DRIVER_PINNED]
 PYTHON_TEST_TIMEZONE = "UTC"
 PYTHON_TEST_ENV = {"TZ": PYTHON_TEST_TIMEZONE}
+# Override with a comma-separated list, for example:
+# PYARROW_COMPAT_VERSIONS=4.0.0,8.0.0,9.0.0.
+# PyArrow 4 is the oldest release with a CPython 3.9 Linux aarch64 wheel.
+PYARROW_COMPAT = [
+    version.strip()
+    for version in os.environ.get("PYARROW_COMPAT_VERSIONS", "4.0.0,8.0.0").split(",")
+    if version.strip()
+]
 CACHE_DIR = Path(__file__).resolve().parent / "cache"
 GITHUB_ARCHIVE_ROOT = "https://github.com/databendlabs"
 HTTP_USER_AGENT = "databend-nox-client"
@@ -486,6 +495,32 @@ def test_suites(session):
     )
     # Usage: nox -s test_suites -- suites/http_handler/test_session.py::test_session
     session.run("pytest", *session.posargs)
+
+
+@nox.session(python="3.9")
+@nox.parametrize("pyarrow_version", PYARROW_COMPAT)
+def pyarrow_compat(session, pyarrow_version):
+    """Read Parquet unload output using explicitly pinned PyArrow versions."""
+    if (
+        platform.system() == "Darwin"
+        and platform.machine() == "arm64"
+        and int(pyarrow_version.split(".", 1)[0]) <= 8
+    ):
+        session.skip("legacy PyArrow Parquet wheels are not usable on macOS arm64")
+
+    # Legacy PyArrow wheels are not compatible with NumPy 2.
+    session.install(
+        "pytest",
+        "requests",
+        "numpy<2",
+        f"pyarrow=={pyarrow_version}",
+    )
+    session.run(
+        "pytest",
+        "pyarrow_compat",
+        *session.posargs,
+        env={"PYARROW_COMPAT_VERSION": pyarrow_version},
+    )
 
 
 @nox.session

--- a/tests/nox/pyarrow_compat/test_parquet_unload.py
+++ b/tests/nox/pyarrow_compat/test_parquet_unload.py
@@ -1,0 +1,144 @@
+import os
+import platform
+import uuid
+from datetime import date, datetime
+from decimal import Decimal
+from urllib.parse import urljoin
+
+import pyarrow as pa
+import pytest
+import requests
+
+
+QUERY_URL = "http://localhost:8000/v1/query"
+QUERY_AUTH = ("root", "root")
+
+
+def _quote_sql_string(value):
+    return str(value).replace("'", "''")
+
+
+def _stage_fs_url(path):
+    return f"fs://{_quote_sql_string(path)}/"
+
+
+def _execute_sql(sql):
+    response = requests.post(
+        QUERY_URL,
+        auth=QUERY_AUTH,
+        json={"sql": sql, "pagination": {"wait_time_secs": 10}},
+        timeout=30,
+    )
+    response.raise_for_status()
+    result = response.json()
+
+    while True:
+        if result.get("error"):
+            raise RuntimeError(f"query failed for {sql}: {result['error']}")
+
+        next_uri = result.get("next_uri")
+        if not next_uri:
+            return
+
+        response = requests.get(
+            urljoin(QUERY_URL, next_uri),
+            auth=QUERY_AUTH,
+            timeout=30,
+        )
+        response.raise_for_status()
+        result = response.json()
+
+
+@pytest.mark.skipif(
+    platform.system() == "Darwin"
+    and platform.machine() == "arm64"
+    and int(pa.__version__.split(".", 1)[0]) <= 8,
+    reason="legacy PyArrow Parquet wheels are not usable on macOS arm64",
+)
+@pytest.mark.parametrize("compression", ["zstd", "none"])
+def test_parquet_unload_is_readable_by_configured_pyarrow(tmp_path, compression):
+    import pyarrow.parquet as pq
+
+    expected_version = os.environ["PYARROW_COMPAT_VERSION"]
+    assert pa.__version__ == expected_version
+
+    stage_name = f"pyarrow_compat_{uuid.uuid4().hex[:8]}"
+    output_path = tmp_path / "unload.parquet"
+
+    _execute_sql(
+        f"create stage {stage_name} "
+        f"url='{_stage_fs_url(tmp_path)}' "
+        f"file_format=(type=parquet compression={compression})"
+    )
+    try:
+        _execute_sql(
+            f"copy into @{stage_name}/unload.parquet from ("
+            "select "
+            "true as b, "
+            "cast(7 as int) as i32, "
+            "cast(42 as bigint) as i64, "
+            "cast(9 as uint64) as u64, "
+            "cast(1.25 as double) as f64, "
+            "'legacy'::string as s, "
+            "to_binary('bytes') as bin, "
+            "cast(123.45 as decimal(18, 2)) as d64, "
+            "cast('12345678901234567890.12' as decimal(30, 2)) as d128, "
+            "cast('12345678901234567890123456789012345678.90' "
+            "as decimal(40, 2)) as d256, "
+            "to_date('2021-01-02') as d, "
+            "to_timestamp('2021-01-02 03:04:05') as ts, "
+            "cast(null as string) as nullable_s, "
+            "['nested'] as nested, "
+            "map(['key'], ['value']) as map_value, "
+            "[0.25, 0.5]::vector(2) as vector_value"
+            f") file_format=(type=parquet compression={compression}) "
+            "single=true use_raw_path=true overwrite=true"
+        )
+
+        table = pq.read_table(output_path)
+
+        assert table.schema.field("b").type == pa.bool_()
+        assert table.schema.field("i32").type == pa.int32()
+        assert table.schema.field("i64").type == pa.int64()
+        assert table.schema.field("u64").type == pa.uint64()
+        assert table.schema.field("f64").type == pa.float64()
+        assert table.schema.field("s").type == pa.string()
+        assert table.schema.field("bin").type == pa.large_binary()
+        assert table.schema.field("d64").type == pa.decimal128(18, 2)
+        assert table.schema.field("d128").type == pa.decimal128(30, 2)
+        assert table.schema.field("d256").type == pa.decimal256(40, 2)
+        assert table.schema.field("d").type == pa.date32()
+        assert table.schema.field("ts").type == pa.timestamp("us")
+        assert table.schema.field("nullable_s").type == pa.string()
+        nested_type = table.schema.field("nested").type
+        assert pa.types.is_large_list(nested_type)
+        assert nested_type.value_type == pa.string()
+        map_type = table.schema.field("map_value").type
+        assert pa.types.is_map(map_type)
+        assert map_type.key_type == pa.string()
+        assert map_type.item_type == pa.string()
+        vector_type = table.schema.field("vector_value").type
+        assert pa.types.is_fixed_size_list(vector_type)
+        assert vector_type.list_size == 2
+        assert vector_type.value_type == pa.float32()
+
+        assert table.num_rows == 1
+        row = {name: values[0] for name, values in table.to_pydict().items()}
+        assert row["b"] is True
+        assert row["i32"] == 7
+        assert row["i64"] == 42
+        assert row["u64"] == 9
+        assert row["f64"] == 1.25
+        assert row["s"] == "legacy"
+        assert row["bin"] == b"bytes"
+        assert row["d64"] == Decimal("123.45")
+        assert row["d128"] == Decimal("12345678901234567890.12")
+        assert row["d256"] == Decimal("12345678901234567890123456789012345678.90")
+        assert row["d"] == date(2021, 1, 2)
+        assert row["ts"] == datetime(2021, 1, 2, 3, 4, 5)
+        assert row["nullable_s"] is None
+        assert row["nested"] == ["nested"]
+        assert row["map_value"] == [("key", "value")]
+        assert row["vector_value"] == pytest.approx([0.25, 0.5])
+    finally:
+        _execute_sql(f"drop stage if exists {stage_name}")

--- a/tests/sqllogictests/suites/base/03_common/03_0028_copy_into_stage.test
+++ b/tests/sqllogictests/suites/base/03_common/03_0028_copy_into_stage.test
@@ -87,6 +87,40 @@ statement ok
 drop table if EXISTS world
 
 statement ok
+DROP STAGE IF EXISTS parquet_legacy_compat
+
+statement ok
+CREATE STAGE parquet_legacy_compat
+
+statement ok
+COPY INTO @parquet_legacy_compat
+FROM (
+    SELECT
+        true AS b,
+        'legacy'::STRING AS s,
+        CAST(123.45 AS DECIMAL(18, 2)) AS d64,
+        CAST('12345678901234567890123456789012345678.90' AS DECIMAL(40, 2)) AS d256,
+        ['nested'] AS nested
+)
+FILE_FORMAT = (type = PARQUET)
+SINGLE = TRUE
+
+query I
+SELECT count_if(
+    b
+    AND s = 'legacy'
+    AND d64 = CAST(123.45 AS DECIMAL(18, 2))
+    AND d256 = CAST('12345678901234567890123456789012345678.90' AS DECIMAL(40, 2))
+    AND nested[1] = 'nested'
+)
+FROM @parquet_legacy_compat
+----
+1
+
+statement ok
+DROP STAGE parquet_legacy_compat
+
+statement ok
 CREATE TABLE stage_partition_src(dt DATE, ts TIMESTAMP, val INT)
 
 statement ok

--- a/tests/sqllogictests/suites/stage/formats/parquet/options/parquet_missing_uuid.test
+++ b/tests/sqllogictests/suites/stage/formats/parquet/options/parquet_missing_uuid.test
@@ -22,10 +22,8 @@ query TI
 select * from t_uuid
 ----
 
-query ???
+statement ok
 copy into @data/parquet/unload/uuid/ from (select 1 as a)  file_format = (type = parquet)
-----
-1 1 414
 
 statement ok
 truncate table t_uuid

--- a/tests/sqllogictests/suites/stage/unload.test
+++ b/tests/sqllogictests/suites/stage/unload.test
@@ -179,10 +179,8 @@ statement error 1006.*file already exists
 copy into @unload/a_raw_path.csv from (select 3,4) file_format=(type=csv) single=true include_query_id=false use_raw_path=true detailed_output=false overwrite=false;
 
 
-query ???
+statement ok
 copy into @unload/array_of_nulls from (select [NULL, NULL]);
-----
-1 8 555
 
 query ?
 select * from @unload/array_of_nulls;

--- a/tests/suites/1_stateful/00_stage/00_0005_copy_into_location.result
+++ b/tests/suites/1_stateful/00_stage/00_0005_copy_into_location.result
@@ -1,4 +1,4 @@
 >>>> create or replace connection c_00_0005 storage_type='s3' access_key_id = 'minioadmin'  endpoint_url = 'http://127.0.0.1:9900' secret_access_key = 'minioadmin'
 >>>> copy into 's3://testbucket/c_00_0005/ab de/f' connection=(connection_name='c_00_0005') from (select 1) detailed_output=true use_raw_path=true single=true overwrite=true
-c_00_0005/ab de/f	414	1
+c_00_0005/ab de/f	1
 <<<<

--- a/tests/suites/1_stateful/00_stage/00_0005_copy_into_location.sh
+++ b/tests/suites/1_stateful/00_stage/00_0005_copy_into_location.sh
@@ -6,4 +6,4 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 stmt "create or replace connection c_00_0005 storage_type='s3' access_key_id = 'minioadmin'  endpoint_url = 'http://127.0.0.1:9900' secret_access_key = 'minioadmin'"
 
-query "copy into 's3://testbucket/c_00_0005/ab de/f' connection=(connection_name='c_00_0005') from (select 1) detailed_output=true use_raw_path=true single=true overwrite=true"
+query "copy into 's3://testbucket/c_00_0005/ab de/f' connection=(connection_name='c_00_0005') from (select 1) detailed_output=true use_raw_path=true single=true overwrite=true" | cut -d$'\t' -f1,3

--- a/tests/suites/1_stateful/00_stage/00_0017_copy_into_parquet.result
+++ b/tests/suites/1_stateful/00_stage/00_0017_copy_into_parquet.result
@@ -1,7 +1,7 @@
 >>>> drop stage if exists s1;
 >>>> create stage s1;
 1
-2
+3
 1
 4
 4

--- a/tests/suites/1_stateful/00_stage/00_0017_copy_into_parquet.sh
+++ b/tests/suites/1_stateful/00_stage/00_0017_copy_into_parquet.sh
@@ -22,7 +22,7 @@ stmt "create stage s1;"
 # one file when #row is small even though multi-threads
 run_copy_count "copy into @s1/ from (select * from numbers(${SINGLE_ROW_COUNT})) max_file_size=${SMALL_FILE_SIZE} detailed_output=true;"
 
-# two files, the larger is 24960476
+# three files with conservative Parquet encodings
 run_copy_count "copy /*+ set_var(max_threads=1) */ into @s1/ from (select * from numbers(${DOUBLE_ROW_COUNT})) max_file_size=${DUAL_FILE_SIZE} detailed_output=true;"
 
 # one file

--- a/tests/suites/1_stateful/01_streaming_load/01_0006_streaming_load_parquet.result
+++ b/tests/suites/1_stateful/01_streaming_load/01_0006_streaming_load_parquet.result
@@ -2,7 +2,7 @@
 >>>> CREATE or replace TABLE streaming_load_parquet (c1 string default 'ok', c2 int, c3 date);
 --'2021-01-01' as c3, '1' as c2
 >>>> copy into @streaming_load_parquet/q1.parquet from (select '2021-01-01' as c3, '1' as c2)  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;
-q1.parquet	637	1
+q1.parquet	1
 >>>> streaming load: q1.parquet error :
 + curl -sS -H x-databend-query-id:load-q1 -H 'X-Databend-SQL:insert into streaming_load_parquet(c2,c3) from @_databend_load file_format = (type='\''parquet'\'', missing_field_as=error, null_if=())' -F upload=@/tmp/streaming_load_parquet/q1.parquet -u root: -XPUT http://localhost:8000/v1/streaming_load
 {"id":"load-q1","stats":{"rows":1,"bytes":29}}
@@ -13,7 +13,7 @@ ok	1	2021-01-01
 >>>> truncate table streaming_load_parquet
 --'2021-01-01' as c3
 >>>> copy into @streaming_load_parquet/q2.parquet from (select '2021-01-01' as c3)  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;
-q2.parquet	431	1
+q2.parquet	1
 >>>> streaming load: q2.parquet error :
 + curl -sS -H x-databend-query-id:load-q2 -H 'X-Databend-SQL:insert into streaming_load_parquet(c2,c3) from @_databend_load file_format = (type='\''parquet'\'', missing_field_as=error, null_if=())' -F upload=@/tmp/streaming_load_parquet/q2.parquet -u root: -XPUT http://localhost:8000/v1/streaming_load
 {"error":{"code":400,"message":"Query execution failed: file q2.parquet missing column `c2`. current FILE_FORMAT option: MISSING_FIELD_AS=ERROR"}}
@@ -23,7 +23,7 @@ q2.parquet	431	1
 >>>> truncate table streaming_load_parquet
 --'2021-01-01' as c3
 >>>> copy into @streaming_load_parquet/q3.parquet from (select '2021-01-01' as c3)  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;
-q3.parquet	431	1
+q3.parquet	1
 >>>> streaming load: q3.parquet field_default :
 + curl -sS -H x-databend-query-id:load-q3 -H 'X-Databend-SQL:insert into streaming_load_parquet(c2,c3) from @_databend_load file_format = (type='\''parquet'\'', missing_field_as=field_default, null_if=())' -F upload=@/tmp/streaming_load_parquet/q3.parquet -u root: -XPUT http://localhost:8000/v1/streaming_load
 {"id":"load-q3","stats":{"rows":1,"bytes":25}}
@@ -34,7 +34,7 @@ ok	NULL	2021-01-01
 >>>> truncate table streaming_load_parquet
 --'2021-01-01' as c3, 'my_null' as c1
 >>>> copy into @streaming_load_parquet/q4.parquet from (select '2021-01-01' as c3, 'my_null' as c1)  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;
-q4.parquet	655	1
+q4.parquet	1
 >>>> streaming load: q4.parquet error :
 + curl -sS -H x-databend-query-id:load-q4 -H 'X-Databend-SQL:insert into streaming_load_parquet(c1,c3) from @_databend_load file_format = (type='\''parquet'\'', missing_field_as=error, null_if=())' -F upload=@/tmp/streaming_load_parquet/q4.parquet -u root: -XPUT http://localhost:8000/v1/streaming_load
 {"id":"load-q4","stats":{"rows":1,"bytes":30}}
@@ -45,7 +45,7 @@ my_null	NULL	2021-01-01
 >>>> truncate table streaming_load_parquet
 --'2021-01-01' as c3, 'my_null' as c1
 >>>> copy into @streaming_load_parquet/q5.parquet from (select '2021-01-01' as c3, 'my_null' as c1)  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;
-q5.parquet	655	1
+q5.parquet	1
 >>>> streaming load: q5.parquet error 'my_null':
 + curl -sS -H x-databend-query-id:load-q5 -H 'X-Databend-SQL:insert into streaming_load_parquet(c1,c3) from @_databend_load file_format = (type='\''parquet'\'', missing_field_as=error, null_if=('\''my_null'\''))' -F upload=@/tmp/streaming_load_parquet/q5.parquet -u root: -XPUT http://localhost:8000/v1/streaming_load
 {"id":"load-q5","stats":{"rows":1,"bytes":7}}

--- a/tests/suites/1_stateful/01_streaming_load/01_0006_streaming_load_parquet.sh
+++ b/tests/suites/1_stateful/01_streaming_load/01_0006_streaming_load_parquet.sh
@@ -12,7 +12,7 @@ stmt "CREATE or replace TABLE streaming_load_parquet (c1 string default 'ok', c2
 
 function run() {
   echo "--$2"
-  stmt "copy into @streaming_load_parquet/$1.parquet from (select $2)  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;"
+  stmt "copy into @streaming_load_parquet/$1.parquet from (select $2)  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;" | cut -d$'\t' -f1,3
   echo ">>>> streaming load: $1.parquet $4 $5:"
   (set -x; curl -sS -H "x-databend-query-id:load-$1" -H "X-Databend-SQL:insert into streaming_load_parquet($3) from @_databend_load file_format = (type='parquet', missing_field_as=$4, null_if=($5))" -F "upload=@$DATA/$1.parquet" -u root: -XPUT "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/streaming_load")
   echo

--- a/tests/suites/1_stateful/01_streaming_load/01_0007_streaming_load_placeholder.result
+++ b/tests/suites/1_stateful/01_streaming_load/01_0007_streaming_load_placeholder.result
@@ -2,7 +2,7 @@
 >>>> CREATE or replace TABLE streaming_load_07 (c1 string default 'ok', c2 int, c3 string, c4 date);
 --csv
 >>>> copy into @streaming_load_07/data.csv from (select '2020-01-02' as c4, 110 as c2) file_format=(type='csv')  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;
-data.csv	17	1
+data.csv	1
 + curl -sS -H x-databend-query-id:load-csv -H 'X-Databend-SQL:insert into streaming_load_07(c3, c4, c2) values ('\''a'\'', ?, ?) from @_databend_load file_format = (type=csv)' -F upload=@/tmp/streaming_load_07/data.csv -u root: -XPUT http://localhost:8000/v1/streaming_load
 {"id":"load-csv","stats":{"rows":1,"bytes":47}}
 <<<<
@@ -12,7 +12,7 @@ ok	110	a	2020-01-02
 >>>> truncate table streaming_load_07
 --text
 >>>> copy into @streaming_load_07/data.text from (select '2020-01-02' as c4, 110 as c2) file_format=(type='text')  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;
-data.text	15	1
+data.text	1
 + curl -sS -H x-databend-query-id:load-text -H 'X-Databend-SQL:insert into streaming_load_07(c3, c4, c2) values ('\''a'\'', ?, ?) from @_databend_load file_format = (type=text)' -F upload=@/tmp/streaming_load_07/data.text -u root: -XPUT http://localhost:8000/v1/streaming_load
 {"id":"load-text","stats":{"rows":1,"bytes":47}}
 <<<<
@@ -22,7 +22,7 @@ ok	110	a	2020-01-02
 >>>> truncate table streaming_load_07
 --ndjson
 >>>> copy into @streaming_load_07/data.ndjson from (select '2020-01-02' as c4, 110 as c2) file_format=(type='ndjson')  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;
-data.ndjson	29	1
+data.ndjson	1
 + curl -sS -H x-databend-query-id:load-ndjson -H 'X-Databend-SQL:insert into streaming_load_07(c3, c4, c2) values ('\''a'\'', ?, ?) from @_databend_load file_format = (type=ndjson)' -F upload=@/tmp/streaming_load_07/data.ndjson -u root: -XPUT http://localhost:8000/v1/streaming_load
 {"id":"load-ndjson","stats":{"rows":1,"bytes":47}}
 <<<<
@@ -32,7 +32,7 @@ ok	110	a	2020-01-02
 >>>> truncate table streaming_load_07
 --parquet
 >>>> copy into @streaming_load_07/data.parquet from (select '2020-01-02' as c4, 110 as c2) file_format=(type='parquet')  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;
-data.parquet	678	1
+data.parquet	1
 + curl -sS -H x-databend-query-id:load-parquet -H 'X-Databend-SQL:insert into streaming_load_07(c3, c4, c2) values ('\''a'\'', ?, ?) from @_databend_load file_format = (type=parquet)' -F upload=@/tmp/streaming_load_07/data.parquet -u root: -XPUT http://localhost:8000/v1/streaming_load
 {"id":"load-parquet","stats":{"rows":1,"bytes":47}}
 <<<<

--- a/tests/suites/1_stateful/01_streaming_load/01_0007_streaming_load_placeholder.sh
+++ b/tests/suites/1_stateful/01_streaming_load/01_0007_streaming_load_placeholder.sh
@@ -12,7 +12,7 @@ stmt "CREATE or replace TABLE streaming_load_07 (c1 string default 'ok', c2 int,
 
 function run() {
   echo "--$1"
-  stmt "copy into @streaming_load_07/data.$1 from (select '2020-01-02' as c4, 110 as c2) file_format=(type='$1')  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;"
+  stmt "copy into @streaming_load_07/data.$1 from (select '2020-01-02' as c4, 110 as c2) file_format=(type='$1')  single=true include_query_id=false use_raw_path=true detailed_output=true overwrite=true;" | cut -d$'\t' -f1,3
   (set -x; curl -sS -H "x-databend-query-id:load-$1" -H "X-Databend-SQL:insert into streaming_load_07(c3, c4, c2) values ('a', ?, ?) from @_databend_load file_format = (type=$1)" -F "upload=@$DATA/data.$1" -u root: -XPUT "http://localhost:${QUERY_HTTP_HANDLER_PORT}/v1/streaming_load")
   echo
   echo "<<<<"

--- a/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.result
+++ b/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.result
@@ -17,6 +17,5 @@
 2	{"k":"v"}
 --- large parquet file should be worked on parallel by rowgroups
 5000000
-├── partitions total: 3
-├── partitions scanned: 3
+parallel scan partitions: true
 5000000

--- a/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.sh
+++ b/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.sh
@@ -47,11 +47,18 @@ echo 'remove @s4;' | bendsql_connect_root
 echo 'remove @s1;' | bendsql_connect_root
 echo "copy into @s4 from (select number a, number::string b, number::decimal(15,2) c from numbers(5000000)) file_format=(type=parquet) single=true;" | bendsql_connect_root | cut -d$'\t' -f1
 
-## 12MB divide by 2MB = 6, so we will read 6 partitions
-echo """
+## A 2 MiB hint should split the large file into multiple scan partitions.
+PARTITIONS=$(echo """
 set parquet_rowgroup_hint_bytes = 2 * 1024 * 1024;
 explain select * from @s4;
-""" | bendsql_connect_root | grep 'partitions ' | sed  's/^[[:space:]]*//g'
+""" | bendsql_connect_root | grep 'partitions ')
+PARTITIONS_TOTAL=$(echo "$PARTITIONS" | awk -F': ' '/partitions total/ {print $2}')
+PARTITIONS_SCANNED=$(echo "$PARTITIONS" | awk -F': ' '/partitions scanned/ {print $2}')
+if [[ $PARTITIONS_TOTAL -le 1 || $PARTITIONS_SCANNED -ne $PARTITIONS_TOTAL ]]; then
+  echo "expected all of multiple partitions to be scanned, got total=$PARTITIONS_TOTAL scanned=$PARTITIONS_SCANNED" >&2
+  exit 1
+fi
+echo 'parallel scan partitions: true'
 
 echo "copy into @s1 from (select * from @s4) file_format=(type=parquet)" | bendsql_connect_root | cut -d$'\t' -f1
 echo "select * from @s1 order by a except (select * from @s4 order by a)" | bendsql_connect_root


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Parquet files produced by `COPY INTO <location>` could use Parquet 2.0 value encodings and embed modern Arrow types in `ARROW:schema`. This caused a real interoperability failure with an Arrow C++ 8 reader and could also affect other older readers.

This change makes Parquet unload output more conservative:

- writes Data Page V1 files with `PARQUET_1_0`;
- disables dictionary encoding so `PARQUET_1_0` output does not still contain the Parquet 2.0 `RLE_DICTIONARY` encoding;
- keeps value pages on `PLAIN` encoding, avoiding delta-encoding compatibility bugs in older readers;
- embeds a storage-equivalent legacy `ARROW:schema`, mapping `Utf8View`, `BinaryView`, `ListView`, `LargeListView`, `Decimal32`, and `Decimal64` recursively to types understood by older Arrow implementations;
- changes only footer metadata for those Arrow types. The original arrays are still written directly, without casting or copying the unload data;
- canonicalizes Parquet map entry names to `key` and `value`, because older PyArrow map scalars look them up by name. Record batches reuse the original arrays and buffers with field-name matching disabled, so this does not copy map data.

`Decimal256` is deliberately preserved because it has no storage-equivalent narrower Arrow type. Files containing it require a reader with Decimal256 support. PyArrow 4.0.0 is the oldest version covered by this PR because it is the first release with a CPython 3.9 Linux aarch64 wheel for the CI runner. PyArrow 8.0.0 remains in the matrix as the user regression case. Databend's unload schema does not produce the other post-1.0 Arrow format types such as `MonthDayNano` or `RunEndEncoded`.

The writer change is limited to Parquet unload and does not affect Fuse's internal Parquet storage.

References:

- [Arrow format versioning](https://arrow.apache.org/docs/format/Versioning.html)
- [Arrow release archive](https://arrow.apache.org/release/)
- [Parquet format versions](https://parquet.apache.org/docs/file-format/versions/)

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation and regression coverage:

- `cargo test -p databend-common-storages-stage parquet_file::writer_processor::tests --lib`
- `cargo clippy -p databend-common-storages-stage --lib -- -D warnings`
- `ruff check tests/nox/noxfile.py tests/nox/pyarrow_compat`
- `nox -f tests/nox/noxfile.py --list`
- CI reads real Zstd-compressed and uncompressed unload output with PyArrow 4.0.0 and 8.0.0, covering primitive, binary/string, Decimal128/256, temporal, nullable, list, map, and vector fields.

The compatibility matrix can be overridden with `PYARROW_COMPAT_VERSIONS`.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent assisted with the Parquet/Arrow compatibility analysis, implementation, regression tests, and compatibility CI session; the responsible human reviewed the final diff and owns the change.
- Responsible human: @youngsofun
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20326)
<!-- Reviewable:end -->
