### PR TITLE
fix(query): reduce privilege check meta requests

### DIFF
--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -21,7 +21,6 @@ use databend_common_base::base::GlobalInstance;
 use databend_common_catalog::catalog::CATALOG_DEFAULT;
 use databend_common_catalog::catalog::Catalog;
 use databend_common_catalog::plan::DataSourceInfo;
-use databend_common_catalog::session_type::SessionType;
 use databend_common_catalog::table::Table;
 use databend_common_config::GlobalConfig;
 use databend_common_exception::ErrorCode;
@@ -40,7 +39,6 @@ use databend_common_meta_app::principal::SENSITIVE_SYSTEM_RESOURCE;
 use databend_common_meta_app::principal::SYSTEM_TABLES_ALLOW_LIST;
 use databend_common_meta_app::principal::StageInfo;
 use databend_common_meta_app::principal::StageType;
-use databend_common_meta_app::principal::TenantOwnershipObjectIdent;
 use databend_common_meta_app::principal::UserGrantSet;
 use databend_common_meta_app::principal::UserPrivilegeSet;
 use databend_common_meta_app::principal::UserPrivilegeType;
@@ -58,10 +56,10 @@ use databend_common_sql::plans::PresignAction;
 use databend_common_sql::plans::RewriteKind;
 use databend_common_sql::plans::TagSetObject;
 use databend_common_users::BUILTIN_ROLE_ACCOUNT_ADMIN;
+use databend_common_users::MGET_OWNERSHIP_BATCH_SIZE;
 use databend_common_users::RoleCacheManager;
 use databend_common_users::UserApiProvider;
 use databend_enterprise_resources_management::ResourcesManagement;
-use databend_meta_client::kvapi::StructKey;
 use databend_meta_client::types::SeqV;
 use databend_storages_common_table_meta::table::OPT_KEY_DATABASE_ID;
 use databend_storages_common_table_meta::table::OPT_KEY_TEMP_PREFIX;
