### PR TITLE
refactor(query): avoid redundant optimizer expression clones

### DIFF
--- a/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/push_down_filter_join/extract_or_predicates.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/push_down_filter_join/extract_or_predicates.rs
@@ -55,16 +55,14 @@ fn extract_or_predicate(
     or_args: &[ScalarExpr],
     required_columns: &ColumnSet,
 ) -> Result<Option<ScalarExpr>> {
-    let flatten_or_args = flatten_ors(or_args);
     let mut extracted_scalars = Vec::new();
-    for or_arg in flatten_or_args.iter() {
+    for or_arg in flatten_ors(or_args) {
         let mut sub_scalars = Vec::new();
         match or_arg {
             ScalarExpr::FunctionCall(func)
                 if matches!(func.func_name.as_str(), "and" | "and_filters") =>
             {
-                let and_args = flatten_and(&func.arguments);
-                for and_arg in and_args.iter() {
+                for and_arg in flatten_and(&func.arguments) {
                     match and_arg {
                         ScalarExpr::FunctionCall(func)
                             if matches!(func.func_name.as_str(), "or" | "or_filters") =>
@@ -107,36 +105,36 @@ fn extract_or_predicate(
 
 // Flatten nested ORs, such as `a=1 or b=1 or c=1`
 // It'll be flatten to [a=1, b=1, c=1]
-fn flatten_ors(or_args: &[ScalarExpr]) -> Vec<ScalarExpr> {
-    let mut flattened_ors = Vec::new();
-    for or_arg in or_args.iter() {
-        match or_arg {
-            ScalarExpr::FunctionCall(func)
-                if matches!(func.func_name.as_str(), "or" | "or_filters") =>
-            {
-                flattened_ors.extend(flatten_ors(&func.arguments))
-            }
-            _ => flattened_ors.push(or_arg.clone()),
-        }
-    }
-    flattened_ors
+fn flatten_ors(or_args: &[ScalarExpr]) -> impl Iterator<Item = &ScalarExpr> {
+    flatten(or_args, |func| {
+        matches!(func.func_name.as_str(), "or" | "or_filters")
+    })
 }
 
-// Flatten nested ORs, such as `a=1 and b=1 and c=1`
+// Flatten nested ANDs, such as `a=1 and b=1 and c=1`
 // It'll be flatten to [a=1, b=1, c=1]
-fn flatten_and(and_args: &[ScalarExpr]) -> Vec<ScalarExpr> {
-    let mut flattened_and = Vec::new();
-    for and_arg in and_args.iter() {
-        match and_arg {
-            ScalarExpr::FunctionCall(func)
-                if matches!(func.func_name.as_str(), "and" | "and_filters") =>
-            {
-                flattened_and.extend(flatten_and(&func.arguments));
+fn flatten_and(and_args: &[ScalarExpr]) -> impl Iterator<Item = &ScalarExpr> {
+    flatten(and_args, |func| {
+        matches!(func.func_name.as_str(), "and" | "and_filters")
+    })
+}
+
+fn flatten(
+    args: &[ScalarExpr],
+    is_nested: impl Fn(&FunctionCall) -> bool,
+) -> impl Iterator<Item = &ScalarExpr> {
+    let mut stack = args.iter().rev().collect::<Vec<_>>();
+    std::iter::from_fn(move || {
+        loop {
+            let scalar = stack.pop()?;
+            match scalar {
+                ScalarExpr::FunctionCall(func) if is_nested(func) => {
+                    stack.extend(func.arguments.iter().rev());
+                }
+                _ => return Some(scalar),
             }
-            _ => flattened_and.push(and_arg.clone()),
         }
-    }
-    flattened_and
+    })
 }
 
 // Merge predicates to AND scalar

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/scalar_rules/rule_normalize_scalar.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/scalar_rules/rule_normalize_scalar.rs
@@ -111,6 +111,10 @@ struct RewritePredicates {}
 
 impl RewritePredicates {
     fn rewrite(&mut self, predicates: &[ScalarExpr]) -> Result<Option<Vec<ScalarExpr>>> {
+        if !Self::may_rewrite(predicates) {
+            return Ok(None);
+        }
+
         let mut expr = if predicates.len() == 1 {
             predicates[0].clone()
         } else {
@@ -138,6 +142,28 @@ impl RewritePredicates {
             }
             expr => Ok(Some(vec![expr])),
         }
+    }
+
+    fn may_rewrite(predicates: &[ScalarExpr]) -> bool {
+        predicates.is_empty()
+            || predicates.iter().any(|predicate| {
+                if is_true(predicate) || is_falsy(predicate) {
+                    return true;
+                }
+
+                let ScalarExpr::FunctionCall(call) = predicate else {
+                    return false;
+                };
+
+                match call.func_name.as_str() {
+                    "and" | "and_filters" | "or" | "or_filters" => true,
+                    "not" => matches!(
+                        call.arguments.first(),
+                        Some(ScalarExpr::FunctionCall(inner)) if inner.func_name == "not"
+                    ),
+                    _ => false,
+                }
+            })
     }
 
     fn rewrite_and(

--- a/src/query/sql/tests/it/optimizer/normalize_scalar.rs
+++ b/src/query/sql/tests/it/optimizer/normalize_scalar.rs
@@ -265,6 +265,12 @@ fn test_normalize_scalar_filter_rule_outcomes() -> Result<()> {
             expr_text: "a != 3 and true and a != 5",
         },
         Case {
+            name: "scan_keeps_simple_comparison",
+            description: "A scan predicate outside the target patterns should remain unchanged.",
+            target: Target::Scan,
+            expr_text: "a = 5",
+        },
+        Case {
             name: "scan_short_circuits_pushdown_or_chain",
             description: "Scan pushdown predicates should also short-circuit truthy OR operands.",
             target: Target::Scan,

--- a/src/query/sql/tests/it/optimizer/normalize_scalar.txt
+++ b/src/query/sql/tests/it/optimizer/normalize_scalar.txt
@@ -2,7 +2,7 @@
 description: A single comparison should remain unchanged.
 operator: filter
 input: a = 5
-changed: true
+changed: false
 output[0]: eq<UInt64, UInt64>(a (#0), 5_u64)
 
 === filter_flattens_and_chain ===
@@ -91,7 +91,7 @@ output[0]: b (#1)
 description: Expressions outside the rule's target patterns should remain intact.
 operator: filter
 input: is_not_null(c < 3 and c < 4)
-changed: true
+changed: false
 output[0]: is_not_null<T0=Boolean><T0 NULL>(and<Boolean NULL, Boolean NULL>(lt<UInt64 NULL, UInt64 NULL>(c (#2), CAST<UInt8>(3_u8 AS UInt64 NULL)), lt<UInt64 NULL, UInt64 NULL>(c (#2), CAST<UInt8>(4_u8 AS UInt64 NULL))))
 
 === scan_normalizes_pushdown_and_chain ===
@@ -101,6 +101,13 @@ input: a != 3 and true and a != 5
 changed: true
 output[0]: noteq<UInt64, UInt64>(a (#0), CAST<UInt8>(3_u8 AS UInt64))
 output[1]: noteq<UInt64, UInt64>(a (#0), CAST<UInt8>(5_u8 AS UInt64))
+
+=== scan_keeps_simple_comparison ===
+description: A scan predicate outside the target patterns should remain unchanged.
+operator: scan
+input: a = 5
+changed: false
+output[0]: eq<UInt64, UInt64>(a (#0), 5_u64)
 
 === scan_short_circuits_pushdown_or_chain ===
 description: Scan pushdown predicates should also short-circuit truthy OR operands.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Add a borrowed fast-path check before RuleNormalizeScalarFilter constructs an owned expression
- Skip cloning Filter and Scan predicates when no top-level AND, OR, double negation, or boolean constant can be normalized
- Convert join OR/AND flatten helpers to borrowed, stack-driven iterators so only predicates retained by extraction are cloned
- Preserve flatten traversal order, empty-predicate behavior, and existing normalization behavior
- Update optimizer golden coverage for unchanged Filter and Scan predicates

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent implemented the borrowed scalar rewrite precheck and join predicate flatten iterators, updated optimizer golden coverage, performed scoped local validation, and prepared this PR.
- Responsible human: @KKould
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20346)
<!-- Reviewable:end -->
