### PR TITLE
fix(query): quote nested SQL in procedure expressions with SQL rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4750,7 +4750,6 @@ version = "0.1.0"
 dependencies = [
  "databend-common-ast",
  "databend-common-exception",
- "derive-visitor",
  "fastrace",
  "goldenfile",
  "tokio",

--- a/src/query/script/Cargo.toml
+++ b/src/query/script/Cargo.toml
@@ -9,7 +9,6 @@ edition = { workspace = true }
 [dependencies]
 databend-common-ast = { workspace = true }
 databend-common-exception = { workspace = true }
-derive-visitor = { workspace = true }
 fastrace = { workspace = true }
 
 [dev-dependencies]

--- a/src/query/script/src/compiler.rs
+++ b/src/query/script/src/compiler.rs
@@ -37,10 +37,11 @@ use databend_common_ast::ast::SetExpr;
 use databend_common_ast::ast::Statement;
 use databend_common_ast::ast::TableReference;
 use databend_common_ast::ast::UnaryOperator;
+use databend_common_ast::visit::VisitControl;
+use databend_common_ast::visit::VisitorMut;
+use databend_common_ast::visit::WalkMut;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
-use derive_visitor::DriveMut;
-use derive_visitor::VisitorMut;
 
 use crate::ir::ColumnAccess;
 use crate::ir::IterRef;
@@ -826,92 +827,72 @@ impl Compiler {
         self.compile_if(span, &conditions, results, else_result)
     }
 
+    fn rewrite_sql_hole_expr(&self, expr: &mut Expr) -> Result<()> {
+        if let Expr::Hole { span, name } = expr {
+            let index = self.lookup_var(&Identifier::from_name(*span, name.clone()))?;
+            *expr = Expr::Hole {
+                span: *span,
+                name: index.index.to_string(),
+            };
+        }
+        Ok(())
+    }
+
+    fn rewrite_sql_hole_ident(&self, ident: &mut Identifier) -> Result<()> {
+        if ident.is_hole() {
+            let index = self.lookup_var(ident)?;
+            *ident = Identifier::from_name(ident.span, index.index.to_string());
+            ident.ident_type = IdentifierType::Hole;
+        }
+        Ok(())
+    }
+
     fn compile_sql_statement(
         &self,
         span: Span,
         stmt: &Statement,
         to_set: SetRef,
     ) -> Result<Vec<ScriptIR>> {
-        #[derive(VisitorMut)]
-        #[visitor(Expr(enter), Identifier(enter), Statement(enter))]
         struct QuoteVisitor<'a> {
             compiler: &'a Compiler,
-            error: Option<ErrorCode>,
         }
 
-        impl QuoteVisitor<'_> {
-            fn enter_expr(&mut self, expr: &mut Expr) {
-                if let Expr::Hole { span, name } = expr {
-                    let index = self
-                        .compiler
-                        .lookup_var(&Identifier::from_name(*span, name.clone()));
-                    match index {
-                        Ok(index) => {
-                            *expr = Expr::Hole {
-                                span: *span,
-                                name: index.index.to_string(),
-                            };
-                        }
-                        Err(e) => {
-                            self.error = Some(e.set_span(*span));
-                        }
-                    }
-                }
+        impl VisitorMut for QuoteVisitor<'_> {
+            type Error = ErrorCode;
+
+            fn visit_expr(&mut self, expr: &mut Expr) -> Result<VisitControl> {
+                self.compiler.rewrite_sql_hole_expr(expr)?;
+                Ok(VisitControl::Continue)
             }
 
-            fn enter_identifier(&mut self, ident: &mut Identifier) {
-                if ident.is_hole() {
-                    let index = self.compiler.lookup_var(ident);
-                    match index {
-                        Ok(index) => {
-                            *ident = Identifier::from_name(ident.span, index.index.to_string());
-                            ident.ident_type = IdentifierType::Hole;
-                        }
-                        Err(e) => {
-                            self.error = Some(e.set_span(ident.span));
-                        }
-                    }
-                }
+            fn visit_identifier(&mut self, ident: &mut Identifier) -> Result<VisitControl> {
+                self.compiler.rewrite_sql_hole_ident(ident)?;
+                Ok(VisitControl::Continue)
             }
 
             // TODO(andylokandy: handle these statement)
-            fn enter_statement(&mut self, stmt: &mut Statement) {
+            fn visit_statement(&mut self, stmt: &mut Statement) -> Result<VisitControl> {
                 match stmt {
-                    Statement::Begin => {
-                        self.error = Some(ErrorCode::Unimplemented(
-                            "BEGIN in script is not supported yet".to_string(),
-                        ));
-                    }
-                    Statement::Commit => {
-                        self.error = Some(ErrorCode::Unimplemented(
-                            "COMMIT in script is not supported yet".to_string(),
-                        ));
-                    }
-                    Statement::Abort => {
-                        self.error = Some(ErrorCode::Unimplemented(
-                            "ABORT in script is not supported yet".to_string(),
-                        ));
-                    }
-                    Statement::Call { .. } => {
-                        self.error = Some(ErrorCode::Unimplemented(
-                            "CALL in script is not supported yet".to_string(),
-                        ));
-                    }
-                    _ => (),
+                    Statement::Begin => Err(ErrorCode::Unimplemented(
+                        "BEGIN in script is not supported yet".to_string(),
+                    )),
+                    Statement::Commit => Err(ErrorCode::Unimplemented(
+                        "COMMIT in script is not supported yet".to_string(),
+                    )),
+                    Statement::Abort => Err(ErrorCode::Unimplemented(
+                        "ABORT in script is not supported yet".to_string(),
+                    )),
+                    Statement::Call { .. } => Err(ErrorCode::Unimplemented(
+                        "CALL in script is not supported yet".to_string(),
+                    )),
+                    _ => Ok(VisitControl::Continue),
                 }
             }
         }
 
         let mut stmt = stmt.clone();
-        let mut visitor = QuoteVisitor {
-            compiler: self,
-            error: None,
-        };
-        stmt.drive_mut(&mut visitor);
-
-        if let Some(e) = visitor.error {
-            return Err(e);
-        }
+        let mut visitor = QuoteVisitor { compiler: self };
+        stmt.walk_mut(&mut visitor)?;
 
         // QUERY <stmt>, to_set
         let stmt = StatementTemplate::new(span, stmt);
@@ -1065,16 +1046,32 @@ impl Compiler {
     }
 
     fn quote_expr(&mut self, expr: &Expr) -> Result<(Vec<ScriptIR>, Expr)> {
-        #[derive(VisitorMut)]
-        #[visitor(Expr(enter), Identifier(enter))]
         struct QuoteVisitor<'a> {
             compiler: &'a mut Compiler,
             output: Vec<ScriptIR>,
-            error: Option<ErrorCode>,
+            query_depth: usize,
         }
 
-        impl QuoteVisitor<'_> {
-            fn enter_expr(&mut self, expr: &mut Expr) {
+        impl VisitorMut for QuoteVisitor<'_> {
+            type Error = ErrorCode;
+
+            fn visit_query(&mut self, _query: &mut Query) -> Result<VisitControl> {
+                self.query_depth += 1;
+                Ok(VisitControl::Continue)
+            }
+
+            fn leave_query(&mut self, _query: &mut Query) -> Result<()> {
+                self.query_depth -= 1;
+                Ok(())
+            }
+
+            fn visit_expr(&mut self, expr: &mut Expr) -> Result<VisitControl> {
+                if self.query_depth > 0 {
+                    // Nested SQL uses the same quoting rules as RESULTSET/RETURN TABLE:
+                    // bare names stay SQL names, `:var` is a script variable.
+                    self.compiler.rewrite_sql_hole_expr(expr)?;
+                    return Ok(VisitControl::Continue);
+                }
                 match expr {
                     // Transform `variable` to `:index`.
                     Expr::ColumnRef {
@@ -1086,18 +1083,11 @@ impl Compiler {
                                 column: ColumnID::Name(column),
                             },
                     } => {
-                        let index = self.compiler.lookup_var(column);
-                        match index {
-                            Ok(index) => {
-                                *expr = Expr::Hole {
-                                    span: *span,
-                                    name: index.index.to_string(),
-                                };
-                            }
-                            Err(e) => {
-                                self.error = Some(e.set_span(*span));
-                            }
-                        }
+                        let index = self.compiler.lookup_var(column)?;
+                        *expr = Expr::Hole {
+                            span: *span,
+                            name: index.index.to_string(),
+                        };
                     }
                     // Transform `iter.column` to `READ <iter>, <column>, to_var`, and replace the
                     // expression with `:to_var_index`.
@@ -1110,55 +1100,50 @@ impl Compiler {
                                 column: ColumnID::Name(column),
                             },
                     } => {
-                        let res = try {
-                            // READ <iter>, <column>, to_var
-                            let to_var = VarRef::new_internal(
-                                column.span,
-                                &format!("{iter}.{column}"),
-                                &mut self.compiler.ref_allocator,
-                            );
-                            let iter = self.compiler.lookup_iter(iter)?;
-                            let column =
-                                ColumnAccess::Name(self.compiler.normalize_ident(column).0);
-                            self.output.push(ScriptIR::Read {
-                                iter,
-                                column,
-                                to_var: to_var.clone(),
-                            });
+                        // READ <iter>, <column>, to_var
+                        let to_var = VarRef::new_internal(
+                            column.span,
+                            &format!("{iter}.{column}"),
+                            &mut self.compiler.ref_allocator,
+                        );
+                        let iter = self.compiler.lookup_iter(iter)?;
+                        let column = ColumnAccess::Name(self.compiler.normalize_ident(column).0);
+                        self.output.push(ScriptIR::Read {
+                            iter,
+                            column,
+                            to_var: to_var.clone(),
+                        });
 
-                            *expr = Expr::Hole {
-                                span: *span,
-                                name: to_var.index.to_string(),
-                            };
+                        *expr = Expr::Hole {
+                            span: *span,
+                            name: to_var.index.to_string(),
                         };
-
-                        if let Err(err) = res {
-                            self.error = Some(err);
-                        }
                     }
                     Expr::Hole { span, .. } => {
-                        self.error = Some(
-                            ErrorCode::ScriptSemanticError(
-                                "variable doesn't need to be quoted in this context, \
+                        return Err(ErrorCode::ScriptSemanticError(
+                            "variable doesn't need to be quoted in this context, \
                                     try removing the colon"
-                                    .to_string(),
-                            )
-                            .set_span(*span),
-                        );
+                                .to_string(),
+                        )
+                        .set_span(*span));
                     }
                     _ => {}
                 }
+                Ok(VisitControl::Continue)
             }
 
-            fn enter_identifier(&mut self, ident: &mut Identifier) {
-                if ident.is_hole() {
-                    self.error = Some(
-                        ErrorCode::ScriptSemanticError(
-                            "variable is not allowed in this context".to_string(),
-                        )
-                        .set_span(ident.span),
-                    );
+            fn visit_identifier(&mut self, ident: &mut Identifier) -> Result<VisitControl> {
+                if self.query_depth > 0 {
+                    self.compiler.rewrite_sql_hole_ident(ident)?;
+                    return Ok(VisitControl::Continue);
                 }
+                if ident.is_hole() {
+                    return Err(ErrorCode::ScriptSemanticError(
+                        "variable is not allowed in this context".to_string(),
+                    )
+                    .set_span(ident.span));
+                }
+                Ok(VisitControl::Continue)
             }
         }
 
@@ -1166,13 +1151,9 @@ impl Compiler {
         let mut visitor = QuoteVisitor {
             compiler: self,
             output: vec![],
-            error: None,
+            query_depth: 0,
         };
-        expr.drive_mut(&mut visitor);
-
-        if let Some(err) = visitor.error {
-            return Err(err);
-        }
+        expr.walk_mut(&mut visitor)?;
 
         Ok((visitor.output, expr))
     }

--- a/src/query/script/src/ir.rs
+++ b/src/query/script/src/ir.rs
@@ -21,10 +21,11 @@ use databend_common_ast::ast::Expr;
 use databend_common_ast::ast::Identifier;
 use databend_common_ast::ast::Literal;
 use databend_common_ast::ast::Statement;
+use databend_common_ast::visit::VisitControl;
+use databend_common_ast::visit::VisitorMut;
+use databend_common_ast::visit::WalkMut;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
-use derive_visitor::DriveMut;
-use derive_visitor::VisitorMut;
 
 pub type VarRef = Ref<0>;
 pub type SetRef = Ref<1>;
@@ -170,34 +171,32 @@ impl StatementTemplate {
     }
 
     pub fn subst(&self, lookup_var: impl Fn(VarRef) -> Result<Expr>) -> Result<Statement> {
-        #[derive(VisitorMut)]
-        #[visitor(Expr(enter), Identifier(enter))]
         struct SubstVisitor<'a> {
             lookup_var: &'a dyn Fn(VarRef) -> Result<Expr>,
-            error: Option<ErrorCode>,
         }
 
-        impl SubstVisitor<'_> {
-            fn enter_expr(&mut self, expr: &mut Expr) {
+        impl VisitorMut for SubstVisitor<'_> {
+            type Error = ErrorCode;
+
+            fn visit_expr(
+                &mut self,
+                expr: &mut Expr,
+            ) -> std::result::Result<VisitControl, ErrorCode> {
                 if let Expr::Hole { span, name } = expr {
                     let index = name.parse::<usize>().unwrap();
-                    let value = (self.lookup_var)(VarRef::placeholder(index));
-                    match value {
-                        Ok(value) => {
-                            *expr = value;
-                        }
-                        Err(e) => {
-                            self.error = Some(e.set_span(*span));
-                        }
-                    }
+                    *expr = (self.lookup_var)(VarRef::placeholder(index))
+                        .map_err(|e| e.set_span(*span))?;
                 }
+                Ok(VisitControl::Continue)
             }
 
-            fn enter_identifier(&mut self, ident: &mut Identifier) {
+            fn visit_identifier(
+                &mut self,
+                ident: &mut Identifier,
+            ) -> std::result::Result<VisitControl, ErrorCode> {
                 if ident.is_hole() {
                     let index = ident.name.parse::<usize>().unwrap();
-                    let value = (self.lookup_var)(VarRef::placeholder(index));
-                    match value {
+                    match (self.lookup_var)(VarRef::placeholder(index)) {
                         Ok(Expr::Literal {
                             value: Literal::String(name),
                             ..
@@ -205,31 +204,25 @@ impl StatementTemplate {
                             *ident = Identifier::from_name(ident.span, name);
                         }
                         Ok(value) => {
-                            self.error = Some(
-                                ErrorCode::ScriptSemanticError(format!(
-                                    "expected string literal, got {value}"
-                                ))
-                                .set_span(ident.span),
-                            );
+                            return Err(ErrorCode::ScriptSemanticError(format!(
+                                "expected string literal, got {value}"
+                            ))
+                            .set_span(ident.span));
                         }
                         Err(e) => {
-                            self.error = Some(e.set_span(ident.span));
+                            return Err(e.set_span(ident.span));
                         }
                     }
                 }
+                Ok(VisitControl::Continue)
             }
         }
 
         let mut stmt = self.stmt.clone();
         let mut visitor = SubstVisitor {
             lookup_var: &lookup_var,
-            error: None,
         };
-        stmt.drive_mut(&mut visitor);
-
-        if let Some(e) = visitor.error {
-            return Err(e);
-        }
+        stmt.walk_mut(&mut visitor)?;
 
         Ok(stmt)
     }

--- a/src/query/script/tests/it/main.rs
+++ b/src/query/script/tests/it/main.rs
@@ -323,6 +323,59 @@ fn test_script() {
             END CASE;
         "#,
     );
+    run_script(
+        file,
+        r#"
+            LET watermark_ts := (
+                SELECT COALESCE(
+                    (SELECT w.last_completed_time
+                     FROM task_run_sync_watermark AS w
+                     WHERE w.id = 1),
+                    7
+                )
+            );
+            RETURN watermark_ts;
+        "#,
+    );
+    run_script(
+        file,
+        r#"
+            LET fallback := 7;
+            LET watermark_ts := (
+                SELECT COALESCE(
+                    (SELECT w.last_completed_time
+                     FROM task_run_sync_watermark AS w
+                     WHERE w.id = 1),
+                    :fallback
+                )
+            );
+            RETURN watermark_ts;
+        "#,
+    );
+    run_script(
+        file,
+        r#"
+            LET x := (SELECT number FROM numbers(3) AS t WHERE t.number = 1);
+            RETURN x;
+        "#,
+    );
+    run_script(
+        file,
+        r#"
+            LET x RESULTSET := SELECT * FROM numbers(3);
+            FOR r IN x DO
+                LET y := (SELECT r.number FROM numbers(3) AS r WHERE r.number = 1);
+                RETURN y;
+            END FOR;
+        "#,
+    );
+    run_script(
+        file,
+        r#"
+            LET ok := EXISTS (SELECT * FROM numbers(1) AS t WHERE t.number = 0);
+            RETURN ok;
+        "#,
+    );
 }
 
 #[test]
@@ -383,6 +436,12 @@ fn test_script_error() {
         r#"
             LET x := 1;
             LET y := :x + 1;
+        "#,
+    );
+    run_script(
+        file,
+        r#"
+            LET x := (SELECT :missing);
         "#,
     );
     run_script(
@@ -487,6 +546,24 @@ fn mock_client() -> MockClient {
             "SELECT a FROM t1",
             MockSet::named(vec!["a"], vec![vec![Literal::UInt64(1)]]),
         )
+        .response_when(
+            "SELECT (SELECT COALESCE((SELECT w.last_completed_time FROM task_run_sync_watermark AS w WHERE w.id = 1), 7))",
+            MockSet::unnamed(vec![vec![Literal::UInt64(7)]]),
+        )
+        .response_when(
+            "SELECT (SELECT number FROM numbers(3) AS t WHERE t.number = 1)",
+            MockSet::unnamed(vec![vec![Literal::UInt64(1)]]),
+        )
+        .response_when(
+            "SELECT (SELECT r.number FROM numbers(3) AS r WHERE r.number = 1)",
+            MockSet::unnamed(vec![vec![Literal::UInt64(1)]]),
+        )
+        .response_when(
+            "SELECT EXISTS (SELECT * FROM numbers(1) AS t WHERE t.number = 0)",
+            MockSet::unnamed(vec![vec![Literal::Boolean(true)]]),
+        )
+        .response_when("SELECT TRUE", MockSet::unnamed(vec![vec![Literal::Boolean(true)]]))
+        .response_when("SELECT 7", MockSet::unnamed(vec![vec![Literal::UInt64(7)]]))
         .response_when(
             "SELECT * FROM generate_series(1, 1 + 2, 1)",
             MockSet::unnamed(vec![

--- a/src/query/script/tests/it/testdata/script-error.txt
+++ b/src/query/script/tests/it/testdata/script-error.txt
@@ -93,6 +93,16 @@ error:
 
 
 ---------- Input ----------
+LET x := (SELECT :missing);
+---------- Output ----------
+error: 
+  --> SQL:1:18
+  |
+1 | LET x := (SELECT :missing);
+  |                  ^^^^^^^^ `missing` is not defined
+
+
+---------- Input ----------
 LET x := 1;
 FOR r IN x DO
     BREAK;

--- a/src/query/script/tests/it/testdata/script.txt
+++ b/src/query/script/tests/it/testdata/script.txt
@@ -868,3 +868,135 @@ BLOCK: ($0): ('OTHER')
 Some(Var(String("OTHER")))
 
 
+---------- Input ----------
+LET watermark_ts := (
+    SELECT COALESCE(
+        (SELECT w.last_completed_time
+         FROM task_run_sync_watermark AS w
+         WHERE w.id = 1),
+        7
+    )
+);
+RETURN watermark_ts;
+---------- IR -------------
+QUERY SELECT (SELECT COALESCE((SELECT w.last_completed_time FROM task_run_sync_watermark AS w WHERE w.id = 1), 7)), __expr_result1(1)
+ITER __expr_result1(1), __expr_result_iter2(2)
+READ __expr_result_iter2(2), $0, watermark_ts(0)
+QUERY SELECT :0, __expr_result4(4)
+ITER __expr_result4(4), __expr_result_iter5(5)
+READ __expr_result_iter5(5), $0, __return_val3(3)
+RETURN __return_val3(3)
+---------- QUERY ---------
+QUERY: SELECT (SELECT COALESCE((SELECT w.last_completed_time FROM task_run_sync_watermark AS w WHERE w.id = 1), 7))
+BLOCK: ($0): (7)
+QUERY: SELECT 7
+BLOCK: ($0): (7)
+---------- Output ---------
+Some(Var(UInt64(7)))
+
+
+---------- Input ----------
+LET fallback := 7;
+LET watermark_ts := (
+    SELECT COALESCE(
+        (SELECT w.last_completed_time
+         FROM task_run_sync_watermark AS w
+         WHERE w.id = 1),
+        :fallback
+    )
+);
+RETURN watermark_ts;
+---------- IR -------------
+QUERY SELECT 7, __expr_result1(1)
+ITER __expr_result1(1), __expr_result_iter2(2)
+READ __expr_result_iter2(2), $0, fallback(0)
+QUERY SELECT (SELECT COALESCE((SELECT w.last_completed_time FROM task_run_sync_watermark AS w WHERE w.id = 1), :0)), __expr_result4(4)
+ITER __expr_result4(4), __expr_result_iter5(5)
+READ __expr_result_iter5(5), $0, watermark_ts(3)
+QUERY SELECT :3, __expr_result7(7)
+ITER __expr_result7(7), __expr_result_iter8(8)
+READ __expr_result_iter8(8), $0, __return_val6(6)
+RETURN __return_val6(6)
+---------- QUERY ---------
+QUERY: SELECT 7
+BLOCK: ($0): (7)
+QUERY: SELECT (SELECT COALESCE((SELECT w.last_completed_time FROM task_run_sync_watermark AS w WHERE w.id = 1), 7))
+BLOCK: ($0): (7)
+QUERY: SELECT 7
+BLOCK: ($0): (7)
+---------- Output ---------
+Some(Var(UInt64(7)))
+
+
+---------- Input ----------
+LET x := (SELECT number FROM numbers(3) AS t WHERE t.number = 1);
+RETURN x;
+---------- IR -------------
+QUERY SELECT (SELECT number FROM numbers(3) AS t WHERE t.number = 1), __expr_result1(1)
+ITER __expr_result1(1), __expr_result_iter2(2)
+READ __expr_result_iter2(2), $0, x(0)
+QUERY SELECT :0, __expr_result4(4)
+ITER __expr_result4(4), __expr_result_iter5(5)
+READ __expr_result_iter5(5), $0, __return_val3(3)
+RETURN __return_val3(3)
+---------- QUERY ---------
+QUERY: SELECT (SELECT number FROM numbers(3) AS t WHERE t.number = 1)
+BLOCK: ($0): (1)
+QUERY: SELECT 1
+BLOCK: ($0): (1)
+---------- Output ---------
+Some(Var(UInt64(1)))
+
+
+---------- Input ----------
+LET x RESULTSET := SELECT * FROM numbers(3);
+FOR r IN x DO
+    LET y := (SELECT r.number FROM numbers(3) AS r WHERE r.number = 1);
+    RETURN y;
+END FOR;
+---------- IR -------------
+QUERY SELECT * FROM numbers(3), x(0)
+ITER x(0), r(3)
+__LOOP1(1):
+JUMP_IF_ENDED r(3), __LOOP_END2(2)
+QUERY SELECT (SELECT r.number FROM numbers(3) AS r WHERE r.number = 1), __expr_result5(5)
+ITER __expr_result5(5), __expr_result_iter6(6)
+READ __expr_result_iter6(6), $0, y(4)
+QUERY SELECT :4, __expr_result8(8)
+ITER __expr_result8(8), __expr_result_iter9(9)
+READ __expr_result_iter9(9), $0, __return_val7(7)
+RETURN __return_val7(7)
+NEXT r(3)
+GOTO __LOOP1(1)
+__LOOP_END2(2):
+---------- QUERY ---------
+QUERY: SELECT * FROM numbers(3)
+BLOCK: (number): (0), (1), (2)
+QUERY: SELECT (SELECT r.number FROM numbers(3) AS r WHERE r.number = 1)
+BLOCK: ($0): (1)
+QUERY: SELECT 1
+BLOCK: ($0): (1)
+---------- Output ---------
+Some(Var(UInt64(1)))
+
+
+---------- Input ----------
+LET ok := EXISTS (SELECT * FROM numbers(1) AS t WHERE t.number = 0);
+RETURN ok;
+---------- IR -------------
+QUERY SELECT EXISTS (SELECT * FROM numbers(1) AS t WHERE t.number = 0), __expr_result1(1)
+ITER __expr_result1(1), __expr_result_iter2(2)
+READ __expr_result_iter2(2), $0, ok(0)
+QUERY SELECT :0, __expr_result4(4)
+ITER __expr_result4(4), __expr_result_iter5(5)
+READ __expr_result_iter5(5), $0, __return_val3(3)
+RETURN __return_val3(3)
+---------- QUERY ---------
+QUERY: SELECT EXISTS (SELECT * FROM numbers(1) AS t WHERE t.number = 0)
+BLOCK: ($0): (TRUE)
+QUERY: SELECT TRUE
+BLOCK: ($0): (TRUE)
+---------- Output ---------
+Some(Var(Boolean(true)))
+
+

--- a/tests/sqllogictests/suites/base/15_procedure/15_0001_execute_immediate.test
+++ b/tests/sqllogictests/suites/base/15_procedure/15_0001_execute_immediate.test
@@ -226,6 +226,77 @@ $$;
 ----
 390
 
+query I
+EXECUTE IMMEDIATE $$
+BEGIN
+    LET watermark_ts := (
+        SELECT COALESCE(
+            (SELECT w.number
+             FROM numbers(3) AS w
+             WHERE w.number = 1),
+            7
+        )
+    );
+    RETURN watermark_ts;
+END;
+$$;
+----
+1
+
+query I
+EXECUTE IMMEDIATE $$
+BEGIN
+    LET fallback := 7;
+    LET watermark_ts := (
+        SELECT COALESCE(
+            (SELECT w.number
+             FROM numbers(3) AS w
+             WHERE w.number = 1),
+            :fallback
+        )
+    );
+    RETURN watermark_ts;
+END;
+$$;
+----
+1
+
+query I
+EXECUTE IMMEDIATE $$
+BEGIN
+    LET x := (SELECT t.number FROM numbers(3) AS t WHERE t.number = 1);
+    RETURN x;
+END;
+$$;
+----
+1
+
+query I
+EXECUTE IMMEDIATE $$
+BEGIN
+    LET rs RESULTSET := SELECT * FROM numbers(3);
+    FOR r IN rs DO
+        LET y := (SELECT r.number FROM numbers(3) AS r WHERE r.number = 1);
+        RETURN y;
+    END FOR;
+END;
+$$;
+----
+1
+
+query error `fallback` is not defined
+EXECUTE IMMEDIATE $$
+BEGIN
+    LET missing := (
+        SELECT COALESCE(
+            (SELECT w.number FROM numbers(3) AS w WHERE w.number = 1),
+            :fallback
+        )
+    );
+    RETURN missing;
+END;
+$$;
+
 statement ok
 unset variable exec_script;
 

--- a/tests/sqllogictests/suites/base/15_procedure/15_0002_procedure.test
+++ b/tests/sqllogictests/suites/base/15_procedure/15_0002_procedure.test
@@ -587,3 +587,26 @@ body BEGIN RETURN a; END;
 
 statement ok
 DROP PROCEDURE test_desc_type_case(STRING, Int32);
+
+statement ok
+CREATE OR REPLACE PROCEDURE hdr() RETURNS INT NOT NULL LANGUAGE SQL AS $$
+BEGIN
+    LET watermark_ts := (
+        SELECT COALESCE(
+            (SELECT w.number
+             FROM numbers(3) AS w
+             WHERE w.number = 1),
+            7
+        )
+    );
+    RETURN watermark_ts;
+END;
+$$;
+
+query I
+call PROCEDURE hdr();
+----
+1
+
+statement ok
+DROP PROCEDURE hdr();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

 Calling a procedure like:

```sql
LET watermark_ts TIMESTAMP := (
    SELECT COALESCE(
        (SELECT w.last_completed_time
         FROM t AS w
         WHERE w.id = 1),
        DATE_SUB(DAY, 7, NOW())
    )
);
```

failed at compile time with `w` is not defined.

`LET x := (SELECT ...)` is a script expression, so the compiler quoted it with script-variable rules. Nested Query trees were walked as if w.id were a row variable, instead of a SQL column/alias. SELECT :x already existed for SQL statements (RESULTSET, RETURN TABLE, standalone SQL); expression-nested SQL did not use that path.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent assisted with implementation.
- Responsible human: @forsaken628
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20338)
<!-- Reviewable:end -->
