### PR TITLE
fix(storage): disable automatic HTTP decompression

### DIFF
--- a/src/common/base/Cargo.toml
+++ b/src/common/base/Cargo.toml
@@ -66,6 +66,7 @@ procfs = { workspace = true }
 anyerror = { workspace = true }
 anyhow = { workspace = true }
 quickcheck = { workspace = true }
+reqwest = { workspace = true, features = ["gzip"] }
 serde_test = { workspace = true }
 
 [lints]

--- a/src/common/base/src/http_client.rs
+++ b/src/common/base/src/http_client.rs
@@ -56,13 +56,26 @@ static GLOBAL_HICKORY_RESOLVER: LazyLock<Arc<HickoryResolver>> = LazyLock::new(|
 /// Please create your own http client if you want dedicated http connection pool.
 pub static GLOBAL_HTTP_CLIENT: OnceLock<HttpClient> = OnceLock::new();
 
+/// Create an HTTP client builder that preserves storage response bytes.
+///
+/// Cargo features are unified across the dependency graph, so another crate can
+/// enable reqwest's content decoders for this client. OpenDAL must receive the
+/// encoded object bytes to keep range lengths and checksums valid.
+pub fn storage_http_client_builder() -> reqwest::ClientBuilder {
+    reqwest::ClientBuilder::new()
+        .no_gzip()
+        .no_brotli()
+        .no_zstd()
+        .no_deflate()
+}
+
 pub fn get_global_http_client(
     pool_max_idle_per_host: usize,
     connect_timeout: u64,
     keepalive: u64,
 ) -> &'static HttpClient {
     GLOBAL_HTTP_CLIENT.get_or_init(move || {
-        let mut builder = reqwest::ClientBuilder::new();
+        let mut builder = storage_http_client_builder();
 
         // Disable http2 for better performance.
         builder = builder.http1_only();
@@ -161,5 +174,61 @@ impl HttpClient {
     /// Get the inner reqwest client.
     pub fn inner(&self) -> reqwest::Client {
         self.client.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::header::CONTENT_ENCODING;
+    use reqwest::header::CONTENT_LENGTH;
+    use tokio::io::AsyncReadExt;
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::TcpListener;
+
+    use super::storage_http_client_builder;
+
+    const GZIP_BODY: &[u8] = &[
+        0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x2b, 0x4a, 0x2c, 0x57, 0x28,
+        0x2e, 0xc9, 0x2f, 0x4a, 0x4c, 0x4f, 0x55, 0xc8, 0x4f, 0xca, 0x4a, 0x4d, 0x2e, 0x51, 0x48,
+        0xaa, 0x2c, 0x49, 0x2d, 0xe6, 0x02, 0x00, 0xae, 0xc5, 0xf2, 0x24, 0x19, 0x00, 0x00, 0x00,
+    ];
+
+    #[tokio::test]
+    async fn test_storage_http_client_preserves_encoded_response() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = crate::runtime::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0; 1024];
+            let bytes_read = stream.read(&mut request).await.unwrap();
+            assert!(bytes_read > 0);
+
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                GZIP_BODY.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+            stream.write_all(GZIP_BODY).await.unwrap();
+        });
+
+        let response = storage_http_client_builder()
+            .build()
+            .unwrap()
+            .get("http://".to_string() + &address.to_string() + "/object.json.gz")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.headers()[CONTENT_ENCODING], "gzip");
+        assert_eq!(
+            response.headers()[CONTENT_LENGTH]
+                .to_str()
+                .unwrap()
+                .parse::<usize>()
+                .unwrap(),
+            GZIP_BODY.len()
+        );
+        assert_eq!(response.bytes().await.unwrap().as_ref(), GZIP_BODY);
+        server.await.unwrap();
     }
 }

