### PR TITLE
feat(query): extract explicit materialized CTE lineage

### DIFF
--- a/src/query/sql/src/planner/binder/bind_table_reference/bind_table.rs
+++ b/src/query/sql/src/planner/binder/bind_table_reference/bind_table.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+
 use databend_common_ast::Span;
 use databend_common_ast::ast::SampleConfig;
 use databend_common_ast::ast::Statement;
@@ -33,8 +35,13 @@ use databend_common_storages_basic::view_table::QUERY;
 use databend_storages_common_table_meta::table::get_change_type;
 
 use crate::BindContext;
+use crate::ColumnEntry;
 use crate::LineageSourceRelation;
+use crate::MaterializedCteLineageSource;
+use crate::Metadata;
+use crate::Symbol;
 use crate::ViewLineageSourceColumn;
+use crate::Visibility;
 use crate::binder::Binder;
 use crate::binder::ViewIdent;
 use crate::binder::lineage_enabled;
@@ -97,6 +104,7 @@ impl Binder {
 
         // Check and bind common table expression
         let mut cte_suffix_name = None;
+        let mut materialized_cte_lineage = None;
         let cte_map = bind_context.cte_context.cte_map.clone();
         if let Some(cte_info) = cte_map.get(&table_name) {
             if let Some(materialized_cte_info) = &cte_info.materialized_cte_info {
@@ -108,6 +116,15 @@ impl Binder {
                     &materialized_cte_info.bound_context.columns,
                 );
             } else if cte_info.user_specified_materialized {
+                if lineage_enabled() {
+                    // The main query scans a temporary table, so retain a separately bound
+                    // producer definition that lineage extraction can follow by output position.
+                    materialized_cte_lineage = Some(self.bind_cte_definition(
+                        &table_name,
+                        cte_map.as_ref(),
+                        &cte_info.query,
+                    )?);
+                }
                 cte_suffix_name = Some(self.ctx.get_id().replace("-", ""));
             } else {
                 if self
@@ -375,6 +392,53 @@ impl Binder {
                     sample,
                     true,
                 )?;
+                if let Some((definition, producer_context)) = materialized_cte_lineage {
+                    let producer_columns = producer_context
+                        .columns
+                        .iter()
+                        .filter(|column| column.visibility == Visibility::Visible)
+                        .collect::<Vec<_>>();
+                    let consumer_column_count = bind_context
+                        .columns
+                        .iter()
+                        .filter(|column| column.visibility == Visibility::Visible)
+                        .count();
+                    if consumer_column_count != producer_columns.len() {
+                        return Err(ErrorCode::Internal(format!(
+                            "Materialized CTE '{}' has {} producer columns but {} temporary-table columns",
+                            table_name,
+                            producer_columns.len(),
+                            consumer_column_count
+                        )));
+                    }
+                    let column_mapping = {
+                        let metadata = self.metadata.read();
+                        bind_context
+                            .columns
+                            .iter()
+                            .filter_map(|consumer| {
+                                let output_position =
+                                    materialized_cte_output_position(&metadata, consumer.index)?;
+                                let producer = producer_columns.get(output_position)?;
+                                Some((
+                                    consumer.index,
+                                    materialized_cte_producer_column(
+                                        &metadata,
+                                        consumer.index,
+                                        producer.index,
+                                    ),
+                                ))
+                            })
+                            .collect::<HashMap<_, _>>()
+                    };
+                    self.metadata.write().add_materialized_cte_lineage_source(
+                        table_index,
+                        MaterializedCteLineageSource {
+                            definition,
+                            column_mapping,
+                        },
+                    );
+                }
                 if let Some(alias) = alias {
                     bind_context.apply_table_alias(alias, &self.name_resolution_ctx)?;
                 }
@@ -409,6 +473,68 @@ impl Binder {
             });
         }
     }