@@ -87,10 +85,26 @@ pub struct PrivilegeAccess {
 #[derive(Default)]
 struct QueryAccessCache {
     database_ids: Mutex<HashMap<(String, String), u64>>,
-    ownership_checks: Mutex<HashMap<(OwnershipObject, bool), bool>>,
+    /// Ownership answers computed against all effective roles.
+    ownership_checks: Mutex<HashMap<OwnershipObject, bool>>,
+    /// Ownership answers restricted to the current role. Kept in its own map, rather than
+    /// widening the key to `(OwnershipObject, bool)`, so a lookup can borrow the object
+    /// instead of cloning one for every probe.
+    current_role_ownership_checks: Mutex<HashMap<OwnershipObject, bool>>,
 }
 
 impl QueryAccessCache {
+    fn ownership_map(
+        &self,
+        check_current_role_only: bool,
+    ) -> &Mutex<HashMap<OwnershipObject, bool>> {
+        if check_current_role_only {
+            &self.current_role_ownership_checks
+        } else {
+            &self.ownership_checks
+        }
+    }
+
     async fn get_or_load_database_id<F, Fut>(
         &self,
         catalog_name: &str,
@@ -121,13 +135,14 @@ impl QueryAccessCache {
         F: FnOnce() -> Fut,
         Fut: Future<Output = Result<bool>>,
     {
-        let key = (object.clone(), check_current_role_only);
-        if let Some(has_ownership) = self.ownership_checks.lock().get(&key) {
-            return Ok(*has_ownership);
+        if let Some(has_ownership) = self.ownership_check(object, check_current_role_only) {
+            return Ok(has_ownership);
         }
 
         let has_ownership = load().await?;
-        self.ownership_checks.lock().insert(key, has_ownership);
+        self.ownership_map(check_current_role_only)
+            .lock()
+            .insert(object.clone(), has_ownership);
         Ok(has_ownership)
     }
 
@@ -136,18 +151,15 @@ impl QueryAccessCache {
         object: &OwnershipObject,
         check_current_role_only: bool,
     ) -> Option<bool> {
-        self.ownership_checks
+        self.ownership_map(check_current_role_only)
             .lock()
-            .get(&(object.clone(), check_current_role_only))
+            .get(object)
             .copied()
     }
 
+    /// Publish prefetched answers, which are always computed against all effective roles.
     fn insert_ownership_checks(&self, checks: impl IntoIterator<Item = (OwnershipObject, bool)>) {
-        self.ownership_checks.lock().extend(
-            checks
-                .into_iter()
-                .map(|(object, has_ownership)| ((object, false), has_ownership)),
-        );
+        self.ownership_checks.lock().extend(checks);
     }
 }
 
@@ -159,49 +171,44 @@ enum ObjectId {
 // table functions that need `Super` privilege
 const SYSTEM_TABLE_FUNCTIONS: [&str; 2] = ["fuse_amend", "set_cache_capacity"];
 
-/// Bound each ownership MGet to avoid oversized Meta RPC payloads for queries
-/// that reference many tables.
-const MGET_OWNERSHIP_BATCH_SIZE: usize = 256;
-
-type TableAccessKey<'a> = (&'a str, &'a str, &'a str, u64);
-
-fn mark_table_access_checked<'a>(
-    checked_tables: &mut HashSet<TableAccessKey<'a>>,
-    catalog: &'a str,
-    database: &'a str,
-    table: &'a str,
-    table_id: u64,
-) -> bool {
-    checked_tables.insert((catalog, database, table, table_id))
-}
-
-fn should_prefetch_ownerships(session_type: &SessionType) -> bool {
-    !matches!(session_type, SessionType::Local)
+/// Whether `db_name` names a schema whose ownership is never consulted.
+///
+/// Must agree with the `system` skip in [`PrivilegeAccess::convert_to_owner_object`], which
+/// compares case-insensitively; prefetching an object that `convert_to_owner_object` then
+/// refuses to look up would issue Meta requests for entries nothing ever reads.
+fn is_ownership_exempt_schema(db_name: &str) -> bool {
+    db_name.eq_ignore_ascii_case("system") || db_name.eq_ignore_ascii_case("information_schema")
 }
 
 #[async_trait::async_trait]
 trait OwnershipPrefetchApi: Send + Sync {
-    async fn mget_ownerships(
+    /// Deliberately named apart from [`UserApiProvider::mget_ownerships`]: an identically
+    /// named trait method would let `self.mget_ownerships(..)` inside the impl resolve back
+    /// to the trait and recurse forever.
+    async fn prefetch_mget_ownerships(
         &self,
         tenant: &Tenant,
         objects: &[OwnershipObject],
     ) -> Result<Vec<Option<OwnershipInfo>>>;
 
-    async fn exists_role(&self, tenant: &Tenant, role: String) -> Result<bool>;
+    /// Whether `role` still exists, matching what [`UserApiProvider::get_ownership`] checks
+    /// before attributing an object to `account_admin`. See
+    /// [`OwnershipPrefetchApi::prefetch_mget_ownerships`] for the naming rationale.
+    async fn prefetch_role_exists(&self, tenant: &Tenant, role: &str) -> Result<bool>;
 }
 
 #[async_trait::async_trait]
 impl OwnershipPrefetchApi for UserApiProvider {
-    async fn mget_ownerships(
+    async fn prefetch_mget_ownerships(
         &self,
         tenant: &Tenant,
         objects: &[OwnershipObject],
     ) -> Result<Vec<Option<OwnershipInfo>>> {
-        UserApiProvider::mget_ownerships(self, tenant, objects).await
+        self.mget_ownerships(tenant, objects).await
     }
 
-    async fn exists_role(&self, tenant: &Tenant, role: String) -> Result<bool> {
-        UserApiProvider::exists_role(self, tenant, role).await
+    async fn prefetch_role_exists(&self, tenant: &Tenant, role: &str) -> Result<bool> {
+        self.exists_role(tenant, role.to_string()).await
     }
 }
 
@@ -220,55 +227,60 @@ async fn prefetch_ownerships_with_api(
         }
     }
 
+    // An object with no ownership record, or one owned by a role that no longer exists, falls
+    // back to account_admin. If account_admin is not effective, that fallback can only answer
+    // `false`, which makes the role-existence lookups below unable to change any outcome.
+    let admin_is_effective = effective_role_names.contains(BUILTIN_ROLE_ACCOUNT_ADMIN);
+
     let mut role_exists = HashMap::new();
-    for objects in unique_objects.chunks(MGET_OWNERSHIP_BATCH_SIZE) {
-        let ownerships = user_api.mget_ownerships(tenant, objects).await?;
-        if ownerships.len() != objects.len() {
+    // Collect every chunk's answers before publishing them, so a failure part way through
+    // leaves the cache untouched instead of half populated.
+    let mut checks = Vec::with_capacity(unique_objects.len());
+    for batch in unique_objects.chunks(MGET_OWNERSHIP_BATCH_SIZE) {
+        let ownerships = user_api.prefetch_mget_ownerships(tenant, batch).await?;
+        if ownerships.len() != batch.len() {
             return Err(ErrorCode::Internal(format!(
                 "ownership MGet returned {} results for {} objects",
                 ownerships.len(),
-                objects.len()
+                batch.len()
             )));
         }
 
-        let mut checks = Vec::with_capacity(objects.len());
-        for (object, ownership) in objects.iter().cloned().zip(ownerships) {
-            let owner_role = match ownership {
+        for (object, ownership) in batch.iter().zip(ownerships) {
+            // `mget_ownerships` maps results positionally onto keys built from `batch`, so a
+            // record's identity comes from its position. `owner.object` is deliberately not
+            // consulted, matching `UserApiProvider::get_ownership`: a table key omits db_id, so
+            // a stored value can legitimately disagree with the object that was requested.
+            let has_ownership = match ownership {
+                None => admin_is_effective,
                 Some(owner) => {
-                    // Compare encoded keys rather than full objects. Table ownership keys
-                    // intentionally omit db_id, so OwnershipInfo may retain the old db_id after
-                    // a legacy or lower-level cross-database rename while still belonging to the
-                    // requested key.
-                    let requested_key =
-                        TenantOwnershipObjectIdent::new(tenant, object.clone()).to_string_key();
-                    let returned_key =
-                        TenantOwnershipObjectIdent::new(tenant, owner.object.clone())
-                            .to_string_key();
-                    if returned_key != requested_key {
-                        return Err(ErrorCode::Internal(format!(
-                            "ownership MGet returned key {returned_key} for requested key {requested_key}"
-                        )));
-                    }
-                    let exists = match role_exists.get(&owner.role) {
-                        Some(exists) => *exists,
-                        None => {
-                            let exists = user_api.exists_role(tenant, owner.role.clone()).await?;
-                            role_exists.insert(owner.role.clone(), exists);
-                            exists
-                        }
-                    };
-                    if exists {
-                        owner.role
+                    let owner_is_effective = effective_role_names.contains(&owner.role);
+                    if owner_is_effective == admin_is_effective {
+                        // The recorded owner and the account_admin fallback lead to the same
+                        // answer, so whether that role still exists cannot change it.
+                        owner_is_effective
                     } else {
-                        BUILTIN_ROLE_ACCOUNT_ADMIN.to_string()
+                        let exists = match role_exists.get(&owner.role) {
+                            Some(exists) => *exists,
+                            None => {
+                                let exists =
+                                    user_api.prefetch_role_exists(tenant, &owner.role).await?;
+                                role_exists.insert(owner.role.clone(), exists);
+                                exists
+                            }
+                        };
+                        if exists {
+                            owner_is_effective
+                        } else {
+                            admin_is_effective
+                        }
                     }
                 }
-                None => BUILTIN_ROLE_ACCOUNT_ADMIN.to_string(),
             };
-            checks.push((object, effective_role_names.contains(&owner_role)));
+            checks.push((object.clone(), has_ownership));
         }
-        cache.insert_ownership_checks(checks);
     }
+    cache.insert_ownership_checks(checks);
     Ok(())
 }
 
@@ -318,7 +330,9 @@ impl PrivilegeAccess {
         }
 
         let session = self.ctx.get_current_session();
-        if !should_prefetch_ownerships(&session.get_type()) {
+        // Such a session answers every ownership check `true` without consulting the owner,
+        // so prefetched answers would never be read.
+        if session.bypasses_ownership_checks() {
             return Ok(());
         }
 
@@ -1824,9 +1838,13 @@ impl AccessChecker for PrivilegeAccess {
                 }
 
                 let metadata = metadata.read().clone();
+                // Warm the ownership cache for the tables the loop below will check. This is a
+                // pure optimization: every object gathered here is re-derived by the checking
+                // loop, so anything skipped only costs an extra round trip later. Errors while
+                // gathering are therefore swallowed rather than propagated - the checking loop
+                // reports them with the user-facing handling each object type expects.
                 let mut ownership_objects = Vec::new();
                 let mut prepared_ownerships = HashSet::new();
-                let mut prepared_tables = HashSet::new();
                 for table in metadata.tables() {
                     if table.is_source_of_view()
                         || table.is_source_of_stage()
@@ -1839,31 +1857,24 @@ impl AccessChecker for PrivilegeAccess {
                     let database = table.database();
                     let table_name = table.name();
                     let catalog_table = table.table();
-                    let table_id = catalog_table.get_id();
-                    if !mark_table_access_checked(
-                        &mut prepared_tables,
-                        catalog_name,
-                        database,
-                        table_name,
-                        table_id,
-                    ) {
-                        continue;
-                    }
-
-                    if database == "information_schema"
-                        || database == "system"
+                    if is_ownership_exempt_schema(database)
                         || is_materialized_view_engine(catalog_table.engine())
                     {
                         continue;
                     }
 
-                    let catalog = self.ctx.get_catalog(catalog_name).await?;
+                    let Ok(catalog) = self.ctx.get_catalog(catalog_name).await else {
+                        continue;
+                    };
                     if catalog.exists_table_function(table_name) {
                         continue;
                     }
-                    let db_id = self
+                    let Ok(db_id) = self
                         .get_database_id(&tenant, catalog_name, &catalog, database)
-                        .await?;
+                        .await
+                    else {
+                        continue;
+                    };
                     let database_owner = OwnershipObject::Database {
                         catalog_name: catalog_name.to_string(),
                         db_id,
@@ -1874,7 +1885,7 @@ impl AccessChecker for PrivilegeAccess {
                     let table_owner = OwnershipObject::Table {
                         catalog_name: catalog_name.to_string(),
                         db_id,
-                        table_id,
+                        table_id: catalog_table.get_id(),
                     };
                     if prepared_ownerships.insert(table_owner.clone()) {
                         ownership_objects.push(table_owner);
@@ -1909,13 +1920,16 @@ impl AccessChecker for PrivilegeAccess {
                         let database = table.database();
                         let table_name = table.name();
                         let catalog_table = table.table();
-                        if mark_table_access_checked(
-                            &mut checked_tables,
+                        // The same table can be bound several times (aliases, subqueries,
+                        // UNION ALL branches); check it once. Keyed by table id as well as
+                        // name so a rebind that resolved to a different table is not skipped.
+                        let first_check = checked_tables.insert((
                             catalog_name,
                             database,
                             table_name,
                             catalog_table.get_id(),
-                        ) {
+                        ));
+                        if first_check {
                             if is_materialized_view_engine(catalog_table.engine()) {
                                 self.validate_mv_source_access(catalog_table.as_ref()).await?;
                             } else {
@@ -2986,7 +3000,6 @@ mod tests {
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering;
 
-    use databend_common_catalog::session_type::SessionType;
     use databend_common_exception::ErrorCode;
     use databend_common_exception::Result;
     use databend_common_meta_app::principal::OwnershipInfo;
@@ -2997,30 +3010,35 @@ mod tests {
     use super::MGET_OWNERSHIP_BATCH_SIZE;
     use super::OwnershipPrefetchApi;
     use super::QueryAccessCache;
-    use super::mark_table_access_checked;
+    use super::is_ownership_exempt_schema;
     use super::prefetch_ownerships_with_api;
-    use super::should_prefetch_ownerships;
 
     #[derive(Default)]
     struct FakeOwnershipApi {
         ownerships: HashMap<OwnershipObject, Option<OwnershipInfo>>,
         existing_roles: HashMap<String, bool>,
         mget_batch_sizes: Mutex<Vec<usize>>,
-        exists_role_calls: Mutex<Vec<String>>,
+        role_exists_calls: Mutex<Vec<String>>,
         mget_error: bool,
-        exists_role_error: Option<String>,
+        /// Fail the MGet once this many calls have already succeeded.
+        fail_mget_after_calls: Option<usize>,
+        role_exists_error: Option<String>,
         truncate_mget_result: bool,
     }
 
     #[async_trait::async_trait]
     impl OwnershipPrefetchApi for FakeOwnershipApi {
-        async fn mget_ownerships(
+        async fn prefetch_mget_ownerships(
             &self,
             _tenant: &Tenant,
             objects: &[OwnershipObject],
         ) -> Result<Vec<Option<OwnershipInfo>>> {
-            self.mget_batch_sizes.lock().push(objects.len());
-            if self.mget_error {
+            let call_index = {
+                let mut sizes = self.mget_batch_sizes.lock();
+                sizes.push(objects.len());
+                sizes.len() - 1
+            };
+            if self.mget_error || self.fail_mget_after_calls == Some(call_index) {
                 return Err(ErrorCode::MetaServiceError("injected MGet failure"));
             }
 
@@ -3034,12 +3052,12 @@ mod tests {
             Ok(ownerships)
         }
 
-        async fn exists_role(&self, _tenant: &Tenant, role: String) -> Result<bool> {
-            self.exists_role_calls.lock().push(role.clone());
-            if self.exists_role_error.as_ref() == Some(&role) {
+        async fn prefetch_role_exists(&self, _tenant: &Tenant, role: &str) -> Result<bool> {
+            self.role_exists_calls.lock().push(role.to_string());
+            if self.role_exists_error.as_deref() == Some(role) {
                 return Err(ErrorCode::MetaServiceError("injected role lookup failure"));
             }
-            Ok(self.existing_roles.get(&role).copied().unwrap_or(false))
+            Ok(self.existing_roles.get(role).copied().unwrap_or(false))
         }
     }
 
@@ -3173,7 +3191,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mark_table_access_checked_uses_catalog_name_and_table_id() {
+    fn test_table_access_dedup_key_covers_catalog_database_name_and_table_id() {
         let accesses = [
             ("default", "db", "t1", 1),
             ("default", "db", "t1", 1),
@@ -3186,17 +3204,28 @@ mod tests {
         let checked_count = accesses
             .into_iter()
             .filter(|(catalog, database, table, table_id)| {
-                mark_table_access_checked(&mut checked_tables, catalog, database, table, *table_id)
+                checked_tables.insert((*catalog, *database, *table, *table_id))
             })
             .count();
         assert_eq!(checked_count, 5);
     }
 
+    /// The prefetch must exempt exactly the schemas `convert_to_owner_object` refuses to
+    /// resolve, which compares case-insensitively.
     #[test]
-    fn test_local_sessions_skip_ownership_prefetch() {
-        assert!(!should_prefetch_ownerships(&SessionType::Local));
-        assert!(should_prefetch_ownerships(&SessionType::MySQL));
-        assert!(should_prefetch_ownerships(&SessionType::Dummy));
+    fn test_ownership_exempt_schemas_match_case_insensitively() {
+        for exempt in [
+            "system",
+            "System",
+            "SYSTEM",
+            "information_schema",
+            "INFORMATION_SCHEMA",
+        ] {
+            assert!(is_ownership_exempt_schema(exempt), "{exempt}");
+        }
+        for owned in ["db", "systems", "my_system", "information_schema_2"] {
+            assert!(!is_ownership_exempt_schema(owned), "{owned}");
+        }
     }
 
     #[tokio::test]
@@ -3280,7 +3309,13 @@ mod tests {
         // Prefetch only populates the all-effective-roles scope.
         assert_eq!(cache.ownership_check(&table_object, true), None);
         assert_eq!(*api.mget_batch_sizes.lock(), vec![4]);
-        assert_eq!(api.exists_role_calls.lock().len(), 3);
+        // Only the two objects whose owner role is not effective need a lookup: for them the
+        // account_admin fallback (effective here) would answer differently. `database` is owned
+        // by an effective role and `unowned` has no record at all, so both are decided outright.
+        assert_eq!(*api.role_exists_calls.lock(), vec![
+            "table_owner".to_string(),
+            "deleted_role".to_string()
+        ]);
 
         let api = FakeOwnershipApi {
             ownerships,
@@ -3326,7 +3361,80 @@ mod tests {
         prefetch_ownerships_with_api(&cache, &tenant, &objects, &role_names(&["owner"]), &api)
             .await?;
         assert_eq!(*api.mget_batch_sizes.lock(), vec![256, 1]);
-        assert_eq!(*api.exists_role_calls.lock(), vec!["owner".to_string()]);
+        assert_eq!(*api.role_exists_calls.lock(), vec!["owner".to_string()]);
+        Ok(())
+    }
+
+    /// Ownership answers are published only after every chunk succeeds, so a plan large enough
+    /// to span batches cannot leave the cache holding a partial view.
+    #[tokio::test]
+    async fn test_ownership_prefetch_publishes_nothing_when_a_later_batch_fails() -> Result<()> {
+        let tenant = Tenant::new_literal("tenant");
+        let objects = (0..MGET_OWNERSHIP_BATCH_SIZE + 1)
+            .map(|db_id| database(db_id as u64))
+            .collect::<Vec<_>>();
+        let api = FakeOwnershipApi {
+            ownerships: objects
+                .iter()
+                .map(|object| (object.clone(), owned_by(object, "owner")))
+                .collect(),
+            existing_roles: HashMap::from([("owner".to_string(), true)]),
+            fail_mget_after_calls: Some(1),
+            ..Default::default()
+        };
+        let cache = QueryAccessCache::default();
+        let error =
+            prefetch_ownerships_with_api(&cache, &tenant, &objects, &role_names(&["owner"]), &api)
+                .await
+                .unwrap_err();
+        assert_eq!(error.code(), ErrorCode::META_SERVICE_ERROR);
+        assert_eq!(*api.mget_batch_sizes.lock(), vec![256, 1]);
+        // The first batch resolved cleanly, but its answers must not be visible.
+        for object in &objects {
+            assert_eq!(cache.ownership_check(object, false), None);
+        }
+        Ok(())
+    }
+
+    /// The owner role lookup exists only to apply the account_admin fallback, so it is skipped
+    /// whenever the recorded owner and that fallback would answer the same way.
+    #[tokio::test]
+    async fn test_ownership_prefetch_skips_role_lookup_that_cannot_change_the_answer() -> Result<()>
+    {
+        let tenant = Tenant::new_literal("tenant");
+        let object = database(1);
+        let objects = [object.clone()];
+        let ownerships = HashMap::from([(object.clone(), owned_by(&object, "owner"))]);
+
+        // Neither the owner role nor account_admin is effective: denied either way.
+        let api = FakeOwnershipApi {
+            ownerships: ownerships.clone(),
+            existing_roles: HashMap::from([("owner".to_string(), true)]),
+            ..Default::default()
+        };
+        let cache = QueryAccessCache::default();
+        prefetch_ownerships_with_api(&cache, &tenant, &objects, &role_names(&["other"]), &api)
+            .await?;
+        assert_eq!(cache.ownership_check(&object, false), Some(false));
+        assert!(api.role_exists_calls.lock().is_empty());
+
+        // Both are effective: granted either way.
+        let api = FakeOwnershipApi {
+            ownerships,
+            existing_roles: HashMap::from([("owner".to_string(), true)]),
+            ..Default::default()
+        };
+        let cache = QueryAccessCache::default();
+        prefetch_ownerships_with_api(
+            &cache,
+            &tenant,
+            &objects,
+            &role_names(&["owner", "account_admin"]),
+            &api,
+        )
+        .await?;
+        assert_eq!(cache.ownership_check(&object, false), Some(true));
+        assert!(api.role_exists_calls.lock().is_empty());
         Ok(())
     }
 
@@ -3356,17 +3464,24 @@ mod tests {
             .await?;
         assert_eq!(cache.ownership_check(&object, false), Some(true));
 
+        // A failing owner-role lookup must not be cached as a denial. account_admin is
+        // effective while the owner role is not, so the lookup is required to decide.
         let object = database(2);
         let cache = QueryAccessCache::default();
         let api = FakeOwnershipApi {
             ownerships: HashMap::from([(object.clone(), owned_by(&object, "owner"))]),
-            exists_role_error: Some("owner".to_string()),
+            role_exists_error: Some("owner".to_string()),
             ..Default::default()
         };
-        let error =
-            prefetch_ownerships_with_api(&cache, &tenant, &[object.clone()], &HashSet::new(), &api)
-                .await
-                .unwrap_err();
+        let error = prefetch_ownerships_with_api(
+            &cache,
+            &tenant,
+            &[object.clone()],
+            &role_names(&["account_admin"]),
+            &api,
+        )
+        .await
+        .unwrap_err();
         assert_eq!(error.code(), ErrorCode::META_SERVICE_ERROR);
         assert_eq!(cache.ownership_check(&object, false), None);
 
@@ -3382,24 +3497,15 @@ mod tests {
                 .unwrap_err();
         assert_eq!(error.code(), ErrorCode::INTERNAL);
         assert_eq!(cache.ownership_check(&object, false), None);
-
-        let object = database(4);
-        let cache = QueryAccessCache::default();
-        let api = FakeOwnershipApi {
-            ownerships: HashMap::from([(object.clone(), owned_by(&database(5), "owner"))]),
-            ..Default::default()
-        };
-        let error =
-            prefetch_ownerships_with_api(&cache, &tenant, &[object.clone()], &HashSet::new(), &api)
-                .await
-                .unwrap_err();
-        assert_eq!(error.code(), ErrorCode::INTERNAL);
-        assert_eq!(cache.ownership_check(&object, false), None);
         Ok(())
     }
 
+    /// A table ownership key omits db_id, so a stored record can carry a stale db_id and still
+    /// be the record for the requested key. `UserApiProvider::get_ownership` accepts such a
+    /// record, and the prefetch must agree with it rather than reject the query.
     #[tokio::test]
-    async fn test_ownership_prefetch_accepts_stale_table_database_id() -> Result<()> {
+    async fn test_ownership_prefetch_accepts_record_whose_value_has_stale_database_id() -> Result<()>
+    {
         let tenant = Tenant::new_literal("tenant");
         let object = table(2, 4);
         let stored_object = table(1, 4);
@@ -3419,7 +3525,38 @@ mod tests {
         .await?;
         assert_eq!(cache.ownership_check(&object, false), Some(true));
         assert_eq!(*api.mget_batch_sizes.lock(), vec![1]);
-        assert_eq!(*api.exists_role_calls.lock(), vec!["owner".to_string()]);
+        // The owner role is effective while account_admin is not, so the fallback would answer
+        // differently and the role must actually be confirmed to exist.
+        assert_eq!(*api.role_exists_calls.lock(), vec!["owner".to_string()]);
+        Ok(())
+    }
+
+    /// Likewise for a record whose stored catalog disagrees with the requested one. Results are
+    /// mapped positionally onto the requested keys, so the value's own fields are not identity.
+    #[tokio::test]
+    async fn test_ownership_prefetch_accepts_record_whose_value_has_other_catalog() -> Result<()> {
+        let tenant = Tenant::new_literal("tenant");
+        let object = OwnershipObject::Table {
+            catalog_name: "iceberg".to_string(),
+            db_id: 1,
+            table_id: 4,
+        };
+        let stored_object = table(1, 4);
+        let cache = QueryAccessCache::default();
+        let api = FakeOwnershipApi {
+            ownerships: HashMap::from([(object.clone(), owned_by(&stored_object, "owner"))]),
+            existing_roles: HashMap::from([("owner".to_string(), true)]),
+            ..Default::default()
+        };
+        prefetch_ownerships_with_api(
+            &cache,
+            &tenant,
+            &[object.clone()],
+            &role_names(&["owner"]),
+            &api,
+        )
+        .await?;
+        assert_eq!(cache.ownership_check(&object, false), Some(true));
         Ok(())
     }
 }

--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -40,6 +40,7 @@ use databend_common_meta_app::principal::SENSITIVE_SYSTEM_RESOURCE;
 use databend_common_meta_app::principal::SYSTEM_TABLES_ALLOW_LIST;
 use databend_common_meta_app::principal::StageInfo;
 use databend_common_meta_app::principal::StageType;
+use databend_common_meta_app::principal::TenantOwnershipObjectIdent;
 use databend_common_meta_app::principal::UserGrantSet;
 use databend_common_meta_app::principal::UserPrivilegeSet;
 use databend_common_meta_app::principal::UserPrivilegeType;
@@ -60,6 +61,7 @@ use databend_common_users::BUILTIN_ROLE_ACCOUNT_ADMIN;
 use databend_common_users::RoleCacheManager;
 use databend_common_users::UserApiProvider;
 use databend_enterprise_resources_management::ResourcesManagement;
+use databend_meta_client::kvapi::StructKey;
 use databend_meta_client::types::SeqV;
 use databend_storages_common_table_meta::table::OPT_KEY_DATABASE_ID;
 use databend_storages_common_table_meta::table::OPT_KEY_TEMP_PREFIX;
@@ -233,10 +235,18 @@ async fn prefetch_ownerships_with_api(
         for (object, ownership) in objects.iter().cloned().zip(ownerships) {
             let owner_role = match ownership {
                 Some(owner) => {
-                    if owner.object != object {
+                    // Compare encoded keys rather than full objects. Table ownership keys
+                    // intentionally omit db_id, so OwnershipInfo may retain the old db_id after
+                    // a legacy or lower-level cross-database rename while still belonging to the
+                    // requested key.
+                    let requested_key =
+                        TenantOwnershipObjectIdent::new(tenant, object.clone()).to_string_key();
+                    let returned_key =
+                        TenantOwnershipObjectIdent::new(tenant, owner.object.clone())
+                            .to_string_key();
+                    if returned_key != requested_key {
                         return Err(ErrorCode::Internal(format!(
-                            "ownership MGet returned {} for requested object {}",
-                            owner.object, object
+                            "ownership MGet returned key {returned_key} for requested key {requested_key}"
                         )));
                     }
                     let exists = match role_exists.get(&owner.role) {
@@ -3385,6 +3395,31 @@ mod tests {
                 .unwrap_err();
         assert_eq!(error.code(), ErrorCode::INTERNAL);
         assert_eq!(cache.ownership_check(&object, false), None);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_ownership_prefetch_accepts_stale_table_database_id() -> Result<()> {
+        let tenant = Tenant::new_literal("tenant");
+        let object = table(2, 4);
+        let stored_object = table(1, 4);
+        let cache = QueryAccessCache::default();
+        let api = FakeOwnershipApi {
+            ownerships: HashMap::from([(object.clone(), owned_by(&stored_object, "owner"))]),
+            existing_roles: HashMap::from([("owner".to_string(), true)]),
+            ..Default::default()
+        };
+        prefetch_ownerships_with_api(
+            &cache,
+            &tenant,
+            &[object.clone()],
+            &role_names(&["owner"]),
+            &api,
+        )
+        .await?;
+        assert_eq!(cache.ownership_check(&object, false), Some(true));
+        assert_eq!(*api.mget_batch_sizes.lock(), vec![1]);
+        assert_eq!(*api.exists_role_calls.lock(), vec!["owner".to_string()]);
         Ok(())
     }
 }

--- a/src/query/service/src/interpreters/access/privilege_access.rs
+++ b/src/query/service/src/interpreters/access/privilege_access.rs
@@ -12,13 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::collections::HashSet;
+use std::future::Future;
 use std::sync::Arc;
 
 use databend_common_base::base::GlobalInstance;
 use databend_common_catalog::catalog::CATALOG_DEFAULT;
 use databend_common_catalog::catalog::Catalog;
 use databend_common_catalog::plan::DataSourceInfo;
+use databend_common_catalog::session_type::SessionType;
 use databend_common_catalog::table::Table;
 use databend_common_config::GlobalConfig;
 use databend_common_exception::ErrorCode;
@@ -60,6 +63,7 @@ use databend_enterprise_resources_management::ResourcesManagement;
 use databend_meta_client::types::SeqV;
 use databend_storages_common_table_meta::table::OPT_KEY_DATABASE_ID;
 use databend_storages_common_table_meta::table::OPT_KEY_TEMP_PREFIX;
+use parking_lot::Mutex;
 
 use crate::history_tables::session::get_history_log_user;
 use crate::interpreters::access::AccessChecker;
@@ -74,6 +78,75 @@ use crate::sql::plans::Plan;
 
 pub struct PrivilegeAccess {
     ctx: Arc<QueryContext>,
+    cache: QueryAccessCache,
+}
+
+// PrivilegeAccess is created for one plan check, so these entries never outlive the query.
+#[derive(Default)]
+struct QueryAccessCache {
+    database_ids: Mutex<HashMap<(String, String), u64>>,
+    ownership_checks: Mutex<HashMap<(OwnershipObject, bool), bool>>,
+}
+
+impl QueryAccessCache {
+    async fn get_or_load_database_id<F, Fut>(
+        &self,
+        catalog_name: &str,
+        database_name: &str,
+        load: F,
+    ) -> Result<u64>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<u64>>,
+    {
+        let key = (catalog_name.to_string(), database_name.to_string());
+        if let Some(db_id) = self.database_ids.lock().get(&key) {
+            return Ok(*db_id);
+        }
+
+        let db_id = load().await?;
+        self.database_ids.lock().insert(key, db_id);
+        Ok(db_id)
+    }
+
+    async fn get_or_load_ownership_check<F, Fut>(
+        &self,
+        object: &OwnershipObject,
+        check_current_role_only: bool,
+        load: F,
+    ) -> Result<bool>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<bool>>,
+    {
+        let key = (object.clone(), check_current_role_only);
+        if let Some(has_ownership) = self.ownership_checks.lock().get(&key) {
+            return Ok(*has_ownership);
+        }
+
+        let has_ownership = load().await?;
+        self.ownership_checks.lock().insert(key, has_ownership);
+        Ok(has_ownership)
+    }
+
+    fn ownership_check(
+        &self,
+        object: &OwnershipObject,
+        check_current_role_only: bool,
+    ) -> Option<bool> {
+        self.ownership_checks
+            .lock()
+            .get(&(object.clone(), check_current_role_only))
+            .copied()
+    }
+
+    fn insert_ownership_checks(&self, checks: impl IntoIterator<Item = (OwnershipObject, bool)>) {
+        self.ownership_checks.lock().extend(
+            checks
+                .into_iter()
+                .map(|(object, has_ownership)| ((object, false), has_ownership)),
+        );
+    }
 }
 
 enum ObjectId {
@@ -84,9 +157,175 @@ enum ObjectId {
 // table functions that need `Super` privilege
 const SYSTEM_TABLE_FUNCTIONS: [&str; 2] = ["fuse_amend", "set_cache_capacity"];
 
+/// Bound each ownership MGet to avoid oversized Meta RPC payloads for queries
+/// that reference many tables.
+const MGET_OWNERSHIP_BATCH_SIZE: usize = 256;
+
+type TableAccessKey<'a> = (&'a str, &'a str, &'a str, u64);
+
+fn mark_table_access_checked<'a>(
+    checked_tables: &mut HashSet<TableAccessKey<'a>>,
+    catalog: &'a str,
+    database: &'a str,
+    table: &'a str,
+    table_id: u64,
+) -> bool {
+    checked_tables.insert((catalog, database, table, table_id))
+}
+
+fn should_prefetch_ownerships(session_type: &SessionType) -> bool {
+    !matches!(session_type, SessionType::Local)
+}
+
+#[async_trait::async_trait]
+trait OwnershipPrefetchApi: Send + Sync {
+    async fn mget_ownerships(
+        &self,
+        tenant: &Tenant,
+        objects: &[OwnershipObject],
+    ) -> Result<Vec<Option<OwnershipInfo>>>;
+
+    async fn exists_role(&self, tenant: &Tenant, role: String) -> Result<bool>;
+}
+
+#[async_trait::async_trait]
+impl OwnershipPrefetchApi for UserApiProvider {
+    async fn mget_ownerships(
+        &self,
+        tenant: &Tenant,
+        objects: &[OwnershipObject],
+    ) -> Result<Vec<Option<OwnershipInfo>>> {
+        UserApiProvider::mget_ownerships(self, tenant, objects).await
+    }
+
+    async fn exists_role(&self, tenant: &Tenant, role: String) -> Result<bool> {
+        UserApiProvider::exists_role(self, tenant, role).await
+    }
+}
+
+async fn prefetch_ownerships_with_api(
+    cache: &QueryAccessCache,
+    tenant: &Tenant,
+    objects: &[OwnershipObject],
+    effective_role_names: &HashSet<String>,
+    user_api: &dyn OwnershipPrefetchApi,
+) -> Result<()> {
+    let mut unique_objects = Vec::with_capacity(objects.len());
+    let mut seen_objects = HashSet::with_capacity(objects.len());
+    for object in objects {
+        if cache.ownership_check(object, false).is_none() && seen_objects.insert(object) {
+            unique_objects.push(object.clone());
+        }
+    }
+
+    let mut role_exists = HashMap::new();
+    for objects in unique_objects.chunks(MGET_OWNERSHIP_BATCH_SIZE) {
+        let ownerships = user_api.mget_ownerships(tenant, objects).await?;
+        if ownerships.len() != objects.len() {
+            return Err(ErrorCode::Internal(format!(
+                "ownership MGet returned {} results for {} objects",
+                ownerships.len(),
+                objects.len()
+            )));
+        }
+
+        let mut checks = Vec::with_capacity(objects.len());
+        for (object, ownership) in objects.iter().cloned().zip(ownerships) {
+            let owner_role = match ownership {
+                Some(owner) => {
+                    if owner.object != object {
+                        return Err(ErrorCode::Internal(format!(
+                            "ownership MGet returned {} for requested object {}",
+                            owner.object, object
+                        )));
+                    }
+                    let exists = match role_exists.get(&owner.role) {
+                        Some(exists) => *exists,
+                        None => {
+                            let exists = user_api.exists_role(tenant, owner.role.clone()).await?;
+                            role_exists.insert(owner.role.clone(), exists);
+                            exists
+                        }
+                    };
+                    if exists {
+                        owner.role
+                    } else {
+                        BUILTIN_ROLE_ACCOUNT_ADMIN.to_string()
+                    }
+                }
+                None => BUILTIN_ROLE_ACCOUNT_ADMIN.to_string(),
+            };
+            checks.push((object, effective_role_names.contains(&owner_role)));
+        }
+        cache.insert_ownership_checks(checks);
+    }
+    Ok(())
+}
+
 impl PrivilegeAccess {
     pub fn create(ctx: Arc<QueryContext>) -> Box<dyn AccessChecker> {
-        Box::new(PrivilegeAccess { ctx })
+        Box::new(PrivilegeAccess {
+            ctx,
+            cache: QueryAccessCache::default(),
+        })
+    }
+
+    async fn get_database_id(
+        &self,
+        tenant: &Tenant,
+        catalog_name: &str,
+        catalog: &Arc<dyn Catalog>,
+        database_name: &str,
+    ) -> Result<u64> {
+        self.cache
+            .get_or_load_database_id(catalog_name, database_name, || async {
+                Ok(catalog
+                    .get_database(tenant, database_name)
+                    .await?
+                    .get_db_info()
+                    .database_id
+                    .db_id)
+            })
+            .await
+    }
+
+    async fn has_ownership_cached(
+        &self,
+        session: &Arc<Session>,
+        object: &OwnershipObject,
+        check_current_role_only: bool,
+    ) -> Result<bool> {
+        self.cache
+            .get_or_load_ownership_check(object, check_current_role_only, || async {
+                session.has_ownership(object, check_current_role_only).await
+            })
+            .await
+    }
+
+    async fn prefetch_ownerships(&self, objects: &[OwnershipObject]) -> Result<()> {
+        if objects.is_empty() {
+            return Ok(());
+        }
+
+        let session = self.ctx.get_current_session();
+        if !should_prefetch_ownerships(&session.get_type()) {
+            return Ok(());
+        }
+
+        let effective_role_names = session
+            .get_all_effective_roles()
+            .await?
+            .into_iter()
+            .map(|role| role.name)
+            .collect::<HashSet<_>>();
+        prefetch_ownerships_with_api(
+            &self.cache,
+            &self.ctx.get_tenant(),
+            objects,
+            &effective_role_names,
+            UserApiProvider::instance().as_ref(),
+        )
+        .await
     }
 
     // PrivilegeAccess checks the privilege by names, we'd need to convert the GrantObject to
@@ -104,15 +343,10 @@ impl PrivilegeAccess {
                 if db_name.to_lowercase() == "system" {
                     return Ok(None);
                 }
+                let catalog = self.ctx.get_catalog(catalog_name).await?;
                 let db_id = self
-                    .ctx
-                    .get_catalog(catalog_name)
-                    .await?
-                    .get_database(&tenant, db_name)
-                    .await?
-                    .get_db_info()
-                    .database_id
-                    .db_id;
+                    .get_database_id(&tenant, catalog_name, &catalog, db_name)
+                    .await?;
                 OwnershipObject::Database {
                     catalog_name: catalog_name.clone(),
                     db_id,
@@ -130,12 +364,9 @@ impl PrivilegeAccess {
                         .await?
                         .disable_table_info_refresh()?
                 };
-                let db_id = catalog
-                    .get_database(&tenant, db_name)
-                    .await?
-                    .get_db_info()
-                    .database_id
-                    .db_id;
+                let db_id = self
+                    .get_database_id(&tenant, catalog_name, &catalog, db_name)
+                    .await?;
                 let table_id = if !disable_table_info_refresh {
                     self.ctx
                         .get_table(catalog_name, db_name, table_name)
@@ -939,34 +1170,40 @@ impl PrivilegeAccess {
                 _ => Err(e.add_message("error on check has_ownership")),
             })?;
         if let Some(object) = &owner_object {
-            if let OwnershipObject::Table {
-                catalog_name,
-                db_id,
-                ..
-            } = object
-            {
-                let database_owner = OwnershipObject::Database {
-                    catalog_name: catalog_name.to_string(),
-                    db_id: *db_id,
-                };
-                // If Table ownership check fails, check for Database ownership
-                if session
-                    .has_ownership(object, check_current_role_only)
-                    .await?
-                    || session
-                        .has_ownership(&database_owner, check_current_role_only)
-                        .await?
-                {
-                    return Ok(true);
-                }
-            } else if session
-                .has_ownership(object, check_current_role_only)
-                .await?
-            {
-                return Ok(true);
-            }
+            return self
+                .has_owner_object(session, object, check_current_role_only)
+                .await;
         }
         Ok(false)
+    }
+
+    async fn has_owner_object(
+        &self,
+        session: &Arc<Session>,
+        object: &OwnershipObject,
+        check_current_role_only: bool,
+    ) -> Result<bool> {
+        if let OwnershipObject::Table {
+            catalog_name,
+            db_id,
+            ..
+        } = object
+        {
+            let database_owner = OwnershipObject::Database {
+                catalog_name: catalog_name.to_string(),
+                db_id: *db_id,
+            };
+            // If Table ownership check fails, check for Database ownership.
+            return Ok(self
+                .has_ownership_cached(session, object, check_current_role_only)
+                .await?
+                || self
+                    .has_ownership_cached(session, &database_owner, check_current_role_only)
+                    .await?);
+        }
+
+        self.has_ownership_cached(session, object, check_current_role_only)
+            .await
     }
 
     async fn validate_access(
@@ -1391,12 +1628,10 @@ impl PrivilegeAccess {
         disable_table_info_refresh: bool,
     ) -> Result<ObjectId> {
         let cat = catalog.clone();
-        let db_id = cat
-            .get_database(tenant, database_name)
-            .await?
-            .get_db_info()
-            .database_id
-            .db_id;
+        let catalog_name = cat.name();
+        let db_id = self
+            .get_database_id(tenant, &catalog_name, &cat, database_name)
+            .await?;
         if let Some(table_name) = table_name {
             let table_id = if !disable_table_info_refresh {
                 self.ctx
@@ -1579,6 +1814,64 @@ impl AccessChecker for PrivilegeAccess {
                 }
 
                 let metadata = metadata.read().clone();
+                let mut ownership_objects = Vec::new();
+                let mut prepared_ownerships = HashSet::new();
+                let mut prepared_tables = HashSet::new();
+                for table in metadata.tables() {
+                    if table.is_source_of_view()
+                        || table.is_source_of_stage()
+                        || table.table().is_temp()
+                    {
+                        continue;
+                    }
+
+                    let catalog_name = table.catalog();
+                    let database = table.database();
+                    let table_name = table.name();
+                    let catalog_table = table.table();
+                    let table_id = catalog_table.get_id();
+                    if !mark_table_access_checked(
+                        &mut prepared_tables,
+                        catalog_name,
+                        database,
+                        table_name,
+                        table_id,
+                    ) {
+                        continue;
+                    }
+
+                    if database == "information_schema"
+                        || database == "system"
+                        || is_materialized_view_engine(catalog_table.engine())
+                    {
+                        continue;
+                    }
+
+                    let catalog = self.ctx.get_catalog(catalog_name).await?;
+                    if catalog.exists_table_function(table_name) {
+                        continue;
+                    }
+                    let db_id = self
+                        .get_database_id(&tenant, catalog_name, &catalog, database)
+                        .await?;
+                    let database_owner = OwnershipObject::Database {
+                        catalog_name: catalog_name.to_string(),
+                        db_id,
+                    };
+                    if prepared_ownerships.insert(database_owner.clone()) {
+                        ownership_objects.push(database_owner);
+                    }
+                    let table_owner = OwnershipObject::Table {
+                        catalog_name: catalog_name.to_string(),
+                        db_id,
+                        table_id,
+                    };
+                    if prepared_ownerships.insert(table_owner.clone()) {
+                        ownership_objects.push(table_owner);
+                    }
+                }
+                self.prefetch_ownerships(&ownership_objects).await?;
+                let mut checked_tables = HashSet::new();
 
                 for table in metadata.tables() {
                     if enable_experimental_rbac_check && table.is_source_of_stage() {
@@ -1603,11 +1896,21 @@ impl AccessChecker for PrivilegeAccess {
                     // like this sql: copy into t from (select * from @s3); will bind a mock table with name `system.read_parquet(s3)`
                     // this is no means to check table `system.read_parquet(s3)` privilege
                     if !table.is_source_of_stage() {
+                        let database = table.database();
+                        let table_name = table.name();
                         let catalog_table = table.table();
-                        if is_materialized_view_engine(catalog_table.engine()) {
-                            self.validate_mv_source_access(catalog_table.as_ref()).await?;
-                        } else {
-                            self.validate_table_access(catalog_name, table.database(), table.name(), UserPrivilegeType::Select, false, false).await?
+                        if mark_table_access_checked(
+                            &mut checked_tables,
+                            catalog_name,
+                            database,
+                            table_name,
+                            catalog_table.get_id(),
+                        ) {
+                            if is_materialized_view_engine(catalog_table.engine()) {
+                                self.validate_mv_source_access(catalog_table.as_ref()).await?;
+                            } else {
+                                self.validate_table_access(catalog_name, database, table_name, UserPrivilegeType::Select, false, false).await?
+                            }
                         }
                     }
                 }
@@ -2664,4 +2967,424 @@ async fn has_priv(
                 _ => false,
             }
         }))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::collections::HashSet;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
+    use databend_common_catalog::session_type::SessionType;
+    use databend_common_exception::ErrorCode;
+    use databend_common_exception::Result;
+    use databend_common_meta_app::principal::OwnershipInfo;
+    use databend_common_meta_app::principal::OwnershipObject;
+    use databend_common_meta_app::tenant::Tenant;
+    use parking_lot::Mutex;
+
+    use super::MGET_OWNERSHIP_BATCH_SIZE;
+    use super::OwnershipPrefetchApi;
+    use super::QueryAccessCache;
+    use super::mark_table_access_checked;
+    use super::prefetch_ownerships_with_api;
+    use super::should_prefetch_ownerships;
+
+    #[derive(Default)]
+    struct FakeOwnershipApi {
+        ownerships: HashMap<OwnershipObject, Option<OwnershipInfo>>,
+        existing_roles: HashMap<String, bool>,
+        mget_batch_sizes: Mutex<Vec<usize>>,
+        exists_role_calls: Mutex<Vec<String>>,
+        mget_error: bool,
+        exists_role_error: Option<String>,
+        truncate_mget_result: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl OwnershipPrefetchApi for FakeOwnershipApi {
+        async fn mget_ownerships(
+            &self,
+            _tenant: &Tenant,
+            objects: &[OwnershipObject],
+        ) -> Result<Vec<Option<OwnershipInfo>>> {
+            self.mget_batch_sizes.lock().push(objects.len());
+            if self.mget_error {
+                return Err(ErrorCode::MetaServiceError("injected MGet failure"));
+            }
+
+            let mut ownerships = objects
+                .iter()
+                .map(|object| self.ownerships.get(object).cloned().unwrap_or(None))
+                .collect::<Vec<_>>();
+            if self.truncate_mget_result {
+                ownerships.pop();
+            }
+            Ok(ownerships)
+        }
+
+        async fn exists_role(&self, _tenant: &Tenant, role: String) -> Result<bool> {
+            self.exists_role_calls.lock().push(role.clone());
+            if self.exists_role_error.as_ref() == Some(&role) {
+                return Err(ErrorCode::MetaServiceError("injected role lookup failure"));
+            }
+            Ok(self.existing_roles.get(&role).copied().unwrap_or(false))
+        }
+    }
+
+    fn database(db_id: u64) -> OwnershipObject {
+        OwnershipObject::Database {
+            catalog_name: "default".to_string(),
+            db_id,
+        }
+    }
+
+    fn table(db_id: u64, table_id: u64) -> OwnershipObject {
+        OwnershipObject::Table {
+            catalog_name: "default".to_string(),
+            db_id,
+            table_id,
+        }
+    }
+
+    fn owned_by(object: &OwnershipObject, role: &str) -> Option<OwnershipInfo> {
+        Some(OwnershipInfo {
+            object: object.clone(),
+            role: role.to_string(),
+        })
+    }
+
+    fn role_names(roles: &[&str]) -> HashSet<String> {
+        roles.iter().map(|role| (*role).to_string()).collect()
+    }
+
+    #[tokio::test]
+    async fn test_query_access_cache_reuses_successes_and_isolates_keys() -> Result<()> {
+        let cache = QueryAccessCache::default();
+        let database_loads = AtomicUsize::new(0);
+
+        let first = cache
+            .get_or_load_database_id("default", "db", || async {
+                database_loads.fetch_add(1, Ordering::Relaxed);
+                Ok(11)
+            })
+            .await?;
+        let repeated = cache
+            .get_or_load_database_id("default", "db", || async {
+                database_loads.fetch_add(1, Ordering::Relaxed);
+                Ok(12)
+            })
+            .await?;
+        let other_catalog = cache
+            .get_or_load_database_id("other", "db", || async {
+                database_loads.fetch_add(1, Ordering::Relaxed);
+                Ok(13)
+            })
+            .await?;
+        assert_eq!((first, repeated, other_catalog), (11, 11, 13));
+        assert_eq!(database_loads.load(Ordering::Relaxed), 2);
+
+        let object = table(11, 22);
+        let ownership_loads = AtomicUsize::new(0);
+        assert!(
+            cache
+                .get_or_load_ownership_check(&object, false, || async {
+                    ownership_loads.fetch_add(1, Ordering::Relaxed);
+                    Ok(true)
+                })
+                .await?
+        );
+        assert!(
+            cache
+                .get_or_load_ownership_check(&object, false, || async {
+                    ownership_loads.fetch_add(1, Ordering::Relaxed);
+                    Ok(false)
+                })
+                .await?
+        );
+        assert!(
+            !cache
+                .get_or_load_ownership_check(&object, true, || async {
+                    ownership_loads.fetch_add(1, Ordering::Relaxed);
+                    Ok(false)
+                })
+                .await?
+        );
+        assert_eq!(ownership_loads.load(Ordering::Relaxed), 2);
+        assert_eq!(cache.ownership_check(&object, false), Some(true));
+        assert_eq!(cache.ownership_check(&object, true), Some(false));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_query_access_cache_does_not_cache_errors() -> Result<()> {
+        let cache = QueryAccessCache::default();
+        let database_loads = AtomicUsize::new(0);
+        let error = cache
+            .get_or_load_database_id("default", "db", || async {
+                database_loads.fetch_add(1, Ordering::Relaxed);
+                Err::<u64, _>(ErrorCode::MetaServiceError("injected database failure"))
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(error.code(), ErrorCode::META_SERVICE_ERROR);
+        assert_eq!(
+            cache
+                .get_or_load_database_id("default", "db", || async {
+                    database_loads.fetch_add(1, Ordering::Relaxed);
+                    Ok(11)
+                })
+                .await?,
+            11
+        );
+        assert_eq!(database_loads.load(Ordering::Relaxed), 2);
+
+        let object = table(11, 22);
+        let ownership_loads = AtomicUsize::new(0);
+        let error = cache
+            .get_or_load_ownership_check(&object, false, || async {
+                ownership_loads.fetch_add(1, Ordering::Relaxed);
+                Err::<bool, _>(ErrorCode::MetaServiceError("injected ownership failure"))
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(error.code(), ErrorCode::META_SERVICE_ERROR);
+        assert!(
+            !cache
+                .get_or_load_ownership_check(&object, false, || async {
+                    ownership_loads.fetch_add(1, Ordering::Relaxed);
+                    Ok(false)
+                })
+                .await?
+        );
+        assert_eq!(ownership_loads.load(Ordering::Relaxed), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn test_mark_table_access_checked_uses_catalog_name_and_table_id() {
+        let accesses = [
+            ("default", "db", "t1", 1),
+            ("default", "db", "t1", 1),
+            ("default", "db", "t1", 2),
+            ("default", "db", "t2", 3),
+            ("default", "other_db", "t1", 1),
+            ("other", "db", "t1", 1),
+        ];
+        let mut checked_tables = HashSet::new();
+        let checked_count = accesses
+            .into_iter()
+            .filter(|(catalog, database, table, table_id)| {
+                mark_table_access_checked(&mut checked_tables, catalog, database, table, *table_id)
+            })
+            .count();
+        assert_eq!(checked_count, 5);
+    }
+
+    #[test]
+    fn test_local_sessions_skip_ownership_prefetch() {
+        assert!(!should_prefetch_ownerships(&SessionType::Local));
+        assert!(should_prefetch_ownerships(&SessionType::MySQL));
+        assert!(should_prefetch_ownerships(&SessionType::Dummy));
+    }
+
+    #[tokio::test]
+    async fn test_ownership_prefetch_batch_boundaries() -> Result<()> {
+        let tenant = Tenant::new_literal("tenant");
+        let cases = [
+            (0, vec![]),
+            (1, vec![1]),
+            (256, vec![256]),
+            (257, vec![256, 1]),
+            (512, vec![256, 256]),
+            (513, vec![256, 256, 1]),
+        ];
+        for (object_count, expected_batch_sizes) in cases {
+            let objects = (0..object_count).map(database).collect::<Vec<_>>();
+            let cache = QueryAccessCache::default();
+            let api = FakeOwnershipApi::default();
+            prefetch_ownerships_with_api(&cache, &tenant, &objects, &HashSet::new(), &api).await?;
+            assert_eq!(*api.mget_batch_sizes.lock(), expected_batch_sizes);
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_ownership_prefetch_preserves_fallback_and_role_semantics() -> Result<()> {
+        let tenant = Tenant::new_literal("tenant");
+        let database = database(1);
+        let table_object = table(1, 2);
+        let unowned = table(1, 3);
+        let deleted_role_owner = table(1, 4);
+        let objects = vec![
+            table_object.clone(),
+            database.clone(),
+            unowned.clone(),
+            deleted_role_owner.clone(),
+            table_object.clone(),
+            database.clone(),
+        ];
+        let ownerships = HashMap::from([
+            (table_object.clone(), owned_by(&table_object, "table_owner")),
+            (database.clone(), owned_by(&database, "database_owner")),
+            (
+                deleted_role_owner.clone(),
+                owned_by(&deleted_role_owner, "deleted_role"),
+            ),
+        ]);
+        let existing_roles = HashMap::from([
+            ("table_owner".to_string(), true),
+            ("database_owner".to_string(), true),
+            ("deleted_role".to_string(), false),
+        ]);
+        let api = FakeOwnershipApi {
+            ownerships: ownerships.clone(),
+            existing_roles: existing_roles.clone(),
+            ..Default::default()
+        };
+        let cache = QueryAccessCache::default();
+        prefetch_ownerships_with_api(
+            &cache,
+            &tenant,
+            &objects,
+            &role_names(&["database_owner", "account_admin"]),
+            &api,
+        )
+        .await?;
+
+        // The table itself is not owned, but its database is. The normal Table -> Database
+        // fallback therefore still grants access.
+        assert_eq!(cache.ownership_check(&table_object, false), Some(false));
+        assert_eq!(cache.ownership_check(&database, false), Some(true));
+        assert!(
+            cache.ownership_check(&table_object, false).unwrap()
+                || cache.ownership_check(&database, false).unwrap()
+        );
+        // Missing ownership and ownership held by a deleted role both fall back to account_admin.
+        assert_eq!(cache.ownership_check(&unowned, false), Some(true));
+        assert_eq!(
+            cache.ownership_check(&deleted_role_owner, false),
+            Some(true)
+        );
+        // Prefetch only populates the all-effective-roles scope.
+        assert_eq!(cache.ownership_check(&table_object, true), None);
+        assert_eq!(*api.mget_batch_sizes.lock(), vec![4]);
+        assert_eq!(api.exists_role_calls.lock().len(), 3);
+
+        let api = FakeOwnershipApi {
+            ownerships,
+            existing_roles,
+            ..Default::default()
+        };
+        let cache = QueryAccessCache::default();
+        prefetch_ownerships_with_api(
+            &cache,
+            &tenant,
+            &objects,
+            &role_names(&["table_owner", "deleted_role"]),
+            &api,
+        )
+        .await?;
+        assert_eq!(cache.ownership_check(&table_object, false), Some(true));
+        assert_eq!(cache.ownership_check(&database, false), Some(false));
+        assert_eq!(cache.ownership_check(&unowned, false), Some(false));
+        assert_eq!(
+            cache.ownership_check(&deleted_role_owner, false),
+            Some(false)
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_ownership_prefetch_deduplicates_owner_role_lookups_across_batches() -> Result<()>
+    {
+        let tenant = Tenant::new_literal("tenant");
+        let objects = (0..MGET_OWNERSHIP_BATCH_SIZE + 1)
+            .map(|db_id| database(db_id as u64))
+            .collect::<Vec<_>>();
+        let ownerships = objects
+            .iter()
+            .map(|object| (object.clone(), owned_by(object, "owner")))
+            .collect();
+        let api = FakeOwnershipApi {
+            ownerships,
+            existing_roles: HashMap::from([("owner".to_string(), true)]),
+            ..Default::default()
+        };
+        let cache = QueryAccessCache::default();
+        prefetch_ownerships_with_api(&cache, &tenant, &objects, &role_names(&["owner"]), &api)
+            .await?;
+        assert_eq!(*api.mget_batch_sizes.lock(), vec![256, 1]);
+        assert_eq!(*api.exists_role_calls.lock(), vec!["owner".to_string()]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_ownership_prefetch_propagates_errors_without_caching_denial() -> Result<()> {
+        let tenant = Tenant::new_literal("tenant");
+        let object = database(1);
+        let objects = vec![object.clone()];
+        let cache = QueryAccessCache::default();
+
+        let api = FakeOwnershipApi {
+            mget_error: true,
+            ..Default::default()
+        };
+        let error = prefetch_ownerships_with_api(&cache, &tenant, &objects, &HashSet::new(), &api)
+            .await
+            .unwrap_err();
+        assert_eq!(error.code(), ErrorCode::META_SERVICE_ERROR);
+        assert_eq!(cache.ownership_check(&object, false), None);
+
+        let api = FakeOwnershipApi {
+            ownerships: HashMap::from([(object.clone(), owned_by(&object, "owner"))]),
+            existing_roles: HashMap::from([("owner".to_string(), true)]),
+            ..Default::default()
+        };
+        prefetch_ownerships_with_api(&cache, &tenant, &objects, &role_names(&["owner"]), &api)
+            .await?;
+        assert_eq!(cache.ownership_check(&object, false), Some(true));
+
+        let object = database(2);
+        let cache = QueryAccessCache::default();
+        let api = FakeOwnershipApi {
+            ownerships: HashMap::from([(object.clone(), owned_by(&object, "owner"))]),
+            exists_role_error: Some("owner".to_string()),
+            ..Default::default()
+        };
+        let error =
+            prefetch_ownerships_with_api(&cache, &tenant, &[object.clone()], &HashSet::new(), &api)
+                .await
+                .unwrap_err();
+        assert_eq!(error.code(), ErrorCode::META_SERVICE_ERROR);
+        assert_eq!(cache.ownership_check(&object, false), None);
+
+        let object = database(3);
+        let cache = QueryAccessCache::default();
+        let api = FakeOwnershipApi {
+            truncate_mget_result: true,
+            ..Default::default()
+        };
+        let error =
+            prefetch_ownerships_with_api(&cache, &tenant, &[object.clone()], &HashSet::new(), &api)
+                .await
+                .unwrap_err();
+        assert_eq!(error.code(), ErrorCode::INTERNAL);
+        assert_eq!(cache.ownership_check(&object, false), None);
+
+        let object = database(4);
+        let cache = QueryAccessCache::default();
+        let api = FakeOwnershipApi {
+            ownerships: HashMap::from([(object.clone(), owned_by(&database(5), "owner"))]),
+            ..Default::default()
+        };
+        let error =
+            prefetch_ownerships_with_api(&cache, &tenant, &[object.clone()], &HashSet::new(), &api)
+                .await
+                .unwrap_err();
+        assert_eq!(error.code(), ErrorCode::INTERNAL);
+        assert_eq!(cache.ownership_check(&object, false), None);
+        Ok(())
+    }
 }

--- a/src/query/service/src/sessions/session.rs
+++ b/src/query/service/src/sessions/session.rs
@@ -375,13 +375,22 @@ impl Session {
             .await
     }
 
+    /// Whether ownership checks are short-circuited to `true` for this session,
+    /// making the owner of record irrelevant.
+    ///
+    /// Callers that batch or cache ownership answers must consult this instead of
+    /// re-deriving the rule, otherwise they would cache answers this session never uses.
+    pub fn bypasses_ownership_checks(&self) -> bool {
+        matches!(self.get_type(), SessionType::Local)
+    }
+
     #[async_backtrace::framed]
     pub async fn has_ownership(
         &self,
         object: &OwnershipObject,
         check_current_role_only: bool,
     ) -> Result<bool> {
-        if matches!(self.get_type(), SessionType::Local) {
+        if self.bypasses_ownership_checks() {
             return Ok(true);
         }
         self.privilege_mgr()

--- a/src/query/users/src/lib.rs
+++ b/src/query/users/src/lib.rs
@@ -48,6 +48,7 @@ pub use user::CertifiedInfo;
 pub use user_api::UserApiProvider;
 pub use visibility_checker::DbTableVisibilityResult;
 pub use visibility_checker::GrantObjectVisibilityChecker;
+pub use visibility_checker::MGET_OWNERSHIP_BATCH_SIZE;
 pub use visibility_checker::Object;
 pub use visibility_checker::TableVisibilityTarget;
 pub use visibility_checker::check_table_visibility_with_roles;

--- a/src/query/users/src/visibility_checker.rs
+++ b/src/query/users/src/visibility_checker.rs
@@ -991,7 +991,7 @@ pub struct DbTableVisibilityResult {
 
 /// Maximum batch size for `mget_ownerships` calls to avoid oversized RPC payloads.
 /// Aligned with `KVPbApi::CHUNK_SIZE = 256` as the default batch size.
-const MGET_OWNERSHIP_BATCH_SIZE: usize = 256;
+pub const MGET_OWNERSHIP_BATCH_SIZE: usize = 256;
 
 /// Filter tables under a single database by visibility using grant-first + lazy ownership.
 ///

--- a/tests/suites/0_stateless/18_rbac/18_0020_privilege_access_prefetch.result
+++ b/tests/suites/0_stateless/18_rbac/18_0020_privilege_access_prefetch.result
@@ -1,0 +1,33 @@
+=== db owner: repeated binds of the same tables ===
+1
+1
+1
+2
+2
+=== table owner: only the owned table ===
+2
+Permission denied
+Permission denied
+=== table owner: owned joined with denied ===
+Permission denied
+=== cross-database plan ===
+1
+Permission denied
+=== system schema mixed with user table ===
+true
+1
+true
+=== table function alongside an owned table ===
+3
+=== name-based grant, no ownership ===
+1
+Permission denied
+=== owner role dropped, falls back to account_admin ===
+0
+0
+Permission denied
+=== temp table alongside an owned table ===
+1
+1
+=== view over owned tables ===
+2

--- a/tests/suites/0_stateless/18_rbac/18_0020_privilege_access_prefetch.sh
+++ b/tests/suites/0_stateless/18_rbac/18_0020_privilege_access_prefetch.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Regression coverage for the query-local privilege cache and the batched ownership
+# prefetch in PrivilegeAccess::check. Each case drives a plan that references the same
+# objects repeatedly, which is what makes the prefetch and the dedup paths run.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$CURDIR"/../../../shell_env.sh
+
+bendsql_connect_root_null <<SQL
+drop database if exists db_0020;
+drop database if exists db_0020_other;
+drop role if exists role_db_0020;
+drop role if exists role_tbl_0020;
+drop role if exists role_gone_0020;
+drop user if exists u_db_0020;
+drop user if exists u_tbl_0020;
+drop user if exists u_grant_0020;
+drop user if exists u_gone_0020;
+create database db_0020;
+create database db_0020_other;
+create table db_0020.t1(id int);
+create table db_0020.t2(id int);
+create table db_0020_other.t3(id int);
+insert into db_0020.t1 values(1);
+insert into db_0020.t2 values(2);
+insert into db_0020_other.t3 values(3);
+create role role_db_0020;
+create role role_tbl_0020;
+create role role_gone_0020;
+grant ownership on db_0020.* to role role_db_0020;
+grant ownership on db_0020.t2 to role role_tbl_0020;
+create user u_db_0020 identified by '123' with default_role = 'role_db_0020';
+create user u_tbl_0020 identified by '123' with default_role = 'role_tbl_0020';
+grant role role_db_0020 to u_db_0020;
+grant role role_tbl_0020 to u_tbl_0020;
+SQL
+
+export USER_DB_CONNECT="bendsql_connect_user u_db_0020 123 -A"
+export USER_TBL_CONNECT="bendsql_connect_user u_tbl_0020 123 -A"
+
+# Database ownership must still cover every table under it, including when a table is
+# bound many times in one plan. Each alias resolves to the same ownership object, so this
+# is the case the prefetch deduplicates.
+echo "=== db owner: repeated binds of the same tables ==="
+echo "select count(*) from db_0020.t1 a, db_0020.t1 b, db_0020.t2 c;" | $USER_DB_CONNECT
+echo "select id from db_0020.t1 union all select id from db_0020.t1 union all select id from db_0020.t2 order by id;" | $USER_DB_CONNECT
+echo "select (select count(*) from db_0020.t1) + (select count(*) from db_0020.t2);" | $USER_DB_CONNECT
+
+# Table ownership alone grants only that table; the sibling under the same database and a
+# table in another database must still be denied.
+echo "=== table owner: only the owned table ==="
+echo "select * from db_0020.t2;" | $USER_TBL_CONNECT
+echo "select * from db_0020.t1;" | $USER_TBL_CONNECT 2>&1 | grep -o "Permission denied" | head -1
+echo "select * from db_0020_other.t3;" | $USER_TBL_CONNECT 2>&1 | grep -o "Permission denied" | head -1
+
+# A plan mixing an owned table with a denied one must be denied as a whole, even though
+# the owned table's ownership entry is prefetched successfully.
+echo "=== table owner: owned joined with denied ==="
+echo "select count(*) from db_0020.t2 a, db_0020.t1 b;" | $USER_TBL_CONNECT 2>&1 | grep -o "Permission denied" | head -1
+
+# Objects spanning two databases exercise the per-catalog/database keying of the db_id cache.
+echo "=== cross-database plan ==="
+echo "grant ownership on db_0020_other.* to role role_db_0020;" | bendsql_connect_root_null
+echo "select count(*) from db_0020.t1 a, db_0020_other.t3 b;" | $USER_DB_CONNECT
+echo "grant ownership on db_0020_other.* to role role_tbl_0020;" | bendsql_connect_root_null
+echo "select count(*) from db_0020.t1 a, db_0020_other.t3 b;" | $USER_DB_CONNECT 2>&1 | grep -o "Permission denied" | head -1
+
+# System and information_schema tables are exempt from ownership; mixing them with a
+# user table must not disturb the user table's check.
+echo "=== system schema mixed with user table ==="
+echo "select count(*) > 0 from system.tables where database = 'db_0020';" | $USER_DB_CONNECT
+echo "select count(*) from db_0020.t1 a, system.one b;" | $USER_DB_CONNECT
+echo "select count(*) > 0 from information_schema.tables where table_schema = 'db_0020';" | $USER_DB_CONNECT
+
+# Table functions carry their own privilege rules and are skipped by the prefetch.
+echo "=== table function alongside an owned table ==="
+echo "select count(*) from db_0020.t1 a, numbers(3) b;" | $USER_DB_CONNECT
+
+# Access granted by a name-based grant rather than ownership: the eager prefetch must not
+# turn a grant-authorized query into a failure.
+echo "=== name-based grant, no ownership ==="
+bendsql_connect_root_null <<SQL
+create user u_grant_0020 identified by '123';
+grant select on db_0020.t1 to u_grant_0020;
+SQL
+export USER_GRANT_CONNECT="bendsql_connect_user u_grant_0020 123 -A"
+echo "select count(*) from db_0020.t1 a, db_0020.t1 b;" | $USER_GRANT_CONNECT
+echo "select * from db_0020.t2;" | $USER_GRANT_CONNECT 2>&1 | grep -o "Permission denied" | head -1
+
+# An object owned by a dropped role falls back to account_admin: root still reads it, the
+# former owner no longer does. This is the fallback the prefetch has to reproduce.
+echo "=== owner role dropped, falls back to account_admin ==="
+bendsql_connect_root_null <<SQL
+create table db_0020.t_gone(id int);
+grant ownership on db_0020.t_gone to role role_gone_0020;
+create user u_gone_0020 identified by '123' with default_role = 'role_gone_0020';
+grant role role_gone_0020 to u_gone_0020;
+SQL
+export USER_GONE_CONNECT="bendsql_connect_user u_gone_0020 123 -A"
+echo "select count(*) from db_0020.t_gone;" | $USER_GONE_CONNECT
+echo "drop role role_gone_0020;" | bendsql_connect_root_null
+echo "select count(*) from db_0020.t_gone;" | bendsql_connect_root
+echo "select count(*) from db_0020.t_gone;" | $USER_GONE_CONNECT 2>&1 | grep -o "Permission denied" | head -1
+
+# Temp tables are skipped by the prefetch and by the ownership check; they must remain
+# usable alongside an owned table in the same session.
+echo "=== temp table alongside an owned table ==="
+echo "create temp table tmp_0020(id int); insert into tmp_0020 values(9); select count(*) from tmp_0020 a, db_0020.t1 b;" | $USER_DB_CONNECT
+
+# A view's source tables are validated through the view, not as directly bound tables.
+echo "=== view over owned tables ==="
+echo "create view db_0020.v as select id from db_0020.t1 union all select id from db_0020.t2; select count(*) from db_0020.v;" | $USER_DB_CONNECT
+
+bendsql_connect_root_null <<SQL
+drop database if exists db_0020;
+drop database if exists db_0020_other;
+drop role if exists role_db_0020;
+drop role if exists role_tbl_0020;
+drop user if exists u_db_0020;
+drop user if exists u_tbl_0020;
+drop user if exists u_grant_0020;
+drop user if exists u_gone_0020;
+SQL


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Reduce redundant Query to Meta round trips when a plan references the same database, table, or ownership object repeatedly
- Cache database IDs and ownership results within one PrivilegeAccess lifecycle, deduplicate repeated metadata table checks, and prefetch remote ownerships with batches capped at 256 objects
- Preserve the existing RBAC model, current-role-only separation, Table to Database ownership fallback, Local Session path, and special handling for views, stages, temporary tables, system schemas, and table functions

## Implementation

- Key database IDs by catalog and database; hold ownership answers for the all-effective-roles scope and the current-role-only scope in separate maps; key table checks by catalog, database, table name, and stable table ID
- Deduplicate ownership objects and owner-role existence lookups, and validate MGet result counts before populating the query-local cache
- Treat the prefetch as a pure optimization. Every object it gathers is re-derived by the checking loop that follows, so errors raised while gathering are not propagated; the checking loop reports them with the `if_exists` and `UNKNOWN_DATABASE` handling each object type expects
- Publish prefetched answers only after every batch succeeds, so a plan spanning several batches cannot leave a partially populated cache behind when a later batch fails
- Map MGet results onto the requested keys positionally, without comparing `OwnershipInfo.object` (see below)
- Skip the owner-role existence lookup when the recorded owner and the `account_admin` fallback would produce the same answer. That lookup exists only to decide between those two, so it cannot change the outcome when they agree
- Cache only successful loads, so Meta failures are propagated instead of becoming cached denials
- Exempt `system` and `information_schema` from the prefetch case-insensitively, matching the comparison `convert_to_owner_object` already performs. Prefetching an object that path then refuses to resolve would issue Meta requests for entries nothing reads
- Route the Local Session ownership short circuit through a single `Session::bypasses_ownership_checks`, and reuse `MGET_OWNERSHIP_BATCH_SIZE` from `databend_common_users` rather than redeclaring the bound
- Keep the current main materialized-view path: skip prefetching the MV object itself and continue validating its source table through `validate_mv_source_access`
- The existing batched ownership helper for system-table visibility has a different scope and does not provide an AccessChecker query-local cache

### On ownership record identity

An earlier commit on this branch compared the encoded ownership key of each returned record against the requested key and raised an internal error on mismatch. The final commit removes that comparison.

`mget_ownerships` maps its results positionally onto the keys it was given, so a record's identity comes from its position rather than from its value. A table ownership key intentionally omits `db_id`, and `UserApiProvider::get_ownership` — the authoritative single-object path — does not inspect the returned value either. Comparing values could therefore turn legitimate stored state into an internal error instead of catching a real inconsistency. The result-count check is retained, since a length mismatch does indicate a broken positional mapping.

## Performance evidence

This change targets sequential Meta round trips during access checking. It does not optimize scan or execution CPU.

Consider a query plan with the following generic shape:

- 1 database
- 32 distinct persistent tables
- 64 metadata table entries because each table is referenced twice from separate aliases or subqueries
- Access is authorized by database ownership, so each table ownership check misses and falls back to the same database owner
- All ownership records refer to one role

On the parent implementation, the AccessChecker can issue:

- 64 database ID resolutions
- Up to 128 individual ownership reads: one table miss and one database fallback per metadata entry
- 64 owner-role existence lookups for the repeated database ownership hits
- 64 table access validations

With this change, the same access check issues:

- 1 database ID resolution
- 1 ownership MGet containing 33 unique objects: 32 tables and 1 database
- 1 owner-role existence lookup
- 32 table access validations

For this shape, the AccessChecker-level Meta-facing calls fall from up to 256 to 3, a 98.8% request-count reduction. This is not a claim of 98.8% lower query wall time: catalog caches may suppress some physical requests, and one MGet does more server work than one point lookup. If Query to Meta round-trip latency is 0.5 to 1 ms, replacing 128 sequential ownership reads with one MGet removes 127 network round trips, corresponding to roughly 63.5 to 127 ms of fixed latency before server processing. Deduplicated database and role lookups can reduce additional latency. This estimate is illustrative and should be replaced by deployment measurements where available.

A reproducible external benchmark can compare the parent and this branch as follows:

1. Create one database with 32 tiny persistent tables and authorize the benchmark role through database ownership.
2. Generate an EXPLAIN query whose aliases or UNION ALL branches reference every table twice. EXPLAIN keeps data execution out of the measurement while still running plan access checks.
3. After warmup, run at least 100 iterations and compare Query to Meta request counts plus p50 and p95 Binding or AccessCheck latency.
4. Run a second variant authorized entirely through explicit grants. That control case measures the cost of the eager ownership prefetch, which may add one batched lookup when ownership would not otherwise be consulted.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - Explain why

Unit tests in `privilege_access.rs` cover the query-local cache scopes, error paths that must not be cached as denials, MGet batch boundaries, owner-role deduplication, the batch-failure publish barrier, the skipped role lookup, and records whose stored value carries a stale `db_id` or a different catalog.

`tests/suites/0_stateless/18_rbac/18_0020_privilege_access_prefetch.sh` adds end-to-end coverage: repeated binds of the same tables, database owner versus table owner boundaries, cross-database plans, `system` and `information_schema` mixed with a user table, table functions, grant-authorized access with no ownership, the `account_admin` fallback after the owner role is dropped, temporary tables, and views. The full `18_rbac` suite passes on a clean standalone deployment.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent adapted the query-local privilege cache and ownership MGet optimization to current main, drafted the regression tests, reviewed the branch and fixed the issues it found, performed local validation, and drafted this PR summary
- Responsible human: @dantengsky
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20329)
<!-- Reviewable:end -->
