### PR TITLE
fix(storage): restore node-global memory budget for recluster

### DIFF
--- a/src/query/service/src/interpreters/hook/compact_hook.rs
+++ b/src/query/service/src/interpreters/hook/compact_hook.rs
@@ -274,6 +274,9 @@ pub(crate) async fn compact_table(
                 &compact_target.database,
                 &compact_target.table,
             )?;
+            // Spill is disabled to keep this synchronous hook fast (spilling adds
+            // disk IO). Admission must then keep tasks inside the memory budget.
+            // TODO: remove once the async hook is enabled.
             ctx.set_enable_sort_spill(false);
             let target = if is_materialized_view_engine(table.engine()) {
                 MaintenanceTarget::MaterializedView {

--- a/src/query/service/src/physical_plans/physical_recluster.rs
+++ b/src/query/service/src/physical_plans/physical_recluster.rs
@@ -14,6 +14,7 @@
 
 use std::any::Any;
 
+use databend_common_base::runtime::GLOBAL_MEM_STAT;
 use databend_common_catalog::plan::BlockMetaOptions;
 use databend_common_catalog::plan::DataSourceInfo;
 use databend_common_catalog::plan::DataSourcePlan;
@@ -113,6 +114,22 @@ impl IPhysicalPlan for Recluster {
                 let table = FuseTable::try_from_table(table.as_ref())?;
 
                 let task = &self.tasks[0];
+                let settings = builder.ctx.get_settings();
+                // Execution-time guard: planning-time admission runs on the
+                // coordinator and cannot see this node's live memory pressure.
+                // Oversized tasks are only tolerable when sort spill can absorb
+                // the pressure; otherwise fail fast instead of risking an OOM kill.
+                if !builder.ctx.get_enable_sort_spill() {
+                    let max_memory_usage = settings.get_max_memory_usage()? as usize;
+                    let global_used = GLOBAL_MEM_STAT.get_memory_usage();
+                    let memory_budget = max_memory_usage.saturating_sub(global_used) * 30 / 100;
+                    if task.total_bytes > memory_budget {
+                        return Err(ErrorCode::MemoryExceedsLimit(format!(
+                            "Not enough memory to execute recluster task on this node: task_bytes = {}, global_used = {}, max_memory_usage = {}.",
+                            task.total_bytes, global_used, max_memory_usage
+                        )));
+                    }
+                }
                 let recluster_block_nums = task.parts.len();
                 let block_thresholds = table.get_block_thresholds();
                 let table_info = table.get_table_info();
@@ -192,7 +209,6 @@ impl IPhysicalPlan for Recluster {
                     });
                 }
 
-                let settings = builder.ctx.get_settings();
                 let max_threads = settings.get_max_threads()? as usize;
 
                 let (rows_per_block, bytes_per_block) = block_thresholds.calc_rows_for_recluster(

--- a/src/query/service/src/physical_plans/physical_recluster.rs
+++ b/src/query/service/src/physical_plans/physical_recluster.rs
@@ -121,13 +121,16 @@ impl IPhysicalPlan for Recluster {
                 // the pressure; otherwise fail fast instead of risking an OOM kill.
                 if !builder.ctx.get_enable_sort_spill() {
                     let max_memory_usage = settings.get_max_memory_usage()? as usize;
-                    let global_used = GLOBAL_MEM_STAT.get_memory_usage();
-                    let memory_budget = max_memory_usage.saturating_sub(global_used) * 30 / 100;
-                    if task.total_bytes > memory_budget {
-                        return Err(ErrorCode::MemoryExceedsLimit(format!(
-                            "Not enough memory to execute recluster task on this node: task_bytes = {}, global_used = {}, max_memory_usage = {}.",
-                            task.total_bytes, global_used, max_memory_usage
-                        )));
+                    // `max_memory_usage == 0` means memory usage is unlimited.
+                    if max_memory_usage != 0 {
+                        let global_used = GLOBAL_MEM_STAT.get_memory_usage();
+                        let memory_budget = max_memory_usage.saturating_sub(global_used) * 30 / 100;
+                        if task.total_bytes > memory_budget {
+                            return Err(ErrorCode::MemoryExceedsLimit(format!(
+                                "Not enough memory to execute recluster task on this node: task_bytes = {}, global_used = {}, max_memory_usage = {}.",
+                                task.total_bytes, global_used, max_memory_usage
+                            )));
+                        }
                     }
                 }
                 let recluster_block_nums = task.parts.len();

--- a/src/query/storages/fuse/src/operations/recluster/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/recluster/recluster_mutator.rs
@@ -19,6 +19,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Instant;
 
+use databend_common_base::runtime::GLOBAL_MEM_STAT;
 use databend_common_base::runtime::Runtime;
 use databend_common_base::runtime::execute_futures_in_parallel;
 use databend_common_catalog::plan::ReclusterParts;
@@ -48,6 +49,7 @@ use fastrace::Span;
 use fastrace::func_path;
 use fastrace::future::FutureExt;
 use log::debug;
+use log::info;
 use opendal::Operator;
 use tokio::sync::Semaphore;
 
@@ -149,6 +151,39 @@ pub struct ReclusterMutator {
     strategy: Arc<dyn ReclusterStrategy>,
 }
 
+/// Caps the selected block bytes of one recluster task.
+///
+/// Takes the tighter of the node-global (`GLOBAL_MEM_STAT`) and query-local
+/// remaining-memory views; logs when pressure shrinks the task below the
+/// nominal `recluster_block_size`.
+fn recluster_memory_threshold(ctx: &dyn TableContext) -> Result<usize> {
+    let settings = ctx.get_settings();
+    let recluster_block_size = settings.get_recluster_block_size()? as usize;
+    let max_memory_usage = settings.get_max_memory_usage()? as usize;
+    debug_assert_ne!(max_memory_usage, 0);
+    let global_memory_usage = GLOBAL_MEM_STAT.get_memory_usage();
+    let query_memory_usage = ctx.get_nodes_memory_usage();
+    // The tighter view wins: the larger of the two usages.
+    let memory_usage = global_memory_usage.max(query_memory_usage);
+    let memory_budget = max_memory_usage.saturating_sub(memory_usage) * 30 / 100;
+    if memory_budget == 0 {
+        return Err(ErrorCode::MemoryExceedsLimit(format!(
+            "Not enough memory for recluster: max_memory_usage = {}, global_used = {}, query_used = {}.",
+            max_memory_usage, global_memory_usage, query_memory_usage
+        )));
+    }
+    // Actual block sizes are checked during task selection.
+    let memory_threshold = recluster_block_size.min(memory_budget);
+    // Log only when pressure actually shrinks the task.
+    if memory_threshold < recluster_block_size {
+        info!(
+            "recluster: memory pressure shrinks task threshold: max_memory_usage = {}, global_used = {}, query_used = {}, threshold = {}.",
+            max_memory_usage, global_memory_usage, query_memory_usage, memory_threshold
+        );
+    }
+    Ok(memory_threshold)
+}
+
 impl ReclusterMutator {
     /// Build a recluster mutator from table metadata and current snapshot state.
     pub fn try_create(
@@ -176,26 +211,10 @@ impl ReclusterMutator {
                 }
             }) as f64;
 
-        let settings = ctx.get_settings();
-        let recluster_block_size = settings.get_recluster_block_size()? as usize;
-        let max_memory_usage = settings.get_max_memory_usage()? as usize;
-        let memory_threshold = if max_memory_usage == 0 {
-            recluster_block_size
-        } else {
-            let memory_usage = ctx.get_nodes_memory_usage();
-            let memory_budget = max_memory_usage.saturating_sub(memory_usage) * 30 / 100;
-            if memory_budget == 0 {
-                return Err(ErrorCode::MemoryExceedsLimit(format!(
-                    "Not enough memory for recluster: max_memory_usage = {}, used = {}.",
-                    max_memory_usage, memory_usage
-                )));
-            }
-            // Actual block sizes are checked during task selection.
-            recluster_block_size.min(memory_budget)
-        };
+        let memory_threshold = recluster_memory_threshold(ctx.as_ref())?;
         let mut max_tasks = 1;
         let cluster = ctx.get_cluster();
-        if !cluster.is_empty() && settings.get_enable_distributed_recluster()? {
+        if !cluster.is_empty() && ctx.get_settings().get_enable_distributed_recluster()? {
             max_tasks = cluster.nodes.len();
         }
 

--- a/src/query/storages/fuse/src/operations/recluster/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/recluster/recluster_mutator.rs
@@ -160,7 +160,10 @@ fn recluster_memory_threshold(ctx: &dyn TableContext) -> Result<usize> {
     let settings = ctx.get_settings();
     let recluster_block_size = settings.get_recluster_block_size()? as usize;
     let max_memory_usage = settings.get_max_memory_usage()? as usize;
-    debug_assert_ne!(max_memory_usage, 0);
+    // `max_memory_usage == 0` means memory usage is unlimited.
+    if max_memory_usage == 0 {
+        return Ok(recluster_block_size);
+    }
     let global_memory_usage = GLOBAL_MEM_STAT.get_memory_usage();
     let query_memory_usage = ctx.get_nodes_memory_usage();
     // The tighter view wins: the larger of the two usages.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Auto recluster can OOM the node: `recluster_memory_threshold` lost its node-global signal (#19840 removed `GLOBAL_MEM_STAT`, #19989 re-added it but with query-scoped `get_nodes_memory_usage()`), and the selector packs tasks up to that threshold. A post-insert auto recluster starts with a light query footprint, so it gets a full-size task even when the node is busy; sort spill is disabled on this path, and the working set inflates ~2x beyond selected bytes.

This PR:

* restores `GLOBAL_MEM_STAT` as the primary admission signal; the query-scoped view stays as a guard for remote fragment memory in distributed mode. The tighter of the two wins.
* logs an info line when pressure shrinks the task threshold.
* adds an execution-time guard in `Recluster::build_pipeline2`: when sort spill is disabled and task bytes exceed 30% of the node's current headroom, fail fast instead of risking an OOM kill. With spill enabled the check is skipped — spill absorbs the pressure there.
* documents why spill is disabled on the synchronous hook path, with a TODO to remove once the async hook lands.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - The budget depends on process-global memory state that cannot be injected in tests. Validated by compiling/linting the affected crates and replaying the incident numbers against the new formula.

```
cargo fmt --check -p databend-common-storages-fuse -p databend-query
cargo clippy -p databend-common-storages-fuse --lib && cargo clippy -p databend-query --lib
cargo check -p databend-query --lib
```

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

## AI assistance

- AI usage: An AI coding agent traced the regression and drafted the fix; I reviewed the final diff and tuned the semantics.
- Responsible human: @zhyass
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20360)
<!-- Reviewable:end -->
