### PR TITLE
fix(query): spill window partitions during output

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/window/partition/transform_window_partition_collect.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/partition/transform_window_partition_collect.rs
@@ -148,6 +148,10 @@ impl<S: DataProcessorStrategy> Processor for TransformWindowPartitionCollect<S> 
                     return Ok(Event::NeedConsume);
                 }
 
+                if self.buffer.need_spill() {
+                    return Ok(Event::Sync);
+                }
+
                 if let Some(block) = self.output_data_blocks.pop_front() {
                     self.output.push_data(Ok(block));
                     return Ok(Event::NeedConsume);
@@ -176,6 +180,11 @@ impl<S: DataProcessorStrategy> Processor for TransformWindowPartitionCollect<S> 
                 Ok(())
             }
             Step::Output => {
+                if self.buffer.need_spill() {
+                    self.buffer.spill()?;
+                    return Ok(());
+                }
+
                 // Restore next non-empty partition and process it.
                 let restored = self.buffer.restore()?;
                 if !restored.is_empty() {

--- a/src/query/service/src/pipelines/processors/transforms/window/partition/transform_window_partition_collect.rs
+++ b/src/query/service/src/pipelines/processors/transforms/window/partition/transform_window_partition_collect.rs
@@ -144,12 +144,12 @@ impl<S: DataProcessorStrategy> Processor for TransformWindowPartitionCollect<S> 
                 Ok(Event::NeedData)
             }
             Step::Output => {
-                if !self.output.can_push() {
-                    return Ok(Event::NeedConsume);
-                }
-
                 if self.buffer.need_spill() {
                     return Ok(Event::Sync);
+                }
+
+                if !self.output.can_push() {
+                    return Ok(Event::NeedConsume);
                 }
 
                 if let Some(block) = self.output_data_blocks.pop_front() {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Restore memory-pressure-driven spilling while `TransformWindowPartitionCollect` is in its output phase.

Before `6a9372ddf4` (`refactor(query): unify window/cte spill to async_buffer path`), the window output state checked `need_spill()` before pushing queued output or restoring another partition. Under memory pressure it transitioned to `Step::Spill`, spilled buffered partitions, and then resumed output.

That refactor made spill and restore synchronous and simplified the processor state machine, but it retained the spill loop only in `Step::Collect`. Once collection finished, `Step::Output` could only restore and process another partition. Query-level or global memory pressure arising during partition restore, sorting, output buffering, or downstream processing could therefore no longer make the window operator release its not-yet-restored partitions.

## Implementation

- In `Step::Output::event()`, check spill pressure before output backpressure. This lets the processor release pending partitions after downstream has pulled the current block but before it requests another one.
- In `Step::Output::process()`, spill one eligible pending partition and return. A later scheduler cycle rechecks memory pressure before either spilling again or restoring the next partition.
- Keep the existing `WindowPartitionBuffer` termination behavior: `need_spill()` is gated by `can_spill`, and `spill()` clears `can_spill` after no eligible buffered partition remains. Persistent query-level pressure therefore does not trap the processor in an infinite spill loop.

Spilling is restricted to `partitions[next_to_restore..]`, so this changes only the storage location and timing for pending partitions. It does not spill a partition that has already been restored for window processing and does not change window result semantics.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Existing end-to-end Window spill coverage includes:

- `tests/sqllogictests/suites/query/window_function/window_partition_spill.test`: forced Window spill with multiple Window functions and both DIO modes; it is also included by the `max_block_size = 1` Window suite.
- `tests/sqllogictests/suites/tpch/window_spill.test`: compares Window results with and without forced spilling, including single-thread execution.
- `tests/sqllogictests/suites/query/issues/issue_17581.test`: exercises Window spill correctness together with Arrow spill files.

These tests cover spill/restore result correctness. Their forced-spill setup normally drains eligible buffers during `Step::Collect`, so they do not deterministically isolate the exact regression where memory pressure first appears after collection. Creating that focused regression would require controllable query-memory pressure at the processor state boundary rather than another forced-spill SQL case.

Local validation:

- `cargo fmt --all -- --check`
- `git diff --check upstream/main...HEAD`

The existing SQL logic suites were identified by source inspection and are expected to run in CI; they were not run locally because the available test binaries predate this patch.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent investigated the window spill state-machine regression, restored the output-phase spill path, scanned the existing Window spill coverage, and drafted the PR description. The responsible human reviewed and discussed every line of the final diff.
- Responsible human: @dqhl76
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20343)
<!-- Reviewable:end -->
