### PR TITLE
fix(query): accelerate multi-key hash shuffle

### DIFF
--- a/src/query/expression/src/aggregate/group_hash.rs
+++ b/src/query/expression/src/aggregate/group_hash.rs
@@ -40,23 +40,28 @@ const NULL_HASH_VAL: u64 = 0xd1cefa08eb382d69;
 pub fn group_hash_entries(entries: ProjectedBlock, values: &mut [u64]) {
     debug_assert!(!entries.is_empty());
     for (i, entry) in entries.iter().enumerate() {
-        debug_assert_eq!(entry.len(), values.len());
-        match entry {
-            BlockEntry::Const(scalar, data_type, _) => {
-                if i == 0 {
-                    combine_group_hash_const::<true>(scalar, data_type, values);
-                } else {
-                    combine_group_hash_const::<false>(scalar, data_type, values);
-                }
-            }
-            BlockEntry::Column(column) => {
-                if i == 0 {
-                    combine_group_hash_column::<true>(column, values);
-                } else {
-                    combine_group_hash_column::<false>(column, values);
-                }
-            }
+        group_hash_entry(entry, values, i == 0);
+    }
+}
+
+/// Hash one group key into `values`.
+///
+/// The first key initializes the hashes; subsequent keys are merged into them.
+pub fn group_hash_entry(entry: &BlockEntry, values: &mut [u64], is_first: bool) {
+    debug_assert_eq!(entry.len(), values.len());
+    if is_first {
+        combine_group_hash_entry::<true>(entry, values);
+    } else {
+        combine_group_hash_entry::<false>(entry, values);
+    }
+}
+
+fn combine_group_hash_entry<const IS_FIRST: bool>(entry: &BlockEntry, values: &mut [u64]) {
+    match entry {
+        BlockEntry::Const(scalar, data_type, _) => {
+            combine_group_hash_const::<IS_FIRST>(scalar, data_type, values);
         }
+        BlockEntry::Column(column) => combine_group_hash_column::<IS_FIRST>(column, values),
     }
 }
 
@@ -684,6 +689,22 @@ mod tests {
             );
             assert_eq!(const_hashes, col_hashes);
         }
