### PR TITLE
feat(query): choose materialized views by rewrite cost

### DIFF
--- a/src/query/sql/src/planner/metadata/metadata.rs
+++ b/src/query/sql/src/planner/metadata/metadata.rs
@@ -385,6 +385,21 @@ impl Metadata {
             .map(Vec::as_slice)
     }
 
+    /// Replace candidate `read_plan`s after statistics have been collected.
+    /// `read_plans` must stay in the same order as the stored candidates.
+    pub fn replace_materialized_view_candidate_read_plans(
+        &mut self,
+        source_table_id: u64,
+        read_plans: Vec<SExpr>,
+    ) {
+        let Some(candidates) = self.materialized_view_candidates.get_mut(&source_table_id) else {
+            return;
+        };
+        for (candidate, read_plan) in candidates.iter_mut().zip(read_plans) {
+            candidate.read_plan = read_plan;
+        }
+    }
+
     pub fn has_materialized_view_candidates(&self) -> bool {
         !self.materialized_view_candidates.is_empty()
     }

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/materialized_view.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/materialized_view.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -22,14 +23,17 @@ use log::info;
 use super::view_rewrite::QueryInfo;
 use super::view_rewrite::ViewInfo;
 use super::view_rewrite::ViewMatcher;
+use super::view_rewrite::ViewRewriteMatch;
 use super::view_rewrite::format_scalar;
 use crate::IndexType;
 use crate::MaterializedViewCandidate;
+use crate::MaterializedViewCandidateReadMode;
 use crate::Metadata;
 use crate::ScalarExpr;
 use crate::Symbol;
 use crate::Visibility;
 use crate::binder::ColumnBindingBuilder;
+use crate::optimizer::ir::RelExpr;
 use crate::optimizer::ir::SExpr;
 use crate::plans::Aggregate;
 use crate::plans::AggregateFunction;
@@ -37,8 +41,49 @@ use crate::plans::AggregateMode;
 use crate::plans::BoundColumnRef;
 use crate::plans::EvalScalar;
 use crate::plans::Filter;
+use crate::plans::RelOperator;
 use crate::plans::ScalarItem;
+use crate::plans::Scan;
 
