### PR TITLE
ci: retry Maven Central 429s in Java/Paimon/Iceberg tests

### DIFF
--- a/.github/actions/test_compat_client_cluster/action.yml
+++ b/.github/actions/test_compat_client_cluster/action.yml
@@ -22,11 +22,25 @@ runs:
         distribution: temurin
         java-version: "17"
 
+    # setup-maven downloads from repo.maven.apache.org and fails CI with HTTP 429.
+    # Apache dist is a separate host and curl retries 429/5xx.
     - name: Set up Maven
       if: ${{ inputs.nox_session == 'java_client' }}
-      uses: stCarolas/setup-maven@v5
-      with:
-        maven-version: 3.9.9
+      shell: bash
+      run: |
+        set -euo pipefail
+        version=3.9.9
+        sha512=a555254d6b53d267965a3404ecb14e53c3827c09c3b94b5678835887ab404556bfaf78dcfe03ba76fa2508649dca8531c74bca4d5846513522404d48e8c4ac8b
+        dest="${RUNNER_TEMP}/apache-maven-${version}"
+        tarball="${RUNNER_TEMP}/apache-maven-${version}-bin.tar.gz"
+        url="https://archive.apache.org/dist/maven/maven-3/${version}/binaries/apache-maven-${version}-bin.tar.gz"
+        curl --connect-timeout 10 --retry 8 --retry-all-errors --retry-delay 5 -fsSL "$url" -o "$tarball"
+        echo "${sha512}  ${tarball}" | sha512sum -c -
+        mkdir -p "$dest"
+        tar -xzf "$tarball" -C "$dest" --strip-components=1
+        echo "$dest/bin" >> "$GITHUB_PATH"
+        echo "MAVEN_HOME=$dest" >> "$GITHUB_ENV"
+        echo "MAVEN_OPTS=-Daether.connector.http.retryHandler.count=8 -Daether.connector.http.retryHandler.interval=2000 ${MAVEN_OPTS:-}" >> "$GITHUB_ENV"
 
     - name: Setup Go
       if: ${{ inputs.nox_session == 'go_client' }}

--- a/tests/nox/noxfile.py
+++ b/tests/nox/noxfile.py
@@ -4,6 +4,8 @@ import platform
 import shutil
 import tarfile
 import tempfile
+import time
+import urllib.error
 import urllib.request
 import xml.etree.ElementTree as ET
 import zipfile
