### PR TITLE
feat(query): minimize deserialize rhs in bitmap functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2477,22 +2477,22 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.9.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3975,7 +3975,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "parquet 58.1.0",
  "rand 0.8.5",
- "roaring 0.10.12",
+ "roaring 0.11.5",
  "serde",
  "serde_json",
  "sha2",
@@ -4190,7 +4190,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_distr",
  "recursive",
- "roaring 0.10.12",
+ "roaring 0.11.5",
  "rust_decimal",
  "rustls 0.23.36",
  "serde",
@@ -4395,7 +4395,7 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "rmp-serde",
- "roaring 0.10.12",
+ "roaring 0.11.5",
  "scroll 0.12.0",
  "serde",
  "smallvec",
@@ -4854,7 +4854,7 @@ dependencies = [
  "prqlc",
  "recursive",
  "regex",
- "roaring 0.10.12",
+ "roaring 0.11.5",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -5095,7 +5095,7 @@ dependencies = [
  "parquet 58.1.0",
  "paste",
  "rand 0.8.5",
- "roaring 0.10.12",
+ "roaring 0.11.5",
  "serde",
  "serde_json",
  "sha2",
@@ -6887,7 +6887,7 @@ dependencies = [
  "parquet 58.1.0",
  "rand 0.8.5",
  "rayon",
- "roaring 0.10.12",
+ "roaring 0.11.5",
  "self_cell",
  "serde",
  "serde_json",
@@ -10574,7 +10574,7 @@ dependencies = [
  "rand 0.8.5",
  "reqsign",
  "reqwest",
- "roaring 0.11.3",
+ "roaring 0.11.5",
  "rust_decimal",
  "serde",
  "serde_bytes",
@@ -11428,7 +11428,7 @@ dependencies = [
  "pin-project",
  "prost 0.14.3",
  "rand 0.9.2",
- "roaring 0.11.3",
+ "roaring 0.11.5",
  "serde_json",
  "snafu 0.9.0",
  "tempfile",
@@ -11608,7 +11608,7 @@ dependencies = [
  "protobuf-src",
  "rand 0.9.2",
  "rangemap",
- "roaring 0.11.3",
+ "roaring 0.11.5",
  "semver",
  "serde",
  "serde_json",
@@ -13555,7 +13555,7 @@ dependencies = [
  "pretty_assertions",
  "regex",
  "reqwest",
- "roaring 0.11.3",
+ "roaring 0.11.5",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -15700,17 +15700,16 @@ checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
 dependencies = [
  "bytemuck",
  "byteorder",
- "serde",
 ]
 
 [[package]]
 name = "roaring"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
+version = "0.11.5"
+source = "git+https://github.com/harry-hao/roaring-rs?rev=0936b936cf6d97da993a65bfb42bd3301f33a346#0936b936cf6d97da993a65bfb42bd3301f33a346"
 dependencies = [
  "bytemuck",
  "byteorder",
+ "serde",
 ]
 
 [[package]]
@@ -16281,9 +16280,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -16329,22 +16328,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -17536,6 +17535,17 @@ name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -431,7 +431,7 @@ reqwest = { version = "0.12", default-features = false, features = [
 reqwest-hickory-resolver = "0.2"
 ringbuffer = "0.14.2"
 rmp-serde = "1.1.1"
-roaring = { version = "^0.10", features = ["serde"] }
+roaring = { version = "0.11.5", features = ["serde"] }
 rust_decimal = "1.26"
 rustc-hash = "2.1.0"
 rustix = { version = "0.38.37", features = ["fs"] }
@@ -655,6 +655,7 @@ map-api = { git = "https://github.com/databendlabs/map-api", tag = "v0.5.0" }
 orc-rust = { git = "https://github.com/datafuse-extras/orc-rust", rev = "fc17101f1c96e1ea7c7a19e931110471a4bd7e21" }
 parquet = { git = "https://github.com/datafuse-extras/arrow-rs.git", rev = "bbbe79543" }
 recursive = { git = "https://github.com/datafuse-extras/recursive.git", rev = "16e433a" }
+roaring = { git = "https://github.com/harry-hao/roaring-rs", rev = "0936b936cf6d97da993a65bfb42bd3301f33a346" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1" }
 state-machine-api = { git = "https://github.com/databendlabs/state-machine-api.git", tag = "v0.4.0" }
 sub-cache = { git = "https://github.com/databendlabs/sub-cache", tag = "v0.2.1" }

--- a/src/common/io/src/bitmap.rs
+++ b/src/common/io/src/bitmap.rs
@@ -314,13 +314,14 @@ impl HybridBitmap {
             (BitmapOp::And, BitmapRhsView::SerializedLarge(rhs)) => {
                 self.bitand_assign_serialized_large(rhs)?
             }
-            (op, BitmapRhsView::SerializedLarge(rhs)) => {
-                let rhs = RoaringTreemap::deserialize_unchecked_from(rhs).map_err(|e| {
-                    let len = rhs.len();
-                    let msg = format!("fail to decode roaring bitmap payload of size {len}: {e}");
-                    ErrorCode::BadBytes(msg)
-                })?;
-                self.apply_rhs(op, BitmapRhsView::Large(rhs))?;
+            (BitmapOp::Or, BitmapRhsView::SerializedLarge(rhs)) => {
+                self.bitor_assign_serialized_large(rhs)?
+            }
+            (BitmapOp::Xor, BitmapRhsView::SerializedLarge(rhs)) => {
+                self.bitxor_assign_serialized_large(rhs)?
+            }
+            (BitmapOp::Sub, BitmapRhsView::SerializedLarge(rhs)) => {
+                self.sub_assign_serialized_large(rhs)?
             }
             (BitmapOp::And, BitmapRhsView::Large(rhs)) => self.bitand_assign_large(rhs),
             (BitmapOp::Or, BitmapRhsView::Large(rhs)) => self.bitor_assign_large(rhs),
@@ -406,7 +407,8 @@ impl HybridBitmap {
     fn bitand_assign_serialized_large(&mut self, rhs: &[u8]) -> Result<()> {
         match self {
             HybridBitmap::Large(lhs_tree) => {
-                reader::intersection_with_serialized(lhs_tree, rhs)?;
+                reader::intersection_assign_with_serialized(lhs_tree, rhs)?;
+                self.try_demote();
             }
             HybridBitmap::Small(lhs_set) => {
                 let rhs = RoaringTreemap::deserialize_unchecked_from(rhs).map_err(|e| {
@@ -415,6 +417,65 @@ impl HybridBitmap {
                     ErrorCode::BadBytes(msg)
                 })?;
                 lhs_set.retain(|value| rhs.contains(*value));
+            }
+        }
+        Ok(())
+    }
+
+    fn bitor_assign_serialized_large(&mut self, rhs: &[u8]) -> Result<()> {
+        match self {
+            HybridBitmap::Large(lhs_tree) => {
+                reader::union_assign_with_serialized(lhs_tree, rhs)?;
+            }
+            HybridBitmap::Small(lhs_set) => {
+                let mut rhs = RoaringTreemap::deserialize_unchecked_from(rhs).map_err(|e| {
+                    let len = rhs.len();
+                    let msg = format!("fail to decode roaring bitmap payload of size {len}: {e}");
+                    ErrorCode::BadBytes(msg)
+                })?;
+                rhs.extend(lhs_set.iter().copied());
+                *self = HybridBitmap::from(rhs);
+            }
+        }
+        Ok(())
+    }
+
+    fn bitxor_assign_serialized_large(&mut self, rhs: &[u8]) -> Result<()> {
+        match self {
+            HybridBitmap::Large(lhs_tree) => {
+                reader::symmetric_difference_assign_with_serialized(lhs_tree, rhs)?;
+                self.try_demote();
+            }
+            HybridBitmap::Small(lhs_set) => {
+                let mut rhs = RoaringTreemap::deserialize_unchecked_from(rhs).map_err(|e| {
+                    let len = rhs.len();
+                    let msg = format!("fail to decode roaring bitmap payload of size {len}: {e}");
+                    ErrorCode::BadBytes(msg)
+                })?;
+                for value in lhs_set.iter().copied() {
+                    if !rhs.remove(value) {
+                        rhs.insert(value);
+                    }
+                }
+                *self = HybridBitmap::from(rhs);
+            }
+        }
+        Ok(())
+    }
+
+    fn sub_assign_serialized_large(&mut self, rhs: &[u8]) -> Result<()> {
+        match self {
+            HybridBitmap::Large(lhs_tree) => {
+                reader::difference_assign_with_serialized(lhs_tree, rhs)?;
+                self.try_demote();
+            }
+            HybridBitmap::Small(lhs_set) => {
+                let rhs = RoaringTreemap::deserialize_unchecked_from(rhs).map_err(|e| {
+                    let len = rhs.len();
+                    let msg = format!("fail to decode roaring bitmap payload of size {len}: {e}");
+                    ErrorCode::BadBytes(msg)
+                })?;
+                lhs_set.retain(|value| !rhs.contains(*value));
             }
         }
         Ok(())

--- a/src/common/io/src/bitmap.rs
+++ b/src/common/io/src/bitmap.rs
@@ -410,14 +410,7 @@ impl HybridBitmap {
                 reader::intersection_assign_with_serialized(lhs_tree, rhs)?;
                 self.try_demote();
             }
-            HybridBitmap::Small(lhs_set) => {
-                let rhs = RoaringTreemap::deserialize_unchecked_from(rhs).map_err(|e| {
-                    let len = rhs.len();
-                    let msg = format!("fail to decode roaring bitmap payload of size {len}: {e}");
-                    ErrorCode::BadBytes(msg)
-                })?;
-                lhs_set.retain(|value| rhs.contains(*value));
-            }
+            HybridBitmap::Small(lhs_set) => small_retain_serialized_large(lhs_set, rhs, false)?,
         }
         Ok(())
     }
@@ -469,14 +462,7 @@ impl HybridBitmap {
                 reader::difference_assign_with_serialized(lhs_tree, rhs)?;
                 self.try_demote();
             }
-            HybridBitmap::Small(lhs_set) => {
-                let rhs = RoaringTreemap::deserialize_unchecked_from(rhs).map_err(|e| {
-                    let len = rhs.len();
-                    let msg = format!("fail to decode roaring bitmap payload of size {len}: {e}");
-                    ErrorCode::BadBytes(msg)
-                })?;
-                lhs_set.retain(|value| !rhs.contains(*value));
-            }
+            HybridBitmap::Small(lhs_set) => small_retain_serialized_large(lhs_set, rhs, true)?,
         }
         Ok(())
     }
@@ -1317,6 +1303,29 @@ fn small_intersection_in_place(target: &mut SmallBitmap, other: &[u64]) {
     target.truncate(write);
 }
 
+fn small_retain_serialized_large(
+    lhs_set: &mut SmallBitmap,
+    rhs: &[u8],
+    invert: bool,
+) -> Result<()> {
+    let reader = reader::TreemapReader::new(rhs)?;
+    let mut err: Option<io::Error> = None;
+    lhs_set.retain(|value| match reader.contains(*value) {
+        Ok(hit) => hit != invert,
+        Err(e) => {
+            err.get_or_insert(e);
+            false
+        }
+    });
+    match err {
+        Some(e) => Err(ErrorCode::BadBytes(format!(
+            "fail to decode roaring bitmap payload of size {}: {e}",
+            rhs.len()
+        ))),
+        None => Ok(()),
+    }
+}
+
 #[inline]
 fn small_intersection_serialized_in_place(target: &mut SmallBitmap, other: &[u8]) {
     if other.is_empty() {
@@ -1705,6 +1714,39 @@ mod tests {
             HybridBitmap::Small(set) => assert_eq!(set.as_slice(), &[1, 5]),
             _ => panic!("expected small hybrid bitmap after serialized intersection"),
         }
+    }
+
+    #[test]
+    fn bitand_small_lhs_with_serialized_large_correct() {
+        let high = 1_u64 << 32;
+        let mut lhs = HybridBitmap::from_iter([1, 5, 100, high + 7, high + 9, u64::MAX]);
+        let rhs = HybridBitmap::from_iter((0_u64..200).chain(high..high + 10));
+        let mut rhs_buf = Vec::new();
+        rhs.serialize_into(&mut rhs_buf).unwrap();
+
+        lhs.bitand_assign_rhs(BitmapRhs::Serialized(&rhs_buf))
+            .unwrap();
+
+        assert_eq!(lhs.iter().collect::<Vec<_>>(), vec![
+            1,
+            5,
+            100,
+            high + 7,
+            high + 9
+        ]);
+    }
+
+    #[test]
+    fn sub_small_lhs_with_serialized_large_correct() {
+        let high = 1_u64 << 32;
+        let mut lhs = HybridBitmap::from_iter([1, 5, 100, high + 7, u64::MAX]);
+        let rhs = HybridBitmap::from_iter((0_u64..200).chain(high..high + 10));
+        let mut rhs_buf = Vec::new();
+        rhs.serialize_into(&mut rhs_buf).unwrap();
+
+        lhs.sub_assign_rhs(BitmapRhs::Serialized(&rhs_buf)).unwrap();
+
+        assert_eq!(lhs.iter().collect::<Vec<_>>(), vec![u64::MAX]);
     }
 
     #[test]

--- a/src/common/io/src/bitmap/reader.rs
+++ b/src/common/io/src/bitmap/reader.rs
@@ -1033,7 +1033,10 @@ mod tests {
             bitmap.insert(value);
         }
         let start = 1u64 << 32;
-        bitmap.insert_range(start..start + 1_000_000);
+        // Loop + insert because insert_range emits run containers, since 0.11.
+        for value in start..start + 1_000_000 {
+            bitmap.insert(value);
+        }
         bitmap.insert(1u64 << 48);
         bitmap
     }
@@ -1042,8 +1045,13 @@ mod tests {
         let mut bitmap = RoaringTreemap::new();
         for prefix in 0..2u64 {
             let base = prefix << 32;
-            bitmap.insert_range((base)..=(base | 0x09000));
-            bitmap.insert_range((base | 0x0A000)..=(base | 0x10000));
+            // Loop + insert because insert_range emits run containers, since 0.11.
+            for value in base..=(base | 0x09000) {
+                bitmap.insert(value);
+            }
+            for value in (base | 0x0A000)..=(base | 0x10000) {
+                bitmap.insert(value);
+            }
             bitmap.insert(base | 0x20000);
             bitmap.insert(base | 0x20005);
             for value in (0..0x10000u64).step_by(2) {

--- a/src/common/io/src/bitmap/reader.rs
+++ b/src/common/io/src/bitmap/reader.rs
@@ -21,7 +21,9 @@ use std::ops::ControlFlow;
 
 use byteorder::LittleEndian;
 use byteorder::ReadBytesExt;
+use roaring::RoaringBitmap;
 use roaring::RoaringTreemap;
+use roaring::treemap::BitmapEntry;
 
 // Sizes of header structures
 const DESCRIPTION_BYTES: usize = 4;
@@ -942,38 +944,97 @@ pub(crate) fn bitmap_has_all(lhs: &[u8], rhs: &[u8]) -> io::Result<bool> {
     ContainerVisitor::new(lhs, rhs, HasAllHandler).visit()
 }
 
-pub fn intersection_with_serialized(tree: &mut RoaringTreemap, buf: &[u8]) -> io::Result<()> {
-    use std::cmp::Ordering::*;
+pub fn intersection_assign_with_serialized(
+    tree: &mut RoaringTreemap,
+    buf: &[u8],
+) -> io::Result<()> {
     let rhs = TreemapReader::new(buf)?;
-    let mut bitmaps = Vec::new();
-    let mut lhs_iter = tree.bitmaps();
-    let mut rhs_iter = rhs.iter();
+    let mut rhs_prefixes: Vec<u32> = Vec::new();
 
-    let mut lhs_curr = lhs_iter.next();
-    let mut rhs_curr = rhs_iter.next().transpose()?;
-
-    while let (Some((lhs_prefix, lhs_bitmap)), Some(rhs_bitmap)) = (lhs_curr, rhs_curr.as_ref()) {
-        match lhs_prefix.cmp(&rhs_bitmap.prefix()) {
-            Less => {
-                lhs_curr = lhs_iter.next();
-            }
-            Greater => {
-                rhs_curr = rhs_iter.next().transpose()?;
-            }
-            Equal => {
-                let intersection = lhs_bitmap
-                    .intersection_with_serialized_unchecked(Cursor::new(rhs_bitmap.bitmap_buf()))?;
-                if !intersection.is_empty() {
-                    bitmaps.push((lhs_prefix, intersection));
-                }
-                lhs_curr = lhs_iter.next();
-                rhs_curr = rhs_iter.next().transpose()?;
+    for item in rhs.iter() {
+        let rb = item?;
+        let prefix = rb.prefix();
+        rhs_prefixes.push(prefix);
+        if let BitmapEntry::Occupied(mut entry) = tree.bitmap_entry(prefix) {
+            let bitmap = entry.get_mut();
+            bitmap.intersection_assign_with_serialized_unchecked(Cursor::new(rb.bitmap_buf()))?;
+            if bitmap.is_empty() {
+                entry.remove();
             }
         }
     }
 
-    *tree = RoaringTreemap::from_bitmaps(bitmaps);
+    let to_remove: Vec<u32> = tree
+        .bitmaps()
+        .filter(|(p, _)| rhs_prefixes.binary_search(p).is_err())
+        .map(|(p, _)| p)
+        .collect();
+    for p in to_remove {
+        if let BitmapEntry::Occupied(entry) = tree.bitmap_entry(p) {
+            entry.remove();
+        }
+    }
 
+    Ok(())
+}
+
+pub fn union_assign_with_serialized(tree: &mut RoaringTreemap, buf: &[u8]) -> io::Result<()> {
+    let rhs = TreemapReader::new(buf)?;
+    for item in rhs.iter() {
+        let rb = item?;
+        match tree.bitmap_entry(rb.prefix()) {
+            BitmapEntry::Occupied(mut entry) => {
+                entry
+                    .get_mut()
+                    .union_assign_with_serialized_unchecked(Cursor::new(rb.bitmap_buf()))?;
+            }
+            BitmapEntry::Vacant(entry) => {
+                let bitmap = RoaringBitmap::deserialize_unchecked_from(rb.bitmap_buf())?;
+                entry.insert(bitmap);
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn difference_assign_with_serialized(tree: &mut RoaringTreemap, buf: &[u8]) -> io::Result<()> {
+    let rhs = TreemapReader::new(buf)?;
+    for item in rhs.iter() {
+        let rb = item?;
+        if let BitmapEntry::Occupied(mut entry) = tree.bitmap_entry(rb.prefix()) {
+            let bitmap = entry.get_mut();
+            bitmap.difference_assign_with_serialized_unchecked(Cursor::new(rb.bitmap_buf()))?;
+            if bitmap.is_empty() {
+                entry.remove();
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn symmetric_difference_assign_with_serialized(
+    tree: &mut RoaringTreemap,
+    buf: &[u8],
+) -> io::Result<()> {
+    let rhs = TreemapReader::new(buf)?;
+    for item in rhs.iter() {
+        let rb = item?;
+        match tree.bitmap_entry(rb.prefix()) {
+            BitmapEntry::Occupied(mut entry) => {
+                let bitmap = entry.get_mut();
+                bitmap.symmetric_difference_assign_with_serialized_unchecked(Cursor::new(
+                    rb.bitmap_buf(),
+                ))?;
+                if bitmap.is_empty() {
+                    entry.remove();
+                }
+            }
+            BitmapEntry::Vacant(entry) => {
+                let bitmap = RoaringBitmap::deserialize_unchecked_from(rb.bitmap_buf())?;
+                entry.insert(bitmap);
+            }
+        }
+    }
     Ok(())
 }
 
@@ -1145,9 +1206,114 @@ mod tests {
         v23.serialize_into(&mut buf)?;
 
         let mut v = v12;
-        intersection_with_serialized(&mut v, &buf)?;
+        intersection_assign_with_serialized(&mut v, &buf)?;
 
         assert_eq!(v, v2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_union() -> io::Result<()> {
+        let v1 = create_bitmap(123);
+        let v2 = create_bitmap(456);
+        let v3 = create_bitmap(789);
+
+        let v12 = &v1 | &v2;
+        let v23 = &v2 | &v3;
+        let expected = &v12 | &v23;
+
+        let mut buf = Vec::new();
+        v23.serialize_into(&mut buf)?;
+
+        let mut v = v12.clone();
+        union_assign_with_serialized(&mut v, &buf)?;
+        assert_eq!(v, expected);
+
+        // Edge cases
+        let empty = RoaringTreemap::new();
+        let empty_buf = {
+            let mut b = Vec::new();
+            empty.serialize_into(&mut b)?;
+            b
+        };
+        let mut v = empty;
+        union_assign_with_serialized(&mut v, &buf)?;
+        assert_eq!(v, v23);
+
+        let mut v = v12.clone();
+        union_assign_with_serialized(&mut v, &empty_buf)?;
+        assert_eq!(v, v12);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_difference() -> io::Result<()> {
+        let v1 = create_bitmap(123);
+        let v2 = create_bitmap(456);
+        let v3 = create_bitmap(789);
+
+        let v12 = &v1 | &v2;
+        let v23 = &v2 | &v3;
+        let expected = &v12 - &v23;
+
+        let mut buf = Vec::new();
+        v23.serialize_into(&mut buf)?;
+
+        let mut v = v12.clone();
+        difference_assign_with_serialized(&mut v, &buf)?;
+        assert_eq!(v, expected);
+
+        // Edge cases
+        let empty = RoaringTreemap::new();
+        let empty_buf = {
+            let mut b = Vec::new();
+            empty.serialize_into(&mut b)?;
+            b
+        };
+        let mut v = v12.clone();
+        difference_assign_with_serialized(&mut v, &empty_buf)?;
+        assert_eq!(v, v12);
+
+        let mut v = empty;
+        difference_assign_with_serialized(&mut v, &buf)?;
+        assert!(v.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_symmetric_difference() -> io::Result<()> {
+        let v1 = create_bitmap(123);
+        let v2 = create_bitmap(456);
+        let v3 = create_bitmap(789);
+
+        let v12 = &v1 | &v2;
+        let v23 = &v2 | &v3;
+        let expected = &v12 ^ &v23;
+
+        let mut buf = Vec::new();
+        v23.serialize_into(&mut buf)?;
+
+        let mut v = v12.clone();
+        symmetric_difference_assign_with_serialized(&mut v, &buf)?;
+        assert_eq!(v, expected);
+
+        // Edge cases
+        let empty = RoaringTreemap::new();
+        let empty_buf = {
+            let mut b = Vec::new();
+            empty.serialize_into(&mut b)?;
+            b
+        };
+        let mut v = v12.clone();
+        symmetric_difference_assign_with_serialized(&mut v, &empty_buf)?;
+        assert_eq!(v, v12);
+
+        let mut v = empty;
+        symmetric_difference_assign_with_serialized(&mut v, &buf)?;
+        assert_eq!(v, v23);
 
         Ok(())
     }

--- a/src/query/functions/benches/bench.rs
+++ b/src/query/functions/benches/bench.rs
@@ -196,6 +196,16 @@ mod bitmap {
         });
     }
 
+    #[divan::bench(args = [1000, 65535])]
+    fn bitmap_not_count(bencher: divan::Bencher, rows: usize) {
+        let column = build_bitmap_column(rows as u64, 125);
+        let entry = column.into();
+
+        bencher.bench(|| {
+            eval_bitmap_result(&entry, rows, "bitmap_not_count");
+        });
+    }
+
     #[divan::bench(args = [100_000, 1_000_000])]
     fn bitmap_intersect_empty(bencher: divan::Bencher, rows: usize) {
         let column = build_disjoint_bitmap_column(rows as u64);

--- a/src/query/functions/benches/bench.rs
+++ b/src/query/functions/benches/bench.rs
@@ -322,6 +322,9 @@ mod bitmap_scalar {
     use databend_common_expression_test_support as parser;
     use databend_common_functions::BUILTIN_FUNCTIONS;
     use databend_common_io::HybridBitmap;
+    use rand::Rng;
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
 
     fn serialize_bitmap(bitmap: &HybridBitmap) -> Vec<u8> {
         let mut data = Vec::new();
@@ -486,39 +489,198 @@ mod bitmap_scalar {
         bencher.bench(|| eval_block(&expr, &block));
     }
 
-    #[divan::bench]
-    fn bitmap_and_large_large(bencher: divan::Bencher) {
-        let a = large_bitmap();
-        let b = overlap_large_bitmap();
+    fn bitmap_workload(lhs_n: u32, rhs_n: u32, shared: u32) -> (HybridBitmap, HybridBitmap) {
+        let lhs_only = lhs_n - shared;
+        let rhs_only = rhs_n - shared;
+        let mut rng = SmallRng::seed_from_u64(42);
+
+        fn fill(bm: &mut HybridBitmap, prefix: u32, rng: &mut SmallRng) {
+            let card = rng.gen_range(100..=10000);
+            for _ in 0..card {
+                bm.insert((prefix as u64) << 32 | rng.r#gen::<u32>() as u64);
+            }
+        }
+
+        let mut lhs = HybridBitmap::new();
+        let mut rhs = HybridBitmap::new();
+        for p in 0..shared {
+            fill(&mut lhs, p, &mut rng);
+            fill(&mut rhs, p, &mut rng);
+        }
+        for i in 0..lhs_only {
+            fill(&mut lhs, shared + i, &mut rng);
+        }
+        for i in 0..rhs_only {
+            fill(&mut rhs, shared + lhs_only + i, &mut rng);
+        }
+        (lhs, rhs)
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum BitmapLargeCase {
+        OrHighOverlap,
+        OrLowOverlap,
+        OrLhsLarger,
+        OrRhsLarger,
+        AndHighOverlap,
+        AndLowOverlap,
+        AndLhsLarger,
+        AndRhsLarger,
+        XorHighOverlap,
+        XorLowOverlap,
+        XorLhsLarger,
+        XorRhsLarger,
+        NotHighOverlap,
+        NotLowOverlap,
+        NotLhsLarger,
+        NotRhsLarger,
+    }
+
+    impl BitmapLargeCase {
+        const ALL: &[BitmapLargeCase] = &[
+            BitmapLargeCase::OrHighOverlap,
+            BitmapLargeCase::OrLowOverlap,
+            BitmapLargeCase::OrLhsLarger,
+            BitmapLargeCase::OrRhsLarger,
+            BitmapLargeCase::AndHighOverlap,
+            BitmapLargeCase::AndLowOverlap,
+            BitmapLargeCase::AndLhsLarger,
+            BitmapLargeCase::AndRhsLarger,
+            BitmapLargeCase::XorHighOverlap,
+            BitmapLargeCase::XorLowOverlap,
+            BitmapLargeCase::XorLhsLarger,
+            BitmapLargeCase::XorRhsLarger,
+            BitmapLargeCase::NotHighOverlap,
+            BitmapLargeCase::NotLowOverlap,
+            BitmapLargeCase::NotLhsLarger,
+            BitmapLargeCase::NotRhsLarger,
+        ];
+
+        fn sql(self) -> &'static str {
+            match self {
+                BitmapLargeCase::OrHighOverlap
+                | BitmapLargeCase::OrLowOverlap
+                | BitmapLargeCase::OrLhsLarger
+                | BitmapLargeCase::OrRhsLarger => "bitmap_or(a, b)",
+                BitmapLargeCase::AndHighOverlap
+                | BitmapLargeCase::AndLowOverlap
+                | BitmapLargeCase::AndLhsLarger
+                | BitmapLargeCase::AndRhsLarger => "bitmap_and(a, b)",
+                BitmapLargeCase::XorHighOverlap
+                | BitmapLargeCase::XorLowOverlap
+                | BitmapLargeCase::XorLhsLarger
+                | BitmapLargeCase::XorRhsLarger => "bitmap_xor(a, b)",
+                BitmapLargeCase::NotHighOverlap
+                | BitmapLargeCase::NotLowOverlap
+                | BitmapLargeCase::NotLhsLarger
+                | BitmapLargeCase::NotRhsLarger => "bitmap_not(a, b)",
+            }
+        }
+
+        fn shape(self) -> (u32, u32, u32) {
+            match self {
+                BitmapLargeCase::OrHighOverlap
+                | BitmapLargeCase::AndHighOverlap
+                | BitmapLargeCase::XorHighOverlap
+                | BitmapLargeCase::NotHighOverlap => (64, 64, 56),
+                BitmapLargeCase::OrLowOverlap
+                | BitmapLargeCase::AndLowOverlap
+                | BitmapLargeCase::XorLowOverlap
+                | BitmapLargeCase::NotLowOverlap => (64, 64, 8),
+                BitmapLargeCase::OrLhsLarger
+                | BitmapLargeCase::AndLhsLarger
+                | BitmapLargeCase::XorLhsLarger
+                | BitmapLargeCase::NotLhsLarger => (256, 32, 32),
+                BitmapLargeCase::OrRhsLarger
+                | BitmapLargeCase::AndRhsLarger
+                | BitmapLargeCase::XorRhsLarger
+                | BitmapLargeCase::NotRhsLarger => (32, 256, 32),
+            }
+        }
+    }
+
+    #[divan::bench(args = BitmapLargeCase::ALL)]
+    fn bitmap_op_large(bencher: divan::Bencher, case: BitmapLargeCase) {
+        let (l, r, s) = case.shape();
+        let (a, b) = bitmap_workload(l, r, s);
         let block = DataBlock::new(vec![bitmap_entry(&a), bitmap_entry(&b)], 1);
-        let expr = build_expr("bitmap_and(a, b)", C2);
+        let expr = build_expr(case.sql(), C2);
         bencher.bench(|| eval_block(&expr, &block));
     }
 
-    #[divan::bench]
-    fn bitmap_and_small_small(bencher: divan::Bencher) {
-        let a = small_bitmap();
-        let b = overlap_small_bitmap();
-        let block = DataBlock::new(vec![bitmap_entry(&a), bitmap_entry(&b)], 1);
-        let expr = build_expr("bitmap_and(a, b)", C2);
-        bencher.bench(|| eval_block(&expr, &block));
+    #[derive(Clone, Copy, Debug)]
+    enum BitmapMixedCase {
+        OrLargeSmall,
+        OrSmallLarge,
+        OrSmallSmall,
+        AndLargeSmall,
+        AndSmallLarge,
+        AndSmallSmall,
+        XorLargeSmall,
+        XorSmallLarge,
+        XorSmallSmall,
+        NotLargeSmall,
+        NotSmallLarge,
+        NotSmallSmall,
     }
 
-    #[divan::bench]
-    fn bitmap_and_large_small(bencher: divan::Bencher) {
-        let a = large_bitmap();
-        let b = small_bitmap();
-        let block = DataBlock::new(vec![bitmap_entry(&a), bitmap_entry(&b)], 1);
-        let expr = build_expr("bitmap_and(a, b)", C2);
-        bencher.bench(|| eval_block(&expr, &block));
+    impl BitmapMixedCase {
+        const ALL: &[BitmapMixedCase] = &[
+            BitmapMixedCase::OrLargeSmall,
+            BitmapMixedCase::OrSmallLarge,
+            BitmapMixedCase::OrSmallSmall,
+            BitmapMixedCase::AndLargeSmall,
+            BitmapMixedCase::AndSmallLarge,
+            BitmapMixedCase::AndSmallSmall,
+            BitmapMixedCase::XorLargeSmall,
+            BitmapMixedCase::XorSmallLarge,
+            BitmapMixedCase::XorSmallSmall,
+            BitmapMixedCase::NotLargeSmall,
+            BitmapMixedCase::NotSmallLarge,
+            BitmapMixedCase::NotSmallSmall,
+        ];
+
+        fn sql(self) -> &'static str {
+            match self {
+                BitmapMixedCase::OrLargeSmall
+                | BitmapMixedCase::OrSmallLarge
+                | BitmapMixedCase::OrSmallSmall => "bitmap_or(a, b)",
+                BitmapMixedCase::AndLargeSmall
+                | BitmapMixedCase::AndSmallLarge
+                | BitmapMixedCase::AndSmallSmall => "bitmap_and(a, b)",
+                BitmapMixedCase::XorLargeSmall
+                | BitmapMixedCase::XorSmallLarge
+                | BitmapMixedCase::XorSmallSmall => "bitmap_xor(a, b)",
+                BitmapMixedCase::NotLargeSmall
+                | BitmapMixedCase::NotSmallLarge
+                | BitmapMixedCase::NotSmallSmall => "bitmap_not(a, b)",
+            }
+        }
+
+        fn pair(self) -> (HybridBitmap, HybridBitmap) {
+            let (small, large) = (small_bitmap(), large_bitmap());
+            match self {
+                BitmapMixedCase::OrLargeSmall
+                | BitmapMixedCase::AndLargeSmall
+                | BitmapMixedCase::XorLargeSmall
+                | BitmapMixedCase::NotLargeSmall => (large, small),
+                BitmapMixedCase::OrSmallLarge
+                | BitmapMixedCase::AndSmallLarge
+                | BitmapMixedCase::XorSmallLarge
+                | BitmapMixedCase::NotSmallLarge => (small, large),
+                BitmapMixedCase::OrSmallSmall
+                | BitmapMixedCase::AndSmallSmall
+                | BitmapMixedCase::XorSmallSmall
+                | BitmapMixedCase::NotSmallSmall => (small_bitmap(), overlap_small_bitmap()),
+            }
+        }
     }
 
-    #[divan::bench]
-    fn bitmap_and_small_large(bencher: divan::Bencher) {
-        let a = small_bitmap();
-        let b = large_bitmap();
+    #[divan::bench(args = BitmapMixedCase::ALL)]
+    fn bitmap_op_mixed(bencher: divan::Bencher, case: BitmapMixedCase) {
+        let (a, b) = case.pair();
         let block = DataBlock::new(vec![bitmap_entry(&a), bitmap_entry(&b)], 1);
-        let expr = build_expr("bitmap_and(a, b)", C2);
+        let expr = build_expr(case.sql(), C2);
         bencher.bench(|| eval_block(&expr, &block));
     }
 

--- a/src/query/functions/src/scalars/bitmap.rs
+++ b/src/query/functions/src/scalars/bitmap.rs
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ops::BitAnd;
-use std::ops::BitOr;
-use std::ops::BitXor;
-use std::ops::Sub;
-
 use databend_common_expression::EvalContext;
 use databend_common_expression::FunctionDomain;
 use databend_common_expression::FunctionRegistry;
@@ -37,6 +32,7 @@ use databend_common_expression::vectorize_with_builder_3_arg;
 use databend_common_expression::with_signed_integer_mapped_type;
 use databend_common_expression::with_unsigned_integer_mapped_type;
 use databend_common_io::HybridBitmap;
+use databend_common_io::bitmap::BitmapRhs::Serialized;
 use databend_common_io::bitmap::bitmap_contains;
 use databend_common_io::bitmap::bitmap_has_all;
 use databend_common_io::bitmap::bitmap_has_any;
@@ -539,7 +535,7 @@ fn bitmap_logic_operate(
         builder.commit_row();
         return;
     }
-    let Some(rb1) = deserialize_bitmap(arg1)
+    let Some(mut rb1) = deserialize_bitmap(arg1)
         .map_err(|e| {
             ctx.set_error(builder.len(), e.to_string());
             builder.commit_row();
@@ -549,23 +545,19 @@ fn bitmap_logic_operate(
         return;
     };
 
-    let Some(rb2) = deserialize_bitmap(arg2)
-        .map_err(|e| {
-            ctx.set_error(builder.len(), e.to_string());
-            builder.commit_row();
-        })
-        .ok()
-    else {
+    let res = match op {
+        LogicOp::Or => rb1.bitor_assign_rhs(Serialized(arg2)),
+        LogicOp::And => rb1.bitand_assign_rhs(Serialized(arg2)),
+        LogicOp::Xor => rb1.bitxor_assign_rhs(Serialized(arg2)),
+        LogicOp::Not => rb1.sub_assign_rhs(Serialized(arg2)),
+    };
+
+    if let Err(e) = res {
+        ctx.set_error(builder.len(), e.to_string());
+        builder.commit_row();
         return;
-    };
+    }
 
-    let rb = match op {
-        LogicOp::Or => rb1.bitor(rb2),
-        LogicOp::And => rb1.bitand(rb2),
-        LogicOp::Xor => rb1.bitxor(rb2),
-        LogicOp::Not => rb1.sub(rb2),
-    };
-
-    rb.serialize_into(&mut builder.data).unwrap();
+    rb1.serialize_into(&mut builder.data).unwrap();
     builder.commit_row();
 }

--- a/src/query/functions/src/scalars/bitmap.rs
+++ b/src/query/functions/src/scalars/bitmap.rs
@@ -535,7 +535,19 @@ fn bitmap_logic_operate(
         builder.commit_row();
         return;
     }
-    let Some(mut rb1) = deserialize_bitmap(arg1)
+
+    // Choose which side to materialize:
+    // - And: materialize the smaller side; so the larger side can be skipped if unmatched
+    // - Or/Xor: materialize the larger side; so the small side lead to lower read cost
+    // - Not is asymmetric and never swapped.
+    let (n1, n2) = (arg1.len(), arg2.len());
+    let (mat, raw) = match op {
+        LogicOp::And if n1 > n2 => (arg2, arg1),
+        LogicOp::Or | LogicOp::Xor if n1 < n2 => (arg2, arg1),
+        _ => (arg1, arg2),
+    };
+
+    let Some(mut mat) = deserialize_bitmap(mat)
         .map_err(|e| {
             ctx.set_error(builder.len(), e.to_string());
             builder.commit_row();
@@ -546,10 +558,10 @@ fn bitmap_logic_operate(
     };
 
     let res = match op {
-        LogicOp::Or => rb1.bitor_assign_rhs(Serialized(arg2)),
-        LogicOp::And => rb1.bitand_assign_rhs(Serialized(arg2)),
-        LogicOp::Xor => rb1.bitxor_assign_rhs(Serialized(arg2)),
-        LogicOp::Not => rb1.sub_assign_rhs(Serialized(arg2)),
+        LogicOp::Or => mat.bitor_assign_rhs(Serialized(raw)),
+        LogicOp::And => mat.bitand_assign_rhs(Serialized(raw)),
+        LogicOp::Xor => mat.bitxor_assign_rhs(Serialized(raw)),
+        LogicOp::Not => mat.sub_assign_rhs(Serialized(raw)),
     };
 
     if let Err(e) = res {
@@ -558,6 +570,6 @@ fn bitmap_logic_operate(
         return;
     }
 
-    rb1.serialize_into(&mut builder.data).unwrap();
+    mat.serialize_into(&mut builder.data).unwrap();
     builder.commit_row();
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fixes: #19101 

Currently, scalar bitmap AND/OR/XOR/NOT deserialize both operands, and
aggregate OR/XOR/NOT deserialize the rhs, into intermediate treemaps
before operating. This PR minimizes deserialization and operates the
serialized rhs directly to improve performance:

- **deps**: 
  - roaring is patched to a fork revision until upstream releases the required APIs (see "Upstream PR status" below).
- **io**: 
  - `HybridBitmap::apply_rhs` dispatches `(Or|Xor|Sub, SerializedLarge)` to new `*_assign_serialized_large` APIs
  - The intersection wrapper is also rewritten to use `*_assign_serialized_large`
  - `*_assign_serialized_large` update the treemap in place instead of rebuilding it
  - avoid deserializing the rhs in the (small lhs, large serialized rhs) case of `bitand_assign_serialized_large` and `sub_assign_serialized_large`
- **functions**: 
  - `bitmap_and/or/xor/not` materialize one side and pass the other as `BitmapRhs::Serialized`
  - picks the materialized side by operand size (smaller for And, larger for Or/Xor)
- **bench**: 
  - `bitmap_op_large` scalar pairwise op bench with large workload
  - `bitmap_op_mixed` scalar pairwise op bench with mixed workload
  - `bitmap_not_count` aggregate bench

### Upstream PR status

[RoaringBitmap/roaring-rs#361](https://github.com/RoaringBitmap/roaring-rs/pull/361)
is ready for review, which provides:

- 3 borrowing APIs (intersection already exists)
- 4 assigning APIs
- treemap entry API which allows maintaining the treemap instead of rebuilding it

This PR will be marked ready for review after the upstream PR is released.

### Performance

> The bench commits sit before the first perf commit, so checking out the last bench commit gives the before numbers and HEAD gives the after numbers.

Scalar functions:

| op / shape | before | after | change |
|---|---|---|---|
| and high-overlap | 23.19 ms | 12.85 ms | −45% |
| and low-overlap | 17.95 ms | 8.76 ms | −51% |
| and lhs-larger | 42.77 ms | 6.62 ms | −85% |
| and rhs-larger | 41.68 ms | 6.93 ms | −83% |
| or high-overlap | 480.6 ms | 459.1 ms | −4% |
| or low-overlap | 90.33 ms | 82.12 ms | −9% |
| or lhs-larger | 314.6 ms | 292.0 ms | −7% |
| or rhs-larger | 311.8 ms | 285.5 ms | −8% |
| xor high-overlap | 32.89 ms | 28.49 ms | −13% |
| xor low-overlap | 27.59 ms | 26.25 ms | −5% |
| xor lhs-larger | 61.90 ms | 59.03 ms | −5% |
| xor rhs-larger | 63.90 ms | 58.35 ms | −9% |
| not high-overlap | 27.05 ms | 18.96 ms | −30% |
| not low-overlap | 22.68 ms | 14.11 ms | −38% |
| not lhs-larger | 61.05 ms | 55.82 ms | −9% |
| not rhs-larger | 40.96 ms | 9.28 ms | −77% |

- and improves most (−45% to −85%): the new impl skips unmatched rhs containers and always takes the larger side as rhs, while the baseline still deserializes both sides and iterates pairwise
- not improves less (−9% on lhs-larger, −30% to −77% elsewhere): for the same reason as and, it performs better when the rhs is larger
- or/xor improve little (−4% to −13%): they need to read all containers and cost is dominated by serialization (deferring serialization might help)

Aggregates:

| workload | before | after | change |
|---|---|---|---|
| bitmap_intersect 1000 | 5.531 ms | 5.256 ms | −5% |
| bitmap_intersect 65535 | 349.0 ms | 349.6 ms | +0.2% |
| bitmap_not_count 1000 | 7.502 ms | 1.942 ms | −74% |
| bitmap_not_count 65535 | 490.2 ms | 121.3 ms | −75% |
| bitmap_union 1000 | 282.4 ms | 154.0 ms | −45% |
| bitmap_union 3000 | 1.766 s | 550.9 ms | −69% |
| bitmap_union 5000 | 4.434 s | 738.6 ms | −83% |
| bitmap_xor_agg_overlap 1000 | 180.1 ms | 147.5 ms | −18% |
| bitmap_xor_agg_overlap 3000 | 1.539 s | 1.357 s | −12% |
| bitmap_xor_agg_overlap 5000 | 4.514 s | 4.087 s | −9% |

- bitmap_intersect does not change because it operates on serialized rhs already and its destruct-then-rebuild cost is low, so _assign does not help
- bitmap_not_count improves a lot (−74% to −75%): the new impl skip unmatched rhs containers via `difference_assign_with_serialized`
- bitmap_union improves with row count (−45% to −83%): new impl avoids len guard in `RoaringTreemap::bitor_assign`, whose cost grows with row count
- bitmap_xor gains less (−9% to −18%): treemap bitxor_assign has no such length guard, so only the constant cost of the rhs intermediate treemap disappears

### Known limitation: support for run containers

This PR upgrades roaring from 0.10.12 to 0.11.5 to get those new APIs. The new version emits run containers when `insert_range` or `optimize` is called. Databend does not support run containers, mainly in `BitmapReader`. This does not impact compatibility, because databend never calls `insert_range` or `optimize`, so run containers will not be created. But this can be a potential optimization for future if we support run container in databend.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [x] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent was used to investigate the codebase and draft the new API plumbing.
- Responsible human: @harry-hao 
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20335)
<!-- Reviewable:end -->