+/// Fallback cost when a scan has no collected table statistics.
+/// Prefer a candidate with known cheaper IO over an unknown plan.
+const UNKNOWN_CARDINALITY_COST: f64 = 1e12;
+const COMPUTE_PER_ROW: f64 = 1.0;
+const AGGREGATE_PER_ROW: f64 = 5.0;
+
+struct RewriteCandidate {
+    replacement: SExpr,
+    mv_table_id: u64,
+    cost: f64,
+    read_mode: MaterializedViewCandidateReadMode,
+    logical_sql: String,
+    requires_aggregate_rollup: bool,
+}
+
+impl RewriteCandidate {
+    fn is_better(&self, other: &Self) -> bool {
+        match self.cost.partial_cmp(&other.cost) {
+            Some(Ordering::Less) => true,
+            Some(Ordering::Greater) => false,
+            _ => match (self.read_mode, other.read_mode) {
+                (
+                    MaterializedViewCandidateReadMode::Fresh,
+                    MaterializedViewCandidateReadMode::Hybrid,
+                ) => true,
+                (
+                    MaterializedViewCandidateReadMode::Hybrid,
+                    MaterializedViewCandidateReadMode::Fresh,
+                ) => false,
+                _ => self.mv_table_id < other.mv_table_id,
+            },
+        }
+    }
+}
+
+/// Choose the cheapest semantically valid materialized-view rewrite.
+/// When several candidates can answer the query, compare the full rewritten
+/// plan cost (scan IO plus extra operators such as rollup aggregates) instead
+/// of taking the first match.
 pub(crate) fn try_rewrite(
     table_index: IndexType,
     table_name: &str,
@@ -59,121 +104,203 @@ pub(crate) fn try_rewrite(
     let query_aggregate = query_info.aggregate.clone();
     let matcher = ViewMatcher::new(query_info).with_aggregate_rollup();
 
+    let mut best: Option<RewriteCandidate> = None;
     for candidate in candidates {
-        let definition_info = QueryInfo::new(
+        let Some((replacement, requires_aggregate_rollup)) = try_build_replacement(
             table_index,
             table_name,
-            metadata.columns_by_table_index(table_index),
-            &candidate.definition,
-        )?;
-        if candidate.definition_output_columns.len() != candidate.read_output_columns.len() {
-            continue;
-        }
-
-        let mut outputs = HashMap::with_capacity(definition_info.output_cols().len());
-        for definition_output in definition_info.output_cols() {
-            let Some(position) = candidate
-                .definition_output_columns
-                .iter()
-                .position(|column| *column == definition_output.index)
-            else {
-                continue;
-            };
-            let read_output = candidate.read_output_columns[position];
-            let display_name =
-                format_scalar(&definition_output.scalar, definition_info.column_map());
-            let replacement = ScalarExpr::BoundColumnRef(BoundColumnRef {
-                span: None,
-                column: ColumnBindingBuilder::new(
-                    metadata.column(read_output).name(),
-                    read_output,
-                    Box::new(metadata.column(read_output).data_type()),
-                    Visibility::Visible,
-                )
-                .build(),
-            });
-            // Aggregate MVs expose finalized logical aggregate values. The
-            // first implementation supports only equal-granularity aggregate
-            // matching; the shared matcher rejects use as an ordinary scalar.
-            let is_aggregate = definition_info.aggregate.as_ref().is_some_and(|aggregate| {
-                aggregate
-                    .aggregate_functions
-                    .iter()
-                    .any(|item| item.index == definition_output.index)
-            });
-            outputs.insert(display_name, (replacement, is_aggregate));
-        }
-
-        let view_info = ViewInfo::new(
-            table_index,
-            table_name,
-            metadata.columns_by_table_index(table_index),
-            &candidate.definition,
-            outputs,
-        )?;
-        let Some(matched) = matcher.try_match(&view_info)? else {
+            metadata,
+            candidate,
+            &matcher,
+            query_aggregate.as_ref(),
+        )?
+        else {
             continue;
         };
-        let post_aggregate_predicates = matched.post_aggregate_predicates.clone();
-
-        if matched.requires_aggregate_rollup {
-            let Some(query_aggregate) = &query_aggregate else {
-                continue;
-            };
-            if let Some(mut replacement) =
-                try_build_state_rollup(candidate, &matched, query_aggregate)?
-            {
-                replacement = apply_post_aggregate_filter(replacement, &post_aggregate_predicates);
-                info!(
-                    "Use materialized view {} with aggregate-state rollup: {}",
-                    candidate.mv_table_id, candidate.logical_sql
-                );
-                return Ok(Some((replacement, candidate.mv_table_id)));
-            }
+        let cost = estimate_rewrite_cost(&replacement);
+        let current = RewriteCandidate {
+            replacement,
+            mv_table_id: candidate.mv_table_id,
+            cost,
+            read_mode: candidate.read_mode,
+            logical_sql: candidate.logical_sql.clone(),
+            requires_aggregate_rollup,
+        };
+        if best.as_ref().is_none_or(|best| current.is_better(best)) {
+            best = Some(current);
         }
-
-        let mut replacement = candidate.read_plan.clone();
-        if !matched.predicates.is_empty() {
-            replacement = SExpr::create_unary(
-                Arc::new(
-                    Filter {
-                        predicates: matched.predicates,
-                    }
-                    .into(),
-                ),
-                Arc::new(replacement),
-            );
-        }
-        if !matched.selection.is_empty() {
-            replacement = SExpr::create_unary(
-                Arc::new(
-                    EvalScalar {
-                        items: matched.selection,
-                    }
-                    .into(),
-                ),
-                Arc::new(replacement),
-            );
-        }
-        if matched.requires_aggregate_rollup {
-            let Some(query_aggregate) = &query_aggregate else {
-                continue;
-            };
-            let Some(aggregate) = build_rollup_aggregate(metadata, query_aggregate)? else {
-                continue;
-            };
-            replacement = SExpr::create_unary(Arc::new(aggregate.into()), Arc::new(replacement));
-        }
-        replacement = apply_post_aggregate_filter(replacement, &post_aggregate_predicates);
-
-        info!(
-            "Use materialized view {}: {}",
-            candidate.mv_table_id, candidate.logical_sql
-        );
-        return Ok(Some((replacement, candidate.mv_table_id)));
     }
 
-    Ok(None)
+    if let Some(best) = best {
+        if best.requires_aggregate_rollup {
+            info!(
+                "Use materialized view {} with aggregate-state rollup (cost={}): {}",
+                best.mv_table_id, best.cost, best.logical_sql
+            );
+        } else {
+            info!(
+                "Use materialized view {} (cost={}): {}",
+                best.mv_table_id, best.cost, best.logical_sql
+            );
+        }
+        Ok(Some((best.replacement, best.mv_table_id)))
+    } else {
+        Ok(None)
+    }
+}
+
+fn try_build_replacement(
+    table_index: IndexType,
+    table_name: &str,
+    metadata: &Metadata,
+    candidate: &MaterializedViewCandidate,
+    matcher: &ViewMatcher,
+    query_aggregate: Option<&Aggregate>,
+) -> Result<Option<(SExpr, bool)>> {
+    let definition_info = QueryInfo::new(
+        table_index,
+        table_name,
+        metadata.columns_by_table_index(table_index),
+        &candidate.definition,
+    )?;
+    if candidate.definition_output_columns.len() != candidate.read_output_columns.len() {
+        return Ok(None);
+    }
+
+    let mut outputs = HashMap::with_capacity(definition_info.output_cols().len());
+    for definition_output in definition_info.output_cols() {
+        let Some(position) = candidate
+            .definition_output_columns
+            .iter()
+            .position(|column| *column == definition_output.index)
+        else {
+            continue;
+        };
+        let read_output = candidate.read_output_columns[position];
+        let display_name = format_scalar(&definition_output.scalar, definition_info.column_map());
+        let replacement = ScalarExpr::BoundColumnRef(BoundColumnRef {
+            span: None,
+            column: ColumnBindingBuilder::new(
+                metadata.column(read_output).name(),
+                read_output,
+                Box::new(metadata.column(read_output).data_type()),
+                Visibility::Visible,
+            )
+            .build(),
+        });
+        // Aggregate MVs expose finalized logical aggregate values. The
+        // first implementation supports only equal-granularity aggregate
+        // matching; the shared matcher rejects use as an ordinary scalar.
+        let is_aggregate = definition_info.aggregate.as_ref().is_some_and(|aggregate| {
+            aggregate
+                .aggregate_functions
+                .iter()
+                .any(|item| item.index == definition_output.index)
+        });
+        outputs.insert(display_name, (replacement, is_aggregate));
+    }
+
+    let view_info = ViewInfo::new(
+        table_index,
+        table_name,
+        metadata.columns_by_table_index(table_index),
+        &candidate.definition,
+        outputs,
+    )?;
+    let Some(matched) = matcher.try_match(&view_info)? else {
+        return Ok(None);
+    };
+    let post_aggregate_predicates = matched.post_aggregate_predicates.clone();
+    let requires_aggregate_rollup = matched.requires_aggregate_rollup;
+
+    if requires_aggregate_rollup {
+        let Some(query_aggregate) = query_aggregate else {
+            return Ok(None);
+        };
+        if let Some(mut replacement) = try_build_state_rollup(candidate, &matched, query_aggregate)?
+        {
+            replacement = apply_post_aggregate_filter(replacement, &post_aggregate_predicates);
+            return Ok(Some((replacement, true)));
+        }
+    }
+
+    let mut replacement = candidate.read_plan.clone();
+    if !matched.predicates.is_empty() {
+        replacement = SExpr::create_unary(
+            Arc::new(
+                Filter {
+                    predicates: matched.predicates,
+                }
+                .into(),
+            ),
+            Arc::new(replacement),
+        );
+    }
+    if !matched.selection.is_empty() {
+        replacement = SExpr::create_unary(
+            Arc::new(
+                EvalScalar {
+                    items: matched.selection,
+                }
+                .into(),
+            ),
+            Arc::new(replacement),
+        );
+    }
+    if requires_aggregate_rollup {
+        let Some(query_aggregate) = query_aggregate else {
+            return Ok(None);
+        };
+        let Some(aggregate) = build_rollup_aggregate(metadata, query_aggregate)? else {
+            return Ok(None);
+        };
+        replacement = SExpr::create_unary(Arc::new(aggregate.into()), Arc::new(replacement));
+    }
+    replacement = apply_post_aggregate_filter(replacement, &post_aggregate_predicates);
+    Ok(Some((replacement, requires_aggregate_rollup)))
+}
+
+fn estimate_rewrite_cost(s_expr: &SExpr) -> f64 {
+    let children_cost: f64 = s_expr.children().map(estimate_rewrite_cost).sum();
+    let node_cost = match s_expr.plan() {
+        RelOperator::Scan(scan) => scan_cost(scan),
+        RelOperator::Aggregate(_) => {
+            input_cardinality(s_expr).unwrap_or(UNKNOWN_CARDINALITY_COST) * AGGREGATE_PER_ROW
+        }
+        RelOperator::UnionAll(_) => {
+            output_cardinality(s_expr).unwrap_or(UNKNOWN_CARDINALITY_COST) * COMPUTE_PER_ROW
+        }
+        RelOperator::Filter(_)
+        | RelOperator::EvalScalar(_)
+        | RelOperator::Sort(_)
+        | RelOperator::TopN(_)
+        | RelOperator::Limit(_) => {
+            output_cardinality(s_expr).unwrap_or(UNKNOWN_CARDINALITY_COST) * COMPUTE_PER_ROW
+        }
+        _ => output_cardinality(s_expr).unwrap_or(UNKNOWN_CARDINALITY_COST) * COMPUTE_PER_ROW,
+    };
+    children_cost + node_cost
+}
+
+fn scan_cost(scan: &Scan) -> f64 {
+    scan.statistics
+        .table_stats
+        .as_ref()
+        .and_then(|stats| stats.num_rows)
+        .map(|rows| rows as f64 * COMPUTE_PER_ROW)
+        .unwrap_or(UNKNOWN_CARDINALITY_COST)
+}
+
+fn input_cardinality(s_expr: &SExpr) -> Option<f64> {
+    s_expr.child(0).ok().and_then(output_cardinality)
+}
+
+fn output_cardinality(s_expr: &SExpr) -> Option<f64> {
+    RelExpr::with_s_expr(s_expr)
+        .derive_cardinality()
+        .ok()
+        .map(|stat| stat.cardinality)
+        .filter(|cardinality| cardinality.is_finite())
 }
 
 fn apply_post_aggregate_filter(
@@ -197,7 +324,7 @@ fn apply_post_aggregate_filter(
 
 fn try_build_state_rollup(
     candidate: &MaterializedViewCandidate,
-    matched: &super::view_rewrite::ViewRewriteMatch,
+    matched: &ViewRewriteMatch,
     query_aggregate: &Aggregate,
 ) -> Result<Option<SExpr>> {
     let Some(final_projection) = candidate.read_plan.plan().as_eval_scalar() else {
@@ -378,4 +505,96 @@ fn column_ref(metadata: &Metadata, index: crate::Symbol) -> ScalarExpr {
         )
         .build(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use databend_common_catalog::table::TableStatistics;
+
+    use super::*;
+    use crate::plans::Statistics;
+
+    fn scan_with_rows(rows: Option<u64>) -> SExpr {
+        SExpr::create_leaf(Scan {
+            statistics: Arc::new(Statistics {
+                table_stats: Some(TableStatistics {
+                    num_rows: rows,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        })
+    }
+
+    fn rewrite_candidate(
+        cost: f64,
+        read_mode: MaterializedViewCandidateReadMode,
+        mv_table_id: u64,
+    ) -> RewriteCandidate {
+        RewriteCandidate {
+            replacement: scan_with_rows(Some(1)),
+            mv_table_id,
+            cost,
+            read_mode,
+            logical_sql: String::new(),
+            requires_aggregate_rollup: false,
+        }
+    }
+
+    #[test]
+    fn cheaper_rewrite_wins() {
+        let cheaper = rewrite_candidate(10.0, MaterializedViewCandidateReadMode::Hybrid, 2);
+        let expensive = rewrite_candidate(20.0, MaterializedViewCandidateReadMode::Fresh, 1);
+        assert!(cheaper.is_better(&expensive));
+        assert!(!expensive.is_better(&cheaper));
+    }
+
+    #[test]
+    fn fresh_beats_hybrid_at_same_cost() {
+        let fresh = rewrite_candidate(10.0, MaterializedViewCandidateReadMode::Fresh, 2);
+        let hybrid = rewrite_candidate(10.0, MaterializedViewCandidateReadMode::Hybrid, 1);
+        assert!(fresh.is_better(&hybrid));
+        assert!(!hybrid.is_better(&fresh));
+    }
+
+    #[test]
+    fn smaller_table_id_breaks_remaining_ties() {
+        let left = rewrite_candidate(10.0, MaterializedViewCandidateReadMode::Fresh, 1);
+        let right = rewrite_candidate(10.0, MaterializedViewCandidateReadMode::Fresh, 2);
+        assert!(left.is_better(&right));
+        assert!(!right.is_better(&left));
+    }
+
+    #[test]
+    fn smaller_scan_is_cheaper_than_larger_scan() {
+        let small = estimate_rewrite_cost(&scan_with_rows(Some(10)));
+        let large = estimate_rewrite_cost(&scan_with_rows(Some(100)));
+        assert!(small < large);
+    }
+
+    #[test]
+    fn extra_aggregate_increases_cost() {
+        let scan = scan_with_rows(Some(100));
+        let with_aggregate = SExpr::create_unary(
+            Arc::new(
+                Aggregate {
+                    mode: AggregateMode::Initial,
+                    ..Default::default()
+                }
+                .into(),
+            ),
+            Arc::new(scan.clone()),
+        );
+        assert!(estimate_rewrite_cost(&scan) < estimate_rewrite_cost(&with_aggregate));
+    }
+
+    #[test]
+    fn unknown_scan_stats_are_more_expensive_than_known_small_scan() {
+        let unknown = estimate_rewrite_cost(&scan_with_rows(None));
+        let known = estimate_rewrite_cost(&scan_with_rows(Some(1)));
+        assert!(known < unknown);
+    }
 }

--- a/src/query/sql/src/planner/optimizer/statistics/collect_statistics.rs
+++ b/src/query/sql/src/planner/optimizer/statistics/collect_statistics.rs
@@ -101,6 +101,9 @@ impl CollectStatisticsOptimizer {
     async fn optimize_async(&mut self, s_expr: &SExpr) -> Result<SExpr> {
         let mut collector = TraceCollector::default();
         let s_expr = self.collect(s_expr, &mut collector).await?;
+        // Candidate read plans live in metadata, not in the query tree. Collect their
+        // scan statistics so materialized-view rewrite can compare rewrite costs.
+        self.collect_materialized_view_candidates().await?;
         if self.should_collect_trace() {
             self.finalize_trace(&s_expr, &mut collector)?;
             if self.enable_trace {
@@ -123,6 +126,43 @@ impl CollectStatisticsOptimizer {
             }
         }
         Ok(s_expr)
+    }
+
+    async fn collect_materialized_view_candidates(&mut self) -> Result<()> {
+        if !self.metadata.read().has_materialized_view_candidates() {
+            return Ok(());
+        }
+
+        let source_table_ids: Vec<u64> = self
+            .metadata
+            .read()
+            .materialized_view_candidates()
+            .keys()
+            .copied()
+            .collect();
+        // Candidate traces must not leak into the query statistics replay.
+        let mut collector = TraceCollector::default();
+        for source_table_id in source_table_ids {
+            let read_plans: Vec<SExpr> = self
+                .metadata
+                .read()
+                .get_materialized_view_candidates(source_table_id)
+                .unwrap_or_default()
+                .iter()
+                .map(|candidate| candidate.read_plan.clone())
+                .collect();
+            if read_plans.is_empty() {
+                continue;
+            }
+            let mut updated = Vec::with_capacity(read_plans.len());
+            for read_plan in read_plans {
+                updated.push(self.collect(&read_plan, &mut collector).await?);
+            }
+            self.metadata
+                .write()
+                .replace_materialized_view_candidate_read_plans(source_table_id, updated);
+        }
+        Ok(())
     }
 
     fn should_collect_trace(&self) -> bool {

--- a/tests/sqllogictests/suites/ee/07_ee_materialized_view/07_0002_materialized_view_rewrite_explain.test
+++ b/tests/sqllogictests/suites/ee/07_ee_materialized_view/07_0002_materialized_view_rewrite_explain.test
@@ -170,16 +170,16 @@ group by a, b, c
 EvalScalar
 ├── output columns: [source.a (#0), source.b (#1), source.c (#2), sum(t) (#7), count(t) (#8)]
 ├── expressions: [mv_by_abc.a (#27), mv_by_abc.b (#28), mv_by_abc.c (#29), sum_t (#32), count_t (#33)]
-├── estimated rows: 1.00
+├── estimated rows: 5.00
 └── AggregateFinal
     ├── output columns: [sum_t (#32), count_t (#33), mv_by_abc.a (#27), mv_by_abc.b (#28), mv_by_abc.c (#29)]
     ├── group by: [a, b, c]
     ├── aggregate functions: [sum_merge(sum_t), count_merge(count_t)]
-    ├── estimated rows: 1.00
+    ├── estimated rows: 5.00
     └── AggregatePartial
         ├── group by: [a, b, c]
         ├── aggregate functions: [sum_merge(sum_t), count_merge(count_t)]
-        ├── estimated rows: 1.00
+        ├── estimated rows: 5.00
         └── TableScan
             ├── table: default.explain_materialized_view_rewrite.mv_by_abc
             ├── scan id: 2
@@ -190,7 +190,7 @@ EvalScalar
             ├── partitions scanned: 2
             ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 2 to 2 cost: <slt:ignore>>, blocks: <range pruning: 2 to 2 cost: <slt:ignore>>]
             ├── push downs: [filters: [], limit: NONE]
-            └── estimated rows: 0.00
+            └── estimated rows: 5.00
 
 # A separate detail MV covers non-aggregate projection and predicate matching.
 statement ok

--- a/tests/sqllogictests/suites/ee/07_ee_materialized_view/07_0003_materialized_view_cost.test
+++ b/tests/sqllogictests/suites/ee/07_ee_materialized_view/07_0003_materialized_view_cost.test
@@ -1,0 +1,120 @@
+# When several materialized views can answer the same query, rewrite must pick
+# the cheaper plan rather than the first matching candidate.
+
+statement ok
+drop database if exists test_materialized_view_cost
+
+statement ok
+create database test_materialized_view_cost
+
+statement ok
+use test_materialized_view_cost
+
+statement ok
+create table source (
+    a int,
+    b int,
+    t int
+)
+
+statement ok
+insert into source values
+    (1, 10, 5),
+    (1, 20, 9),
+    (1, 30, 100),
+    (2, 10, 7),
+    (2, 20, 70),
+    (2, 30, 3),
+    (3, 10, 8),
+    (3, 20, 4)
+
+# Create the more expensive fine-grained MV first so first-match would pick it.
+statement ok
+create materialized view mv_by_ab (
+    a,
+    b,
+    sum_t
+) as
+select a, b, sum(t)
+from source
+group by a, b
+
+statement ok
+refresh materialized view mv_by_ab
+
+statement ok
+create materialized view mv_by_a (
+    a,
+    sum_t
+) as
+select a, sum(t)
+from source
+group by a
+
+statement ok
+refresh materialized view mv_by_a
+
+# GROUP BY a can use either MV. The exact-granularity MV has fewer stored rows
+# and needs no extra rollup, so it must win on cost.
+query T
+explain select a, sum(t)
+from source
+group by a
+----
+<slt:ignore>table: default.test_materialized_view_cost.mv_by_a<slt:ignore>
+
+query II rowsort
+select a, sum(t)
+from source
+group by a
+----
+1 114
+2 80
+3 12
+
+statement ok
+create table detail_source (
+    id int,
+    amount int
+)
+
+statement ok
+insert into detail_source values
+    (1, 10),
+    (2, 15),
+    (3, 20),
+    (4, 25),
+    (5, 30),
+    (6, 35)
+
+# Create the wider predicate first so first-match would pick the larger scan.
+statement ok
+create materialized view mv_amount_gt_10 (id, amount) as
+select id, amount from detail_source where amount > 10
+
+statement ok
+refresh materialized view mv_amount_gt_10
+
+statement ok
+create materialized view mv_amount_gt_20 (id, amount) as
+select id, amount from detail_source where amount > 20
+
+statement ok
+refresh materialized view mv_amount_gt_20
+
+# amount > 20 can use either MV. The tighter MV stores fewer rows and needs no
+# compensating filter, so it must win on cost.
+query T
+explain select id, amount from detail_source where amount > 20
+----
+<slt:ignore>table: default.test_materialized_view_cost.mv_amount_gt_20<slt:ignore>
+
+query II rowsort
+select id, amount from detail_source where amount > 20
+----
+4 25
+5 30
+6 35
+
+statement ok
+drop database test_materialized_view_cost


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

When a source table has several matching materialized views, rewrite used to take the first semantic match. This PR chooses the cheapest rewritten plan instead.

## Changes

- Collect scan statistics for candidate MV `read_plan`s during `CollectStatisticsOptimizer`, so rewrite cost can see stored row counts.
- Compare every matching rewrite by plan-tree cost (scan IO plus extra operators such as rollup aggregates / compensating filters / hybrid unions).
- Prefer Fresh over Hybrid, then smaller `mv_table_id`, when costs are equal.

Example: `GROUP BY a` can use both `mv_by_a` and a finer `mv_by_ab`. The exact-granularity MV wins because it stores fewer rows and needs no extra rollup.

## Implementation

1. `CollectStatisticsOptimizer` walks candidate `read_plan`s after collecting the query tree and writes stats back through `Metadata::replace_materialized_view_candidate_read_plans`.
2. `try_rewrite` builds a replacement for every matching candidate, estimates rewrite cost, and keeps the cheapest one.
3. Scan cost uses collected `table_stats.num_rows`. Unknown stats are treated as expensive so a known cheaper plan wins.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - Pair with the reviewer to explain why

- Unit tests cover cost comparison, Fresh vs Hybrid ties, scan size, extra aggregate, and unknown stats.
- Logic test `07_0003_materialized_view_cost.test` creates the more expensive MV first so first-match would pick the wrong one.

Validation:

```
cargo test -p databend-common-sql --lib planner::optimizer::optimizers::rule::agg_rules::materialized_view::tests
```

## Type of change

- [x] New Feature (non-breaking change which adds functionality)

## AI assistance

- AI usage: An AI coding agent drafted the optimizer rewrite, statistics collection, unit tests, and this PR description; I reviewed the final diff
- Responsible human: @sundy-li
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20337)
<!-- Reviewable:end -->
