### PR TITLE
chore(query): clarify rollback warning for incompatible grants

### DIFF
--- a/src/meta/proto-conv/src/impls/user.rs
+++ b/src/meta/proto-conv/src/impls/user.rs
@@ -380,15 +380,16 @@ impl FromToProto for mt::principal::UserGrantSet {
 
         let mut entries = Vec::new();
         for entry in p.entries.into_iter() {
-            // If we add new GrantObject in new version
-            // Rollback to old version, GrantEntry.object will be None
-            // GrantEntry::from_pb will return err so user can not login in old version.
-            // Silently dropping unrecognized grant entries and logging the error is
-            // intentional: the node must still start and serve other users even when
-            // some grant entries are unrecognizable (e.g. during a version rollback).
+            // If we add a new GrantObject in a newer version, after rollback its protobuf
+            // oneof variant is unknown and GrantEntry.object will be None.
+            // GrantEntry::from_pb will return an error. Dropping only that entry and logging
+            // a warning is intentional: the principal remains usable, while all other grants
+            // and role memberships are preserved.
             match mt::principal::GrantEntry::from_pb(entry) {
                 Ok(entry) => entries.push(entry),
-                Err(e) => log::error!("GrantEntry::from_pb with error : {e}"),
+                Err(error) => log::warn!(
+                    "Skipped one incompatible grant entry while decoding grants for a user or role: {error}. Impact: only this grant entry is ignored; all other grants and role memberships are preserved, and this incompatibility does not by itself block login"
+                ),
             }
         }
         let mut roles = HashSet::new();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Log skipped incompatible grant entries as warnings and clarify that only the affected entry is ignored while other grants and role memberships remain available.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - moidfy a log level

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe):

## AI assistance

<!--
See AI_POLICY.md. Agent-opened PRs are welcome; a responsible human on the author side must own the change.
The responsible human is NOT the reviewer — it is the submitter-side owner who has read the diff,
can explain each change, and will answer questions during review.
Write "None" for AI usage if no AI was involved.
-->

- AI usage:None
- Responsible human: @TCeason 
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20347)
<!-- Reviewable:end -->