--- a/src/common/base/src/http_client.rs
+++ b/src/common/base/src/http_client.rs
@@ -179,42 +179,78 @@ impl HttpClient {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use reqwest::header::CONTENT_ENCODING;
     use reqwest::header::CONTENT_LENGTH;
     use tokio::io::AsyncReadExt;
     use tokio::io::AsyncWriteExt;
     use tokio::net::TcpListener;
+    use tokio::time::timeout;
 
     use super::storage_http_client_builder;
 
+    // gzip of "raw storage object bytes\n"
     const GZIP_BODY: &[u8] = &[
         0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x2b, 0x4a, 0x2c, 0x57, 0x28,
         0x2e, 0xc9, 0x2f, 0x4a, 0x4c, 0x4f, 0x55, 0xc8, 0x4f, 0xca, 0x4a, 0x4d, 0x2e, 0x51, 0x48,
         0xaa, 0x2c, 0x49, 0x2d, 0xe6, 0x02, 0x00, 0xae, 0xc5, 0xf2, 0x24, 0x19, 0x00, 0x00, 0x00,
     ];
+    const RAW_BODY: &[u8] = b"raw storage object bytes\n";
 
-    #[tokio::test]
-    async fn test_storage_http_client_preserves_encoded_response() {
+    async fn serve_gzip_object() -> (std::net::SocketAddr, crate::runtime::JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let server = crate::runtime::spawn(async move {
-            let (mut stream, _) = listener.accept().await.unwrap();
-            let mut request = [0; 1024];
-            let bytes_read = stream.read(&mut request).await.unwrap();
-            assert!(bytes_read > 0);
+            timeout(Duration::from_secs(5), async {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let mut request = Vec::new();
+                let mut buf = [0; 1024];
+                loop {
+                    let n = stream.read(&mut buf).await.unwrap();
+                    assert!(n > 0);
+                    request.extend_from_slice(&buf[..n]);
+                    if request.windows(4).any(|w| w == b"\r\n\r\n") {
+                        break;
+                    }
+                }
 
-            let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-                GZIP_BODY.len()
-            );
-            stream.write_all(response.as_bytes()).await.unwrap();
-            stream.write_all(GZIP_BODY).await.unwrap();
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    GZIP_BODY.len()
+                );
+                stream.write_all(response.as_bytes()).await.unwrap();
+                stream.write_all(GZIP_BODY).await.unwrap();
+                stream.flush().await.unwrap();
+                let _ = stream.shutdown().await;
+            })
+            .await
+            .expect("gzip fixture server timed out");
         });
+        (address, server)
+    }
 
+    #[tokio::test]
+    async fn test_storage_http_client_preserves_encoded_response() {
+        let (address, server) = serve_gzip_object().await;
+        let url = format!("http://{address}/object.json.gz");
+
+        let decoded = reqwest::ClientBuilder::new()
+            .build()
+            .unwrap()
+            .get(&url)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(decoded.bytes().await.unwrap().as_ref(), RAW_BODY);
+        server.await.unwrap();
+
+        let (address, server) = serve_gzip_object().await;
+        let url = format!("http://{address}/object.json.gz");
         let response = storage_http_client_builder()
             .build()
             .unwrap()
-            .get("http://".to_string() + &address.to_string() + "/object.json.gz")
+            .get(&url)
             .send()
             .await
             .unwrap();

--- a/src/common/base/src/http_client.rs
+++ b/src/common/base/src/http_client.rs
@@ -51,9 +51,9 @@ static GLOBAL_HICKORY_RESOLVER: LazyLock<Arc<HickoryResolver>> = LazyLock::new(|
     )
 });
 
-/// Global shared http client.
+/// Global shared HTTP client for OpenDAL storage transports.
 ///
-/// Please create your own http client if you want dedicated http connection pool.
+/// Please create your own HTTP client if you want a dedicated connection pool.
 pub static GLOBAL_HTTP_CLIENT: OnceLock<HttpClient> = OnceLock::new();
 
 /// Create an HTTP client builder that preserves storage response bytes.
