### PR TITLE
fix: avoid mechanically removing Exchange operators

### DIFF
--- a/src/query/sql/src/planner/optimizer/optimizer.rs
+++ b/src/query/sql/src/planner/optimizer/optimizer.rs
@@ -36,7 +36,6 @@ use crate::optimizer::optimizers::CommonSubexpressionOptimizer;
 use crate::optimizer::optimizers::DPhpyOptimizer;
 use crate::optimizer::optimizers::EliminateSelfJoinOptimizer;
 use crate::optimizer::optimizers::distributed::BroadcastToShuffleOptimizer;
-use crate::optimizer::optimizers::distributed::MaterializedCTEDistributionOptimizer;
 use crate::optimizer::optimizers::operator::CleanupUnusedCTEOptimizer;
 use crate::optimizer::optimizers::operator::DeduplicateJoinConditionOptimizer;
 use crate::optimizer::optimizers::operator::FinalizeSpatialJoinOptimizer;
@@ -331,8 +330,6 @@ async fn optimize_query_inner(
         )
         // Cascades optimizer may fail due to timeout, fallback to heuristic optimizer in this case.
         .add(CascadesOptimizer::new(opt_ctx.clone())?)
-        // Normalize distributed MaterializedCTE producers after physical properties are settled.
-        .add(MaterializedCTEDistributionOptimizer::new(opt_ctx.clone()))
         // Eliminate unnecessary scalar calculations to clean up the final plan
         .add_if(
             !opt_ctx.get_planning_agg_index(),

--- a/src/query/sql/src/planner/optimizer/optimizer_context.rs
+++ b/src/query/sql/src/planner/optimizer/optimizer_context.rs
@@ -35,6 +35,7 @@ pub struct OptimizerContext {
 
     // Optimizer configurations
     enable_distributed_optimization: RwLock<bool>,
+    force_local_execution: RwLock<bool>,
     enable_join_reorder: RwLock<bool>,
     enable_dphyp: RwLock<bool>,
     max_push_down_limit: RwLock<usize>,
@@ -77,6 +78,7 @@ impl OptimizerContext {
             metadata,
 
             enable_distributed_optimization: RwLock::new(false),
+            force_local_execution: RwLock::new(false),
             enable_join_reorder: RwLock::new(true),
             enable_dphyp: RwLock::new(true),
             max_push_down_limit: RwLock::new(10000),
@@ -115,7 +117,17 @@ impl OptimizerContext {
     }
 
     pub fn get_enable_distributed_optimization(&self) -> bool {
-        *self.enable_distributed_optimization.read()
+        *self.enable_distributed_optimization.read() && !*self.force_local_execution.read()
+    }
+
+    /// Force the query to remain in one local execution graph.
+    ///
+    /// Unlike `Distribution::Serial`, this prevents distributed fragments from
+    /// being created below a serial operator. The decision is sticky for the
+    /// lifetime of this optimizer context.
+    pub fn set_force_local_execution(self: &Arc<Self>) -> &Arc<Self> {
+        *self.force_local_execution.write() = true;
+        self
     }
 
     fn set_enable_join_reorder(self: &Arc<Self>, enable: bool) -> &Arc<Self> {

--- a/src/query/sql/src/planner/optimizer/optimizers/cascades/cascade.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/cascades/cascade.rs
@@ -34,6 +34,8 @@ use crate::optimizer::optimizers::cascades::tasks::OptimizeGroupTask;
 use crate::optimizer::optimizers::cascades::tasks::Task;
 use crate::optimizer::optimizers::cascades::tasks::TaskManager;
 use crate::optimizer::optimizers::distributed::DistributedOptimizer;
+use crate::optimizer::optimizers::distributed::MaterializedCTEDistribution;
+use crate::optimizer::optimizers::distributed::MaterializedCTEDistributionOptimizer;
 use crate::optimizer::optimizers::distributed::SortAndLimitPushDownOptimizer;
 use crate::optimizer::optimizers::rule::RuleSet;
 use crate::optimizer::optimizers::rule::TransformResult;
@@ -86,41 +88,63 @@ impl CascadesOptimizer {
     #[recursive::recursive]
     pub fn optimize_sync(&mut self, s_expr: SExpr) -> Result<SExpr> {
         let opt_ctx = self.opt_ctx.clone();
+        let distributed = opt_ctx.get_enable_distributed_optimization();
 
-        // Try to optimize using the internal optimizer
-        let result = self.optimize_internal(s_expr.clone());
+        // Settle distribution properties first. Exchange-sensitive operators
+        // are lowered only after materialized CTE placement is known.
+        let optimized_expr = self.optimize_without_staging(&s_expr)?;
 
-        // Process different cases based on the result
-        let optimized_expr = match result {
-            Ok(expr) => {
-                // After successful optimization, apply sort and limit push down if distributed optimization is enabled
-                if opt_ctx.get_enable_distributed_optimization() {
-                    let sort_and_limit_optimizer = SortAndLimitPushDownOptimizer::create();
-                    sort_and_limit_optimizer.optimize(&expr)?
-                } else {
-                    expr
+        if !distributed {
+            return Ok(optimized_expr);
+        }
+
+        let optimized_expr = if opt_ctx
+            .is_optimizer_disabled(MaterializedCTEDistributionOptimizer::NAME)
+        {
+            optimized_expr
+        } else {
+            let optimizer = MaterializedCTEDistributionOptimizer::create();
+            match optimizer.optimize(&optimized_expr)? {
+                MaterializedCTEDistribution::Distributed(expr) => expr,
+                MaterializedCTEDistribution::RequiresLocal => {
+                    info!(
+                        "Force local execution because a materialized CTE producer cannot participate in the distributed fragment graph"
+                    );
+                    opt_ctx.set_force_local_execution();
+
+                    // Re-plan from the pre-Cascades expression instead of
+                    // deleting Exchanges from a distributed physical choice.
+                    let mut local_optimizer = CascadesOptimizer::new(opt_ctx)?;
+                    let local_expr = local_optimizer.optimize_without_staging(&s_expr)?;
+                    self.memo = local_optimizer.memo;
+                    return Ok(local_expr);
                 }
             }
+        };
 
+        let sort_and_limit_optimizer = SortAndLimitPushDownOptimizer::create();
+        let optimized_expr = sort_and_limit_optimizer.optimize(&optimized_expr)?;
+
+        Ok(optimized_expr)
+    }
+
+    fn optimize_without_staging(&mut self, s_expr: &SExpr) -> Result<SExpr> {
+        match self.optimize_internal(s_expr.clone()) {
+            Ok(expr) => Ok(expr),
             Err(e) => {
-                // Optimization failed, log the error and fall back to heuristic optimizer
                 info!(
                     "CascadesOptimizer failed, fallback to heuristic optimizer: {}",
                     e
                 );
 
-                // If distributed optimization is enabled, use the distributed optimizer
-                if opt_ctx.get_enable_distributed_optimization() {
-                    let distributed_optimizer = DistributedOptimizer::new(opt_ctx);
-                    distributed_optimizer.optimize(&s_expr)?
+                if self.opt_ctx.get_enable_distributed_optimization() {
+                    let distributed_optimizer = DistributedOptimizer::new(self.opt_ctx.clone());
+                    distributed_optimizer.optimize(s_expr)
                 } else {
-                    // Otherwise return the original expression
-                    s_expr.clone()
+                    Ok(s_expr.clone())
                 }
             }
-        };
-
-        Ok(optimized_expr)
+        }
     }
 
     fn optimize_internal(&mut self, s_expr: SExpr) -> Result<SExpr> {

--- a/src/query/sql/src/planner/optimizer/optimizers/distributed/distributed.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/distributed/distributed.rs
@@ -17,7 +17,6 @@ use std::sync::Arc;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
 
-use super::sort_and_limit::SortAndLimitPushDownOptimizer;
 use crate::optimizer::OptimizerContext;
 use crate::optimizer::ir::Distribution;
 use crate::optimizer::ir::PropertyEnforcer;
@@ -27,12 +26,12 @@ use crate::optimizer::ir::SExpr;
 use crate::plans::Exchange;
 
 /// DistributedOptimizer optimizes a query plan for distributed execution.
-/// It enforces distribution properties and applies sort/limit push down optimizations.
+/// It only enforces distribution properties; Exchange-sensitive stage lowering
+/// is applied after materialized CTE placement has been resolved.
 ///
 /// TODO(leiysky): Consider deprecating this in favor of cascades planner for distributed optimization.
 pub struct DistributedOptimizer {
     ctx: Arc<dyn TableContext>,
-    sort_limit_optimizer: SortAndLimitPushDownOptimizer,
 }
 
 impl DistributedOptimizer {
@@ -40,11 +39,11 @@ impl DistributedOptimizer {
     pub fn new(opt_ctx: Arc<OptimizerContext>) -> Self {
         Self {
             ctx: opt_ctx.get_table_ctx(),
-            sort_limit_optimizer: SortAndLimitPushDownOptimizer::create(),
         }
     }
 
-    /// Optimize the given SExpr for distributed execution
+    /// Enforce distribution properties without lowering Exchange-sensitive
+    /// operators into their partial and final stages.
     #[recursive::recursive]
     pub fn optimize(&self, s_expr: &SExpr) -> Result<SExpr> {
         // Step 1: Set the initial distribution requirement (Any)
@@ -54,19 +53,16 @@ impl DistributedOptimizer {
 
         // Step 2: Enforce the property
         let enforcer = PropertyEnforcer::new(self.ctx.clone());
-        let result = enforcer.require_property(&required, s_expr)?;
+        let mut result = enforcer.require_property(&required, s_expr)?;
 
-        // Step 3: Apply the sort and limit push down optimization
-        let mut result = self.sort_limit_optimizer.optimize(&result)?;
-
-        // Step 4: Check if the result satisfies the required distribution property
+        // Step 3: Check if the result satisfies the required distribution property
         let rel_expr = RelExpr::with_s_expr(&result);
         let physical_prop = rel_expr.derive_physical_prop()?;
         let root_required = RequiredProperty {
             distribution: Distribution::Serial,
         };
 
-        // Step 5: If not satisfied, manually enforce serial distribution
+        // Step 4: If not satisfied, manually enforce serial distribution
         if !root_required.satisfied_by(&physical_prop) {
             // Add an Exchange::Merge operator
             result = SExpr::create_unary(Arc::new(Exchange::Merge.into()), Arc::new(result));

--- a/src/query/sql/src/planner/optimizer/optimizers/distributed/materialized_cte.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/distributed/materialized_cte.rs
@@ -19,8 +19,6 @@ use databend_common_exception::Result;
 use databend_common_expression::Scalar;
 use databend_common_expression::types::NumberScalar;
 
-use crate::optimizer::Optimizer;
-use crate::optimizer::OptimizerContext;
 use crate::optimizer::ir::Distribution;
 use crate::optimizer::ir::RelExpr;
 use crate::optimizer::ir::SExpr;
@@ -31,31 +29,35 @@ use crate::plans::Exchange;
 use crate::plans::RelOperator;
 use crate::plans::ScalarExpr;
 
-pub struct MaterializedCTEDistributionOptimizer {
-    ctx: Arc<OptimizerContext>,
+/// Outcome of aligning materialized CTE placement with the distributed plan.
+pub enum MaterializedCTEDistribution {
+    Distributed(SExpr),
+    RequiresLocal,
 }
 
+pub struct MaterializedCTEDistributionOptimizer;
+
 impl MaterializedCTEDistributionOptimizer {
-    pub fn new(ctx: Arc<OptimizerContext>) -> Self {
-        Self { ctx }
+    pub const NAME: &'static str = "MaterializedCTEDistributionOptimizer";
+
+    pub fn create() -> Self {
+        Self
     }
 
-    pub fn optimize_sync(&self, s_expr: &SExpr) -> Result<SExpr> {
-        let mut result = if self.ctx.get_enable_distributed_optimization() {
-            s_expr
-                .accept(&mut SerialProducerRedistributor)?
-                .unwrap_or_else(|| s_expr.clone())
-        } else {
-            s_expr.clone()
-        };
+    /// Resolve materialized CTE placement after distribution properties are
+    /// settled, but before Exchange-sensitive operators are split into stages.
+    pub fn optimize(&self, s_expr: &SExpr) -> Result<MaterializedCTEDistribution> {
+        let result = s_expr
+            .accept(&mut SerialProducerRedistributor)?
+            .unwrap_or_else(|| s_expr.clone());
 
         let mut finder = SerialSequenceFinder::default();
         result.accept(&mut finder)?;
         if finder.found {
-            result = result.accept(&mut ExchangeRemover)?.unwrap_or(result);
+            return Ok(MaterializedCTEDistribution::RequiresLocal);
         }
 
-        Ok(result)
+        Ok(MaterializedCTEDistribution::Distributed(result))
     }
 }
 
@@ -63,9 +65,9 @@ impl MaterializedCTEDistributionOptimizer {
 /// its CTE definition is serial because it consumes a Merge exchange,
 /// redistribute the result after that operator instead of forcing the entire
 /// query to run without Exchanges. Other serial sources, such as
-/// DummyTableScan, are not coordinator-only Merge consumers and must keep the
-/// existing serial fallback. Hashing by a constant preserves the producer's
-/// rows without broadcasting or changing scalar empty-input behavior.
+/// DummyTableScan, are not coordinator-only Merge consumers and require local
+/// re-planning. Hashing by a constant preserves the producer's rows without
+/// broadcasting or changing scalar empty-input behavior.
 struct SerialProducerRedistributor;
 
 impl SerialProducerRedistributor {
@@ -146,32 +148,5 @@ impl SExprVisitor for SerialSequenceFinder {
         }
 
         Ok(VisitAction::Continue)
-    }
-}
-
-struct ExchangeRemover;
-
-impl SExprVisitor for ExchangeRemover {
-    fn visit(&mut self, _expr: &SExpr) -> Result<VisitAction> {
-        Ok(VisitAction::Continue)
-    }
-
-    fn post_visit(&mut self, expr: &SExpr) -> Result<VisitAction> {
-        if matches!(expr.plan(), RelOperator::Exchange(_)) {
-            Ok(VisitAction::Replace(expr.unary_child().clone()))
-        } else {
-            Ok(VisitAction::Continue)
-        }
-    }
-}
-
-#[async_trait::async_trait]
-impl Optimizer for MaterializedCTEDistributionOptimizer {
-    fn name(&self) -> String {
-        "MaterializedCTEDistributionOptimizer".to_string()
-    }
-
-    async fn optimize(&mut self, s_expr: &SExpr) -> Result<SExpr> {
-        self.optimize_sync(s_expr)
     }
 }

--- a/src/query/sql/src/planner/optimizer/optimizers/distributed/mod.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/distributed/mod.rs
@@ -20,5 +20,6 @@ mod sort_and_limit;
 
 pub use distributed::DistributedOptimizer;
 pub use distributed_merge::BroadcastToShuffleOptimizer;
+pub use materialized_cte::MaterializedCTEDistribution;
 pub use materialized_cte::MaterializedCTEDistributionOptimizer;
 pub use sort_and_limit::SortAndLimitPushDownOptimizer;

--- a/src/query/sql/test-support/data/cases/regressions/20370_materialized_cte_window_sort.yaml
+++ b/src/query/sql/test-support/data/cases/regressions/20370_materialized_cte_window_sort.yaml
@@ -1,0 +1,21 @@
+name: "20370_materialized_cte_window_sort"
+description: "A serial materialized CTE producer must force local planning before window sort staging"
+
+node_num: 3
+
+sql: |
+  SETTINGS (enable_auto_materialize_cte = 1) WITH queries AS (
+      SELECT
+          CAST('2026-01-01 00:00:01' AS TIMESTAMP NULL) AS start_time,
+          CAST('2026-01-01 00:00:02' AS TIMESTAMP NULL) AS end_time
+  ),
+  timeline AS (
+      SELECT start_time AS ts, 1 AS delta FROM queries
+      UNION ALL
+      SELECT end_time AS ts, -1 AS delta FROM queries
+  )
+  SELECT
+      ts,
+      delta,
+      sum(delta) OVER (ORDER BY ts) AS running
+  FROM timeline;

--- a/src/query/sql/test-support/data/results/regressions/20370_materialized_cte_window_sort_optimized.txt
+++ b/src/query/sql/test-support/data/results/regressions/20370_materialized_cte_window_sort_optimized.txt
@@ -1,0 +1,35 @@
+Sequence(Sequence)
+├── MaterializedCTE
+│   ├── cte_name: __materialized_cte_0_queries
+│   ├── ref_count: 2
+│   ├── channel_size: None
+│   └── EvalScalar
+│       ├── scalars: [CAST('2026-01-01 00:00:01' AS Timestamp NULL) AS (#0), CAST('2026-01-01 00:00:02' AS Timestamp NULL) AS (#1)]
+│       └── DummyTableScan(DummyTableScan { source_table_indexes: [] })
+└── Window
+    ├── aggregate function: sum
+    ├── partition items: []
+    ├── order by items: [ts (#8) AS (#8)]
+    ├── frame: [Range: Preceding(None) ~ CurrentRow]
+    └── Sort
+        ├── sort keys: [ts (#8) ASC NULLS LAST]
+        ├── limit: [NONE]
+        └── UnionAll
+            ├── output: [ts (#8), delta (#9)]
+            ├── left: [start_time (#2), CAST(delta (#4) AS Int16)]
+            ├── right: [end_time (#6), CAST(delta (#7) AS Int16)]
+            ├── cte_scan_names: []
+            ├── logical_recursive_cte_id: None
+            ├── EvalScalar
+            │   ├── scalars: [start_time (#2) AS (#2), 1 AS (#4)]
+            │   └── MaterializedCTERef
+            │       ├── cte_name: __materialized_cte_0_queries
+            │       ├── output columns: [start_time (#2), end_time (#3)]
+            │       └── column mapping: [start_time (#2) -> start_time (#0), end_time (#3) -> end_time (#1)]
+            └── EvalScalar
+                ├── scalars: [end_time (#6) AS (#6), -1 AS (#7)]
+                └── MaterializedCTERef
+                    ├── cte_name: __materialized_cte_0_queries
+                    ├── output columns: [start_time (#5), end_time (#6)]
+                    └── column mapping: [start_time (#5) -> start_time (#0), end_time (#6) -> end_time (#1)]
+

--- a/src/query/sql/test-support/data/results/regressions/20370_materialized_cte_window_sort_physical.txt
+++ b/src/query/sql/test-support/data/results/regressions/20370_materialized_cte_window_sort_physical.txt
@@ -1,0 +1,37 @@
+Sequence
+├── MaterializedCTE: queries
+│   └── EvalScalar
+│       ├── output columns: [start_time (#0), end_time (#1)]
+│       ├── expressions: ['2026-01-01 00:00:01.000000', '2026-01-01 00:00:02.000000']
+│       ├── estimated rows: 1.00
+│       └── DummyTableScan
+└── Window
+    ├── output columns: [ts (#8), delta (#9), sum(delta) OVER (ORDER BY ts) (#10)]
+    ├── aggregate function: [sum(delta)]
+    ├── partition by: []
+    ├── order by: [ts]
+    ├── frame: [Range: Preceding(None) ~ CurrentRow]
+    └── Sort(Single)
+        ├── output columns: [ts (#8), delta (#9)]
+        ├── sort keys: [ts ASC NULLS LAST]
+        ├── estimated rows: 2.00
+        └── UnionAll
+            ├── output columns: [ts (#8), delta (#9)]
+            ├── estimated rows: 2.00
+            ├── EvalScalar
+            │   ├── output columns: [start_time (#2), delta (#4)]
+            │   ├── expressions: [1]
+            │   ├── estimated rows: 1.00
+            │   └── MaterializeCTERef
+            │       ├── cte_name: queries
+            │       ├── cte_schema: [start_time (#2), end_time (#3)]
+            │       └── estimated rows: 1.00
+            └── EvalScalar
+                ├── output columns: [end_time (#6), delta (#7)]
+                ├── expressions: [-1]
+                ├── estimated rows: 1.00
+                └── MaterializeCTERef
+                    ├── cte_name: queries
+                    ├── cte_schema: [start_time (#5), end_time (#6)]
+                    └── estimated rows: 1.00
+

--- a/src/query/sql/test-support/data/results/regressions/20370_materialized_cte_window_sort_raw.txt
+++ b/src/query/sql/test-support/data/results/regressions/20370_materialized_cte_window_sort_raw.txt
@@ -1,0 +1,39 @@
+Sequence(Sequence)
+├── MaterializedCTE
+│   ├── cte_name: __materialized_cte_0_queries
+│   ├── ref_count: 0
+│   ├── channel_size: None
+│   └── EvalScalar
+│       ├── scalars: [CAST('2026-01-01 00:00:01' AS Timestamp NULL) AS (#0), CAST('2026-01-01 00:00:02' AS Timestamp NULL) AS (#1)]
+│       └── DummyTableScan(DummyTableScan { source_table_indexes: [] })
+└── EvalScalar
+    ├── scalars: [ts (#8) AS (#8), delta (#9) AS (#9), sum(delta) OVER (ORDER BY ts) (#10) AS (#10)]
+    └── Window
+        ├── aggregate function: sum
+        ├── partition items: []
+        ├── order by items: [ts (#8) AS (#8)]
+        ├── frame: [Range: Preceding(None) ~ CurrentRow]
+        └── Sort
+            ├── sort keys: [ts (#8) ASC NULLS LAST]
+            ├── limit: [NONE]
+            └── EvalScalar
+                ├── scalars: [ts (#8) AS (#8), delta (#9) AS (#9)]
+                └── UnionAll
+                    ├── output: [ts (#8), delta (#9)]
+                    ├── left: [start_time (#2), CAST(delta (#4) AS Int16)]
+                    ├── right: [end_time (#6), CAST(delta (#7) AS Int16)]
+                    ├── cte_scan_names: []
+                    ├── logical_recursive_cte_id: None
+                    ├── EvalScalar
+                    │   ├── scalars: [start_time (#2) AS (#2), 1 AS (#4)]
+                    │   └── MaterializedCTERef
+                    │       ├── cte_name: __materialized_cte_0_queries
+                    │       ├── output columns: [start_time (#2), end_time (#3)]
+                    │       └── column mapping: [start_time (#2) -> start_time (#0), end_time (#3) -> end_time (#1)]
+                    └── EvalScalar
+                        ├── scalars: [end_time (#6) AS (#6), -1 AS (#7)]
+                        └── MaterializedCTERef
+                            ├── cte_name: __materialized_cte_0_queries
+                            ├── output columns: [start_time (#5), end_time (#6)]
+                            └── column mapping: [start_time (#5) -> start_time (#0), end_time (#6) -> end_time (#1)]
+

--- a/tests/sqllogictests/suites/mode/cluster/exchange.test
+++ b/tests/sqllogictests/suites/mode/cluster/exchange.test
@@ -230,8 +230,9 @@ Exchange
         └── estimated rows: 2.00
 
 # The grand-total MaterializedCTE is scalar and ends in Merge exchange. The
-# post-Cascades MCTE optimizer redistributes it with a constant-key GlobalHash,
-# exercising Merge-input fragment scheduling on a real MCTE producer chain.
+# MCTE placement optimizer redistributes it with a constant-key GlobalHash
+# before Exchange-sensitive stage lowering, exercising Merge-input fragment
+# scheduling on a real MCTE producer chain.
 statement ok
 set grouping_sets_to_union = 1;
 

--- a/tests/sqllogictests/suites/mode/cluster/window.test
+++ b/tests/sqllogictests/suites/mode/cluster/window.test
@@ -250,3 +250,60 @@ DROP TABLE departments;
 
 statement ok
 DROP TABLE sales;
+
+# Regression for #20370: a constant materialized CTE is local-only. The query
+# must be planned locally before the window sort is split into Final/Partial.
+statement ok
+set enable_auto_materialize_cte = 1;
+
+query TII
+WITH
+queries AS (
+    SELECT
+        CAST(to_timestamp('2026-01-01 00:00:01') AS TIMESTAMP NULL) AS start_time,
+        CAST(to_timestamp('2026-01-01 00:00:02') AS TIMESTAMP NULL) AS end_time
+),
+timeline AS (
+    SELECT start_time AS ts, 1 AS delta FROM queries
+    UNION ALL
+    SELECT end_time AS ts, -1 AS delta FROM queries
+)
+SELECT
+    ts,
+    delta,
+    sum(delta) OVER (ORDER BY ts) AS running
+FROM timeline;
+----
+2026-01-01 00:00:01.000000 1 1
+2026-01-01 00:00:02.000000 -1 0
+
+query IRI
+WITH
+queries AS (
+    SELECT
+        CAST(to_timestamp('2026-01-01 00:00:01') AS TIMESTAMP NULL) AS start_time,
+        CAST(to_timestamp('2026-01-01 00:00:02') AS TIMESTAMP NULL) AS end_time
+),
+timeline AS (
+    SELECT start_time AS ts, 1 AS delta FROM queries
+    UNION ALL
+    SELECT end_time AS ts, -1 AS delta FROM queries
+)
+SELECT
+    max(running) AS max_concurrency,
+    avg(running) AS avg_concurrency,
+    count(*) AS event_points
+FROM (
+    SELECT
+        sum(delta) OVER (ORDER BY ts) AS running
+    FROM (
+        SELECT ts, sum(delta) AS delta
+        FROM timeline
+        GROUP BY ts
+    )
+);
+----
+1 0.5 2
+
+statement ok
+unset enable_auto_materialize_cte;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Mechanically removing Exchange operators is not a sound design approach, because stripping Exchanges from a distributed plan does not make it equivalent to a plan generated for single-node execution. This PR re-plans local-only queries before distributed stage lowering instead, fixing #20370.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:

- `cargo test -p databend-common-sql --test it optimizer::materialized_cte_distribution::test_materialized_cte_distribution_optimizer_outcomes -- --exact --nocapture`
- `TEST_SUBDIR=regressions cargo test -p databend-query --test it sql::planner::optimizer::optimizer_test::test_optimizer -- --exact --nocapture`
- `TEST_SUBDIR=regressions cargo test -p databend-common-sql --test it planner::test_lite_replay_service_optimizer_cases -- --exact --nocapture`
- `target/debug/databend-sqllogictests --handlers mysql --run tests/sqllogictests/suites/mode/cluster/window.test --parallel 1` on a three-node cluster (22/22 passed)
- `cargo build -p databend-binaries --bin databend-query`
- `cargo fmt --all -- --check`
- `git diff --check`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent helped investigate the root cause, draft the optimizer changes and regression tests, and run validation; the responsible human reviewed the final diff.
- Responsible human: @SkyFan2002
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20371)
<!-- Reviewable:end -->
