### PR TITLE
fix(query): preserve null validity in correlated joins

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_probe_state.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/hash_join_probe_state.rs
@@ -230,10 +230,7 @@ impl HashJoinProbeState {
         }
 
         let is_null_equal = &self.hash_join_state.hash_join_desc.is_null_equal;
-        let valids = if !Self::check_for_eliminate_valids(
-            self.hash_join_state.hash_join_desc.from_correlated_subquery,
-            &self.hash_join_state.hash_join_desc.join_type,
-        ) && probe_keys.iter().any(|expr| {
+        let valids = if probe_keys.iter().any(|expr| {
             let ty = expr.data_type();
             ty.is_nullable() || ty.is_null()
         }) {
@@ -383,29 +380,6 @@ impl HashJoinProbeState {
                 "Aborted query, because the hash table is uninitialized.",
             )),
         })
-    }
-
-    /// Checks if a join type can eliminate valids.
-    pub fn check_for_eliminate_valids(
-        from_correlated_subquery: bool,
-        join_type: &JoinType,
-    ) -> bool {
-        if !from_correlated_subquery {
-            return false;
-        }
-        matches!(
-            join_type,
-            JoinType::Inner
-                | JoinType::InnerAny
-                | JoinType::Full
-                | JoinType::Left
-                | JoinType::LeftAny
-                | JoinType::LeftSingle
-                | JoinType::LeftAnti
-                | JoinType::LeftSemi
-                | JoinType::LeftMark
-                | JoinType::RightMark
-        )
     }
 
     /// Checks if the join type need to use unmatched selection.

