### PR TITLE
refactor(query): optimize column collection and replacement

### DIFF
--- a/src/query/service/src/physical_plans/physical_aggregate_final.rs
+++ b/src/query/service/src/physical_plans/physical_aggregate_final.rs
@@ -219,7 +219,7 @@ impl PhysicalPlanBuilder {
         let mut used = vec![];
         for item in &agg.aggregate_functions {
             if required.contains(&item.index) {
-                required.extend(item.scalar.used_columns());
+                item.scalar.collect_used_columns(&mut required);
                 used.push(item.clone());
             }
         }

--- a/src/query/service/src/physical_plans/physical_async_func.rs
+++ b/src/query/service/src/physical_plans/physical_async_func.rs
@@ -139,7 +139,7 @@ impl PhysicalPlanBuilder {
         let mut used = vec![];
         for item in async_func_plan.items.iter() {
             if required.contains(&item.index) {
-                required.extend(item.scalar.used_columns());
+                item.scalar.collect_used_columns(&mut required);
                 used.push(item.clone());
             }
         }

--- a/src/query/service/src/physical_plans/physical_eval_scalar.rs
+++ b/src/query/service/src/physical_plans/physical_eval_scalar.rs
@@ -224,9 +224,7 @@ impl PhysicalPlanBuilder {
             // The item defines this output index. Only request the child column
             // when the defining expression itself references that index.
             required.remove(&s.index);
-            s.scalar.used_columns().iter().for_each(|c| {
-                required.insert(*c);
-            })
+            s.scalar.collect_used_columns(&mut required);
         }
         // 2. Build physical plan.
         if used.is_empty() {

--- a/src/query/service/src/physical_plans/physical_exchange.rs
+++ b/src/query/service/src/physical_plans/physical_exchange.rs
@@ -104,7 +104,7 @@ impl PhysicalPlanBuilder {
         | databend_common_sql::plans::Exchange::GlobalHash(exprs) = exchange
         {
             for expr in exprs {
-                required.extend(expr.used_columns());
+                expr.collect_used_columns(&mut required);
             }
         }
 

--- a/src/query/service/src/physical_plans/physical_filter.rs
+++ b/src/query/service/src/physical_plans/physical_filter.rs
@@ -152,9 +152,10 @@ impl PhysicalPlanBuilder {
         stat_info: PlanStatsInfo,
     ) -> Result<PhysicalPlan> {
         // 1. Prune unused Columns.
-        let used = filter.predicates.iter().fold(required.clone(), |acc, v| {
-            acc.union(&v.used_columns()).cloned().collect()
-        });
+        let mut used = required.clone();
+        for predicate in &filter.predicates {
+            predicate.collect_used_columns(&mut used);
+        }
 
         // 2. Build physical plan.
         let input = self.build(s_expr.child(0)?, used).await?;

--- a/src/query/service/src/physical_plans/physical_hash_join.rs
+++ b/src/query/service/src/physical_plans/physical_hash_join.rs
@@ -823,8 +823,9 @@ impl PhysicalPlanBuilder {
             // Prepare runtime filter expression
             let left_expr_for_runtime_filter = self.prepare_runtime_filter_expr(left_condition)?;
 
-            let build_table_index = if right_condition.used_columns().len() == 1 {
-                let column_idx = *right_condition.used_columns().iter().next().unwrap();
+            let right_used_columns = right_condition.used_columns();
+            let build_table_index = if right_used_columns.len() == 1 {
+                let column_idx = *right_used_columns.iter().next().unwrap();
                 if matches!(
                     self.metadata.read().column(column_idx),
                     ColumnEntry::BaseTableColumn(_)

--- a/src/query/service/src/physical_plans/physical_join.rs
+++ b/src/query/service/src/physical_plans/physical_join.rs
@@ -137,12 +137,10 @@ impl PhysicalPlanBuilder {
         stat_info: PlanStatsInfo,
     ) -> Result<PhysicalPlan> {
         // 1. Prune unused Columns.
-        let mut others_required = join
-            .non_equi_conditions
-            .iter()
-            .fold(required.clone(), |acc, v| {
-                acc.union(&v.used_columns()).cloned().collect()
-            });
+        let mut others_required = required.clone();
+        for condition in &join.non_equi_conditions {
+            condition.collect_used_columns(&mut others_required);
+        }
         if let Some(cache_info) = &join.build_side_cache_info {
             for column in &cache_info.columns {
                 others_required.insert(*column);
@@ -150,26 +148,12 @@ impl PhysicalPlanBuilder {
         }
 
         // Include columns referenced in left conditions and right conditions.
-        let left_required: ColumnSet = join
-            .equi_conditions
-            .iter()
-            .fold(required.clone(), |acc, v| {
-                acc.union(&v.left.used_columns()).cloned().collect()
-            })
-            .union(&others_required)
-            .cloned()
-            .collect();
-        let right_required: ColumnSet = join
-            .equi_conditions
-            .iter()
-            .fold(required.clone(), |acc, v| {
-                acc.union(&v.right.used_columns()).cloned().collect()
-            })
-            .union(&others_required)
-            .cloned()
-            .collect();
-        let left_required: ColumnSet = left_required.union(&others_required).cloned().collect();
-        let right_required: ColumnSet = right_required.union(&others_required).cloned().collect();
+        let mut left_required = others_required.clone();
+        let mut right_required = others_required.clone();
+        for condition in &join.equi_conditions {
+            condition.left.collect_used_columns(&mut left_required);
+            condition.right.collect_used_columns(&mut right_required);
+        }
 
         // 2. Try Build physical spatial join plan.
         if let Some(candidate) = join.spatial_join.clone() {

--- a/src/query/service/src/physical_plans/physical_mutation.rs
+++ b/src/query/service/src/physical_plans/physical_mutation.rs
@@ -272,11 +272,11 @@ impl PhysicalPlanBuilder {
         let mut maybe_udfs = BTreeSet::new();
         for matched_evaluator in matched_evaluators {
             if let Some(condition) = &matched_evaluator.condition {
-                maybe_udfs.extend(condition.used_columns());
+                condition.collect_used_columns(&mut maybe_udfs);
             }
             if let Some(update_list) = &matched_evaluator.update {
                 for update_scalar in update_list.values() {
-                    maybe_udfs.extend(update_scalar.used_columns());
+                    update_scalar.collect_used_columns(&mut maybe_udfs);
                 }
             }
         }
@@ -285,17 +285,17 @@ impl PhysicalPlanBuilder {
         let mut unmatched_required = BTreeSet::new();
         for unmatched_evaluator in unmatched_evaluators {
             if let Some(condition) = &unmatched_evaluator.condition {
-                maybe_udfs.extend(condition.used_columns());
-                unmatched_required.extend(condition.used_columns());
+                condition.collect_used_columns(&mut maybe_udfs);
+                condition.collect_used_columns(&mut unmatched_required);
             }
             for value in &unmatched_evaluator.values {
-                maybe_udfs.extend(value.used_columns());
-                unmatched_required.extend(value.used_columns());
+                value.collect_used_columns(&mut maybe_udfs);
+                value.collect_used_columns(&mut unmatched_required);
             }
         }
         required.extend(unmatched_required);
         for filter_value in direct_filter {
-            maybe_udfs.extend(filter_value.used_columns());
+            filter_value.collect_used_columns(&mut maybe_udfs);
         }
 
         let udf_ids = s_expr.get_udfs_col_ids()?;

--- a/src/query/service/src/physical_plans/physical_plan_builder.rs
+++ b/src/query/service/src/physical_plans/physical_plan_builder.rs
@@ -213,46 +213,40 @@ impl PhysicalPlanBuilder {
                 let req = &mut child_required[0];
                 for item in &eval_scalar.items {
                     if parent_required.contains(&item.index) {
-                        for col in item.scalar.used_columns() {
-                            req.insert(col);
-                        }
+                        item.scalar.collect_used_columns(req);
                     }
                 }
             }
             RelOperator::Filter(filter) => {
                 let req = &mut child_required[0];
                 for predicate in &filter.predicates {
-                    req.extend(predicate.used_columns());
+                    predicate.collect_used_columns(req);
                 }
             }
             RelOperator::Aggregate(agg) => {
                 let req = &mut child_required[0];
                 for item in &agg.group_items {
                     req.insert(item.index);
-                    for col in item.scalar.used_columns() {
-                        req.insert(col);
-                    }
+                    item.scalar.collect_used_columns(req);
                 }
                 for item in &agg.aggregate_functions {
                     if parent_required.contains(&item.index) {
-                        for col in item.scalar.used_columns() {
-                            req.insert(col);
-                        }
+                        item.scalar.collect_used_columns(req);
                     }
                 }
             }
             RelOperator::Window(window) => {
                 let req = &mut child_required[0];
                 for item in &window.arguments {
-                    req.extend(item.scalar.used_columns());
+                    item.scalar.collect_used_columns(req);
                     req.insert(item.index);
                 }
                 for item in &window.partition_by {
-                    req.extend(item.scalar.used_columns());
+                    item.scalar.collect_used_columns(req);
                     req.insert(item.index);
                 }
                 for item in &window.order_by {
-                    req.extend(item.order_by_item.scalar.used_columns());
+                    item.order_by_item.scalar.collect_used_columns(req);
                     req.insert(item.order_by_item.index);
                 }
             }
@@ -262,20 +256,20 @@ impl PhysicalPlanBuilder {
                     req.remove(&window.index);
                 }
                 for item in &window_group.scalar_items {
-                    req.extend(item.scalar.used_columns());
+                    item.scalar.collect_used_columns(req);
                     req.insert(item.index);
                 }
                 for window in &window_group.windows {
                     for item in &window.arguments {
-                        req.extend(item.scalar.used_columns());
+                        item.scalar.collect_used_columns(req);
                         req.insert(item.index);
                     }
                     for item in &window.partition_by {
-                        req.extend(item.scalar.used_columns());
+                        item.scalar.collect_used_columns(req);
                         req.insert(item.index);
                     }
                     for item in &window.order_by {
-                        req.extend(item.order_by_item.scalar.used_columns());
+                        item.order_by_item.scalar.collect_used_columns(req);
                         req.insert(item.order_by_item.index);
                     }
                 }
@@ -293,39 +287,25 @@ impl PhysicalPlanBuilder {
                 }
             }
             RelOperator::Join(join) => {
-                let mut others_required = join
-                    .non_equi_conditions
-                    .iter()
-                    .fold(parent_required.clone(), |acc, v| {
-                        acc.union(&v.used_columns()).cloned().collect()
-                    });
+                let mut others_required = parent_required.clone();
+                for condition in &join.non_equi_conditions {
+                    condition.collect_used_columns(&mut others_required);
+                }
                 if let Some(cache_info) = &join.build_side_cache_info {
                     for column in &cache_info.columns {
                         others_required.insert(*column);
                     }
                 }
 
-                let left_required: ColumnSet = join
-                    .equi_conditions
-                    .iter()
-                    .fold(parent_required.clone(), |acc, v| {
-                        acc.union(&v.left.used_columns()).cloned().collect()
-                    })
-                    .union(&others_required)
-                    .cloned()
-                    .collect();
-                let right_required: ColumnSet = join
-                    .equi_conditions
-                    .iter()
-                    .fold(parent_required.clone(), |acc, v| {
-                        acc.union(&v.right.used_columns()).cloned().collect()
-                    })
-                    .union(&others_required)
-                    .cloned()
-                    .collect();
+                let mut left_required = others_required.clone();
+                let mut right_required = others_required;
+                for condition in &join.equi_conditions {
+                    condition.left.collect_used_columns(&mut left_required);
+                    condition.right.collect_used_columns(&mut right_required);
+                }
 
-                child_required[0] = left_required.union(&others_required).cloned().collect();
-                child_required[1] = right_required.union(&others_required).cloned().collect();
+                child_required[0] = left_required;
+                child_required[1] = right_required;
             }
             RelOperator::UnionAll(union_all) => {
                 let (left_required, right_required) = if !union_all.cte_scan_names.is_empty() {
@@ -368,24 +348,20 @@ impl PhysicalPlanBuilder {
             RelOperator::Exchange(databend_common_sql::plans::Exchange::NodeToNodeHash(exprs)) => {
                 let req = &mut child_required[0];
                 for expr in exprs {
-                    req.extend(expr.used_columns());
+                    expr.collect_used_columns(req);
                 }
             }
             RelOperator::ProjectSet(project_set) => {
                 let req = &mut child_required[0];
                 for item in &project_set.srfs {
-                    for col in item.scalar.used_columns() {
-                        req.insert(col);
-                    }
+                    item.scalar.collect_used_columns(req);
                 }
             }
             RelOperator::Udf(udf) => {
                 let req = &mut child_required[0];
                 for item in &udf.items {
                     if parent_required.contains(&item.index) {
-                        for col in item.scalar.used_columns() {
-                            req.insert(col);
-                        }
+                        item.scalar.collect_used_columns(req);
                     }
                 }
             }
@@ -393,9 +369,7 @@ impl PhysicalPlanBuilder {
                 let req = &mut child_required[0];
                 for item in &async_func.items {
                     if parent_required.contains(&item.index) {
-                        for col in item.scalar.used_columns() {
-                            req.insert(col);
-                        }
+                        item.scalar.collect_used_columns(req);
                     }
                 }
             }

--- a/src/query/service/src/physical_plans/physical_project_set.rs
+++ b/src/query/service/src/physical_plans/physical_project_set.rs
@@ -155,7 +155,7 @@ impl PhysicalPlanBuilder {
         // 1. Prune unused Columns.
         let column_projections = required.clone().into_iter().collect::<Vec<_>>();
         for s in project_set.srfs.iter() {
-            required.extend(s.scalar.used_columns().iter().copied());
+            s.scalar.collect_used_columns(&mut required);
         }
 
         // 2. Build physical plan.

--- a/src/query/service/src/physical_plans/physical_table_scan.rs
+++ b/src/query/service/src/physical_plans/physical_table_scan.rs
@@ -324,7 +324,7 @@ impl PhysicalPlanBuilder {
             // on tenant_id would fail when the query only selects id.
             if let Some(secure_preds) = &scan.secure_predicates {
                 for pred in secure_preds {
-                    used = used.union(&pred.used_columns()).cloned().collect();
+                    pred.collect_used_columns(&mut used);
                 }
             }
 

--- a/src/query/service/src/physical_plans/physical_udf.rs
+++ b/src/query/service/src/physical_plans/physical_udf.rs
@@ -190,7 +190,7 @@ impl PhysicalPlanBuilder {
         let mut used = vec![];
         for item in udf_plan.items.iter() {
             if required.contains(&item.index) {
-                required.extend(item.scalar.used_columns());
+                item.scalar.collect_used_columns(&mut required);
                 used.push(item.clone());
             }
         }

--- a/src/query/service/src/physical_plans/physical_window.rs
+++ b/src/query/service/src/physical_plans/physical_window.rs
@@ -523,20 +523,22 @@ impl PhysicalPlanBuilder {
             required.remove(&window.index);
         }
         for item in &window_group.scalar_items {
-            required.extend(item.scalar.used_columns());
+            item.scalar.collect_used_columns(&mut required);
             required.insert(item.index);
         }
         for window in &window_group.windows {
             for item in &window.arguments {
-                required.extend(item.scalar.used_columns());
+                item.scalar.collect_used_columns(&mut required);
                 required.insert(item.index);
             }
             for item in &window.partition_by {
-                required.extend(item.scalar.used_columns());
+                item.scalar.collect_used_columns(&mut required);
                 required.insert(item.index);
             }
             for item in &window.order_by {
-                required.extend(item.order_by_item.scalar.used_columns());
+                item.order_by_item
+                    .scalar
+                    .collect_used_columns(&mut required);
                 required.insert(item.order_by_item.index);
             }
         }
@@ -616,15 +618,17 @@ impl PhysicalPlanBuilder {
         // The scalar items in window function is not replaced yet.
         // The will be replaced in physical plan builder.
         window.arguments.iter().for_each(|item| {
-            required.extend(item.scalar.used_columns());
+            item.scalar.collect_used_columns(&mut required);
             required.insert(item.index);
         });
         window.partition_by.iter().for_each(|item| {
-            required.extend(item.scalar.used_columns());
+            item.scalar.collect_used_columns(&mut required);
             required.insert(item.index);
         });
         window.order_by.iter().for_each(|item| {
-            required.extend(item.order_by_item.scalar.used_columns());
+            item.order_by_item
+                .scalar
+                .collect_used_columns(&mut required);
             required.insert(item.order_by_item.index);
         });
 

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/flatten_plan.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/flatten_plan.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use databend_common_exception::ErrorCode;
@@ -82,14 +81,10 @@ impl SubqueryDecorrelatorOptimizer {
 
     fn remap_secure_predicates(
         secure_preds: &mut [ScalarExpr],
-        column_mapping: &HashMap<Symbol, Symbol>,
+        derived_columns: &DerivedColumnScope,
     ) -> Result<()> {
         for pred in secure_preds.iter_mut() {
-            for old_col in pred.used_columns() {
-                if let Some(&new_col) = column_mapping.get(&old_col) {
-                    pred.replace_column(old_col, new_col)?;
-                }
-            }
+            pred.replace_columns(|old| Ok(derived_columns.resolve_or_self(old)))?;
         }
         Ok(())
     }
@@ -453,12 +448,13 @@ impl SubqueryDecorrelatorOptimizer {
                     .iter()
                     .map(|condition| {
                         let mut new_condition = condition.clone();
-                        for col in condition.used_columns() {
+                        new_condition.replace_columns(|col| {
                             if correlated_columns.contains(&col) {
-                                let new_col = derived_columns.must_resolve(col)?;
-                                new_condition.replace_column(col, new_col)?;
+                                derived_columns.must_resolve(col)
+                            } else {
+                                Ok(col)
                             }
-                        }
+                        })?;
                         Ok(new_condition)
                     })
                     .collect()
@@ -1077,7 +1073,7 @@ impl SubqueryDecorrelatorOptimizer {
                     return Ok((old, expr));
                 };
                 if let Some(expr) = &mut expr {
-                    expr.replace_column(old, new)?;
+                    expr.replace_columns(|column| Ok(if column == old { new } else { column }))?;
                 };
                 Ok((new, expr))
             })
@@ -1186,25 +1182,26 @@ impl SubqueryDecorrelatorOptimizer {
             RelOperator::Limit(limit) => limit.clone().into(),
             RelOperator::Sort(sort) => {
                 let mut sort = sort.clone();
-                for old in sort.used_columns() {
-                    sort.replace_column(old, derived_columns.must_resolve(old)?);
-                }
+                sort.replace_columns(|old| derived_columns.must_resolve(old))?;
                 sort.into()
             }
             RelOperator::Filter(filter) => {
                 let mut filter = filter.clone();
                 for predicate in &mut filter.predicates {
-                    for old in predicate.used_columns() {
-                        predicate.replace_column(old, derived_columns.must_resolve(old)?)?;
-                    }
+                    predicate.replace_columns(|old| derived_columns.must_resolve(old))?;
                 }
                 filter.into()
             }
             RelOperator::Join(join) => {
                 let mut join = join.clone();
-                for old in join.used_columns()? {
-                    join.replace_column(old, derived_columns.must_resolve(old)?)?;
-                }
+                let marker_index = join.marker_index;
+                join.replace_columns(|old| {
+                    if marker_index == Some(old) {
+                        Ok(old)
+                    } else {
+                        derived_columns.must_resolve(old)
+                    }
+                })?;
                 if let Some(mark) = &mut join.marker_index {
                     let mut metadata = self.metadata.write();
                     let column_entry = metadata.column(*mark);
@@ -1301,7 +1298,7 @@ impl SubqueryDecorrelatorOptimizer {
         // new derived column IDs. Without this, RAP predicates would reference
         // stale column symbols after decorrelation.
         if let Some(secure_preds) = &mut new_scan.secure_predicates {
-            Self::remap_secure_predicates(secure_preds, &derived_columns.snapshot())?;
+            Self::remap_secure_predicates(secure_preds, derived_columns)?;
         }
 
         Ok(new_scan.into())
@@ -1351,12 +1348,7 @@ impl SubqueryDecorrelatorOptimizer {
                     return Ok((old, expr));
                 };
                 if let Some(expr) = &mut expr {
-                    for used_column in expr.used_columns() {
-                        expr.replace_column(
-                            used_column,
-                            derived_columns.must_resolve(used_column)?,
-                        )?;
-                    }
+                    expr.replace_columns(|column| derived_columns.must_resolve(column))?;
                 }
                 Ok((new, expr))
             })
@@ -1369,12 +1361,7 @@ impl SubqueryDecorrelatorOptimizer {
                     return Ok((old, expr));
                 };
                 if let Some(expr) = &mut expr {
-                    for used_column in expr.used_columns() {
-                        expr.replace_column(
-                            used_column,
-                            derived_columns.must_resolve(used_column)?,
-                        )?;
-                    }
+                    expr.replace_columns(|column| derived_columns.must_resolve(column))?;
                 }
                 Ok((new, expr))
             })
@@ -1435,9 +1422,7 @@ impl SubqueryDecorrelatorOptimizer {
                 })
             }
             _ => {
-                for old in scalar.used_columns() {
-                    scalar.replace_column(old, derived_columns.must_resolve(old)?)?;
-                }
+                scalar.replace_columns(|old| derived_columns.must_resolve(old))?;
                 let column_entry = metadata.column(index);
                 let name = column_entry.name();
                 let data_type = column_entry.data_type();

--- a/src/query/sql/src/planner/plans/join.rs
+++ b/src/query/sql/src/planner/plans/join.rs
@@ -689,17 +689,22 @@ impl Join {
     }
 
     pub fn replace_column(&mut self, old: Symbol, new: Symbol) -> Result<()> {
+        self.replace_columns(|column| Ok(if column == old { new } else { column }))
+    }
+
+    pub fn replace_columns<F>(&mut self, mut replace: F) -> Result<()>
+    where F: FnMut(Symbol) -> Result<Symbol> {
         for condition in &mut self.equi_conditions {
-            condition.left.replace_column(old, new)?;
-            condition.right.replace_column(old, new)?;
+            condition.left.replace_columns(&mut replace)?;
+            condition.right.replace_columns(&mut replace)?;
         }
 
         for condition in &mut self.non_equi_conditions {
-            condition.replace_column(old, new)?;
+            condition.replace_columns(&mut replace)?;
         }
 
-        if self.marker_index == Some(old) {
-            self.marker_index = Some(new)
+        if let Some(marker_index) = &mut self.marker_index {
+            *marker_index = replace(*marker_index)?;
         }
 
         self.build_side_cache_info = None;

--- a/src/query/sql/src/planner/plans/scalar_expr.rs
+++ b/src/query/sql/src/planner/plans/scalar_expr.rs
@@ -315,23 +315,25 @@ impl ScalarExpr {
     }
 
     pub fn replace_column(&mut self, old: Symbol, new: Symbol) -> Result<()> {
-        struct ReplaceColumnVisitor {
-            old: Symbol,
-            new: Symbol,
+        self.replace_columns(|column| Ok(if column == old { new } else { column }))
+    }
+
+    pub fn replace_columns<F>(&mut self, replace: F) -> Result<()>
+    where F: FnMut(Symbol) -> Result<Symbol> {
+        struct ReplaceColumnsVisitor<F> {
+            replace: F,
         }
 
-        impl VisitorMut<'_> for ReplaceColumnVisitor {
+        impl<F> VisitorMut<'_> for ReplaceColumnsVisitor<F>
+        where F: FnMut(Symbol) -> Result<Symbol>
+        {
             fn visit_bound_column_ref(&mut self, col: &mut BoundColumnRef) -> Result<()> {
-                if col.column.index == self.old {
-                    col.column.index = self.new;
-                }
+                col.column.index = (self.replace)(col.column.index)?;
                 Ok(())
             }
         }
 
-        let mut visitor = ReplaceColumnVisitor { old, new };
-        visitor.visit(self)?;
-        Ok(())
+        ReplaceColumnsVisitor { replace }.visit(self)
     }
 
     pub fn replace_column_binding(
@@ -1783,6 +1785,21 @@ mod tests {
     use databend_common_expression::types::number::NumberDataType;
 
     use super::*;
+    use crate::ColumnBindingBuilder;
+    use crate::Visibility;
+
+    fn column_expr(index: usize) -> ScalarExpr {
+        ScalarExpr::BoundColumnRef(BoundColumnRef {
+            span: None,
+            column: ColumnBindingBuilder::new(
+                format!("c{index}"),
+                Symbol::new(index),
+                Box::new(DataType::Number(NumberDataType::Int32)),
+                Visibility::Visible,
+            )
+            .build(),
+        })
+    }
 
     fn casted_nextval_expr() -> ScalarExpr {
         ScalarExpr::CastExpr(CastExpr {
@@ -1880,5 +1897,42 @@ mod tests {
         });
 
         assert_stored_type_matches_inferred(&expr);
+    }
+
+    #[test]
+    fn test_replace_columns_visits_each_column_reference_once() -> Result<()> {
+        let mut expr = ScalarExpr::FunctionCall(FunctionCall {
+            span: None,
+            func_name: "test".to_string(),
+            params: vec![],
+            arguments: vec![
+                column_expr(1),
+                ScalarExpr::CastExpr(CastExpr {
+                    span: None,
+                    is_try: false,
+                    argument: Box::new(column_expr(2)),
+                    target_type: Box::new(DataType::Number(NumberDataType::Int64)),
+                }),
+                column_expr(1),
+            ],
+            return_type: Box::new(DataType::Number(NumberDataType::Int32)),
+        });
+        let mut visited = Vec::new();
+
+        expr.replace_columns(|column| {
+            visited.push(column);
+            Ok(Symbol::new(column.as_usize() + 10))
+        })?;
+
+        assert_eq!(visited, vec![
+            Symbol::new(1),
+            Symbol::new(2),
+            Symbol::new(1)
+        ]);
+        assert_eq!(
+            expr.used_columns(),
+            [Symbol::new(11), Symbol::new(12)].into_iter().collect()
+        );
+        Ok(())
     }
 }

--- a/src/query/sql/src/planner/plans/sort.rs
+++ b/src/query/sql/src/planner/plans/sort.rs
@@ -69,6 +69,25 @@ impl Sort {
             unimplemented!()
         };
     }
+
+    pub fn replace_columns<F>(&mut self, mut replace: F) -> Result<()>
+    where F: FnMut(Symbol) -> Result<Symbol> {
+        for item in &mut self.items {
+            item.index = replace(item.index)?;
+        }
+
+        if let Some(projection) = &mut self.pre_projection {
+            for index in projection {
+                *index = replace(*index)?;
+            }
+        }
+
+        if self.window_partition.is_some() {
+            unimplemented!()
+        };
+
+        Ok(())
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Collect scalar expression column references directly into existing required-column sets
- Remove repeated temporary `BTreeSet` construction from physical plan pruning paths
- Build join required-column sets in place instead of repeatedly using `union().cloned().collect()`
- Replace decorrelator columns in one visitor pass instead of collecting `used_columns()` and rescanning the expression once per distinct column
- Reduce remaining `used_columns()` calls under `physical_plans` from 50 to 3; the remaining callers need the materialized set

The resulting required-column sets and optimizer plans are unchanged. This refactor removes temporary collections and repeated expression traversals without changing SQL behavior.

## Implementation

- Add a fallible `ScalarExpr::replace_columns(Symbol -> Result<Symbol>)` visitor and reuse it from the existing single-column replacement API
- Add matching one-pass replacement helpers for `Join` and `Sort`
- Convert all nine decorrelator replacement sites to direct symbol mapping
- Remap secure predicates directly from `DerivedColumnScope` without materializing a mapping snapshot

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - Pair with the reviewer to explain why

Validation performed:

- `cargo test -p databend-common-sql test_replace_columns_visits_each_column_reference_once`
- `cargo test -p databend-common-sql --test it test_decorrelate_correlated_alias_regressions -- --nocapture`
- `cargo clippy -p databend-common-sql --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent identified and implemented the physical-plan collection refactor and single-pass decorrelator column replacement, added unit coverage, and ran local validation
- Responsible human: @KKould
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20345)
<!-- Reviewable:end -->