+}
+
+fn materialized_cte_producer_column(
+    metadata: &Metadata,
+    consumer_index: Symbol,
+    producer_index: Symbol,
+) -> Symbol {
+    let ColumnEntry::BaseTableColumn(consumer) = metadata.column(consumer_index) else {
+        return producer_index;
+    };
+    let Some(consumer_path) = consumer.path_indices.as_deref() else {
+        return producer_index;
+    };
+    let Some(nested_path) = consumer_path.get(1..) else {
+        return producer_index;
+    };
+
+    let ColumnEntry::BaseTableColumn(producer) = metadata.column(producer_index) else {
+        return producer_index;
+    };
+    let mut producer_path = if let Some(path) = &producer.path_indices {
+        path.clone()
+    } else if let Some(position) = materialized_cte_output_position(metadata, producer_index) {
+        vec![position]
+    } else {
+        return producer_index;
+    };
+    producer_path.extend_from_slice(nested_path);
+
+    metadata
+        .columns_by_table_index(producer.table_index)
+        .find_map(|column| match column {
+            ColumnEntry::BaseTableColumn(column)
+                if column.path_indices.as_deref() == Some(producer_path.as_slice()) =>
+            {
+                Some(column.column_index)
+            }
+            _ => None,
+        })
+        .unwrap_or(producer_index)
+}
+
+fn materialized_cte_output_position(metadata: &Metadata, column_index: Symbol) -> Option<usize> {
+    let ColumnEntry::BaseTableColumn(column) = metadata.column(column_index) else {
+        return None;
+    };
+    if let Some(path) = &column.path_indices {
+        return path.first().copied();
+    }
+    if let Some(position) = column.column_position {
+        return position.checked_sub(1);
+    }
+
+    metadata
+        .columns_by_table_index(column.table_index)
+        .filter(|column| {
+            matches!(
+                column,
+                ColumnEntry::BaseTableColumn(column) if column.path_indices.is_none()
+            )
+        })
+        .position(|column| column.index() == column_index)
 }
 
 fn stream_lineage_source_relation(

--- a/src/query/sql/src/planner/lineage.rs
+++ b/src/query/sql/src/planner/lineage.rs
@@ -790,7 +790,19 @@ impl LineageResolver {
         let RelOperator::Scan(scan) = operator else {
             return Ok(());
         };
+        let materialized_cte = metadata.materialized_cte_lineage_source(scan.table_index);
+        if let Some(source) = materialized_cte {
+            self.collect_s_expr(&source.definition, metadata)?;
+        }
         for column in &scan.columns {
+            if let Some(output_column) = materialized_cte
+                .and_then(|source| source.column_mapping.get(column))
+                .copied()
+            {
+                self.definitions
+                    .insert(*column, vec![SourceExpr::Symbol(output_column)]);
+                continue;
+            }
             let Some(source) = source_column_from_symbol(metadata, *column)? else {
                 continue;
             };
@@ -936,6 +948,14 @@ fn source_column_from_output(
 
 fn source_column_from_symbol(metadata: &Metadata, symbol: Symbol) -> Result<Option<SourceColumn>> {
     if symbol.is_dummy_column() || symbol.as_usize() >= metadata.columns().len() {
+        return Ok(None);
+    }
+
+    // A user-specified materialized CTE is scanned through a temporary table,
+    // but its outputs retain producer definitions in metadata for lineage.
+    // Prefer those definitions because the temporary table is only an
+    // execution detail, not a lineage source.
+    if metadata.materialized_cte_lineage_output(symbol).is_some() {
         return Ok(None);
     }
 

--- a/src/query/sql/src/planner/metadata/metadata.rs
+++ b/src/query/sql/src/planner/metadata/metadata.rs
@@ -88,6 +88,10 @@ pub struct Metadata {
     /// View output symbols that should remain at the view boundary after the
     /// view query is expanded into the surrounding plan.
     view_lineage_source_columns: HashMap<Symbol, Vec<ViewLineageSourceColumn>>,
+    /// Explicit materialized CTEs are executed through temporary tables. Keep
+    /// one producer definition and its temporary-table output mappings so
+    /// lineage extraction can look through that execution detail.
+    materialized_cte_lineage_sources: HashMap<IndexType, MaterializedCteLineageSource>,
     next_runtime_filter_id: usize,
     next_logical_recursive_cte_id: u32,
     next_materialized_cte_id: usize,
@@ -602,6 +606,31 @@ impl Metadata {
             })
     }
 
+    pub(crate) fn add_materialized_cte_lineage_source(
+        &mut self,
+        table_index: IndexType,
+        source: MaterializedCteLineageSource,
+    ) {
+        self.materialized_cte_lineage_sources
+            .insert(table_index, source);
+    }
+
+    pub(crate) fn materialized_cte_lineage_source(
+        &self,
+        table_index: IndexType,
+    ) -> Option<&MaterializedCteLineageSource> {
+        self.materialized_cte_lineage_sources.get(&table_index)
+    }
+
+    pub(crate) fn materialized_cte_lineage_output(&self, column_index: Symbol) -> Option<Symbol> {
+        let table_index = self.columns.get(column_index.as_usize())?.table_index()?;
+        self.materialized_cte_lineage_sources
+            .get(&table_index)?
+            .column_mapping
+            .get(&column_index)
+            .copied()
+    }
+
     pub(crate) fn set_stream_lineage_source(
         &mut self,
         table_index: IndexType,
@@ -615,6 +644,12 @@ impl Metadata {
             entry.table = table.clone();
         }
     }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct MaterializedCteLineageSource {
+    pub(crate) definition: SExpr,
+    pub(crate) column_mapping: HashMap<Symbol, Symbol>,
 }
 
 #[derive(Clone)]

--- a/src/query/sql/tests/it/planner/lineage.rs
+++ b/src/query/sql/tests/it/planner/lineage.rs
@@ -20,10 +20,12 @@ use databend_common_config::InnerConfig;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::ColumnId;
+use databend_common_expression::DataBlock;
 use databend_common_meta_app::schema::CatalogType;
 use databend_common_sql::LineageSource;
 use databend_common_sql::LineageTarget;
 use databend_common_sql::Planner;
+use databend_common_sql::QueryExecutor;
 use databend_common_sql::QueryLineage;
 use databend_common_sql::QueryLineageColumn;
 use databend_common_sql::QueryLineageColumnEdge;
@@ -162,6 +164,53 @@ async fn test_query_lineage_insert_select_with_auto_materialized_cte_from_sql() 
     assert_lineage_sources(&lineage, QueryLineageKind::Dml, "dst", "x", &[
         "src.a", "src.b",
     ]);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_query_lineage_insert_select_with_explicit_materialized_cte_from_sql() -> Result<()> {
+    let ctx = lineage_test_context().await?;
+    ctx.register_setup_sql("CREATE TABLE src(a INT, b INT, c INT)")
+        .await?;
+    ctx.register_setup_sql("CREATE TABLE dst(x INT)").await?;
+
+    let sql = "INSERT INTO dst WITH q(x, filter_col) AS MATERIALIZED (SELECT a + b, c FROM src) SELECT x FROM q WHERE filter_col > 0";
+    let mut planner = Planner::new_with_query_executor(
+        ctx.clone(),
+        Arc::new(LineageQueryExecutor { ctx: ctx.clone() }),
+    );
+    let (plan, _) = planner.plan_sql(sql).await?;
+    let lineage = plan
+        .query_lineage()?
+        .ok_or_else(|| ErrorCode::Internal(format!("missing query lineage for SQL: {sql}")))?;
+
+    assert_lineage_sources(&lineage, QueryLineageKind::Dml, "dst", "x", &[
+        "src.a", "src.b",
+    ]);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_query_lineage_explicit_materialized_cte_tuple_field_from_sql() -> Result<()> {
+    let ctx = lineage_test_context().await?;
+    ctx.register_setup_sql("CREATE TABLE src(t TUPLE(a INT, b INT))")
+        .await?;
+    ctx.register_setup_sql("CREATE TABLE dst(x INT)").await?;
+
+    let direct = query_lineage_from_sql(&ctx, "INSERT INTO dst SELECT t.1 FROM src").await?;
+    assert_lineage_sources(&direct, QueryLineageKind::Dml, "dst", "x", &["src.t:a"]);
+
+    let sql = "INSERT INTO dst WITH q(t) AS MATERIALIZED (SELECT t FROM src) SELECT t.1 FROM q";
+    let mut planner = Planner::new_with_query_executor(
+        ctx.clone(),
+        Arc::new(LineageQueryExecutor { ctx: ctx.clone() }),
+    );
+    let (plan, _) = planner.plan_sql(sql).await?;
+    let lineage = plan
+        .query_lineage()?
+        .ok_or_else(|| ErrorCode::Internal(format!("missing query lineage for SQL: {sql}")))?;
+
+    assert_lineage_sources(&lineage, QueryLineageKind::Dml, "dst", "x", &["src.t:a"]);
     Ok(())
 }
 
@@ -479,6 +528,18 @@ async fn lineage_test_context() -> Result<Arc<LiteTableContext>> {
     // thread before LiteTableContext::create() attempts to install the default configuration.
     init_testing_globals_with_config(config);
     LiteTableContext::create().await
+}
+
+struct LineageQueryExecutor {
+    ctx: Arc<LiteTableContext>,
+}
+
+#[async_trait::async_trait]
+impl QueryExecutor for LineageQueryExecutor {
+    async fn execute_query_with_sql_string(&self, sql: &str) -> Result<Vec<DataBlock>> {
+        self.ctx.register_table_sql(sql).await?;
+        Ok(Vec::new())
+    }
 }
 
 async fn query_lineage_from_sql(ctx: &Arc<LiteTableContext>, sql: &str) -> Result<QueryLineage> {

--- a/tests/lineage/sqllogic/check/04_statement_coverage.test
+++ b/tests/lineage/sqllogic/check/04_statement_coverage.test
@@ -26,6 +26,19 @@ FROM get_lineage('lineage_history_statements.insert_dst', 'TABLE', 'UPSTREAM', 1
 ----
 1 lineage_history_statements src lineage_history_statements insert_dst
 
+query ISS rowsort
+SELECT distance, source_column_name, target_column_name
+FROM get_lineage('lineage_history_statements.mcte_dst.x', 'COLUMN', 'UPSTREAM', 1)
+----
+1 a x
+1 b x
+
+query ISS
+SELECT distance, source_column_name, target_column_name
+FROM get_lineage('lineage_history_statements.mcte_tuple_dst.x', 'COLUMN', 'UPSTREAM', 1)
+----
+1 t x
+
 query I
 SELECT count(*)
 FROM system_history.lineage_history

--- a/tests/lineage/sqllogic/setup/04_statement_coverage.test
+++ b/tests/lineage/sqllogic/setup/04_statement_coverage.test
@@ -35,6 +35,30 @@ statement ok
 INSERT INTO lineage_history_statements.insert_dst
 SELECT a, b FROM lineage_history_statements.src
 
+# Explicit materialized CTE outputs must resolve through the temporary table to the producer.
+statement ok
+CREATE TABLE lineage_history_statements.mcte_dst(x INT)
+
+statement ok
+INSERT INTO lineage_history_statements.mcte_dst
+WITH q(x, filter_col) AS MATERIALIZED (
+  SELECT a + b, c FROM lineage_history_statements.src
+)
+SELECT x FROM q WHERE filter_col > 0
+
+statement ok
+CREATE TABLE lineage_history_statements.mcte_tuple_src(t TUPLE(a INT, b INT))
+
+statement ok
+CREATE TABLE lineage_history_statements.mcte_tuple_dst(x INT)
+
+statement ok
+INSERT INTO lineage_history_statements.mcte_tuple_dst
+WITH q(t) AS MATERIALIZED (
+  SELECT t FROM lineage_history_statements.mcte_tuple_src
+)
+SELECT t.1 FROM q
+
 # EXPLAIN PIPELINE builds the inner DML pipeline without executing it, so it must not leak
 # captured inner lineage into the outer EXPLAIN query finish log.
 statement ok


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Extract source relation and column lineage through user-specified `AS MATERIALIZED` CTEs.

This is a focused follow-up to #20201. Automatic materialized CTEs already preserve a producer-to-consumer mapping in the logical plan, but explicit materialized CTEs are executed through temporary tables and previously lost their upstream lineage at that boundary.

## Motivation

Lineage for statements such as the following incorrectly stopped at the internal MCTE temporary table instead of reporting `src.a` and `src.b` as the sources of `dst.x`:

```sql
INSERT INTO dst
WITH q(x, filter_col) AS MATERIALIZED (
  SELECT a + b, c FROM src
)
SELECT x FROM q WHERE filter_col > 0;
```

The temporary table is an execution detail and should not appear as a lineage source. This change retains the explicit MCTE producer definition and maps visible temporary-table outputs back to producer outputs by position, allowing the existing lineage resolver to continue to base relations and columns.

The mapping is collected only when lineage capture is enabled and does not change MCTE execution behavior.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:

- `cargo test -p databend-common-sql --test it planner::lineage -- --nocapture`
- `cargo clippy -p databend-common-sql --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Added planner coverage and an end-to-end lineage sqllogictest asserting that `dst.x` resolves to `src.a` and `src.b`, while the filter-only `src.c` column is excluded.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent investigated the explicit MCTE planner shape, drafted the producer-output mapping, added planner and lineage sqllogictest coverage, ran local validation, and prepared this PR description.
- Responsible human: @youngsofun
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20327)
<!-- Reviewable:end -->