--- a/src/query/service/src/pipelines/processors/transforms/new_hash_join/memory/inner_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/new_hash_join/memory/inner_join.rs
@@ -129,10 +129,7 @@ impl Join for InnerHashJoin {
         let probe_keys = self.desc.probe_key(&data, &self.function_ctx)?;
 
         let mut keys = DataBlock::new(probe_keys, data.num_rows());
-        let valids = match self.desc.from_correlated_subquery {
-            true => None,
-            false => self.desc.build_valids_by_keys(&keys)?,
-        };
+        let valids = self.desc.build_valids_by_keys(&keys)?;
 
         self.desc.remove_keys_nullable(&mut keys);
         let probe_block = data.project(&self.desc.probe_projection);

--- a/src/query/service/src/pipelines/processors/transforms/new_hash_join/memory/left_join.rs
+++ b/src/query/service/src/pipelines/processors/transforms/new_hash_join/memory/left_join.rs
@@ -127,10 +127,7 @@ impl Join for OuterLeftHashJoin {
         let probe_keys = self.desc.probe_key(&data, &self.function_ctx)?;
 
         let mut keys = DataBlock::new(probe_keys, data.num_rows());
-        let valids = match self.desc.from_correlated_subquery {
-            true => None,
-            false => self.desc.build_valids_by_keys(&keys)?,
-        };
+        let valids = self.desc.build_valids_by_keys(&keys)?;
 
         self.desc.remove_keys_nullable(&mut keys);
         let probe_block = data.project(&self.desc.probe_projection);

--- a/src/query/service/src/pipelines/processors/transforms/new_hash_join/memory/left_join_anti.rs
+++ b/src/query/service/src/pipelines/processors/transforms/new_hash_join/memory/left_join_anti.rs
@@ -108,10 +108,7 @@ impl Join for AntiLeftHashJoin {
         let probe_keys = self.desc.probe_key(&data, &self.function_ctx)?;
 
         let mut keys = DataBlock::new(probe_keys, data.num_rows());
-        let valids = match self.desc.from_correlated_subquery {
-            true => None,
-            false => self.desc.build_valids_by_keys(&keys)?,
-        };
+        let valids = self.desc.build_valids_by_keys(&keys)?;
 
         self.desc.remove_keys_nullable(&mut keys);
         let probe_block = data.project(&self.desc.probe_projection);

--- a/src/query/service/src/pipelines/processors/transforms/new_hash_join/memory/left_join_semi.rs
+++ b/src/query/service/src/pipelines/processors/transforms/new_hash_join/memory/left_join_semi.rs
@@ -131,10 +131,7 @@ impl Join for SemiLeftHashJoin {
         let probe_keys = self.desc.probe_key(&data, &self.function_ctx)?;
 
         let mut keys = DataBlock::new(probe_keys, data.num_rows());
-        let valids = match self.desc.from_correlated_subquery {
-            true => None,
-            false => self.desc.build_valids_by_keys(&keys)?,
-        };
+        let valids = self.desc.build_valids_by_keys(&keys)?;
 
         self.desc.remove_keys_nullable(&mut keys);
         let probe_block = data.project(&self.desc.probe_projection);

--- a/tests/sqllogictests/suites/query/subquery.test
+++ b/tests/sqllogictests/suites/query/subquery.test
@@ -26,6 +26,87 @@ FROM t1;
 2 1 0
 NULL 0 1
 
+statement ok
+CREATE OR REPLACE TABLE nullable_fixed_probe_a (
+    decimal_key DECIMAL(6, 0) NULL,
+    boolean_key BOOLEAN NULL,
+    timestamp_key TIMESTAMP NULL
+);
+
+statement ok
+CREATE OR REPLACE TABLE nullable_fixed_probe_b (
+    decimal_key DECIMAL(6, 0) NULL,
+    boolean_key BOOLEAN NULL,
+    timestamp_key TIMESTAMP NULL
+);
+
+statement ok
+INSERT INTO nullable_fixed_probe_a VALUES
+    (NULL, NULL, NULL),
+    (0, false, TIMESTAMP '1970-01-01 00:00:00'),
+    (1, true, TIMESTAMP '1970-01-01 00:00:01');
+
+statement ok
+INSERT INTO nullable_fixed_probe_b VALUES
+    (0, false, TIMESTAMP '1970-01-01 00:00:00');
+
+query T rowsort
+SELECT to_string(decimal_key)
+FROM nullable_fixed_probe_a AS a
+WHERE EXISTS (
+    SELECT 1 FROM nullable_fixed_probe_b AS b WHERE b.decimal_key = a.decimal_key
+);
+----
+0
+
+query T rowsort
+SELECT to_string(decimal_key)
+FROM nullable_fixed_probe_a AS a
+WHERE NOT EXISTS (
+    SELECT 1 FROM nullable_fixed_probe_b AS b WHERE b.decimal_key = a.decimal_key
+);
+----
+1
+NULL
+
+query TBB rowsort
+SELECT
+    to_string(decimal_key),
+    EXISTS (SELECT 1 FROM nullable_fixed_probe_b AS b WHERE b.boolean_key = a.boolean_key),
+    EXISTS (SELECT 1 FROM nullable_fixed_probe_b AS b WHERE b.timestamp_key = a.timestamp_key)
+FROM nullable_fixed_probe_a AS a;
+----
+0 1 1
+1 0 0
+NULL 0 0
+
+query TI rowsort
+SELECT
+    to_string(decimal_key),
+    (SELECT COUNT(*) FROM nullable_fixed_probe_b AS b WHERE b.decimal_key = a.decimal_key)
+FROM nullable_fixed_probe_a AS a;
+----
+0 1
+1 0
+NULL 0
+
+statement ok
+SET enable_experimental_new_join = 0;
+
+query TBB rowsort
+SELECT
+    to_string(decimal_key),
+    EXISTS (SELECT 1 FROM nullable_fixed_probe_b AS b WHERE b.boolean_key = a.boolean_key),
+    EXISTS (SELECT 1 FROM nullable_fixed_probe_b AS b WHERE b.timestamp_key = a.timestamp_key)
+FROM nullable_fixed_probe_a AS a;
+----
+0 1 1
+1 0 0
+NULL 0 0
+
+statement ok
+SET enable_experimental_new_join = 1;
+
 query IBB rowsort
 SELECT
       t1.a,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Fixes #20351
- Preserve probe-key validity for correlated hash joins instead of treating nullable fixed-width keys as their default values
- Honor the planner's per-key `is_null_equal` flags in both the legacy and experimental hash-join implementations
- Add regression coverage for correlated `EXISTS`, `NOT EXISTS`, and scalar subqueries with nullable DECIMAL, BOOLEAN, and TIMESTAMP keys

## Root cause

Correlated joins bypassed probe-key validity filtering before nullable key wrappers were removed. For fixed-width hash methods, a NULL DECIMAL, BOOLEAN, or TIMESTAMP key was then probed using its underlying default value (`0`, `false`, or the epoch), which could produce a false match.

The planner already records whether each equality key is null-safe in `is_null_equal`. This change always derives the validity bitmap from those flags, so regular equality rejects NULL while null-safe correlation keys continue to match according to the plan.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation performed:

- `cargo fmt --all -- --check`
- `cargo check -p databend-query`
- `cargo clippy -p databend-query --lib -- -D warnings`
- `target/debug/databend-sqllogictests --handlers http --port 18000 --run 'tests/sqllogictests/suites/query/subquery.test'` (255 tests passed)

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent investigated the hash-join probe paths, drafted the focused fix and regression tests, and ran the listed validation commands
- Responsible human: @sundy-li
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20354)
<!-- Reviewable:end -->