@@ -54,6 +56,8 @@ JDBC_MAIN_TEST_ARGS = [
     "test",
     "-Dgroups=IT",
     "-DexcludedGroups=FLAKY",
+    "-Daether.connector.http.retryHandler.count=8",
+    "-Daether.connector.http.retryHandler.interval=2000",
 ]
 JDBC_TEST_LIBS = [
     "https://repo.maven.apache.org/maven2/org/testng/testng/7.11.0/testng-7.11.0.jar",
@@ -131,18 +135,44 @@ def prepare_source_archive(
     return source_dir
 
 
-def download_file(url, target):
+def download_file(url, target, attempts=8):
     if target.exists():
         return target
 
     target.parent.mkdir(parents=True, exist_ok=True)
-    with urllib.request.urlopen(get_request(url)) as response:
-        with tempfile.NamedTemporaryFile(dir=target.parent, delete=False) as temp_file:
-            shutil.copyfileobj(response, temp_file)
-            temp_path = Path(temp_file.name)
-
-    temp_path.replace(target)
-    return target
+    last_error = None
+    for attempt in range(1, attempts + 1):
+        temp_path = None
+        retryable = False
+        try:
+            with urllib.request.urlopen(get_request(url)) as response:
+                with tempfile.NamedTemporaryFile(
+                    dir=target.parent, delete=False
+                ) as temp_file:
+                    temp_path = Path(temp_file.name)
+                    shutil.copyfileobj(response, temp_file)
+            temp_path.replace(target)
+            return target
+        except urllib.error.HTTPError as exc:
+            last_error = exc
+            retryable = exc.code in {408, 425, 429, 500, 502, 503, 504}
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            last_error = exc
+            retryable = True
+        finally:
+            if temp_path is not None and temp_path.exists() and temp_path != target:
+                temp_path.unlink()
+        if not retryable or attempt == attempts:
+            break
+        delay = min(60, 2 ** (attempt - 1))
+        print(
+            f"download {url} failed on attempt {attempt}/{attempts}: {last_error}; "
+            f"retrying in {delay}s"
+        )
+        time.sleep(delay)
+    raise RuntimeError(
+        f"failed to download {url} after {attempts} attempts"
+    ) from last_error
 
 
 def merge_env(*env_sets):
@@ -157,7 +187,9 @@ def resolve_python_driver_version(driver_version):
     if driver_version != "latest":
         return driver_version
 
-    return resolve_latest_release_tag(PYTHON_CLIENT_LATEST_RELEASE_URL).removeprefix("v")
+    return resolve_latest_release_tag(PYTHON_CLIENT_LATEST_RELEASE_URL).removeprefix(
+        "v"
+    )
 
 
 def prepare_python_client_source():
@@ -312,7 +344,9 @@ def build_jdbc_testng_suite(test_jar):
     suite_path = CACHE_DIR / "generated" / f"{test_jar.stem}-testng.xml"
     suite_path.parent.mkdir(parents=True, exist_ok=True)
 
-    suite = ET.Element("suite", {"name": "DatabendJdbcTests", "verbose": "10", "parallel": "none"})
+    suite = ET.Element(
+        "suite", {"name": "DatabendJdbcTests", "verbose": "10", "parallel": "none"}
+    )
     test = ET.SubElement(suite, "test", {"name": "AllTests"})
     groups = ET.SubElement(test, "groups")
     run = ET.SubElement(groups, "run")
@@ -432,7 +466,9 @@ def python_client(session, driver_version):
         )
         with session.chdir(str(bindings_dir)):
             for impl in ["blocking", "asyncio", "cursor"]:
-                session.run("behave", f"tests/{impl}", env=merge_env(PYTHON_TEST_ENV, env))
+                session.run(
+                    "behave", f"tests/{impl}", env=merge_env(PYTHON_TEST_ENV, env)
+                )
     finally:
         current_timezone = get_current_timezone()
         if current_timezone != original_timezone:

--- a/tests/shell_env.sh
+++ b/tests/shell_env.sh
@@ -39,6 +39,21 @@ bendsql_connect_root_null() {
 	bendsql_connect_root --output null "$@"
 }
 
+# Keep Spark/Maven bootstrap logs out of databend-test .result files.
+# On failure, dump the captured log so CI shows HTTP 429 / missing jars.
+prepare_paimon_fs_data() {
+	local script_dir prepare_script log
+	script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	prepare_script="${script_dir}/sqllogictests/scripts/prepare_paimon_fs_data.sh"
+	log="$(mktemp)"
+	trap 'rm -f "${log}"' RETURN
+	if ! "${prepare_script}" >"${log}" 2>&1; then
+		echo "FAIL: paimon warehouse prepare failed" >&2
+		cat "${log}" >&2
+		return 1
+	fi
+}
+
 # share client
 export QUERY_MYSQL_HANDLER_SHARE_PROVIDER_PORT="18000"
 export QUERY_MYSQL_HANDLER_SHARE_CONSUMER_PORT="28000"

--- a/tests/sqllogictests/scripts/iceberg-driver/Dockerfile
+++ b/tests/sqllogictests/scripts/iceberg-driver/Dockerfile
@@ -3,7 +3,22 @@ FROM maven:3.9.5-eclipse-temurin-11 AS builder
 WORKDIR /app
 COPY pom.xml .
 COPY src ./src
-RUN mvn clean package -DskipTests && ls -lh target
+# Maven Central rate-limits GitHub runners (HTTP 429). Retry the package
+# step instead of failing the Iceberg fixture image on the first rejection.
+RUN set -eux; \
+    attempt=1; \
+    while :; do \
+      if mvn -B -ntp clean package -DskipTests \
+        -Daether.connector.http.retryHandler.count=8 \
+        -Daether.connector.http.retryHandler.interval=2000; then \
+        break; \
+      fi; \
+      if [ "$attempt" -ge 8 ]; then exit 1; fi; \
+      echo "Maven package failed on attempt ${attempt}; retrying..."; \
+      sleep $((attempt * 5)); \
+      attempt=$((attempt + 1)); \
+    done; \
+    ls -lh target
 
 FROM eclipse-temurin:11-jdk
 

--- a/tests/sqllogictests/scripts/maven_artifact.py
+++ b/tests/sqllogictests/scripts/maven_artifact.py
@@ -1,0 +1,165 @@
+"""Download Maven Central artifacts with retries for HTTP 429/5xx."""
+
+from __future__ import annotations
+
+import os
+import random
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+MAVEN_CENTRAL = "https://repo.maven.apache.org/maven2"
+USER_AGENT = "databend-ci-maven-artifact"
+DEFAULT_ATTEMPTS = 8
+RETRY_STATUS = {408, 425, 429, 500, 502, 503, 504}
+
+
+def parse_maven_coord(coord: str) -> tuple[str, str, str]:
+    parts = coord.split(":")
+    if len(parts) != 3 or not all(parts):
+        raise ValueError(f"expected group:artifact:version, got {coord!r}")
+    return parts[0], parts[1], parts[2]
+
+
+def maven_jar_url(group_id: str, artifact_id: str, version: str) -> str:
+    group_path = group_id.replace(".", "/")
+    return (
+        f"{MAVEN_CENTRAL}/{group_path}/{artifact_id}/{version}/"
+        f"{artifact_id}-{version}.jar"
+    )
+
+
+def download_maven_jars(coords: list[str], dest_dir: Path | None = None) -> list[str]:
+    return [
+        download_maven_jar(*parse_maven_coord(coord), dest_dir=dest_dir)
+        for coord in coords
+    ]
+
+
+def retry_call(fn, *, attempts: int = DEFAULT_ATTEMPTS, what: str = "operation"):
+    last_error: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return fn()
+        except Exception as exc:  # noqa: BLE001 - CI bootstrap retries transient IO
+            last_error = exc
+            if attempt == attempts:
+                break
+            delay = min(60.0, (2 ** (attempt - 1)) + random.uniform(0, 1))
+            print(
+                f"{what} failed on attempt {attempt}/{attempts}: {exc}; "
+                f"retrying in {delay:.1f}s",
+                flush=True,
+            )
+            time.sleep(delay)
+    raise RuntimeError(f"{what} failed after {attempts} attempts") from last_error
+
+
+def download_maven_jar(
+    group_id: str,
+    artifact_id: str,
+    version: str,
+    dest_dir: Path | None = None,
+) -> str:
+    dest_dir = dest_dir or Path(
+        os.environ.get(
+            "MAVEN_ARTIFACT_CACHE",
+            Path.home() / ".cache" / "databend-maven",
+        )
+    )
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    target = dest_dir / f"{artifact_id}-{version}.jar"
+    if target.exists() and target.stat().st_size > 0:
+        return str(target)
+
+    download_url(maven_jar_url(group_id, artifact_id, version), target)
+    return str(target)
+
+
+def download_url(url: str, target: Path, attempts: int = DEFAULT_ATTEMPTS) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    last_error: Exception | None = None
+
+    for attempt in range(1, attempts + 1):
+        tmp_path = target.with_suffix(f"{target.suffix}.tmp.{os.getpid()}.{attempt}")
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                with tmp_path.open("wb") as tmp_file:
+                    while True:
+                        chunk = response.read(1024 * 1024)
+                        if not chunk:
+                            break
+                        tmp_file.write(chunk)
+            if tmp_path.stat().st_size <= 0:
+                raise RuntimeError(f"downloaded empty file from {url}")
+            tmp_path.replace(target)
+            return
+        except urllib.error.HTTPError as exc:
+            last_error = exc
+            retryable = exc.code in RETRY_STATUS
+        except (urllib.error.URLError, TimeoutError, OSError, RuntimeError) as exc:
+            last_error = exc
+            retryable = True
+        finally:
+            if tmp_path.exists():
+                tmp_path.unlink()
+
+        if not retryable or attempt == attempts:
+            break
+
+        delay = min(60.0, (2 ** (attempt - 1)) + random.uniform(0, 1))
+        print(
+            f"download {url} failed on attempt {attempt}/{attempts}: {last_error}; "
+            f"retrying in {delay:.1f}s",
+            flush=True,
+        )
+        time.sleep(delay)
+
+    raise RuntimeError(
+        f"failed to download {url} after {attempts} attempts"
+    ) from last_error
+
+
+if __name__ == "__main__":
+    import http.server
+    import socketserver
+    import threading
+
+    hits = {"n": 0}
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            hits["n"] += 1
+            if hits["n"] < 3:
+                self.send_error(429, "Too Many Requests")
+                return
+            body = b"ok-artifact"
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format, *args):
+            return
+
+    with socketserver.TCPServer(("127.0.0.1", 0), Handler) as httpd:
+        host, port = httpd.server_address
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        dest = Path("/tmp") / f"databend-maven-artifact-test-{os.getpid()}.jar"
+        dest.unlink(missing_ok=True)
+        try:
+            download_url(f"http://{host}:{port}/artifact.jar", dest, attempts=5)
+            assert dest.read_bytes() == b"ok-artifact"
+            assert hits["n"] == 3
+            assert parse_maven_coord("org.apache.paimon:paimon-s3:1.4.1") == (
+                "org.apache.paimon",
+                "paimon-s3",
+                "1.4.1",
+            )
+            print("maven_artifact local 429 retry ok")
+        finally:
+            dest.unlink(missing_ok=True)
+            httpd.shutdown()