@@ -127,12 +127,12 @@ impl Default for HttpClient {
 }
 
 impl HttpClient {
-    /// Create a new http client.
+    /// Create a general-purpose HTTP client.
     ///
-    /// # Notes
-    ///
-    /// This client is optimized for interact with storage services.
-    /// Please tune the settings if you want to use it for other purposes.
+    /// This client may transparently decode responses when reqwest content-decoder
+    /// features are enabled. Do not use it as an OpenDAL object-storage transport;
+    /// use [`storage_http_client_builder`] when the encoded response bytes must be
+    /// preserved.
     pub fn new() -> Self {
         let mut builder = reqwest::ClientBuilder::new();
 

--- a/src/common/base/src/http_client.rs
+++ b/src/common/base/src/http_client.rs
@@ -230,8 +230,14 @@ mod tests {
         (address, server)
     }
 
+    /// Negative control for [`test_storage_http_client_preserves_encoded_response`].
+    ///
+    /// A default reqwest client must decode the gzip body. If this test starts
+    /// failing because the body comes back encoded, `reqwest/gzip` is no longer
+    /// active in this crate's test graph (it comes in via the `reqwest`
+    /// dev-dependency), and the test below proves nothing.
     #[tokio::test]
-    async fn test_storage_http_client_preserves_encoded_response() {
+    async fn test_default_http_client_decodes_encoded_response() {
         let (address, server) = serve_gzip_object().await;
         let url = format!("http://{address}/object.json.gz");
 
@@ -244,7 +250,10 @@ mod tests {
             .unwrap();
         assert_eq!(decoded.bytes().await.unwrap().as_ref(), RAW_BODY);
         server.await.unwrap();
+    }
 
+    #[tokio::test]
+    async fn test_storage_http_client_preserves_encoded_response() {
         let (address, server) = serve_gzip_object().await;
         let url = format!("http://{address}/object.json.gz");
         let response = storage_http_client_builder()

--- a/src/common/storage/Cargo.toml
+++ b/src/common/storage/Cargo.toml
@@ -44,6 +44,7 @@ tokio = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
+reqwest = { workspace = true, features = ["gzip"] }
 
 [lints]
 workspace = true

--- a/src/common/storage/src/http_client.rs
+++ b/src/common/storage/src/http_client.rs
@@ -364,6 +364,50 @@ mod tests {
         }
     }
 
+    // gzip of "raw storage object bytes\n"
+    const GZIP_BODY: &[u8] = &[
+        0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x2b, 0x4a, 0x2c, 0x57, 0x28,
+        0x2e, 0xc9, 0x2f, 0x4a, 0x4c, 0x4f, 0x55, 0xc8, 0x4f, 0xca, 0x4a, 0x4d, 0x2e, 0x51, 0x48,
+        0xaa, 0x2c, 0x49, 0x2d, 0xe6, 0x02, 0x00, 0xae, 0xc5, 0xf2, 0x24, 0x19, 0x00, 0x00, 0x00,
+    ];
+
+    async fn serve_gzip_object() -> (SocketAddr, databend_common_base::runtime::JoinHandle<()>) {
+        use tokio::io::AsyncReadExt;
+        use tokio::io::AsyncWriteExt;
+        use tokio::net::TcpListener;
+        use tokio::time::timeout;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = databend_common_base::runtime::spawn(async move {
+            timeout(Duration::from_secs(5), async {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let mut request = Vec::new();
+                let mut buf = [0; 1024];
+                loop {
+                    let n = stream.read(&mut buf).await.unwrap();
+                    assert!(n > 0);
+                    request.extend_from_slice(&buf[..n]);
+                    if request.windows(4).any(|w| w == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    GZIP_BODY.len()
+                );
+                stream.write_all(response.as_bytes()).await.unwrap();
+                stream.write_all(GZIP_BODY).await.unwrap();
+                stream.flush().await.unwrap();
+                let _ = stream.shutdown().await;
+            })
+            .await
+            .expect("gzip fixture server timed out");
+        });
+        (address, server)
+    }
+
     fn populate_checked_endpoint_cache(
         client: &StorageHttpClient,
         url: &Url,
@@ -496,5 +540,64 @@ mod tests {
         let client = make_client(EndpointPolicyScope::Trusted);
         assert_eq!(client.endpoint_policy_scope, EndpointPolicyScope::Trusted);
         assert_eq!(checked_endpoint_cache_len(&client), 0);
+    }
+
+    #[tokio::test]
+    async fn test_storage_http_client_fetch_preserves_encoded_response() {
+        use http::Request;
+        use opendal::Buffer;
+        use opendal::raw::HttpFetch;
+        use reqwest::header::CONTENT_ENCODING;
+
+        let (address, server) = serve_gzip_object().await;
+        let url = format!("http://{address}/object.json.gz");
+        let req = Request::builder()
+            .method("GET")
+            .uri(&url)
+            .body(Buffer::new())
+            .unwrap();
+
+        let client = make_client(EndpointPolicyScope::Trusted);
+        let mut resp = client.fetch(req).await.unwrap();
+        assert_eq!(resp.headers()[CONTENT_ENCODING], "gzip");
+        assert_eq!(
+            resp.body_mut().to_buffer().await.unwrap().to_vec(),
+            GZIP_BODY
+        );
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_storage_http_client_pinned_fetch_preserves_encoded_response() {
+        use http::Request;
+        use opendal::Buffer;
+        use opendal::raw::HttpFetch;
+        use reqwest::header::CONTENT_ENCODING;
+
+        let (address, server) = serve_gzip_object().await;
+        let url = Url::parse(&format!("http://{address}/object.json.gz")).unwrap();
+        let req = Request::builder()
+            .method("GET")
+            .uri(url.as_str())
+            .body(Buffer::new())
+            .unwrap();
+
+        let client = make_client(EndpointPolicyScope::External);
+        populate_checked_endpoint_cache(
+            &client,
+            &url,
+            EndpointUrlCheck {
+                resolved_addrs: Some(vec![address]),
+            },
+            Duration::ZERO,
+        );
+
+        let mut resp = client.fetch(req).await.unwrap();
+        assert_eq!(resp.headers()[CONTENT_ENCODING], "gzip");
+        assert_eq!(
+            resp.body_mut().to_buffer().await.unwrap().to_vec(),
+            GZIP_BODY
+        );
+        server.await.unwrap();
     }
 }

--- a/src/common/storage/src/http_client.rs
+++ b/src/common/storage/src/http_client.rs
@@ -25,6 +25,7 @@ use std::time::Instant;
 use databend_common_base::http_client::GLOBAL_HICKORY_POSITIVE_MIN_TTL;
 use databend_common_base::http_client::get_global_hickory_resolver;
 use databend_common_base::http_client::get_global_http_client;
+use databend_common_base::http_client::storage_http_client_builder;
 use databend_common_metrics::storage::metrics_inc_storage_http_requests_count;
 use futures::TryStreamExt;
 use http::Request;
@@ -138,7 +139,7 @@ impl StorageHttpClient {
                 // window) and IP-literal endpoints (closing a 30x
                 // bounce-to-internal bypass), since check_url_with_dns now
                 // populates resolved_addrs for IP literals as well.
-                let mut builder = reqwest::ClientBuilder::new()
+                let mut builder = storage_http_client_builder()
                     .http1_only()
                     .use_native_tls()
                     .dns_resolver(get_global_hickory_resolver())

--- a/src/common/storage/src/http_client.rs
+++ b/src/common/storage/src/http_client.rs
@@ -370,6 +370,7 @@ mod tests {
         0x2e, 0xc9, 0x2f, 0x4a, 0x4c, 0x4f, 0x55, 0xc8, 0x4f, 0xca, 0x4a, 0x4d, 0x2e, 0x51, 0x48,
         0xaa, 0x2c, 0x49, 0x2d, 0xe6, 0x02, 0x00, 0xae, 0xc5, 0xf2, 0x24, 0x19, 0x00, 0x00, 0x00,
     ];
+    const RAW_BODY: &[u8] = b"raw storage object bytes\n";
 
     async fn serve_gzip_object() -> (SocketAddr, databend_common_base::runtime::JoinHandle<()>) {
         use tokio::io::AsyncReadExt;
@@ -540,6 +541,28 @@ mod tests {
         let client = make_client(EndpointPolicyScope::Trusted);
         assert_eq!(client.endpoint_policy_scope, EndpointPolicyScope::Trusted);
         assert_eq!(checked_endpoint_cache_len(&client), 0);
+    }
+
+    /// Negative control for the two `fetch` tests below.
+    ///
+    /// A default reqwest client must decode the gzip body. If this test starts
+    /// failing because the body comes back encoded, `reqwest/gzip` is no longer
+    /// active in this crate's test graph (it comes in via the `reqwest`
+    /// dev-dependency), and the `fetch` tests below prove nothing.
+    #[tokio::test]
+    async fn test_default_http_client_decodes_encoded_response() {
+        let (address, server) = serve_gzip_object().await;
+        let url = format!("http://{address}/object.json.gz");
+
+        let decoded = reqwest::ClientBuilder::new()
+            .build()
+            .unwrap()
+            .get(&url)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(decoded.bytes().await.unwrap().as_ref(), RAW_BODY);
+        server.await.unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR fixes `COPY INTO` failures when reading externally gzip-encoded objects through OpenDAL after Lance support enabled reqwest's `gzip` feature in the shared dependency graph.

The affected objects are unusual: they were uploaded with `Content-Encoding: gzip` manually set in S3 object metadata. S3 does not normally infer this header from a `.gz` filename, so ordinary `.json.gz` objects without that metadata are unaffected.

Typical failure:

```text
StorageOther. Code: 4000, Text = Unexpected (persistent) => reader got too much data
Context:
  expect: 430
  actual: 8089
```

The fix makes the reqwest clients used by Databend's main OpenDAL storage path (`init_operator` / `StorageHttpClient`, including the shared global client and External-scope pinned clients) explicitly preserve encoded storage bytes by disabling automatic gzip, brotli, zstd, and deflate response decoding.

Two pre-existing operator construction paths still fall back to OpenDAL's default reqwest client and are not changed here: `IcebergFileIO::build_operator` (`Operator::via_iter` with no `HttpClientLayer`) and `bendsave`'s `Operator::from_iter`. Hitting those paths still requires object metadata with `Content-Encoding: gzip`, which is uncommon for parquet/orc. Follow-up if Iceberg table files or bendsave objects start carrying that header.

## Root cause

### What changed

The issue was introduced indirectly by `4f33092048` (`feat: support copy into lance dataset`). That change added Lance dependencies. Their generated REST namespace client, `lance-namespace-reqwest-client`, declares reqwest like this:

```toml
[dependencies.reqwest]
version = "^0.12"
features = [
    "json",
    "multipart",
    "charset",
    "gzip",
    "http2",
    "stream",
    "rustls-tls-native-roots",
]
default-features = false
```

Before that dependency was added, the resolved reqwest package did not include `async-compression`; afterward, `reqwest/gzip` was enabled for the process.

### Upstream behavior that exposes the bug

There are two upstream behaviors involved:

1. `lance-namespace-reqwest-client` unconditionally enables `reqwest/gzip` for its REST client instead of making response decompression independently configurable.
2. Cargo unifies features for the same package/version across normal dependencies. Therefore `reqwest/gzip` is not confined to Lance: the single resolved reqwest 0.12 package used by Databend is compiled with gzip support everywhere.

This is not a reqwest protocol bug. reqwest documents that when its `gzip` feature is compiled in, automatic gzip decoding is enabled by default for every newly constructed `ClientBuilder`. On a response with `Content-Encoding: gzip`, reqwest removes `Content-Encoding` and `Content-Length` and exposes decoded response bytes.

That behavior is appropriate for REST APIs such as Lance, but not for an object-storage transport. OpenDAL must receive the exact encoded object bytes returned by S3-compatible storage because object sizes, range boundaries, checksums, and retry offsets refer to the stored representation.

### How the failure happens

The failure requires all of the following:

1. The binary is compiled with `reqwest/gzip`; in the affected release this is enabled transitively by Lance.
2. The S3 object was uploaded with `Content-Encoding: gzip` explicitly set in its object metadata, so the storage service returns that HTTP response header. This is an uncommon, manually supplied metadata setting; it is not the normal consequence of storing a file whose name ends in `.gz`. A `.gz` suffix by itself does not trigger the issue.
3. Databend reads the object through the custom reqwest-backed OpenDAL HTTP transport.
4. OpenDAL performs a bounded/ranged read and expects the number of encoded bytes requested from storage.

For example, OpenDAL requests/expects 430 stored bytes. reqwest sees `Content-Encoding: gzip` and transparently expands them to 8,089 bytes. OpenDAL's `CompleteReader` compares its requested range size with the delivered byte count and correctly reports:

```text
reader got too much data
expect: 430
actual: 8089
```

Production diagnostics showed the same invariant repeatedly: expected values matched small compressed representations, while actual values were much larger decoded payloads. The working release and failing release used the same reqwest version; the relevant difference was whether `reqwest/gzip` was present in the resolved feature set.

## Why not disable `gzip` only for Lance?

Cargo features are additive and unified per package/version. Databend cannot express "enable `reqwest/gzip` for Lance's reqwest client, but disable it for OpenDAL's reqwest client" when both use the same reqwest 0.12 package in the normal dependency graph.

In particular:

- Setting `default-features = false` on Databend's direct reqwest dependency does not cancel a feature selected by another dependency.
- Setting `default-features = false` on a direct Lance dependency does not remove a normal feature explicitly requested inside the transitive `lance-namespace-reqwest-client` manifest.
- Cargo resolver v2 does not isolate features between two normal runtime users of the same package/version; it mainly avoids unification across selected target, build/proc-macro, and inactive dev-dependency boundaries.
- Removing `gzip` would require patching/forking the generated upstream Lance client, and could remove behavior that its REST API expects. It would also be fragile: any future dependency could enable a reqwest decoder again.

reqwest provides `no_gzip()`, `no_brotli()`, `no_zstd()`, and `no_deflate()` specifically for this situation: these methods force behavior per client even if another dependency enables the corresponding compile-time feature.

Therefore the robust boundary is the Databend storage-client constructor. Lance and other REST clients can retain automatic HTTP decoding, while OpenDAL always receives byte-for-byte storage responses.

## Implementation

- Add `storage_http_client_builder()` that explicitly disables every reqwest automatic content decoder.
- Use it for the shared OpenDAL storage client.
- Use it for endpoint-pinned storage clients created for external endpoint policy enforcement.
- Add a regression test that compiles the test target with `reqwest/gzip`, serves a gzip-encoded response locally, and verifies that both encoding headers and raw compressed bytes are preserved.
- Add a negative control in the same test: a default `reqwest::ClientBuilder` must decode the same response, so the gzip feature is actually active.
- Cover `StorageHttpClient::fetch` for both Trusted (global client) and External (pinned client) paths.

The test-only `features = ["gzip"]` is intentional: without it, the test could pass vacuously when built in a reduced package graph where no other crate enables the decoder. It reproduces the feature-unification condition that caused the release regression. The negative control fails if that feature is later dropped.

## Compatibility and risk

The change is scoped to `StorageHttpClient` / `init_operator`. It does not disable decompression globally for unrelated reqwest REST clients, and it does not yet wrap IcebergFileIO or bendsave operator construction. Storage format decompression still happens in Databend's format readers after OpenDAL has returned the exact object bytes.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validated with:

```text
cargo fmt --all -- --check
cargo test -p databend-common-base --lib
cargo test -p databend-common-storage --lib
cargo clippy -p databend-common-base -p databend-common-storage --all-targets -- -D warnings
```

Results: 90 base tests and 59 storage tests passed; Clippy and formatting passed.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature which could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent assisted with root-cause analysis across release dependencies, drafted the storage HTTP fix and regression test, and helped prepare this PR description; I reviewed the resulting change and validation evidence.
- Responsible human: @youngsofun
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20339)
<!-- Reviewable:end -->