+    }
+
+    #[test]
+    fn test_incremental_group_hash_equals_projected_block() {
+        let block = sample_block(5).convert_to_full();
+        let projection = (0..block.num_columns()).collect::<Vec<_>>();
+        let entries = ProjectedBlock::project(&projection, &block);
+        let mut projected_hashes = vec![0; block.num_rows()];
+        let mut incremental_hashes = vec![0; block.num_rows()];
+
+        group_hash_entries(entries, &mut projected_hashes);
+        for (index, entry) in entries.iter().enumerate() {
+            group_hash_entry(entry, &mut incremental_hashes, index == 0);
+        }
+
+        assert_eq!(projected_hashes, incremental_hashes);
     }
 
     fn sample_block(num_rows: usize) -> DataBlock {

--- a/src/query/functions/Cargo.toml
+++ b/src/query/functions/Cargo.toml
@@ -70,6 +70,10 @@ goldenfile = { workspace = true }
 name = "bench"
 harness = false
 
+[[bench]]
+name = "flight_scatter_hash"
+harness = false
+
 [lints]
 workspace = true
 

--- a/src/query/functions/benches/flight_scatter_hash.rs
+++ b/src/query/functions/benches/flight_scatter_hash.rs
@@ -1,0 +1,189 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::Hasher;
+
+use databend_common_expression::BlockEntry;
+use databend_common_expression::ColumnRef;
+use databend_common_expression::DataBlock;
+use databend_common_expression::Evaluator;
+use databend_common_expression::Expr;
+use databend_common_expression::FromData;
+use databend_common_expression::FunctionContext;
+use databend_common_expression::Value;
+use databend_common_expression::group_hash_entry;
+use databend_common_expression::type_check::check_function;
+use databend_common_expression::types::AccessType;
+use databend_common_expression::types::AnyType;
+use databend_common_expression::types::DataType;
+use databend_common_expression::types::NumberDataType;
+use databend_common_expression::types::NumberType;
+use databend_common_expression::types::StringType;
+use databend_common_expression::types::UInt64Type;
+use databend_common_functions::BUILTIN_FUNCTIONS;
+
+const ROWS: usize = 1 << 16;
+const PARTITIONS: usize = 8;
+
+fn main() {
+    divan::main();
+}
+
+fn column_expr(id: usize, data_type: DataType) -> Expr {
+    Expr::ColumnRef(ColumnRef {
+        span: None,
+        id,
+        data_type,
+        display_name: format!("#{id}"),
+    })
+}
+
+struct BenchmarkInput {
+    block: DataBlock,
+    keys: Vec<Expr>,
+    legacy_hash_keys: Vec<Expr>,
+}
+
+fn benchmark_input(key_count: usize) -> BenchmarkInput {
+    let text_keys = (0..ROWS)
+        .map(|row| format!("key-{row:016x}"))
+        .collect::<Vec<_>>();
+    let tag_keys = (0..ROWS)
+        .map(|row| format!("tag-{:08x}", row.wrapping_mul(17)))
+        .collect::<Vec<_>>();
+    let key_num_1 = (0..ROWS).map(|row| row as u64).collect::<Vec<_>>();
+    let key_num_2 = (0..ROWS)
+        .map(|row| row.wrapping_mul(31) as u64)
+        .collect::<Vec<_>>();
+    let key_num_3 = (0..ROWS).map(|row| (row % 2048) as u64).collect::<Vec<_>>();
+    let block = DataBlock::new_from_columns(vec![
+        StringType::from_data(text_keys),
+        StringType::from_data(tag_keys),
+        UInt64Type::from_data(key_num_1),
+        UInt64Type::from_data(key_num_2),
+        UInt64Type::from_data(key_num_3),
+    ]);
+
+    let text_key = column_expr(0, DataType::String);
+    let tag_key = column_expr(1, DataType::String);
+    let mut keys = vec![
+        check_function(
+            None,
+            "lower",
+            &[],
+            std::slice::from_ref(&text_key),
+            &BUILTIN_FUNCTIONS,
+        )
+        .unwrap(),
+        check_function(
+            None,
+            "concat",
+            &[],
+            &[text_key, tag_key],
+            &BUILTIN_FUNCTIONS,
+        )
+        .unwrap(),
+        column_expr(2, DataType::Number(NumberDataType::UInt64)),
+        column_expr(3, DataType::Number(NumberDataType::UInt64)),
+        column_expr(4, DataType::Number(NumberDataType::UInt64)),
+    ];
+    keys.truncate(key_count);
+    let legacy_hash_keys = keys
+        .iter()
+        .map(|key| {
+            check_function(
+                None,
+                "siphash",
+                &[],
+                std::slice::from_ref(key),
+                &BUILTIN_FUNCTIONS,
+            )
+            .unwrap()
+        })
+        .collect();
+    BenchmarkInput {
+        block,
+        keys,
+        legacy_hash_keys,
+    }
+}
+
+fn legacy_scatter_indices(input: &BenchmarkInput) -> Vec<u64> {
+    let func_ctx = FunctionContext::default();
+    let evaluator = Evaluator::new(&input.block, &func_ctx, &BUILTIN_FUNCTIONS);
+    let hash_keys = input
+        .legacy_hash_keys
+        .iter()
+        .map(|expr| match evaluator.run(expr).unwrap() {
+            Value::<AnyType>::Column(column) => {
+                NumberType::<u64>::try_downcast_column(&column).unwrap()
+            }
+            Value::<AnyType>::Scalar(_) => unreachable!(),
+        })
+        .collect::<Vec<_>>();
+
+    let mut hashes = vec![DefaultHasher::default(); input.block.num_rows()];
+    for key in hash_keys {
+        for (hash, value) in hashes.iter_mut().zip(key.iter()) {
+            hash.write_u64(*value);
+        }
+    }
+    hashes
+        .into_iter()
+        .map(|hash| hash.finish() % PARTITIONS as u64)
+        .collect()
+}
+
+fn group_hash_scatter_indices(input: &BenchmarkInput) -> Vec<u64> {
+    let func_ctx = FunctionContext::default();
+    let evaluator = Evaluator::new(&input.block, &func_ctx, &BUILTIN_FUNCTIONS);
+    let num_rows = input.block.num_rows();
+    let mut hashes = vec![0; num_rows];
+
+    for (index, expr) in input.keys.iter().enumerate() {
+        let entry = BlockEntry::new(evaluator.run(expr).unwrap(), || {
+            (expr.data_type().clone(), num_rows)
+        });
+        group_hash_entry(&entry, &mut hashes, index == 0);
+    }
+
+    for hash in &mut hashes {
+        *hash %= PARTITIONS as u64;
+    }
+    hashes
+}
+
+#[divan::bench_group(max_time = 2)]
+mod multi_key_scatter {
+    use super::*;
+
+    #[divan::bench(args = [2, 5])]
+    fn legacy(bencher: divan::Bencher, key_count: usize) {
+        let input = benchmark_input(key_count);
+        assert_eq!(legacy_scatter_indices(&input).len(), ROWS);
+        bencher.bench(|| {
+            divan::black_box(legacy_scatter_indices(divan::black_box(&input)));
+        });
+    }
+
+    #[divan::bench(args = [2, 5])]
+    fn group_hash(bencher: divan::Bencher, key_count: usize) {
+        let input = benchmark_input(key_count);
+        assert_eq!(group_hash_scatter_indices(&input).len(), ROWS);
+        bencher.bench(|| {
+            divan::black_box(group_hash_scatter_indices(divan::black_box(&input)));
+        });
+    }
+}

--- a/src/query/service/src/servers/flight/v1/scatter/flight_scatter_hash.rs
+++ b/src/query/service/src/servers/flight/v1/scatter/flight_scatter_hash.rs
@@ -19,11 +19,10 @@ use databend_common_expression::Evaluator;
 use databend_common_expression::Expr;
 use databend_common_expression::FunctionContext;
 use databend_common_expression::FunctionID;
-use databend_common_expression::ProjectedBlock;
 use databend_common_expression::RemoteExpr;
 use databend_common_expression::Scalar;
 use databend_common_expression::Value;
-use databend_common_expression::group_hash_entries;
+use databend_common_expression::group_hash_entry;
 use databend_common_expression::type_check::check_function;
 use databend_common_expression::types::AccessType;
 use databend_common_expression::types::AnyType;
@@ -184,18 +183,13 @@ impl HashFlightScatter {
         }
 
         let evaluator = Evaluator::new(data_block, &self.func_ctx, &BUILTIN_FUNCTIONS);
-        let hash_keys = self
-            .hash_key
-            .iter()
-            .map(|expr| {
-                Ok(BlockEntry::new(evaluator.run(expr)?, || {
-                    (expr.data_type().clone(), num_rows)
-                }))
-            })
-            .collect::<Result<Vec<_>>>()?;
-
         let mut hashes = vec![0; num_rows];
-        group_hash_entries(ProjectedBlock::from(&hash_keys), &mut hashes);
+        for (index, expr) in self.hash_key.iter().enumerate() {
+            let entry = BlockEntry::new(evaluator.run(expr)?, || {
+                (expr.data_type().clone(), num_rows)
+            });
+            group_hash_entry(&entry, &mut hashes, index == 0);
+        }
 
         let scatter_size = self.scatter_size as u64;
         for hash in &mut hashes {
@@ -342,12 +336,12 @@ mod tests {
 
     #[test]
     fn hashes_evaluated_and_materialized_keys_consistently() -> Result<()> {
-        let raw_addresses = StringType::from_data(vec!["AbC", "DEF", "ghI", "Jkl"]);
-        let lower_addresses = StringType::from_data(vec!["abc", "def", "ghi", "jkl"]);
-        let wallet_ids = UInt64Type::from_data(vec![1, 2, 3, 4]);
+        let text_keys = StringType::from_data(vec!["AbC", "DEF", "ghI", "Jkl"]);
+        let normalized_text_keys = StringType::from_data(vec!["abc", "def", "ghi", "jkl"]);
+        let numeric_keys = UInt64Type::from_data(vec![1, 2, 3, 4]);
 
-        let raw_block = DataBlock::new_from_columns(vec![raw_addresses, wallet_ids.clone()]);
-        let lower_block = DataBlock::new_from_columns(vec![lower_addresses, wallet_ids]);
+        let raw_block = DataBlock::new_from_columns(vec![text_keys, numeric_keys.clone()]);
+        let lower_block = DataBlock::new_from_columns(vec![normalized_text_keys, numeric_keys]);
 
         let lower_expr = check_function(
             None,
@@ -480,23 +474,23 @@ mod tests {
     fn distributes_five_mixed_keys_across_partitions() -> Result<()> {
         const ROWS: usize = 1 << 16;
 
-        let addresses = (0..ROWS)
+        let text_keys = (0..ROWS)
             .map(|row| format!("{row:042x}"))
             .collect::<Vec<_>>();
-        let raw_addresses = (0..ROWS)
+        let tag_keys = (0..ROWS)
             .map(|row| format!("{:042x}", row.wrapping_mul(17)))
             .collect::<Vec<_>>();
-        let user_ids = (0..ROWS).map(|row| row as u64).collect::<Vec<_>>();
-        let chain_ids = (0..ROWS).map(|row| (row % 2048) as u64).collect::<Vec<_>>();
-        let wallet_ids = (0..ROWS)
+        let key_num_1 = (0..ROWS).map(|row| row as u64).collect::<Vec<_>>();
+        let key_num_2 = (0..ROWS).map(|row| (row % 2048) as u64).collect::<Vec<_>>();
+        let key_num_3 = (0..ROWS)
             .map(|row| row.wrapping_mul(31) as u64)
             .collect::<Vec<_>>();
         let block = DataBlock::new_from_columns(vec![
-            StringType::from_data(addresses),
-            StringType::from_data(raw_addresses),
-            UInt64Type::from_data(user_ids),
-            UInt64Type::from_data(chain_ids),
-            UInt64Type::from_data(wallet_ids),
+            StringType::from_data(text_keys),
+            StringType::from_data(tag_keys),
+            UInt64Type::from_data(key_num_1),
+            UInt64Type::from_data(key_num_2),
+            UInt64Type::from_data(key_num_3),
         ]);
 
         for partitions in [3, 4, 8] {

--- a/src/query/service/src/servers/flight/v1/scatter/flight_scatter_hash.rs
+++ b/src/query/service/src/servers/flight/v1/scatter/flight_scatter_hash.rs
@@ -12,19 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::hash_map::DefaultHasher;
-use std::hash::Hasher;
-
-use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_expression::BlockEntry;
 use databend_common_expression::DataBlock;
 use databend_common_expression::Evaluator;
 use databend_common_expression::Expr;
 use databend_common_expression::FunctionContext;
 use databend_common_expression::FunctionID;
+use databend_common_expression::ProjectedBlock;
 use databend_common_expression::RemoteExpr;
 use databend_common_expression::Scalar;
 use databend_common_expression::Value;
+use databend_common_expression::group_hash_entries;
 use databend_common_expression::type_check::check_function;
 use databend_common_expression::types::AccessType;
 use databend_common_expression::types::AnyType;
@@ -62,16 +61,8 @@ impl HashFlightScatter {
         }
         let hash_key = hash_keys
             .iter()
-            .map(|key| {
-                check_function(
-                    None,
-                    "siphash",
-                    &[],
-                    &[key.as_expr(&BUILTIN_FUNCTIONS)],
-                    &BUILTIN_FUNCTIONS,
-                )
-            })
-            .collect::<Result<_>>()?;
+            .map(|key| key.as_expr(&BUILTIN_FUNCTIONS))
+            .collect();
 
         Ok(Box::new(Self {
             func_ctx,
@@ -167,19 +158,7 @@ impl FlightScatter for HashFlightScatter {
     }
 
     fn execute(&self, data_block: DataBlock) -> Result<Vec<DataBlock>> {
-        let evaluator = Evaluator::new(&data_block, &self.func_ctx, &BUILTIN_FUNCTIONS);
-        let num = data_block.num_rows();
-        let indices = if !self.hash_key.is_empty() {
-            let mut hash_keys = Vec::with_capacity(self.hash_key.len());
-            for expr in &self.hash_key {
-                let indices = evaluator.run(expr).unwrap();
-                let indices = get_hash_values(indices, num, 0)?;
-                hash_keys.push(indices)
-            }
-            self.combine_hash_keys(&hash_keys, num)
-        } else {
-            Ok(vec![0; num])
-        }?;
+        let indices = self.build_scatter_indices(&data_block)?;
 
         let block_meta = data_block.get_meta();
         let data_blocks = DataBlock::scatter(&data_block, &indices, self.scatter_size)?;
@@ -193,43 +172,36 @@ impl FlightScatter for HashFlightScatter {
     }
 
     fn scatter_indices(&self, data_block: &DataBlock) -> Result<Option<Vec<u64>>> {
-        let evaluator = Evaluator::new(data_block, &self.func_ctx, &BUILTIN_FUNCTIONS);
-        let num = data_block.num_rows();
-        let indices = if !self.hash_key.is_empty() {
-            let mut hash_keys = Vec::with_capacity(self.hash_key.len());
-            for expr in &self.hash_key {
-                let indices = evaluator.run(expr).unwrap();
-                let indices = get_hash_values(indices, num, 0)?;
-                hash_keys.push(indices)
-            }
-            self.combine_hash_keys(&hash_keys, num)
-        } else {
-            Ok(vec![0; num])
-        }?;
-        Ok(Some(indices))
+        Ok(Some(self.build_scatter_indices(data_block)?))
     }
 }
 
 impl HashFlightScatter {
-    pub fn combine_hash_keys(
-        &self,
-        hash_keys: &[Buffer<u64>],
-        num_rows: usize,
-    ) -> Result<Vec<u64>> {
-        if self.hash_key.len() != hash_keys.len() {
-            return Err(ErrorCode::Internal(
-                "Hash keys and hash functions must be the same length.",
-            ));
-        }
-        let mut hash = vec![DefaultHasher::default(); num_rows];
-        for keys in hash_keys.iter() {
-            for (i, value) in keys.iter().enumerate() {
-                hash[i].write_u64(*value);
-            }
+    fn build_scatter_indices(&self, data_block: &DataBlock) -> Result<Vec<u64>> {
+        let num_rows = data_block.num_rows();
+        if self.hash_key.is_empty() {
+            return Ok(vec![0; num_rows]);
         }
 
-        let m = self.scatter_size as u64;
-        Ok(hash.into_iter().map(|h| h.finish() % m).collect())
+        let evaluator = Evaluator::new(data_block, &self.func_ctx, &BUILTIN_FUNCTIONS);
+        let hash_keys = self
+            .hash_key
+            .iter()
+            .map(|expr| {
+                Ok(BlockEntry::new(evaluator.run(expr)?, || {
+                    (expr.data_type().clone(), num_rows)
+                }))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let mut hashes = vec![0; num_rows];
+        group_hash_entries(ProjectedBlock::from(&hash_keys), &mut hashes);
+
+        let scatter_size = self.scatter_size as u64;
+        for hash in &mut hashes {
+            *hash %= scatter_size;
+        }
+        Ok(hashes)
     }
 }
 
@@ -310,5 +282,227 @@ fn get_hash_values(
                     .collect())
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_expression::ColumnRef;
+    use databend_common_expression::FromData;
+    use databend_common_expression::types::StringType;
+    use databend_common_expression::types::UInt64Type;
+
+    use super::*;
+
+    fn column_expr(id: usize, data_type: DataType) -> Expr {
+        Expr::ColumnRef(ColumnRef {
+            span: None,
+            id,
+            data_type,
+            display_name: format!("#{id}"),
+        })
+    }
+
+    fn scatter(hash_key: Vec<Expr>, scatter_size: usize) -> Result<Box<dyn FlightScatter>> {
+        let hash_key = hash_key.iter().map(Expr::as_remote_expr).collect();
+        HashFlightScatter::try_create(FunctionContext::default(), hash_key, scatter_size, 0)
+    }
+
+    fn scatter_indices(
+        hash_key: Vec<Expr>,
+        scatter_size: usize,
+        block: &DataBlock,
+    ) -> Result<Vec<u64>> {
+        Ok(scatter(hash_key, scatter_size)?
+            .scatter_indices(block)?
+            .unwrap())
+    }
+
+    fn block_hash_keys(block: &DataBlock) -> Vec<Expr> {
+        block
+            .columns()
+            .iter()
+            .enumerate()
+            .map(|(index, entry)| column_expr(index, entry.data_type()))
+            .collect()
+    }
+
+    fn assert_balanced(indices: &[u64], partitions: usize) {
+        let mut counts = vec![0_usize; partitions];
+        for &index in indices {
+            counts[index as usize] += 1;
+        }
+
+        let max_partition = counts.iter().copied().max().unwrap_or_default();
+        assert!(
+            max_partition * partitions * 20 <= indices.len() * 21,
+            "partition counts are imbalanced: {counts:?}"
+        );
+    }
+
+    #[test]
+    fn hashes_evaluated_and_materialized_keys_consistently() -> Result<()> {
+        let raw_addresses = StringType::from_data(vec!["AbC", "DEF", "ghI", "Jkl"]);
+        let lower_addresses = StringType::from_data(vec!["abc", "def", "ghi", "jkl"]);
+        let wallet_ids = UInt64Type::from_data(vec![1, 2, 3, 4]);
+
+        let raw_block = DataBlock::new_from_columns(vec![raw_addresses, wallet_ids.clone()]);
+        let lower_block = DataBlock::new_from_columns(vec![lower_addresses, wallet_ids]);
+
+        let lower_expr = check_function(
+            None,
+            "lower",
+            &[],
+            &[column_expr(0, DataType::String)],
+            &BUILTIN_FUNCTIONS,
+        )?;
+        let evaluated_keys = vec![
+            lower_expr,
+            column_expr(1, DataType::Number(NumberDataType::UInt64)),
+        ];
+        let materialized_keys = block_hash_keys(&lower_block);
+
+        for partitions in [3, 4, 8] {
+            let evaluated = scatter_indices(evaluated_keys.clone(), partitions, &raw_block)?;
+            let materialized =
+                scatter_indices(materialized_keys.clone(), partitions, &lower_block)?;
+            assert_eq!(evaluated, materialized);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn hashes_scalar_and_materialized_keys_consistently() -> Result<()> {
+        let ids = UInt64Type::from_data(vec![1, 2, 3, 4]);
+        let scalar_block = DataBlock::new_from_columns(vec![ids.clone()]);
+        let materialized_block =
+            DataBlock::new_from_columns(vec![ids, UInt64Type::from_data(vec![7, 7, 7, 7])]);
+        let scalar_keys = vec![
+            column_expr(0, DataType::Number(NumberDataType::UInt64)),
+            Expr::constant(
+                Scalar::Number(NumberScalar::UInt64(7)),
+                Some(DataType::Number(NumberDataType::UInt64)),
+            ),
+        ];
+
+        for partitions in [3, 4, 8] {
+            let scalar = scatter_indices(scalar_keys.clone(), partitions, &scalar_block)?;
+            let materialized = scatter_indices(
+                block_hash_keys(&materialized_block),
+                partitions,
+                &materialized_block,
+            )?;
+            assert_eq!(scalar, materialized);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn hashes_nullable_keys_by_value_and_validity() -> Result<()> {
+        let validity = vec![true, false, true, false];
+        let left = DataBlock::new_from_columns(vec![
+            StringType::from_data_with_validity(
+                vec!["alpha", "ignored-left", "gamma", "hidden-left"],
+                validity.clone(),
+            ),
+            UInt64Type::from_data_with_validity(vec![11, 1001, 13, 1003], validity.clone()),
+        ]);
+        let right = DataBlock::new_from_columns(vec![
+            StringType::from_data_with_validity(
+                vec!["alpha", "ignored-right", "gamma", "hidden-right"],
+                validity.clone(),
+            ),
+            UInt64Type::from_data_with_validity(vec![11, 2001, 13, 2003], validity),
+        ]);
+
+        for partitions in [3, 4, 8] {
+            let left_indices = scatter_indices(block_hash_keys(&left), partitions, &left)?;
+            let right_indices = scatter_indices(block_hash_keys(&right), partitions, &right)?;
+            assert_eq!(left_indices, right_indices);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn hashes_valid_nullable_and_non_nullable_keys_consistently() -> Result<()> {
+        let validity = vec![true, true, true, true];
+        let nullable_block = DataBlock::new_from_columns(vec![
+            StringType::from_data_with_validity(
+                vec!["alpha", "beta", "gamma", "delta"],
+                validity.clone(),
+            ),
+            UInt64Type::from_data_with_validity(vec![11, 12, 13, 14], validity),
+        ]);
+        let non_nullable_block = DataBlock::new_from_columns(vec![
+            StringType::from_data(vec!["alpha", "beta", "gamma", "delta"]),
+            UInt64Type::from_data(vec![11, 12, 13, 14]),
+        ]);
+
+        for partitions in [3, 4, 8] {
+            let nullable = scatter_indices(
+                block_hash_keys(&nullable_block),
+                partitions,
+                &nullable_block,
+            )?;
+            let non_nullable = scatter_indices(
+                block_hash_keys(&non_nullable_block),
+                partitions,
+                &non_nullable_block,
+            )?;
+            assert_eq!(nullable, non_nullable);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn handles_single_key_empty_keys_and_empty_blocks() -> Result<()> {
+        let one_row = DataBlock::new_from_columns(vec![UInt64Type::from_data(vec![42])]);
+        let single_key = block_hash_keys(&one_row);
+        let single_key_scatter = scatter(single_key, 3)?;
+        assert_eq!(single_key_scatter.name(), "OneHashKey");
+        assert_eq!(
+            single_key_scatter.scatter_indices(&one_row)?.unwrap().len(),
+            1
+        );
+
+        let no_columns = DataBlock::new(vec![], 3);
+        assert_eq!(scatter_indices(vec![], 4, &no_columns)?, vec![0, 0, 0]);
+
+        let empty = DataBlock::new_from_columns(vec![
+            StringType::from_data(Vec::<String>::new()),
+            UInt64Type::from_data(Vec::<u64>::new()),
+        ]);
+        assert!(scatter_indices(block_hash_keys(&empty), 8, &empty)?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn distributes_five_mixed_keys_across_partitions() -> Result<()> {
+        const ROWS: usize = 1 << 16;
+
+        let addresses = (0..ROWS)
+            .map(|row| format!("{row:042x}"))
+            .collect::<Vec<_>>();
+        let raw_addresses = (0..ROWS)
+            .map(|row| format!("{:042x}", row.wrapping_mul(17)))
+            .collect::<Vec<_>>();
+        let user_ids = (0..ROWS).map(|row| row as u64).collect::<Vec<_>>();
+        let chain_ids = (0..ROWS).map(|row| (row % 2048) as u64).collect::<Vec<_>>();
+        let wallet_ids = (0..ROWS)
+            .map(|row| row.wrapping_mul(31) as u64)
+            .collect::<Vec<_>>();
+        let block = DataBlock::new_from_columns(vec![
+            StringType::from_data(addresses),
+            StringType::from_data(raw_addresses),
+            UInt64Type::from_data(user_ids),
+            UInt64Type::from_data(chain_ids),
+            UInt64Type::from_data(wallet_ids),
+        ]);
+
+        for partitions in [3, 4, 8] {
+            let indices = scatter_indices(block_hash_keys(&block), partitions, &block)?;
+            assert_balanced(&indices, partitions);
+        }
+        Ok(())
     }
 }

--- a/tests/sqllogictests/suites/mode/cluster/shuffle_join.test
+++ b/tests/sqllogictests/suites/mode/cluster/shuffle_join.test
@@ -507,3 +507,78 @@ drop table t2
 
 statement ok
 set prefer_broadcast_join = 1
+
+statement ok
+set enforce_shuffle_join = 1
+
+statement ok
+create or replace table multi_key_scatter_probe(
+    address string not null,
+    user_id uint64 not null,
+    chain_id uint64 not null,
+    wallet_id uint64 not null,
+    payload string not null
+)
+
+statement ok
+create or replace table multi_key_scatter_build(
+    address_lower string not null,
+    address_raw string not null,
+    user_id uint64 not null,
+    chain_id uint64 not null,
+    wallet_id uint64 not null
+)
+
+statement ok
+insert into multi_key_scatter_probe values
+    ('AbC', 1, 10, 100, 'matched-1'),
+    ('DEF', 2, 20, 200, 'unmatched-2'),
+    ('ghi', 3, 30, 300, 'matched-3'),
+    ('Jkl', 4, 40, 400, 'unmatched-4')
+
+statement ok
+insert into multi_key_scatter_build values
+    ('abc', 'AbC', 1, 10, 100),
+    ('def', 'DEF', 2, 20, 999),
+    ('ghi', 'ghi', 3, 30, 300),
+    ('jkl', 'Jkl', 4, 999, 400)
+
+query TT
+select p.address, p.payload
+from multi_key_scatter_probe as p
+inner join multi_key_scatter_build as b
+    on lower(p.address) = b.address_lower
+   and p.address = b.address_raw
+   and p.user_id = b.user_id
+   and p.chain_id = b.chain_id
+   and p.wallet_id = b.wallet_id
+order by p.address
+----
+AbC matched-1
+ghi matched-3
+
+query TT
+select p.address, p.payload
+from multi_key_scatter_probe as p
+where not exists (
+    select 1
+    from multi_key_scatter_build as b
+    where lower(p.address) = b.address_lower
+      and p.address = b.address_raw
+      and p.user_id = b.user_id
+      and p.chain_id = b.chain_id
+      and p.wallet_id = b.wallet_id
+)
+order by p.address
+----
+DEF unmatched-2
+Jkl unmatched-4
+
+statement ok
+drop table multi_key_scatter_probe
+
+statement ok
+drop table multi_key_scatter_build
+
+statement ok
+unset enforce_shuffle_join

--- a/tests/sqllogictests/suites/mode/cluster/shuffle_join.test
+++ b/tests/sqllogictests/suites/mode/cluster/shuffle_join.test
@@ -513,20 +513,20 @@ set enforce_shuffle_join = 1
 
 statement ok
 create or replace table multi_key_scatter_probe(
-    address string not null,
-    user_id uint64 not null,
-    chain_id uint64 not null,
-    wallet_id uint64 not null,
+    text_key string not null,
+    key_num_1 uint64 not null,
+    key_num_2 uint64 not null,
+    key_num_3 uint64 not null,
     payload string not null
 )
 
 statement ok
 create or replace table multi_key_scatter_build(
-    address_lower string not null,
-    address_raw string not null,
-    user_id uint64 not null,
-    chain_id uint64 not null,
-    wallet_id uint64 not null
+    normalized_text_key string not null,
+    raw_text_key string not null,
+    key_num_1 uint64 not null,
+    key_num_2 uint64 not null,
+    key_num_3 uint64 not null
 )
 
 statement ok
@@ -544,32 +544,32 @@ insert into multi_key_scatter_build values
     ('jkl', 'Jkl', 4, 999, 400)
 
 query TT
-select p.address, p.payload
+select p.text_key, p.payload
 from multi_key_scatter_probe as p
 inner join multi_key_scatter_build as b
-    on lower(p.address) = b.address_lower
-   and p.address = b.address_raw
-   and p.user_id = b.user_id
-   and p.chain_id = b.chain_id
-   and p.wallet_id = b.wallet_id
-order by p.address
+    on lower(p.text_key) = b.normalized_text_key
+   and p.text_key = b.raw_text_key
+   and p.key_num_1 = b.key_num_1
+   and p.key_num_2 = b.key_num_2
+   and p.key_num_3 = b.key_num_3
+order by p.text_key
 ----
 AbC matched-1
 ghi matched-3
 
 query TT
-select p.address, p.payload
+select p.text_key, p.payload
 from multi_key_scatter_probe as p
 where not exists (
     select 1
     from multi_key_scatter_build as b
-    where lower(p.address) = b.address_lower
-      and p.address = b.address_raw
-      and p.user_id = b.user_id
-      and p.chain_id = b.chain_id
-      and p.wallet_id = b.wallet_id
+    where lower(p.text_key) = b.normalized_text_key
+      and p.text_key = b.raw_text_key
+      and p.key_num_1 = b.key_num_1
+      and p.key_num_2 = b.key_num_2
+      and p.key_num_3 = b.key_num_3
 )
-order by p.address
+order by p.text_key
 ----
 DEF unmatched-2
 Jkl unmatched-4


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Flight hash scatter previously hashed every shuffle key into a separate row-wise `u64` buffer, then constructed a `DefaultHasher` per row to combine those intermediate hashes. The repeated passes, temporary buffers, and per-row hasher work become expensive for multi-key exchanges.

This change:

- evaluates and hashes one shuffle key at a time, releasing allocating derived columns before evaluating the next key;
- incrementally combines keys with the shared group-hash implementation into one row-wise hash buffer;
- removes the intermediate per-key SipHash buffers and per-row `DefaultHasher` combination;
- preserves the specialized single-key scatter path and the empty-key behavior;
- adds regression coverage for evaluated, scalar, nullable, empty, and five-key inputs.

Mixed Query binary deployments are not supported. The partition mapping changes without a Flight wire-schema change or hash-version negotiation, so different Query versions executing one distributed query could route equal keys to different partitions. Upgrades must drain or restart Query nodes so every node uses the same binary before accepting queries again.

## Performance evidence

Reproduce with:

```shell
cargo bench -p databend-common-functions --bench flight_scatter_hash
```

The benchmark uses 65,536 generated rows and 8 partitions. It measures two-key and five-key inputs, including allocating `lower` and `concat` expressions. Input construction is outside the timed loop. The legacy case reproduces the previous per-key SipHash buffers plus per-row `DefaultHasher`; the group-hash case evaluates and combines each key incrementally.

Median latency from the same optimized build and host:

| Keys | Legacy | Incremental group hash | Reduction |
| ---: | ---: | ---: | ---: |
| 2 | 17.49 ms | 14.21 ms | 18.7% |
| 5 | 20.18 ms | 14.52 ms | 28.0% |

The benchmark isolates scatter-key evaluation, hash combination, and partition reduction. It does not claim end-to-end query wall-time improvement.

## Tests

- [x] Unit Test
- [x] Logic Test
- [x] Benchmark Test
- [ ] No Test - _Explain why_

Validated from the final tree:

- `cargo test -p databend-query --lib flight_scatter_hash` (6 passed)
- `cargo test -p databend-common-expression test_incremental_group_hash_equals_projected_block` (1 passed)
- `cargo bench -p databend-common-functions --bench flight_scatter_hash` (two stable runs)
- `cargo clippy -p databend-common-expression -p databend-common-functions -p databend-query --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The forced-shuffle Inner and Anti cluster logic cases remain covered by the cluster sqllogictest suite.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: A coding agent drafted the Flight scatter implementation, incremental hashing fix, regression tests, benchmark, validation plan, and PR summary
- Responsible human: @dantengsky
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20331)
<!-- Reviewable:end -->