--- a/tests/sqllogictests/scripts/prepare_iceberg_test_data.py
+++ b/tests/sqllogictests/scripts/prepare_iceberg_test_data.py
@@ -1,31 +1,49 @@
-from pyspark.sql import SparkSession
-from pyspark.sql.types import StructType, StructField, StringType, IntegerType
+import sys
+from pathlib import Path
 
-spark = (
-    SparkSession.builder.appName("CSV to Iceberg REST Catalog")
-    .config(
-        "spark.sql.extensions",
-        "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
-    )
-    .config("spark.sql.catalog.iceberg", "org.apache.iceberg.spark.SparkCatalog")
-    .config("spark.sql.catalog.iceberg.type", "rest")
-    .config("spark.sql.catalog.iceberg.uri", "http://127.0.0.1:8181")
-    .config("spark.sql.catalog.iceberg.io-impl", "org.apache.iceberg.aws.s3.S3FileIO")
-    .config("spark.sql.catalog.iceberg.warehouse", "s3://iceberg-tpch/")
-    .config("spark.sql.catalog.iceberg.s3.access-key-id", "admin")
-    .config("spark.sql.catalog.iceberg.s3.secret-access-key", "password")
-    .config("spark.sql.catalog.iceberg.s3.path-style-access", "true")
-    .config("spark.sql.catalog.iceberg.s3.endpoint", "http://127.0.0.1:9002")
-    .config("spark.sql.catalog.iceberg.client.region", "us-east-1")
-    .config(
-        "spark.jars.packages",
-        "org.apache.iceberg:iceberg-aws-bundle:1.10.0,org.apache.iceberg:iceberg-spark-runtime-4.0_2.13:1.10.0",
-    )
-    # for delete file
-    .config("spark.sql.shuffle.partitions", "1")
-    # for delete file
-    .config("spark.default.parallelism", "1")
-    .getOrCreate()
+from pyspark.sql import SparkSession
+from pyspark.sql.types import IntegerType, StringType, StructField, StructType
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+from maven_artifact import download_maven_jars, retry_call  # noqa: E402
+
+jars = download_maven_jars(
+    [
+        "org.apache.iceberg:iceberg-aws-bundle:1.10.0",
+        "org.apache.iceberg:iceberg-spark-runtime-4.0_2.13:1.10.0",
+    ]
+)
+
+spark = retry_call(
+    lambda: (
+        SparkSession.builder.appName("CSV to Iceberg REST Catalog")
+        .config(
+            "spark.sql.extensions",
+            "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+        )
+        .config("spark.sql.catalog.iceberg", "org.apache.iceberg.spark.SparkCatalog")
+        .config("spark.sql.catalog.iceberg.type", "rest")
+        .config("spark.sql.catalog.iceberg.uri", "http://127.0.0.1:8181")
+        .config(
+            "spark.sql.catalog.iceberg.io-impl", "org.apache.iceberg.aws.s3.S3FileIO"
+        )
+        .config("spark.sql.catalog.iceberg.warehouse", "s3://iceberg-tpch/")
+        .config("spark.sql.catalog.iceberg.s3.access-key-id", "admin")
+        .config("spark.sql.catalog.iceberg.s3.secret-access-key", "password")
+        .config("spark.sql.catalog.iceberg.s3.path-style-access", "true")
+        .config("spark.sql.catalog.iceberg.s3.endpoint", "http://127.0.0.1:9002")
+        .config("spark.sql.catalog.iceberg.client.region", "us-east-1")
+        .config("spark.jars", ",".join(jars))
+        # for delete file
+        .config("spark.sql.shuffle.partitions", "1")
+        # for delete file
+        .config("spark.default.parallelism", "1")
+        .getOrCreate()
+    ),
+    what="create Iceberg test Spark session",
 )
 
 spark.sql("CREATE NAMESPACE IF NOT EXISTS iceberg.test")

--- a/tests/sqllogictests/scripts/prepare_iceberg_tpch_data.py
+++ b/tests/sqllogictests/scripts/prepare_iceberg_tpch_data.py
@@ -1,33 +1,50 @@
+import sys
+from pathlib import Path
+
 from pyspark.sql import SparkSession
 from pyspark.sql.types import (
-    StructType,
-    StructField,
-    IntegerType,
-    DoubleType,
-    StringType,
     DateType,
     DecimalType,
+    DoubleType,
+    IntegerType,
+    StringType,
+    StructField,
+    StructType,
 )
 
-data_path = "tests/sqllogictests/data/tests/suites/0_stateless/13_tpch/data"
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
 
-spark = (
-    SparkSession.builder.appName("CSV to Iceberg REST Catalog")
-    .config("spark.sql.catalog.iceberg", "org.apache.iceberg.spark.SparkCatalog")
-    .config("spark.sql.catalog.iceberg.type", "rest")
-    .config("spark.sql.catalog.iceberg.uri", "http://127.0.0.1:8181")
-    .config("spark.sql.catalog.iceberg.io-impl", "org.apache.iceberg.aws.s3.S3FileIO")
-    .config("spark.sql.catalog.iceberg.warehouse", "s3://iceberg-tpch/")
-    .config("spark.sql.catalog.iceberg.s3.access-key-id", "admin")
-    .config("spark.sql.catalog.iceberg.s3.secret-access-key", "password")
-    .config("spark.sql.catalog.iceberg.s3.path-style-access", "true")
-    .config("spark.sql.catalog.iceberg.s3.endpoint", "http://127.0.0.1:9002")
-    .config("spark.sql.catalog.iceberg.client.region", "us-east-1")
-    .config(
-        "spark.jars.packages",
-        "org.apache.iceberg:iceberg-aws-bundle:1.10.0,org.apache.iceberg:iceberg-spark-runtime-4.0_2.13:1.10.0",
-    )
-    .getOrCreate()
+from maven_artifact import download_maven_jars, retry_call  # noqa: E402
+
+data_path = "tests/sqllogictests/data/tests/suites/0_stateless/13_tpch/data"
+jars = download_maven_jars(
+    [
+        "org.apache.iceberg:iceberg-aws-bundle:1.10.0",
+        "org.apache.iceberg:iceberg-spark-runtime-4.0_2.13:1.10.0",
+    ]
+)
+
+spark = retry_call(
+    lambda: (
+        SparkSession.builder.appName("CSV to Iceberg REST Catalog")
+        .config("spark.sql.catalog.iceberg", "org.apache.iceberg.spark.SparkCatalog")
+        .config("spark.sql.catalog.iceberg.type", "rest")
+        .config("spark.sql.catalog.iceberg.uri", "http://127.0.0.1:8181")
+        .config(
+            "spark.sql.catalog.iceberg.io-impl", "org.apache.iceberg.aws.s3.S3FileIO"
+        )
+        .config("spark.sql.catalog.iceberg.warehouse", "s3://iceberg-tpch/")
+        .config("spark.sql.catalog.iceberg.s3.access-key-id", "admin")
+        .config("spark.sql.catalog.iceberg.s3.secret-access-key", "password")
+        .config("spark.sql.catalog.iceberg.s3.path-style-access", "true")
+        .config("spark.sql.catalog.iceberg.s3.endpoint", "http://127.0.0.1:9002")
+        .config("spark.sql.catalog.iceberg.client.region", "us-east-1")
+        .config("spark.jars", ",".join(jars))
+        .getOrCreate()
+    ),
+    what="create Iceberg TPCH Spark session",
 )
 
 spark.sql("CREATE NAMESPACE IF NOT EXISTS iceberg.tpch")

--- a/tests/sqllogictests/scripts/prepare_paimon_fs_data.py
+++ b/tests/sqllogictests/scripts/prepare_paimon_fs_data.py
@@ -13,6 +13,12 @@ from pathlib import Path
 
 from pyspark.sql import SparkSession
 
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+from maven_artifact import download_maven_jars, retry_call  # noqa: E402
+
 warehouse = os.environ.get(
     "PAIMON_WAREHOUSE",
     str(Path(__file__).resolve().parents[2] / "data" / "paimon_warehouse"),
@@ -25,14 +31,15 @@ else:
     Path(warehouse).mkdir(parents=True, exist_ok=True)
     warehouse_uri = f"file://{warehouse}"
 
-packages = "org.apache.paimon:paimon-spark-3.5_2.12:1.4.1"
+coords = ["org.apache.paimon:paimon-spark-3.5_2.12:1.4.1"]
 if warehouse.startswith("s3://"):
-    packages += ",org.apache.paimon:paimon-s3:1.4.1"
+    coords.append("org.apache.paimon:paimon-s3:1.4.1")
+jars = download_maven_jars(coords)
 
 builder = (
     SparkSession.builder.appName("prepare-paimon-fs-data")
     .master("local[4]")
-    .config("spark.jars.packages", packages)
+    .config("spark.jars", ",".join(jars))
     .config(
         "spark.sql.extensions",
         "org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions",
@@ -61,7 +68,7 @@ if warehouse.startswith("s3://"):
         .config("spark.sql.catalog.paimon.s3.region", "us-east-1")
     )
 
-spark = builder.getOrCreate()
+spark = retry_call(builder.getOrCreate, what="create Paimon Spark session")
 
 
 def prepare_tables() -> None:

--- a/tests/suites/3_stateful_paimon/00_catalog/00_0000_create_and_show.sh
+++ b/tests/suites/3_stateful_paimon/00_catalog/00_0000_create_and_show.sh
@@ -5,7 +5,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 WAREHOUSE_PATH="${PAIMON_WAREHOUSE_PATH:-${TESTS_DATA_DIR}/paimon_warehouse}"
 
-"${CURDIR}"/../../../sqllogictests/scripts/prepare_paimon_fs_data.sh >/dev/null 2>&1
+prepare_paimon_fs_data || exit 1
 
 echo "DROP CATALOG IF EXISTS paimon_fs" | bendsql_connect_root
 

--- a/tests/suites/3_stateful_paimon/01_read/01_0000_append_pk.sh
+++ b/tests/suites/3_stateful_paimon/01_read/01_0000_append_pk.sh
@@ -5,7 +5,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 WAREHOUSE_PATH="${PAIMON_WAREHOUSE_PATH:-${TESTS_DATA_DIR}/paimon_warehouse}"
 
-"${CURDIR}"/../../../sqllogictests/scripts/prepare_paimon_fs_data.sh >/dev/null 2>&1
+prepare_paimon_fs_data || exit 1
 
 echo "DROP CATALOG IF EXISTS paimon_fs" | bendsql_connect_root
 

--- a/tests/suites/3_stateful_paimon/02_cluster/02_0000_multi_node_scan.sh
+++ b/tests/suites/3_stateful_paimon/02_cluster/02_0000_multi_node_scan.sh
@@ -7,7 +7,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 WAREHOUSE_PATH="${PAIMON_WAREHOUSE_PATH:-${TESTS_DATA_DIR}/paimon_warehouse}"
 
-"${CURDIR}"/../../../sqllogictests/scripts/prepare_paimon_fs_data.sh >/dev/null 2>&1
+prepare_paimon_fs_data
 
 echo "DROP CATALOG IF EXISTS paimon_fs" | bendsql_connect_root
 

--- a/tests/suites/3_stateful_paimon/02_cluster/02_0001_cluster_write.sh
+++ b/tests/suites/3_stateful_paimon/02_cluster/02_0001_cluster_write.sh
@@ -28,10 +28,7 @@ fi
 WAREHOUSE_PATH="$(cd "${WAREHOUSE_PATH}" && pwd)"
 
 echo "===== prepare warehouse ====="
-if ! "${CURDIR}"/../../../sqllogictests/scripts/prepare_paimon_fs_data.sh >/dev/null 2>&1; then
-	echo "FAIL: paimon warehouse prepare failed"
-	exit 1
-fi
+prepare_paimon_fs_data
 echo "prepare_ok"
 
 sql "DROP CATALOG IF EXISTS paimon_fs" >/dev/null

--- a/tests/suites/3_stateful_paimon/02_system/02_0000_system_tables.sh
+++ b/tests/suites/3_stateful_paimon/02_system/02_0000_system_tables.sh
@@ -5,7 +5,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 WAREHOUSE_PATH="${PAIMON_WAREHOUSE_PATH:-${TESTS_DATA_DIR}/paimon_warehouse}"
 
-"${CURDIR}"/../../../sqllogictests/scripts/prepare_paimon_fs_data.sh >/dev/null 2>&1
+prepare_paimon_fs_data || exit 1
 
 echo "DROP CATALOG IF EXISTS paimon_fs" | bendsql_connect_root
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

CI jobs that bootstrap Java/Spark fixtures were failing before the actual tests started because Maven Central returned HTTP 429 to GitHub runners. This showed up as:

- `linux / test_compat_java_client_cluster`: `stCarolas/setup-maven` downloading Maven 3.9.9 from `repo.maven.apache.org` (`Unexpected HTTP response: 429`)
- `linux / sqllogic / standalone_iceberg_tpch`: Iceberg driver image `mvn clean package` (`status code: 429`)
- `linux / sqllogic / standalone_paimon` and `linux / test_stateful_paimon_cluster`: Spark Ivy resolving `paimon-spark-3.5_2.12:1.4.1` / `paimon-s3:1.4.1` as `not found` after the same rate limit

The Paimon artifacts exist on Maven Central. Spark just reports a failed fetch as missing. Stateful Paimon also swallowed prepare stderr (`>/dev/null 2>&1`), so CI only showed `FAIL: paimon warehouse prepare failed`.

This PR retries those downloads instead of mixing a Maven-mirror change into an unrelated storage fix.

## Changes

- Install Maven 3.9.9 from `archive.apache.org` with `curl --retry-all-errors` and a SHA-512 check. Keep Maven HTTP retries for later `mvn` calls.
- Retry Iceberg driver `mvn package` on 429/5xx.
- Pre-download Paimon/Iceberg fat jars with retries and pass them through `spark.jars` so Spark does not hit Ivy/`spark.jars.packages` on the first 429.
- Dump Paimon warehouse-prepare logs on failure instead of hiding them.
- Retry nox JDBC test-lib downloads on 429/5xx.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - CI bootstrap only; local check was `python3 tests/sqllogictests/scripts/maven_artifact.py` (retries two 429s then succeeds)

## Type of change

- [x] Other (please describe): CI reliability for Maven Central rate limits

## AI assistance

- AI usage: An AI coding agent diagnosed the Maven Central 429 CI failures, drafted the retry/pre-download changes, and helped prepare this PR; I reviewed the resulting diff.
- Responsible human: @youngsofun
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20342)
<!-- Reviewable:end -->
