### PR TITLE
fix(query): fix distributed grouping sets with materialized CTEs

### DIFF
--- a/src/query/service/src/schedulers/fragments/fragmenter.rs
+++ b/src/query/service/src/schedulers/fragments/fragmenter.rs
@@ -59,18 +59,13 @@ use crate::sessions::TableContextSettings;
 pub struct Fragmenter {
     ctx: Arc<QueryContext>,
     query_id: String,
-    fragments: Vec<PlanFragment>,
 }
 
 impl Fragmenter {
     pub fn try_create(ctx: Arc<QueryContext>) -> Result<Self> {
         let query_id = ctx.get_id();
 
-        Ok(Self {
-            ctx,
-            fragments: vec![],
-            query_id,
-        })
+        Ok(Self { ctx, query_id })
     }
 
     /// Get ids of executor nodes.
@@ -111,12 +106,22 @@ impl Fragmenter {
             fragment_id: self.ctx.fragment_id().next_fragment_id(),
             exchange: None,
             query_id: self.query_id.clone(),
-            source_fragments: self.fragments,
+            has_merge_input: false,
         });
 
         let edges = Self::collect_fragments_edge(fragments.values());
 
         for (source, target) in edges {
+            let has_merge_input = fragments
+                .get(&source)
+                .is_some_and(|fragment| matches!(fragment.exchange, Some(DataExchange::Merge(_))));
+
+            if has_merge_input {
+                if let Some(fragment) = fragments.get_mut(&target) {
+                    fragment.has_merge_input = true;
+                }
+            }
+
             let Some(fragment) = fragments.get_mut(&source) else {
                 continue;
             };
@@ -317,9 +322,9 @@ impl DeriveHandle for FragmentDeriveHandle {
                 plan,
                 exchange,
                 fragment_type,
-                source_fragments: vec![],
                 fragment_id: source_fragment_id,
                 query_id: self.query_id.clone(),
+                has_merge_input: false,
             };
 
             self.fragments.insert(source_fragment_id, source_fragment);
@@ -354,7 +359,7 @@ impl DeriveHandle for FragmentDeriveHandle {
                 fragment_id,
                 exchange: None,
                 query_id: self.query_id.clone(),
-                source_fragments: vec![],
+                has_merge_input: false,
             };
 
             self.fragments.insert(fragment_id, fragment);

--- a/src/query/service/src/schedulers/fragments/plan_fragment.rs
+++ b/src/query/service/src/schedulers/fragments/plan_fragment.rs
@@ -23,6 +23,7 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::BlockEntry;
 use databend_common_expression::Column;
+use databend_common_expression::ColumnBuilder;
 use databend_common_expression::DataBlock;
 use databend_common_settings::ReplaceIntoShuffleStrategy;
 use databend_storages_common_table_meta::meta::BlockSlotDescription;
@@ -36,6 +37,7 @@ use crate::physical_plans::IPhysicalPlan;
 use crate::physical_plans::MutationSource;
 use crate::physical_plans::PhysicalPlan;
 use crate::physical_plans::PhysicalPlanCast;
+use crate::physical_plans::PhysicalPlanMeta;
 use crate::physical_plans::PhysicalPlanVisitor;
 use crate::physical_plans::Recluster;
 use crate::physical_plans::ReplaceDeduplicate;
@@ -77,9 +79,7 @@ pub struct PlanFragment {
     pub fragment_id: usize,
     pub exchange: Option<DataExchange>,
     pub query_id: String,
-
-    // The fragments to ask data from.
-    pub source_fragments: Vec<PlanFragment>,
+    pub has_merge_input: bool,
 }
 
 impl PlanFragment {
@@ -88,10 +88,6 @@ impl PlanFragment {
         ctx: Arc<QueryContext>,
         actions: &mut QueryFragmentsActions,
     ) -> Result<()> {
-        // for input in self.source_fragments.iter() {
-        //     input.get_actions(ctx.clone(), actions)?;
-        // }
-
         let mut fragment_actions = QueryFragmentActions::create(self.fragment_id);
 
         match &self.fragment_type {
@@ -103,18 +99,46 @@ impl PlanFragment {
                 fragment_actions.add_action(action);
             }
             FragmentType::Intermediate => {
-                if self
-                    .source_fragments
-                    .iter()
-                    .any(|fragment| matches!(&fragment.exchange, Some(DataExchange::Merge(_))))
-                {
-                    // If this is a intermediate fragment with merge input,
-                    // we will only send it to coordinator node.
-                    let action = QueryFragmentAction::create(
-                        Fragmenter::get_local_executor(ctx),
-                        self.plan.clone(),
-                    );
+                if self.has_merge_input {
+                    // Only the coordinator can consume the merge input. Other shuffle
+                    // destinations still need this fragment to receive remote data.
+                    let local_executor = Fragmenter::get_local_executor(ctx);
+                    let action =
+                        QueryFragmentAction::create(local_executor.clone(), self.plan.clone());
                     fragment_actions.add_action(action);
+
+                    if let Some(exchange) = &self.exchange {
+                        let mut empty_plan = self.plan.clone();
+                        let Some(exchange_sink) =
+                            ExchangeSink::from_mut_physical_plan(&mut empty_plan)
+                        else {
+                            return Err(ErrorCode::Internal(
+                                "Intermediate fragment exchange plan has no ExchangeSink",
+                            ));
+                        };
+                        exchange_sink.input = PhysicalPlan::new(ConstantTableScan {
+                            meta: PhysicalPlanMeta::new("ConstantTableScan"),
+                            values: exchange_sink
+                                .schema
+                                .fields()
+                                .iter()
+                                .map(|field| {
+                                    ColumnBuilder::with_capacity(field.data_type(), 0).build()
+                                })
+                                .collect(),
+                            num_rows: 0,
+                            output_schema: exchange_sink.schema.clone(),
+                        });
+
+                        for executor in exchange.get_destinations() {
+                            if executor != local_executor {
+                                fragment_actions.add_action(QueryFragmentAction::create(
+                                    executor,
+                                    empty_plan.clone(),
+                                ));
+                            }
+                        }
+                    }
                 } else {
                     // Otherwise distribute the fragment to all the executors.
                     for executor in Fragmenter::get_executors(ctx) {

--- a/src/query/sql/src/planner/optimizer/optimizer.rs
+++ b/src/query/sql/src/planner/optimizer/optimizer.rs
@@ -36,6 +36,7 @@ use crate::optimizer::optimizers::CommonSubexpressionOptimizer;
 use crate::optimizer::optimizers::DPhpyOptimizer;
 use crate::optimizer::optimizers::EliminateSelfJoinOptimizer;
 use crate::optimizer::optimizers::distributed::BroadcastToShuffleOptimizer;
+use crate::optimizer::optimizers::distributed::MaterializedCTEDistributionOptimizer;
 use crate::optimizer::optimizers::operator::CleanupUnusedCTEOptimizer;
 use crate::optimizer::optimizers::operator::DeduplicateJoinConditionOptimizer;
 use crate::optimizer::optimizers::operator::FinalizeSpatialJoinOptimizer;
@@ -330,6 +331,8 @@ async fn optimize_query_inner(
         )
         // Cascades optimizer may fail due to timeout, fallback to heuristic optimizer in this case.
         .add(CascadesOptimizer::new(opt_ctx.clone())?)
+        // Normalize distributed MaterializedCTE producers after physical properties are settled.
+        .add(MaterializedCTEDistributionOptimizer::new(opt_ctx.clone()))
         // Eliminate unnecessary scalar calculations to clean up the final plan
         .add_if(
             !opt_ctx.get_planning_agg_index(),

--- a/src/query/sql/src/planner/optimizer/optimizers/cascades/cascade.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/cascades/cascade.rs
@@ -25,7 +25,6 @@ use crate::optimizer::OptimizerContext;
 use crate::optimizer::cost::CostModel;
 use crate::optimizer::ir::Distribution;
 use crate::optimizer::ir::Memo;
-use crate::optimizer::ir::RelExpr;
 use crate::optimizer::ir::RequiredProperty;
 use crate::optimizer::ir::SExpr;
 use crate::optimizer::optimizers::cascades::cost::DefaultCostModel;
@@ -38,7 +37,6 @@ use crate::optimizer::optimizers::distributed::DistributedOptimizer;
 use crate::optimizer::optimizers::distributed::SortAndLimitPushDownOptimizer;
 use crate::optimizer::optimizers::rule::RuleSet;
 use crate::optimizer::optimizers::rule::TransformResult;
-use crate::plans::RelOperator;
 
 /// A cascades-style search engine to enumerate possible alternations of a relational expression and
 /// find the optimal one.
@@ -93,7 +91,7 @@ impl CascadesOptimizer {
         let result = self.optimize_internal(s_expr.clone());
 
         // Process different cases based on the result
-        let mut optimized_expr = match result {
+        let optimized_expr = match result {
             Ok(expr) => {
                 // After successful optimization, apply sort and limit push down if distributed optimization is enabled
                 if opt_ctx.get_enable_distributed_optimization() {
@@ -122,52 +120,7 @@ impl CascadesOptimizer {
             }
         };
 
-        optimized_expr = Self::remove_exchanges_for_serial_sequence(optimized_expr)?;
-
         Ok(optimized_expr)
-    }
-
-    fn remove_exchanges_for_serial_sequence(s_expr: SExpr) -> Result<SExpr> {
-        if Self::has_sequence_with_serial_left_child(&s_expr)? {
-            Self::remove_all_exchanges(s_expr)
-        } else {
-            Ok(s_expr)
-        }
-    }
-
-    fn has_sequence_with_serial_left_child(s_expr: &SExpr) -> Result<bool> {
-        if let RelOperator::Sequence(_) = s_expr.plan.as_ref() {
-            let left_child = s_expr.left_child();
-            let rel_expr = RelExpr::with_s_expr(left_child);
-            let physical_prop = rel_expr.derive_physical_prop()?;
-
-            if physical_prop.distribution == Distribution::Serial {
-                return Ok(true);
-            }
-        }
-
-        for child in s_expr.children() {
-            if Self::has_sequence_with_serial_left_child(child)? {
-                return Ok(true);
-            }
-        }
-
-        Ok(false)
-    }
-
-    fn remove_all_exchanges(s_expr: SExpr) -> Result<SExpr> {
-        if let RelOperator::Exchange(_) = s_expr.plan.as_ref() {
-            return Self::remove_all_exchanges(s_expr.unary_child().clone());
-        }
-
-        let mut new_children = Vec::new();
-        for child in s_expr.children() {
-            let processed_child = Self::remove_all_exchanges(child.clone())?;
-            new_children.push(Arc::new(processed_child));
-        }
-
-        let result = s_expr.replace_children(new_children);
-        Ok(result)
     }
 
     fn optimize_internal(&mut self, s_expr: SExpr) -> Result<SExpr> {

--- a/src/query/sql/src/planner/optimizer/optimizers/distributed/materialized_cte.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/distributed/materialized_cte.rs
@@ -60,11 +60,48 @@ impl MaterializedCTEDistributionOptimizer {
 }
 
 /// A Sequence producer must participate in the distributed fragment graph. When
-/// its CTE definition ends in a scalar operator, redistribute the result after
-/// that operator instead of forcing the entire query to run without Exchanges.
-/// Hashing by a constant preserves the producer's rows without broadcasting or
-/// changing the scalar operator's empty-input behavior.
+/// its CTE definition is serial because it consumes a Merge exchange,
+/// redistribute the result after that operator instead of forcing the entire
+/// query to run without Exchanges. Other serial sources, such as
+/// DummyTableScan, are not coordinator-only Merge consumers and must keep the
+/// existing serial fallback. Hashing by a constant preserves the producer's
+/// rows without broadcasting or changing scalar empty-input behavior.
 struct SerialProducerRedistributor;
+
+impl SerialProducerRedistributor {
+    fn match_merge_backed_producer(expr: &SExpr) -> Result<Option<&SExpr>> {
+        let RelOperator::Sequence(_) = expr.plan() else {
+            return Ok(None);
+        };
+
+        let producer = expr.left_child();
+        let physical_prop = RelExpr::with_s_expr(producer).derive_physical_prop()?;
+        if physical_prop.distribution != Distribution::Serial {
+            return Ok(None);
+        }
+
+        let RelOperator::MaterializedCTE(_) = producer.plan() else {
+            return Err(ErrorCode::Internal(
+                "Sequence left child is expected to be MaterializedCTE".to_string(),
+            ));
+        };
+
+        let mut expr = producer.unary_child();
+        loop {
+            let physical_prop = RelExpr::with_s_expr(expr).derive_physical_prop()?;
+            if physical_prop.distribution != Distribution::Serial {
+                return Ok(None);
+            }
+
+            match expr.plan() {
+                RelOperator::Exchange(Exchange::Merge) => return Ok(Some(producer)),
+                RelOperator::Exchange(_) => return Ok(None),
+                _ if expr.arity() == 1 => expr = expr.unary_child(),
+                _ => return Ok(None),
+            }
+        }
+    }
+}
 
 impl SExprVisitor for SerialProducerRedistributor {
     fn visit(&mut self, _expr: &SExpr) -> Result<VisitAction> {
@@ -72,30 +109,19 @@ impl SExprVisitor for SerialProducerRedistributor {
     }
 
     fn post_visit(&mut self, expr: &SExpr) -> Result<VisitAction> {
-        if !matches!(expr.plan(), RelOperator::Sequence(_)) {
+        let Some(producer) = Self::match_merge_backed_producer(expr)? else {
             return Ok(VisitAction::Continue);
-        }
-
-        let left = expr.left_child();
-        let physical_prop = RelExpr::with_s_expr(left).derive_physical_prop()?;
-        if physical_prop.distribution != Distribution::Serial {
-            return Ok(VisitAction::Continue);
-        }
-        if !matches!(left.plan(), RelOperator::MaterializedCTE(_)) {
-            return Err(ErrorCode::Internal(
-                "Sequence left child is expected to be MaterializedCTE".to_string(),
-            ));
-        }
+        };
 
         let hash_key = ScalarExpr::ConstantExpr(ConstantExpr {
             value: Scalar::Number(NumberScalar::UInt32(0)),
             span: None,
         });
-        let exchange = left
+        let exchange = producer
             .unary_child_arc()
             .ref_build_unary(Exchange::GlobalHash(vec![hash_key]));
-        let left = left.replace_children([Arc::new(exchange)]);
-        Ok(VisitAction::Replace(expr.replace_left_child(left)))
+        let producer = producer.replace_children([Arc::new(exchange)]);
+        Ok(VisitAction::Replace(expr.replace_left_child(producer)))
     }
 }
 

--- a/src/query/sql/src/planner/optimizer/optimizers/distributed/materialized_cte.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/distributed/materialized_cte.rs
@@ -1,0 +1,151 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use databend_common_exception::ErrorCode;
+use databend_common_exception::Result;
+use databend_common_expression::Scalar;
+use databend_common_expression::types::NumberScalar;
+
+use crate::optimizer::Optimizer;
+use crate::optimizer::OptimizerContext;
+use crate::optimizer::ir::Distribution;
+use crate::optimizer::ir::RelExpr;
+use crate::optimizer::ir::SExpr;
+use crate::optimizer::ir::SExprVisitor;
+use crate::optimizer::ir::VisitAction;
+use crate::plans::ConstantExpr;
+use crate::plans::Exchange;
+use crate::plans::RelOperator;
+use crate::plans::ScalarExpr;
+
+pub struct MaterializedCTEDistributionOptimizer {
+    ctx: Arc<OptimizerContext>,
+}
+
+impl MaterializedCTEDistributionOptimizer {
+    pub fn new(ctx: Arc<OptimizerContext>) -> Self {
+        Self { ctx }
+    }
+
+    pub fn optimize_sync(&self, s_expr: &SExpr) -> Result<SExpr> {
+        let mut result = if self.ctx.get_enable_distributed_optimization() {
+            s_expr
+                .accept(&mut SerialProducerRedistributor)?
+                .unwrap_or_else(|| s_expr.clone())
+        } else {
+            s_expr.clone()
+        };
+
+        let mut finder = SerialSequenceFinder::default();
+        result.accept(&mut finder)?;
+        if finder.found {
+            result = result.accept(&mut ExchangeRemover)?.unwrap_or(result);
+        }
+
+        Ok(result)
+    }
+}
+
+/// A Sequence producer must participate in the distributed fragment graph. When
+/// its CTE definition ends in a scalar operator, redistribute the result after
+/// that operator instead of forcing the entire query to run without Exchanges.
+/// Hashing by a constant preserves the producer's rows without broadcasting or
+/// changing the scalar operator's empty-input behavior.
+struct SerialProducerRedistributor;
+
+impl SExprVisitor for SerialProducerRedistributor {
+    fn visit(&mut self, _expr: &SExpr) -> Result<VisitAction> {
+        Ok(VisitAction::Continue)
+    }
+
+    fn post_visit(&mut self, expr: &SExpr) -> Result<VisitAction> {
+        if !matches!(expr.plan(), RelOperator::Sequence(_)) {
+            return Ok(VisitAction::Continue);
+        }
+
+        let left = expr.left_child();
+        let physical_prop = RelExpr::with_s_expr(left).derive_physical_prop()?;
+        if physical_prop.distribution != Distribution::Serial {
+            return Ok(VisitAction::Continue);
+        }
+        if !matches!(left.plan(), RelOperator::MaterializedCTE(_)) {
+            return Err(ErrorCode::Internal(
+                "Sequence left child is expected to be MaterializedCTE".to_string(),
+            ));
+        }
+
+        let hash_key = ScalarExpr::ConstantExpr(ConstantExpr {
+            value: Scalar::Number(NumberScalar::UInt32(0)),
+            span: None,
+        });
+        let exchange = left
+            .unary_child_arc()
+            .ref_build_unary(Exchange::GlobalHash(vec![hash_key]));
+        let left = left.replace_children([Arc::new(exchange)]);
+        Ok(VisitAction::Replace(expr.replace_left_child(left)))
+    }
+}
+
+#[derive(Default)]
+struct SerialSequenceFinder {
+    found: bool,
+}
+
+impl SExprVisitor for SerialSequenceFinder {
+    fn visit(&mut self, expr: &SExpr) -> Result<VisitAction> {
+        if self.found {
+            return Ok(VisitAction::SkipChildren);
+        }
+
+        if matches!(expr.plan(), RelOperator::Sequence(_)) {
+            let left = expr.left_child();
+            let physical_prop = RelExpr::with_s_expr(left).derive_physical_prop()?;
+            if physical_prop.distribution == Distribution::Serial {
+                self.found = true;
+                return Ok(VisitAction::SkipChildren);
+            }
+        }
+
+        Ok(VisitAction::Continue)
+    }
+}
+
+struct ExchangeRemover;
+
+impl SExprVisitor for ExchangeRemover {
+    fn visit(&mut self, _expr: &SExpr) -> Result<VisitAction> {
+        Ok(VisitAction::Continue)
+    }
+
+    fn post_visit(&mut self, expr: &SExpr) -> Result<VisitAction> {
+        if matches!(expr.plan(), RelOperator::Exchange(_)) {
+            Ok(VisitAction::Replace(expr.unary_child().clone()))
+        } else {
+            Ok(VisitAction::Continue)
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Optimizer for MaterializedCTEDistributionOptimizer {
+    fn name(&self) -> String {
+        "MaterializedCTEDistributionOptimizer".to_string()
+    }
+
+    async fn optimize(&mut self, s_expr: &SExpr) -> Result<SExpr> {
+        self.optimize_sync(s_expr)
+    }
+}

--- a/src/query/sql/src/planner/optimizer/optimizers/distributed/mod.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/distributed/mod.rs
@@ -15,8 +15,10 @@
 #[allow(clippy::module_inception)]
 mod distributed;
 mod distributed_merge;
+mod materialized_cte;
 mod sort_and_limit;
 
 pub use distributed::DistributedOptimizer;
 pub use distributed_merge::BroadcastToShuffleOptimizer;
+pub use materialized_cte::MaterializedCTEDistributionOptimizer;
 pub use sort_and_limit::SortAndLimitPushDownOptimizer;

--- a/src/query/sql/tests/it/optimizer/materialized_cte_distribution.rs
+++ b/src/query/sql/tests/it/optimizer/materialized_cte_distribution.rs
@@ -1,0 +1,89 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use databend_common_catalog::table_context::TableContextSettings;
+use databend_common_exception::Result;
+
+use crate::framework::LiteTableContext;
+use crate::framework::golden::SqlTestCase;
+use crate::framework::golden::open_golden_file;
+use crate::framework::golden::write_case_header;
+
+async fn write_optimized_case(
+    file: &mut impl std::io::Write,
+    case: &SqlTestCase,
+    grouping_sets_to_union: bool,
+) -> Result<()> {
+    let ctx = LiteTableContext::create().await?;
+    ctx.set_table_warehouse_distribution(true);
+    ctx.set_cluster_node_num(3);
+    for setup_sql in case.setup_sqls {
+        ctx.register_setup_sql(setup_sql).await?;
+    }
+    if grouping_sets_to_union {
+        ctx.get_settings()
+            .set_setting("grouping_sets_to_union".to_string(), "1".to_string())?;
+    }
+
+    let raw_plan = ctx.bind_sql(case.sql).await?;
+    let optimized_plan = ctx.optimize_plan(raw_plan.clone()).await?;
+
+    write_case_header(file, case)?;
+    writeln!(file, "raw_plan:")?;
+    writeln!(file, "{}", raw_plan.format_indent(Default::default())?)?;
+    writeln!(file, "optimized_plan:")?;
+    writeln!(
+        file,
+        "{}",
+        optimized_plan.format_indent(Default::default())?
+    )?;
+    writeln!(file)?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_materialized_cte_distribution_optimizer_outcomes() -> Result<()> {
+    let mut file = open_golden_file("optimizer", "materialized_cte_distribution.txt")?;
+
+    let merge_backed = SqlTestCase {
+        name: "merge_backed_scalar_producer_is_redistributed",
+        description: "A scalar grouping-set MCTE backed by Merge should be redistributed after the final aggregate.",
+        setup_sqls: &[MCTE_INPUT_TABLE],
+        sql: "SELECT a, b, sum(v)
+FROM mcte_input
+GROUP BY ROLLUP(a, b)",
+    };
+    write_optimized_case(&mut file, &merge_backed, true).await?;
+
+    let dummy_scan = SqlTestCase {
+        name: "dummy_scan_serial_producer_is_not_redistributed",
+        description: "Seriality from DummyTableScan is not evidence of a Merge-backed MCTE producer.",
+        setup_sqls: &[],
+        sql: "WITH c AS (SELECT 1 AS x)
+SELECT * FROM c
+UNION ALL
+SELECT * FROM c",
+    };
+    write_optimized_case(&mut file, &dummy_scan, false).await?;
+
+    Ok(())
+}
+
+const MCTE_INPUT_TABLE: &str = "CREATE TABLE mcte_input
+(
+    a INTEGER,
+    b INTEGER,
+    v INTEGER
+)";

--- a/src/query/sql/tests/it/optimizer/materialized_cte_distribution.txt
+++ b/src/query/sql/tests/it/optimizer/materialized_cte_distribution.txt
@@ -1,0 +1,165 @@
+=== merge_backed_scalar_producer_is_redistributed ===
+description: A scalar grouping-set MCTE backed by Merge should be redistributed after the final aggregate.
+sql: SELECT a, b, sum(v)
+FROM mcte_input
+GROUP BY ROLLUP(a, b)
+raw_plan:
+EvalScalar
+├── scalars: [mcte_input.a (#0) AS (#0), mcte_input.b (#1) AS (#1), sum(v) (#6) AS (#6)]
+└── Aggregate(Initial)
+    ├── group items: [mcte_input.a (#0) AS (#0), mcte_input.b (#1) AS (#1), _grouping_id (#5) AS (#5)]
+    ├── aggregate functions: [sum(mcte_input.v (#2)) AS (#6)]
+    └── EvalScalar
+        ├── scalars: [mcte_input.a (#0) AS (#0), mcte_input.b (#1) AS (#1), mcte_input.v (#2) AS (#2)]
+        └── Scan
+            ├── table: default.mcte_input (#0)
+            ├── filters: []
+            ├── order by: []
+            └── limit: NONE
+
+optimized_plan:
+Exchange(Merge)
+└── Sequence(Sequence)
+    ├── MaterializedCTE
+    │   ├── cte_name: cte_hierarchical_groupingsets_3903119124984149517_cols_0_1
+    │   ├── ref_count: 3
+    │   ├── channel_size: Some(2)
+    │   └── Aggregate(Final)
+    │       ├── group items: [mcte_input.a (#0) AS (#0), mcte_input.b (#1) AS (#1)]
+    │       ├── aggregate functions: [sum(mcte_input.v (#2)) AS (#6)]
+    │       └── Aggregate(Partial)
+    │           ├── group items: [mcte_input.a (#0) AS (#0), mcte_input.b (#1) AS (#1)]
+    │           ├── aggregate functions: [sum(mcte_input.v (#2)) AS (#6)]
+    │           └── Exchange(Hash)
+    │               ├── Exchange(Hash): keys: [mcte_input.a (#0)]
+    │               └── Scan
+    │                   ├── table: default.mcte_input (#0)
+    │                   ├── filters: []
+    │                   ├── order by: []
+    │                   └── limit: NONE
+    └── Sequence(Sequence)
+        ├── MaterializedCTE
+        │   ├── cte_name: cte_hierarchical_groupingsets_3903119124984149517_cols_0
+        │   ├── ref_count: 1
+        │   ├── channel_size: Some(2)
+        │   └── Aggregate(Final)
+        │       ├── group items: [mcte_input.a (#0) AS (#0)]
+        │       ├── aggregate functions: [sum(sum(v) (#6)) AS (#6)]
+        │       └── Aggregate(Partial)
+        │           ├── group items: [mcte_input.a (#0) AS (#0)]
+        │           ├── aggregate functions: [sum(sum(v) (#6)) AS (#6)]
+        │           └── Exchange(Hash)
+        │               ├── Exchange(Hash): keys: [mcte_input.a (#0)]
+        │               └── MaterializedCTERef
+        │                   ├── cte_name: cte_hierarchical_groupingsets_3903119124984149517_cols_0_1
+        │                   ├── output columns: [sum(v) (#6), mcte_input.a (#0), mcte_input.b (#1)]
+        │                   └── column mapping: [mcte_input.a (#0) -> mcte_input.a (#0), mcte_input.b (#1) -> mcte_input.b (#1), sum(v) (#6) -> sum(v) (#6)]
+        └── Sequence(Sequence)
+            ├── MaterializedCTE
+            │   ├── cte_name: cte_hierarchical_groupingsets_3903119124984149517_empty
+            │   ├── ref_count: 1
+            │   ├── channel_size: Some(2)
+            │   └── Exchange(Hash)
+            │       ├── Exchange(Hash): keys: [0]
+            │       └── Aggregate(Final)
+            │           ├── group items: []
+            │           ├── aggregate functions: [sum(sum(v) (#6)) AS (#6)]
+            │           └── Exchange(Merge)
+            │               └── Aggregate(Partial)
+            │                   ├── group items: []
+            │                   ├── aggregate functions: [sum(sum(v) (#6)) AS (#6)]
+            │                   └── MaterializedCTERef
+            │                       ├── cte_name: cte_hierarchical_groupingsets_3903119124984149517_cols_0_1
+            │                       ├── output columns: [sum(v) (#6), mcte_input.a (#0), mcte_input.b (#1)]
+            │                       └── column mapping: [mcte_input.a (#0) -> mcte_input.a (#0), mcte_input.b (#1) -> mcte_input.b (#1), sum(v) (#6) -> sum(v) (#6)]
+            └── UnionAll
+                ├── output: [mcte_input.a (#0), mcte_input.b (#1), sum(v) (#6), _grouping_id (#5)]
+                ├── left: [mcte_input.a (#0), mcte_input.b (#1), sum(v) (#6), _grouping_id (#5)]
+                ├── right: [mcte_input.a (#0), mcte_input.b (#1), sum(v) (#6), _grouping_id (#5)]
+                ├── cte_scan_names: []
+                ├── logical_recursive_cte_id: None
+                ├── UnionAll
+                │   ├── output: [mcte_input.a (#0), mcte_input.b (#1), sum(v) (#6), _grouping_id (#5)]
+                │   ├── left: [mcte_input.a (#0), mcte_input.b (#1), sum(v) (#6), _grouping_id (#5)]
+                │   ├── right: [mcte_input.a (#0), mcte_input.b (#1), sum(v) (#6), _grouping_id (#5)]
+                │   ├── cte_scan_names: []
+                │   ├── logical_recursive_cte_id: None
+                │   ├── EvalScalar
+                │   │   ├── scalars: [CAST(mcte_input.a (#0) AS Int32 NULL) AS (#0), CAST(mcte_input.b (#1) AS Int32 NULL) AS (#1), 0 AS (#5), sum(v) (#6) AS (#6)]
+                │   │   └── MaterializedCTERef
+                │   │       ├── cte_name: cte_hierarchical_groupingsets_3903119124984149517_cols_0_1
+                │   │       ├── output columns: [sum(v) (#6), mcte_input.a (#0), mcte_input.b (#1)]
+                │   │       └── column mapping: [mcte_input.a (#0) -> mcte_input.a (#0), mcte_input.b (#1) -> mcte_input.b (#1), sum(v) (#6) -> sum(v) (#6)]
+                │   └── EvalScalar
+                │       ├── scalars: [CAST(mcte_input.a (#0) AS Int32 NULL) AS (#0), NULL AS (#1), 2 AS (#5), sum(v) (#6) AS (#6)]
+                │       └── MaterializedCTERef
+                │           ├── cte_name: cte_hierarchical_groupingsets_3903119124984149517_cols_0
+                │           ├── output columns: [sum(v) (#6), mcte_input.a (#0)]
+                │           └── column mapping: [mcte_input.a (#0) -> mcte_input.a (#0), sum(v) (#6) -> sum(v) (#6)]
+                └── EvalScalar
+                    ├── scalars: [NULL AS (#0), NULL AS (#1), 3 AS (#5), sum(v) (#6) AS (#6)]
+                    └── MaterializedCTERef
+                        ├── cte_name: cte_hierarchical_groupingsets_3903119124984149517_empty
+                        ├── output columns: [sum(v) (#6)]
+                        └── column mapping: [sum(v) (#6) -> sum(v) (#6)]
+
+
+=== dummy_scan_serial_producer_is_not_redistributed ===
+description: Seriality from DummyTableScan is not evidence of a Merge-backed MCTE producer.
+sql: WITH c AS (SELECT 1 AS x)
+SELECT * FROM c
+UNION ALL
+SELECT * FROM c
+raw_plan:
+Sequence(Sequence)
+├── MaterializedCTE
+│   ├── cte_name: __materialized_cte_0_c
+│   ├── ref_count: 0
+│   ├── channel_size: None
+│   └── EvalScalar
+│       ├── scalars: [1 AS (#0)]
+│       └── DummyTableScan(DummyTableScan { source_table_indexes: [] })
+└── UnionAll
+    ├── output: [x (#3)]
+    ├── left: [x (#1)]
+    ├── right: [x (#2)]
+    ├── cte_scan_names: []
+    ├── logical_recursive_cte_id: None
+    ├── EvalScalar
+    │   ├── scalars: [x (#1) AS (#1)]
+    │   └── MaterializedCTERef
+    │       ├── cte_name: __materialized_cte_0_c
+    │       ├── output columns: [x (#1)]
+    │       └── column mapping: [x (#1) -> x (#0)]
+    └── EvalScalar
+        ├── scalars: [x (#2) AS (#2)]
+        └── MaterializedCTERef
+            ├── cte_name: __materialized_cte_0_c
+            ├── output columns: [x (#2)]
+            └── column mapping: [x (#2) -> x (#0)]
+
+optimized_plan:
+Sequence(Sequence)
+├── MaterializedCTE
+│   ├── cte_name: __materialized_cte_0_c
+│   ├── ref_count: 2
+│   ├── channel_size: None
+│   └── EvalScalar
+│       ├── scalars: [1 AS (#0)]
+│       └── DummyTableScan(DummyTableScan { source_table_indexes: [] })
+└── UnionAll
+    ├── output: [x (#3)]
+    ├── left: [x (#1)]
+    ├── right: [x (#2)]
+    ├── cte_scan_names: []
+    ├── logical_recursive_cte_id: None
+    ├── MaterializedCTERef
+    │   ├── cte_name: __materialized_cte_0_c
+    │   ├── output columns: [x (#1)]
+    │   └── column mapping: [x (#1) -> x (#0)]
+    └── MaterializedCTERef
+        ├── cte_name: __materialized_cte_0_c
+        ├── output columns: [x (#2)]
+        └── column mapping: [x (#2) -> x (#0)]
+
+

--- a/src/query/sql/tests/it/optimizer/mod.rs
+++ b/src/query/sql/tests/it/optimizer/mod.rs
@@ -24,6 +24,7 @@ mod collect_statistics;
 mod decorrelate_correlated_aliases;
 mod eager_aggregation;
 mod join_cardinality;
+mod materialized_cte_distribution;
 mod normalize_scalar;
 mod outer_join_to_anti;
 mod push_down_filter_project_set;

--- a/tests/sqllogictests/suites/mode/cluster/exchange.test
+++ b/tests/sqllogictests/suites/mode/cluster/exchange.test
@@ -229,6 +229,39 @@ Exchange
         ├── apply join filters: [#0]
         └── estimated rows: 2.00
 
+# The grand-total MaterializedCTE is scalar and ends in Merge exchange. The
+# post-Cascades MCTE optimizer redistributes it with a constant-key GlobalHash,
+# exercising Merge-input fragment scheduling on a real MCTE producer chain.
+statement ok
+set grouping_sets_to_union = 1;
+
+query III rowsort
+select number % 2 as a, number % 3 as b, sum(number)
+from numbers(6)
+group by rollup(a, b);
+----
+0 0 0
+0 1 4
+0 2 2
+0 NULL 6
+1 0 3
+1 1 1
+1 2 5
+1 NULL 9
+NULL NULL 15
+
+# Keep scalar aggregate semantics for an empty MCTE input while exercising the
+# same Merge-to-GlobalHash fragment topology.
+query III
+select number % 2 as a, number % 3 as b, count()
+from numbers(0)
+group by rollup(a, b);
+----
+NULL NULL 0
+
+statement ok
+unset grouping_sets_to_union;
+
 query T
 explain fragments select * from (select sum(number) as number from numbers(1) group by number) t, numbers(2) t1 where t.number = t1.number
 ----


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Fix distributed `ROLLUP` and grouping-set queries whose materialized CTE producer crosses a Merge exchange.
- Normalize serial MCTE producers after Cascades by redistributing their output with a constant-key `GlobalHash`, preserving scalar aggregate and empty-input semantics without disabling distributed exchanges for the whole query.
- Derive Merge-input relationships from the flat `ExchangeSource` fragment graph, schedule the real intermediate fragment on the coordinator, and create schema-correct empty plans for the remaining exchange destinations.
- Remove the stale recursive `source_fragments` state and add cluster logic tests covering both normal and empty ROLLUP inputs.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent assisted with implementation.
- Responsible human:  @forsaken628
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20328)
<!-- Reviewable:end -->
