### PR TITLE
fix(query): preserve arguments after identity cast elimination

### DIFF
--- a/src/query/sql/src/planner/semantic/type_check/scalar_function.rs
+++ b/src/query/sql/src/planner/semantic/type_check/scalar_function.rs
@@ -643,12 +643,27 @@ where A: TypeCheckAdapter
         // will be folded from `timestamp > to_timestamp('2001-01-01')` to `timestamp > 978307200000000`
         // Note: check function may reorder the args
 
+        let checked_func_name = BUILTIN_FUNCTIONS
+            .aliases
+            .get(func_name)
+            .map_or(func_name, String::as_str);
+
+        // `check_function` may eliminate an identity conversion and return its argument.
+        // In that case, the checked root arguments no longer correspond to the original call.
+        let checked_root_matches = match &expr {
+            expr::Expr::FunctionCall(expr::FunctionCall {
+                function,
+                args: checked_args,
+                ..
+            }) => function.signature.name == checked_func_name && checked_args.len() == args.len(),
+            _ => false,
+        };
         let mut folded_args = match &expr {
             expr::Expr::FunctionCall(expr::FunctionCall {
                 function,
                 args: checked_args,
                 ..
-            }) => checked_args
+            }) if checked_root_matches => checked_args
                 .iter()
                 .zip(
                     function

--- a/src/query/sql/tests/it/semantic/type_check/scalar_function.rs
+++ b/src/query/sql/tests/it/semantic/type_check/scalar_function.rs
@@ -15,6 +15,12 @@ async fn test_type_check_scalar_function_rules() -> Result<()> {
             setup_sqls: &[],
             sql: "to_decimal(number, number)",
         },
+        SqlTestCase {
+            name: "identity_cast_preserves_complete_argument",
+            description: "An eliminated identity cast must not remap an inner function argument onto the original call.",
+            setup_sqls: &[],
+            sql: "to_int64(100000000 + ((854435761::UInt64 * number + 123456789) % 900000000))",
+        },
     ];
 
     run_type_check_cases("scalar_function.txt", &cases).await

--- a/src/query/sql/tests/it/semantic/type_check/scalar_function.txt
+++ b/src/query/sql/tests/it/semantic/type_check/scalar_function.txt
@@ -11,3 +11,10 @@ sql: to_decimal(number, number)
 status: error
 code: 1065
 message: Invalid arguments for `to_decimal`, precision is only allowed to be a constant
+
+=== identity_cast_preserves_complete_argument ===
+description: An eliminated identity cast must not remap an inner function argument onto the original call.
+sql: to_int64(100000000 + ((854435761::UInt64 * number + 123456789) % 900000000))
+status: ok
+scalar: to_int64(plus(100000000, modulo(plus(multiply(854435761, number (#0)), 123456789), 900000000)))
+type: Int64 NULL


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Prevent scalar type checking from remapping an inner function's arguments onto the original call after an identity cast is eliminated
- Reuse checked arguments only when the checked expression still has the same root function and arity, including alias resolution

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent assisted with implementation.
- Responsible human: @forsaken628
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20357)
<!-- Reviewable:end -->
