### PR TITLE
fix(query): ignore system sources in lineage

### DIFF
--- a/src/query/service/src/interpreters/common/lineage_log.rs
+++ b/src/query/service/src/interpreters/common/lineage_log.rs
@@ -229,6 +229,9 @@ pub(crate) fn build_semantic_edges(lineage: QueryLineage) -> Vec<SemanticLineage
     for lineage_target in lineage.targets {
         let target = endpoint_from_relation(lineage.kind, false, &lineage_target.relation);
         for lineage_source in lineage_target.sources {
+            if is_ignored_system_source(&lineage_source.relation) {
+                continue;
+            }
             let source = endpoint_from_relation(lineage.kind, true, &lineage_source.relation);
             if source.lineage_key == target.lineage_key {
                 continue;
@@ -257,6 +260,14 @@ pub(crate) fn build_semantic_edges(lineage: QueryLineage) -> Vec<SemanticLineage
     }
 
     entries
+}
+
+fn is_ignored_system_source(relation: &QueryLineageRelation) -> bool {
+    relation.catalog_type == Some(CatalogType::Default)
+        && relation.catalog.eq_ignore_ascii_case("default")
+        && ["system", "information_schema"]
+            .iter()
+            .any(|database| relation.database.eq_ignore_ascii_case(database))
 }
 
 fn into_log_entry(edge: SemanticLineageEdge, process: LineageProcessMetadata) -> LineageLogEntry {

--- a/tests/lineage/sqllogic/check/04_statement_coverage.test
+++ b/tests/lineage/sqllogic/check/04_statement_coverage.test
@@ -249,6 +249,21 @@ FROM get_lineage('lineage_history_statements.insert_stage_dst.a', 'COLUMN', 'UPS
 ----
 0
 
+# System and information_schema describe runtime metadata rather than business datasets, so INSERT,
+# CTAS, CREATE VIEW, and View refresh do not persist them as source endpoints.
+query I
+SELECT count(*)
+FROM system_history.lineage_history
+WHERE source_database IN ('system', 'information_schema')
+  AND target_database = 'lineage_history_statements'
+  AND target_name IN (
+    'system_source_dst',
+    'information_schema_source_dst',
+    'system_source_view'
+  )
+----
+0
+
 statement ok
 DROP DATABASE lineage_history_statements
 

--- a/tests/lineage/sqllogic/setup/04_statement_coverage.test
+++ b/tests/lineage/sqllogic/setup/04_statement_coverage.test
@@ -145,6 +145,22 @@ statement ok
 INSERT INTO lineage_history_statements.insert_select_stage_dst
 SELECT a, b FROM @lineage_history_statements_stage
 
+# Built-in metadata sources are intentionally omitted from persisted lineage.
+statement ok
+CREATE TABLE lineage_history_statements.system_source_dst(x UInt8)
+
+statement ok
+INSERT INTO lineage_history_statements.system_source_dst
+SELECT dummy FROM system.one
+
+statement ok
+CREATE TABLE lineage_history_statements.information_schema_source_dst AS
+SELECT table_name FROM information_schema.views
+
+statement ok
+CREATE VIEW lineage_history_statements.system_source_view AS
+SELECT dummy FROM system.one
+
 # INSERT FROM Stage uses the COPY plan path and purges input files, so keep it last.
 statement ok
 CREATE TABLE lineage_history_statements.insert_stage_dst(a INT, b INT)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Lineage currently persists `system` and `information_schema` sources for statements such as INSERT and CTAS. These built-in metadata relations are not business datasets, create noisy high-fanout lineage nodes, and use synthetic table IDs that are not guaranteed to remain stable across versions.

This PR filters sources from `default.system` and `default.information_schema` in the shared semantic-edge builder, so the behavior applies consistently to DML, CTAS, CREATE VIEW, and refreshed View lineage. Other sources in a mixed query remain intact, and `system_history` continues to be retained because it contains persistent data with normal Meta identities.

Validation:

- `cargo check -p databend-query --lib`
- `cargo fmt --all -- --check`
- `git diff --check up/main...HEAD`

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent investigated system-table identity stability, drafted the shared lineage-source filter, added logic regression coverage, and prepared the PR description; I reviewed the final diff and behavior
- Responsible human: @youngsofun
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20349)
<!-- Reviewable:end -->
