### PR TITLE
fix(query): match empty LIKE patterns exactly

### DIFF
--- a/src/query/expression/src/filter/like.rs
+++ b/src/query/expression/src/filter/like.rs
@@ -219,7 +219,7 @@ pub fn generate_like_pattern<'a, B: Into<Cow<'a, [u8]>>>(
     let pattern: Cow<'a, [u8]> = pattern.into();
     let len = pattern.len();
     if len == 0 {
-        return LikePattern::Constant(true);
+        return LikePattern::OrdinalStr(pattern);
     }
 
     let mut index = 0;
@@ -478,6 +478,7 @@ fn test_generate_like_pattern() {
         "warehouse".as_bytes().to_vec(),
     ];
     let test_cases = vec![
+        ("", LikePattern::OrdinalStr("".as_bytes().into())),
         (
             "databend",
             LikePattern::OrdinalStr("databend".as_bytes().into()),
@@ -583,6 +584,14 @@ fn test_generate_like_pattern() {
     for (pattern, pattern_type) in test_cases {
         assert_eq!(pattern_type, generate_like_pattern(pattern.as_bytes(), 1));
     }
+}
+
+#[test]
+fn test_empty_like_pattern_only_matches_empty_haystack() {
+    let pattern = generate_like_pattern("".as_bytes(), 0);
+
+    assert!(pattern.compare("".as_bytes()));
+    assert!(!pattern.compare("anything".as_bytes()));
 }
 
 #[test]

--- a/src/query/functions/src/scalars/comparison.rs
+++ b/src/query/functions/src/scalars/comparison.rs
@@ -2917,16 +2917,20 @@ mod tests {
     }
 
     #[test]
-    fn test_calc_like_domain_empty_pattern_does_not_fold_to_all_true() {
+    fn test_calc_like_domain_empty_pattern_matches_empty_string() {
         let domain = StringDomain {
             min: "".to_string(),
             max: Some("zzz".to_string()),
         };
+        let empty = StringDomain {
+            min: "".to_string(),
+            max: Some("".to_string()),
+        };
 
         assert_eq!(
             calc_like_domain(&domain, "".to_string()),
-            None,
-            "empty patterns should not reuse repeated all-% folding"
+            Some(domain.domain_eq(&empty)),
+            "empty patterns should use empty-string equality semantics"
         );
     }
 

--- a/src/query/functions/tests/it/scalars/comparison.rs
+++ b/src/query/functions/tests/it/scalars/comparison.rs
@@ -532,6 +532,12 @@ fn test_like(file: &mut impl Write) {
     ];
     run_ast(file, "lhs like rhs", &columns);
 
+    let columns = [
+        ("lhs", StringType::from_data(vec!["x", "", "x"])),
+        ("rhs", StringType::from_data(vec!["", "", "%"])),
+    ];
+    run_ast(file, "lhs like rhs", &columns);
+
     run_ast(file, "parse_json('\"hello\"') like 'h%'", &[]);
     run_ast(file, "parse_json('{\"abc\":1,\"def\":22}') like '%e%'", &[]);
     run_ast(

--- a/src/query/functions/tests/it/scalars/testdata/comparison.txt
+++ b/src/query/functions/tests/it/scalars/testdata/comparison.txt
@@ -1879,6 +1879,29 @@ evaluation (internal):
 +--------+------------------------------------------+
 
 
+ast            : lhs like rhs
+raw expr       : like(lhs::String, rhs::String)
+checked expr   : like<String, String>(lhs, rhs)
+evaluation:
++--------+------------+------------+---------------+
+|        | lhs        | rhs        | Output        |
++--------+------------+------------+---------------+
+| Type   | String     | String     | Boolean       |
+| Domain | {""..="x"} | {""..="%"} | {FALSE, TRUE} |
+| Row 0  | 'x'        | ''         | false         |
+| Row 1  | ''         | ''         | true          |
+| Row 2  | 'x'        | '%'        | true          |
++--------+------------+------------+---------------+
+evaluation (internal):
++--------+------------------------------+
+| Column | Data                         |
++--------+------------------------------+
+| lhs    | Column(StringColumn[x, , x]) |
+| rhs    | Column(StringColumn[, , %])  |
+| Output | Boolean([0b_____110])        |
++--------+------------------------------+
+
+
 ast            : parse_json('"hello"') like 'h%'
 raw expr       : like(parse_json('"hello"'), 'h%')
 checked expr   : like<Variant, String>(CAST<String>("\"hello\"" AS Variant), "h%")

--- a/tests/sqllogictests/suites/query/issues/issue_20358.test
+++ b/tests/sqllogictests/suites/query/issues/issue_20358.test
@@ -1,0 +1,23 @@
+# GitHub issue: https://github.com/databendlabs/databend/issues/20358
+
+statement ok
+DROP TABLE IF EXISTS issue_20358_patterns
+
+statement ok
+CREATE TABLE issue_20358_patterns(pattern VARCHAR)
+
+statement ok
+INSERT INTO issue_20358_patterns VALUES ('')
+
+query B
+SELECT 'x' LIKE pattern FROM issue_20358_patterns
+----
+0
+
+query B
+SELECT '' LIKE pattern FROM issue_20358_patterns
+----
+1
+
+statement ok
+DROP TABLE issue_20358_patterns


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Fix runtime `LIKE` evaluation when an empty pattern comes from a column
- Compile an empty pattern as an exact empty-string match instead of a constant true matcher
- Keep LIKE domain inference consistent with empty-string equality semantics

Fixes #20358

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent analyzed the root cause, drafted the matcher and domain changes, added regression coverage, and prepared the PR summary
- Responsible human: @KKould
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20363)
<!-- Reviewable:end -->
