### PR TITLE
fix(storage): stream small parquet file batches

### DIFF
--- a/src/query/storages/parquet/src/parquet_part.rs
+++ b/src/query/storages/parquet/src/parquet_part.rs
@@ -24,6 +24,7 @@ use databend_common_catalog::plan::PartInfo;
 use databend_common_catalog::plan::PartInfoPtr;
 use databend_common_catalog::plan::PartStatistics;
 use databend_common_catalog::plan::Partitions;
+use databend_common_catalog::plan::PartitionsShuffleKind;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -276,7 +277,7 @@ pub(crate) fn collect_parts(
     num_columns_to_read: usize,
     total_columns_to_read: usize,
 ) -> Result<(PartStatistics, Partitions)> {
-    let mut partitions = Partitions::default();
+    let mut partitions = Partitions::create(PartitionsShuffleKind::Mod, vec![]);
     let mut stats = PartStatistics::default();
 
     let fast_read_bytes = ctx.get_settings().get_parquet_fast_read_bytes()?;

--- a/src/query/storages/parquet/src/parquet_reader/reader/builder.rs
+++ b/src/query/storages/parquet/src/parquet_reader/reader/builder.rs
@@ -227,7 +227,15 @@ impl<'a> ParquetReaderBuilder<'a> {
         need_file_row_number: bool,
     ) -> Result<ParquetWholeFileReader> {
         let batch_size = self.ctx.get_settings().get_parquet_max_block_size()? as usize;
+        self.build_full_reader_with_batch_size(source_type, need_file_row_number, batch_size)
+    }
 
+    pub fn build_full_reader_with_batch_size(
+        &mut self,
+        source_type: ParquetSourceType,
+        need_file_row_number: bool,
+        batch_size: usize,
+    ) -> Result<ParquetWholeFileReader> {
         if !need_file_row_number {
             self.build_predicate()?;
         }

--- a/src/query/storages/parquet/src/parquet_table/read.rs
+++ b/src/query/storages/parquet/src/parquet_table/read.rs
@@ -100,9 +100,11 @@ impl ParquetTable {
             builder.build_row_group_reader(ParquetSourceType::StageTable, need_row_number)?,
         );
         let full_file_reader = if has_file_part {
-            Some(Arc::new(builder.build_full_reader(
+            let batch_size = ctx.get_settings().get_max_block_size()? as usize;
+            Some(Arc::new(builder.build_full_reader_with_batch_size(
                 ParquetSourceType::StageTable,
                 need_row_number,
+                batch_size,
             )?))
         } else {
             None

--- a/src/query/storages/parquet/src/source.rs
+++ b/src/query/storages/parquet/src/source.rs
@@ -50,6 +50,7 @@ use crate::ParquetReaderBuilder;
 use crate::meta::check_parquet_schema;
 use crate::meta::read_metadata_async_cached;
 use crate::parquet_part::DeleteTask;
+use crate::parquet_reader::DataBlockIterator;
 use crate::parquet_reader::ParquetWholeFileReader;
 use crate::parquet_reader::RowGroupReader;
 use crate::parquet_reader::cached_range_full_read;
@@ -65,8 +66,58 @@ enum State {
         location: String,
         meta: ParquetFileMeta,
     },
-    // (bytes, path, file-meta)
-    ReadFiles(Vec<(Bytes, String, ParquetFileMeta)>),
+    ReadFiles {
+        // Compressed files are fetched concurrently, then decoded one at a time.
+        buffers: VecDeque<(Bytes, String, ParquetFileMeta)>,
+        reader: Option<SmallFileReader>,
+    },
+}
+
+struct SmallFileReader {
+    blocks: DataBlockIterator,
+    path: String,
+    meta: ParquetFileMeta,
+    rows_start: u64,
+    copy_status_registered: bool,
+}
+
+impl SmallFileReader {
+    fn next_block(
+        &mut self,
+        internal_columns: &[InternalColumnType],
+        is_copy: bool,
+        copy_status: &CopyStatus,
+    ) -> Result<Option<DataBlock>> {
+        let Some(mut block) = self.blocks.next().transpose()? else {
+            if is_copy && !self.copy_status_registered {
+                copy_status.add_chunk(self.path.as_str(), FileStatus {
+                    num_rows_loaded: 0,
+                    error: None,
+                });
+                self.copy_status_registered = true;
+            }
+            return Ok(None);
+        };
+
+        add_internal_columns_with_meta(
+            internal_columns,
+            self.path.clone(),
+            &mut block,
+            &mut self.rows_start,
+            self.meta.content_key.as_deref(),
+            self.meta.last_modified,
+        );
+
+        if is_copy {
+            copy_status.add_chunk(self.path.as_str(), FileStatus {
+                num_rows_loaded: block.num_rows(),
+                error: None,
+            });
+            self.copy_status_registered = true;
+        }
+
+        Ok(Some(block))
+    }
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -193,7 +244,7 @@ impl Processor for ParquetSource {
             None => match &self.state {
                 State::Init => Ok(Event::Async),
                 State::ReadRowGroup { .. } => Ok(Event::Sync),
-                State::ReadFiles(_) => Ok(Event::Sync),
+                State::ReadFiles { .. } => Ok(Event::Sync),
             },
             Some(data_block) => {
                 let progress_values = ProgressValues {
@@ -247,42 +298,43 @@ impl Processor for ParquetSource {
                 }
                 // Else: The reader is finished. We should try to build another reader.
             }
-            State::ReadFiles(buffers) => {
-                let mut blocks = Vec::with_capacity(buffers.len());
-                for (buffer, path, meta) in buffers {
-                    let bs: Result<Vec<DataBlock>> = self
+            State::ReadFiles {
+                mut buffers,
+                mut reader,
+            } => {
+                loop {
+                    if let Some(current) = reader.as_mut() {
+                        if let Some(block) = current.next_block(
+                            &self.internal_columns,
+                            self.is_copy,
+                            &self.copy_status,
+                        )? {
+                            self.generated_data = Some(block);
+                            break;
+                        }
+                        reader = None;
+                    }
+
+                    let Some((buffer, path, meta)) = buffers.pop_front() else {
+                        break;
+                    };
+                    let blocks = self
                         .whole_file_reader
                         .as_ref()
                         .unwrap()
-                        .read_blocks_from_binary(buffer, &path)?
-                        .collect();
-                    let mut bs = bs?;
-
-                    if self.is_copy {
-                        let num_rows = bs.iter().map(|b| b.num_rows()).sum();
-                        self.copy_status.add_chunk(path.as_str(), FileStatus {
-                            num_rows_loaded: num_rows,
-                            error: None,
-                        });
-                    }
-                    let mut rows_start = 0;
-                    for b in bs.iter_mut() {
-                        add_internal_columns_with_meta(
-                            &self.internal_columns,
-                            path.to_string(),
-                            b,
-                            &mut rows_start,
-                            meta.content_key.as_deref(),
-                            meta.last_modified,
-                        );
-                    }
-                    blocks.extend(bs);
+                        .read_blocks_from_binary(buffer, &path)?;
+                    reader = Some(SmallFileReader {
+                        blocks,
+                        path,
+                        meta,
+                        rows_start: 0,
+                        copy_status_registered: false,
+                    });
                 }
 
-                if !blocks.is_empty() {
-                    self.generated_data = Some(DataBlock::concat(&blocks)?);
+                if reader.is_some() || !buffers.is_empty() {
+                    self.state = State::ReadFiles { buffers, reader };
                 }
-                // Else: no output data is generated.
             }
             _ => unreachable!(),
         }
@@ -340,7 +392,10 @@ impl Processor for ParquetSource {
                                 });
                             }
                             let results = futures::future::try_join_all(handlers).await?;
-                            self.state = State::ReadFiles(results);
+                            self.state = State::ReadFiles {
+                                buffers: results.into(),
+                                reader: None,
+                            };
                         }
                         ParquetPart::File(part) => {
                             let readers = self.get_rows_readers(part, None).await?;

--- a/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.result
+++ b/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.result
@@ -15,6 +15,13 @@
 2	70
 1	[1,2,3]
 2	{"k":"v"}
+--- small parquet file should stream multiple blocks
+131073
+131073	0	131072	0	131072	131073
+131073
+131073	0	131072	0	131072	131073
+0
+0
 --- large parquet file should be worked on parallel by rowgroups
 5000000
 parallel scan partitions: true

--- a/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.sh
+++ b/tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.sh
@@ -41,6 +41,27 @@ echo "create stage s4 FILE_FORMAT = (type = PARQUET);" | bendsql_connect_root
 echo "copy into @s4 from t2;" | bendsql_connect_root | cut -d$'\t' -f1,2
 echo "select * from @s4;" | bendsql_connect_root
 
+echo '--- small parquet file should stream multiple blocks'
+echo 'remove @s4;' | bendsql_connect_root
+echo "copy into @s4 from (select number a from numbers(131073)) file_format=(type=parquet) single=true;" | bendsql_connect_root | cut -d$'\t' -f1
+echo "select /*+ set_var(parquet_fast_read_bytes=1073741824) set_var(max_block_size=65536) */ count(), min(a), max(a), min(metadata\$file_row_number), max(metadata\$file_row_number), count(distinct metadata\$file_row_number) from @s4;" | bendsql_connect_root
+echo 'drop table if exists small_parquet_streaming;' | bendsql_connect_root
+echo 'create table small_parquet_streaming(a uint64, row_number uint64);' | bendsql_connect_root
+echo "copy /*+ set_var(parquet_fast_read_bytes=1073741824) set_var(max_block_size=65536) */ into small_parquet_streaming from (select a, metadata\$file_row_number from @s4) force=true;" | bendsql_connect_root | cut -d$'\t' -f2
+echo 'select count(), min(a), max(a), min(row_number), max(row_number), count(distinct row_number) from small_parquet_streaming;' | bendsql_connect_root
+echo 'truncate table small_parquet_streaming;' | bendsql_connect_root
+# A valid 332-byte Parquet file with one UInt64 column and zero rows.
+EMPTY_PARQUET_DIR="/tmp/databend_empty_parquet_$$"
+mkdir -p "$EMPTY_PARQUET_DIR"
+printf '%s' 'UEFSMRUEFQAVAkwVABUAEgAAABUEGSw1ABgGc2NoZW1hFQIAFQQlAhgBYSUcTKwTQBIAAAAWABkcGRwmABwVBBklAAYZGAFhFQIWABYcFh4mACYIKRwVBBUAFQIAAAAWHBYAJggWHgAZHBgMQVJST1c6c2NoZW1hGKABLy8vLy8zQUFBQUFRQUFBQUFBQUtBQXdBQmdBRkFBZ0FDZ0FBQUFBQkJBQU1BQUFBQ0FBSUFBQUFCQUFJQUFBQUJBQUFBQUVBQUFBVUFBQUFFQUFVQUFnQUJnQUhBQXdBQUFBUUFCQUFBQUFBQUFFQ0VBQUFBQmdBQUFBRUFBQUFBQUFBQUFFQUFBQmhBQVlBQ0FBRUFBWUFBQUJBQUFBQQAYIHBhcnF1ZXQtY3BwLWFycm93IHZlcnNpb24gMjEuMC4wGRwcAAAAMQEAAFBBUjE=' | base64 --decode > "$EMPTY_PARQUET_DIR/empty.parquet"
+echo 'drop stage if exists empty_parquet;' | bendsql_connect_root
+echo "create stage empty_parquet url = 'fs://$EMPTY_PARQUET_DIR/' file_format = (type = parquet);" | bendsql_connect_root
+echo "copy /*+ set_var(parquet_fast_read_bytes=1073741824) set_var(max_block_size=65536) */ into small_parquet_streaming from (select a, metadata\$file_row_number from @empty_parquet) force=true;" | bendsql_connect_root | cut -d$'\t' -f2
+echo 'select count() from small_parquet_streaming;' | bendsql_connect_root
+echo 'drop stage empty_parquet;' | bendsql_connect_root
+rm -rf "$EMPTY_PARQUET_DIR"
+echo 'drop table small_parquet_streaming;' | bendsql_connect_root
+
 ## generate large parquet files will cause timeout, we comment it now
 echo '--- large parquet file should be worked on parallel by rowgroups'
 echo 'remove @s4;' | bendsql_connect_root


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Stream decoded batches from `SmallFiles` Parquet partitions instead of collecting every block and concatenating the whole partition
- Keep concurrent downloads within each small-files partition, while decoding one file at a time with pipeline backpressure
- Use the normal stage-table `max_block_size` for the whole-file reader so small and regular Parquet paths emit consistently sized batches
- Distribute Parquet partitions with deterministic modulo hashing so `File` and `SmallFiles` paths are not assigned to nodes in contiguous groups

Previously, a `SmallFiles` partition retained the compressed buffers for all files, collected every decoded block, and then allocated another full-size block through `DataBlock::concat`. For wide Parquet inputs and multiple concurrent sources, these overlapping allocations could amplify peak memory far beyond the data-size difference between nodes. This change removes the partition-wide collect/concat peak while preserving file download concurrency.

Compression-ratio estimation, partition sizing, and source concurrency estimation are intentionally unchanged and will be handled separately.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:

- `cargo clippy -p databend-common-storages-parquet -- -D warnings`
- `cargo fmt --all -- --check`
- `bash -n tests/suites/1_stateful/08_select_stage/08_00_parquet/08_00_00_basic.sh`

The stateful case creates a 131,073-row small Parquet file with a 65,536-row block size to exercise three streamed batches. It verifies that `metadata$file_row_number` remains continuous and unique across batches, that COPY status accumulates all 131,073 loaded rows when status is updated per batch, and that a valid non-empty Parquet file containing zero rows still appears in the COPY result with `rows_loaded = 0`.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

## Risk

The streaming change is limited to the StageTable `SmallFiles` read path. It preserves concurrent file downloads, predicate handling, internal-column generation, and COPY row accounting. Whole-file readers used by streaming load and external table engines keep their existing `parquet_max_block_size` behavior. Stage Parquet partitions now use deterministic modulo-hash distribution instead of sequential distribution; this changes node assignment order but not partition contents or query results.

## AI assistance

- AI usage: An AI coding agent investigated the Parquet memory amplification, drafted the streaming state-machine change and regression tests, and ran focused validation
- Responsible human: @youngsofun
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20356)

<!-- Reviewable:end -->
