### PR TITLE
refactor(query): consume expressions in constant folder

### DIFF
--- a/src/query/expression/src/constant_folder.rs
+++ b/src/query/expression/src/constant_folder.rs
@@ -53,11 +53,11 @@ pub struct ConstantFolder<'a, Index: ColumnIndex> {
 impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
     /// Fold a single expression, returning the new expression and the domain of the new expression.
     pub fn fold(
-        expr: &Expr<Index>,
+        expr: Expr<Index>,
         func_ctx: &'a FunctionContext,
         fn_registry: &'a FunctionRegistry,
     ) -> (Expr<Index>, Option<Domain>) {
-        let input_domains = Self::full_input_domains(expr);
+        let input_domains = Self::full_input_domains(&expr);
 
         let folder = ConstantFolder {
             input_domains: &input_domains,
@@ -71,7 +71,7 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
     /// Fold a single expression with columns' domain, and then return the new expression and the
     /// domain of the new expression.
     pub fn fold_with_domain(
-        expr: &Expr<Index>,
+        expr: Expr<Index>,
         input_domains: &'a HashMap<Index, Domain>,
         func_ctx: &'a FunctionContext,
         fn_registry: &'a FunctionRegistry,
@@ -97,52 +97,49 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
 
     /// Running `fold_once()` for only one time may not reach the simplest form of expression,
     /// therefore we need to call it repeatedly until the expression becomes stable.
-    fn fold_to_stable(&self, expr: &Expr<Index>) -> (Expr<Index>, Option<Domain>) {
+    fn fold_to_stable(&self, mut expr: Expr<Index>) -> (Expr<Index>, Option<Domain>) {
         const MAX_ITERATIONS: usize = 1024;
 
-        let mut old_expr = expr.clone();
-        let mut old_domain = None;
+        let mut domain = None;
         for _ in 0..MAX_ITERATIONS {
-            let (new_expr, new_domain) = self.fold_once(&old_expr);
-
-            if new_expr == old_expr {
+            let (new_expr, new_domain, changed) = self.fold_once(expr);
+            if !changed {
                 return (new_expr, new_domain);
             }
-            old_expr = new_expr;
-            old_domain = new_domain;
+            expr = new_expr;
+            domain = new_domain;
         }
 
         error!("maximum iterations reached while folding expression");
 
-        (old_expr, old_domain)
+        (expr, domain)
     }
 
     /// Fold expression by one step, specifically, by reducing expression by domain calculation and then
     /// folding the function calls whose all arguments are constants.
     #[recursive::recursive]
-    fn fold_once(&self, expr: &Expr<Index>) -> (Expr<Index>, Option<Domain>) {
-        let (new_expr, domain) = match expr {
-            Expr::Constant(Constant {
-                scalar, data_type, ..
-            }) => (expr.clone(), Some(scalar.as_ref().domain(data_type))),
-            Expr::ColumnRef(ColumnRef {
-                span,
-                id,
-                data_type,
-                ..
-            }) => {
-                let domain = &self.input_domains[id];
-                let expr = domain
-                    .as_singleton()
-                    .map(|scalar| {
+    fn fold_once(&self, expr: Expr<Index>) -> (Expr<Index>, Option<Domain>, bool) {
+        let data_type = expr.data_type().clone();
+        let (new_expr, domain, changed) = match expr {
+            Expr::Constant(constant) => {
+                let domain = constant.scalar.as_ref().domain(&constant.data_type);
+                (Expr::Constant(constant), Some(domain), false)
+            }
+            Expr::ColumnRef(column_ref) => {
+                let domain = &self.input_domains[&column_ref.id];
+                if let Some(scalar) = domain.as_singleton() {
+                    (
                         Expr::Constant(Constant {
-                            span: *span,
+                            span: column_ref.span,
                             scalar,
-                            data_type: data_type.clone(),
-                        })
-                    })
-                    .unwrap_or_else(|| expr.clone());
-                (expr, Some(domain.clone()))
+                            data_type: column_ref.data_type,
+                        }),
+                        Some(domain.clone()),
+                        true,
+                    )
+                } else {
+                    (Expr::ColumnRef(column_ref), Some(domain.clone()), false)
+                }
             }
             Expr::Cast(Cast {
                 span,
@@ -150,102 +147,95 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                 expr,
                 dest_type,
             }) => {
-                let (inner_expr, inner_domain) = self.fold_once(expr);
+                let src_type = expr.data_type().clone();
+                let (inner_expr, inner_domain, inner_changed) = self.fold_once(*expr);
 
-                let new_domain = if *is_try {
+                let new_domain = if is_try {
                     inner_domain.and_then(|inner_domain| {
-                        self.calculate_try_cast(*span, expr.data_type(), dest_type, &inner_domain)
+                        self.calculate_try_cast(span, &src_type, &dest_type, &inner_domain)
                     })
                 } else {
                     inner_domain.and_then(|inner_domain| {
-                        self.calculate_cast(*span, expr.data_type(), dest_type, &inner_domain)
+                        self.calculate_cast(span, &src_type, &dest_type, &inner_domain)
                     })
                 };
 
+                let inner_is_constant = inner_expr.as_constant().is_some();
                 let cast_expr = Expr::Cast(Cast {
-                    span: *span,
-                    is_try: *is_try,
-                    expr: Box::new(inner_expr.clone()),
-                    dest_type: dest_type.clone(),
+                    span,
+                    is_try,
+                    expr: Box::new(inner_expr),
+                    dest_type,
                 });
 
-                if inner_expr.as_constant().is_some() {
-                    let block = DataBlock::empty_with_rows(1);
-                    let evaluator = Evaluator::new(&block, self.func_ctx, self.fn_registry);
-                    // Since we know the expression is constant, it'll be safe to change its column index type.
-                    let cast_expr = cast_expr.project_column_ref(|_| unreachable!()).unwrap();
-                    if let Ok(Value::Scalar(scalar)) = evaluator.run(&cast_expr) {
-                        return (
-                            Expr::Constant(Constant {
-                                span: *span,
-                                scalar,
-                                data_type: dest_type.clone(),
-                            }),
-                            None,
-                        );
-                    }
+                let (cast_expr, folded) = if inner_is_constant {
+                    self.try_fold_constant_expr(cast_expr)
+                } else {
+                    (cast_expr, false)
+                };
+                if folded {
+                    return (cast_expr, None, true);
                 }
 
-                (
-                    new_domain
-                        .as_ref()
-                        .and_then(Domain::as_singleton)
-                        .map(|scalar| {
-                            Expr::Constant(Constant {
-                                span: *span,
-                                scalar,
-                                data_type: dest_type.clone(),
-                            })
-                        })
-                        .unwrap_or(cast_expr),
-                    new_domain,
-                )
+                if let Some(scalar) = new_domain.as_ref().and_then(Domain::as_singleton) {
+                    let span = cast_expr.span();
+                    let data_type = cast_expr.into_data_type();
+                    (
+                        Expr::Constant(Constant {
+                            span,
+                            scalar,
+                            data_type,
+                        }),
+                        new_domain,
+                        true,
+                    )
+                } else {
+                    (cast_expr, new_domain, inner_changed)
+                }
             }
-            Expr::FunctionCall(FunctionCall {
-                span,
-                id,
-                function,
-                generics,
-                args,
-                return_type,
-            }) if matches!(
-                function.signature.name.as_str(),
-                "and_filters" | "or_filters"
-            ) =>
+            Expr::FunctionCall(mut call)
+                if matches!(
+                    call.function.signature.name.as_str(),
+                    "and_filters" | "or_filters"
+                ) =>
             {
-                let is_or = function.signature.name.starts_with("or_");
+                let is_or = call.function.signature.name.starts_with("or_");
 
-                if args.len() > MAX_FUNCTION_ARGS_TO_FOLD {
-                    return (expr.clone(), None);
+                if call.args.len() > MAX_FUNCTION_ARGS_TO_FOLD {
+                    return (Expr::FunctionCall(call), None, false);
                 }
 
-                let mut args_expr = Vec::new();
+                let mut changed = false;
+                let args = std::mem::take(&mut call.args);
+                let mut args_expr = Vec::with_capacity(args.len());
                 let mut result_domain = Some(BooleanDomain {
                     has_true: true,
                     has_false: true,
                 });
 
                 for arg in args {
-                    let (expr, domain) = self.fold_once(arg);
+                    let (arg, domain, arg_changed) = self.fold_once(arg);
+                    changed |= arg_changed;
                     // A temporary hack to make `and_filters` shortcut on false.
                     // TODO(andylokandy): make it a rule in the optimizer.
                     if let Expr::Constant(Constant {
                         scalar: Scalar::Boolean(result),
                         ..
-                    }) = &expr
+                    }) = &arg
                     {
                         if is_or == *result {
                             return (
                                 Expr::Constant(Constant {
-                                    span: *span,
+                                    span: call.span,
                                     scalar: Scalar::Boolean(is_or),
                                     data_type: DataType::Boolean,
                                 }),
                                 None,
+                                true,
                             );
                         }
                     }
-                    args_expr.push(expr);
+                    args_expr.push(arg);
 
                     result_domain = result_domain.zip(domain).map(|(func_domain, domain)| {
                         let (domain_has_true, domain_has_false) = match &domain {
@@ -288,11 +278,12 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                         if is_or == result {
                             return (
                                 Expr::Constant(Constant {
-                                    span: *span,
+                                    span: call.span,
                                     scalar: Scalar::Boolean(result),
                                     data_type: DataType::Boolean,
                                 }),
                                 None,
+                                true,
                             );
                         }
                     }
@@ -306,11 +297,12 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                         if is_mutually_exclusive {
                             return (
                                 Expr::Constant(Constant {
-                                    span: *span,
+                                    span: call.span,
                                     scalar: Scalar::Boolean(false),
                                     data_type: DataType::Boolean,
                                 }),
                                 None,
+                                true,
                             );
                         }
                     }
@@ -322,82 +314,57 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                 {
                     return (
                         Expr::Constant(Constant {
-                            span: *span,
+                            span: call.span,
                             scalar,
                             data_type: DataType::Boolean,
                         }),
                         None,
+                        true,
                     );
                 }
 
                 let all_args_is_scalar = args_expr.iter().all(|arg| arg.as_constant().is_some());
-
-                let func_expr = Expr::FunctionCall(FunctionCall {
-                    span: *span,
-                    id: id.clone(),
-                    function: function.clone(),
-                    generics: generics.clone(),
-                    args: args_expr,
-                    return_type: return_type.clone(),
-                });
+                call.args = args_expr;
+                let func_expr = Expr::FunctionCall(call);
 
                 if all_args_is_scalar {
-                    let block = DataBlock::empty_with_rows(1);
-                    let evaluator = Evaluator::new(&block, self.func_ctx, self.fn_registry);
-                    // Since we know the expression is constant, it'll be safe to change its column index type.
-                    let func_expr = func_expr.project_column_ref(|_| unreachable!()).unwrap();
-                    if let Ok(Value::Scalar(scalar)) = evaluator.run(&func_expr) {
-                        return (
-                            Expr::Constant(Constant {
-                                span: *span,
-                                scalar,
-                                data_type: return_type.clone(),
-                            }),
-                            None,
-                        );
-                    }
+                    let (func_expr, folded) = self.try_fold_constant_expr(func_expr);
+                    return (
+                        func_expr,
+                        if folded {
+                            None
+                        } else {
+                            result_domain.map(Domain::Boolean)
+                        },
+                        changed || folded,
+                    );
                 }
 
-                (func_expr, result_domain.map(Domain::Boolean))
+                (func_expr, result_domain.map(Domain::Boolean), changed)
             }
-            Expr::FunctionCall(FunctionCall {
-                span,
-                id,
-                function,
-                generics,
-                args,
-                return_type,
-            }) => {
-                if args.len() > MAX_FUNCTION_ARGS_TO_FOLD {
-                    return (expr.clone(), None);
+            Expr::FunctionCall(mut call) => {
+                if call.args.len() > MAX_FUNCTION_ARGS_TO_FOLD {
+                    return (Expr::FunctionCall(call), None, false);
                 }
 
-                let (mut args_expr, mut args_domain) = (
-                    Vec::with_capacity(args.len()),
-                    Some(Vec::with_capacity(args.len())),
-                );
+                let mut changed = false;
+                let args = std::mem::take(&mut call.args);
+                let mut args_expr = Vec::with_capacity(args.len());
+                let mut args_domain = Some(Vec::with_capacity(args.len()));
                 for arg in args {
-                    let (expr, domain) = self.fold_once(arg);
-                    args_expr.push(expr);
+                    let (arg, domain, arg_changed) = self.fold_once(arg);
+                    changed |= arg_changed;
+                    args_expr.push(arg);
                     args_domain = args_domain.zip(domain).map(|(mut domains, domain)| {
                         domains.push(domain);
                         domains
                     });
                 }
 
-                if function.signature.name == "if" {
+                if call.function.signature.name == "if" {
                     if args_expr.len() < 3 || args_expr.len().is_multiple_of(2) {
-                        return (
-                            Expr::FunctionCall(FunctionCall {
-                                span: *span,
-                                id: id.clone(),
-                                function: function.clone(),
-                                generics: generics.clone(),
-                                args: args_expr,
-                                return_type: return_type.clone(),
-                            }),
-                            None,
-                        );
+                        call.args = args_expr;
+                        return (Expr::FunctionCall(call), None, changed);
                     }
 
                     let mut simplified_args = Vec::with_capacity(args_expr.len());
@@ -406,7 +373,7 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                         match args_expr[cond_idx].as_constant().map(|c| &c.scalar) {
                             Some(Scalar::Boolean(true)) => {
                                 if simplified_args.is_empty() {
-                                    return (args_expr[cond_idx + 1].clone(), None);
+                                    return (args_expr.remove(cond_idx + 1), None, true);
                                 }
                                 simplified_args.push(args_expr[cond_idx + 1].clone());
                                 found_true_branch = true;
@@ -421,20 +388,20 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                     }
 
                     if simplified_args.is_empty() {
-                        return (args_expr.last().unwrap().clone(), None);
+                        return (args_expr.pop().unwrap(), None, true);
                     }
                     if !found_true_branch {
                         simplified_args.push(args_expr.last().unwrap().clone());
                     }
                     if simplified_args.len() != args_expr.len() {
                         if let Ok(func_expr) = check_function(
-                            *span,
+                            call.span,
                             "if",
-                            id.params(),
+                            call.id.params(),
                             &simplified_args,
                             self.fn_registry,
                         ) {
-                            return (func_expr, None);
+                            return (func_expr, None, true);
                         }
                     }
                 }
@@ -443,7 +410,7 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                 let is_monotonicity = self
                     .fn_registry
                     .properties
-                    .get(&function.signature.name)
+                    .get(&call.function.signature.name)
                     .map(|p| {
                         args_expr.len() == 1
                             && (p.monotonicity
@@ -453,12 +420,12 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                 let monotonicity_check = self
                     .fn_registry
                     .properties
-                    .get(&function.signature.name)
+                    .get(&call.function.signature.name)
                     .and_then(|p| p.monotonicity_check)
                     .filter(|_| args_expr.len() == 1);
 
                 // Check for mutually exclusive ranges in AND function
-                if function.signature.name == "and"
+                if call.function.signature.name == "and"
                     && args_expr.len() >= 2
                     && args_expr
                         .iter()
@@ -470,31 +437,24 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                         if is_mutually_exclusive {
                             return (
                                 Expr::Constant(Constant {
-                                    span: *span,
+                                    span: call.span,
                                     scalar: Scalar::Boolean(false),
                                     data_type: DataType::Boolean,
                                 }),
                                 None,
+                                true,
                             );
                         }
                     }
                 }
 
-                let func_expr = Expr::FunctionCall(FunctionCall {
-                    span: *span,
-                    id: id.clone(),
-                    function: function.clone(),
-                    generics: generics.clone(),
-                    args: args_expr,
-                    return_type: return_type.clone(),
-                });
-
-                let (calc_domain, eval) = match &function.eval {
+                let (calc_domain, eval) = match &call.function.eval {
                     FunctionEval::Scalar {
                         calc_domain, eval, ..
                     } => (calc_domain, eval),
                     FunctionEval::SRF { .. } => {
-                        return (func_expr, None);
+                        call.args = args_expr;
+                        return (Expr::FunctionCall(call), None, changed);
                     }
                 };
 
@@ -508,7 +468,7 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                     match (res, is_monotonic) {
                         (FunctionDomain::MayThrow | FunctionDomain::Full, true) => {
                             let domain = domains.first().unwrap();
-                            if args[0].data_type().is_nullable_or_null() {
+                            if args_expr[0].data_type().is_nullable_or_null() {
                                 return None;
                             }
 
@@ -519,7 +479,7 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
 
                             {
                                 let mut ctx = EvalContext {
-                                    generics,
+                                    generics: &call.generics,
                                     num_rows: 2,
                                     validity: None,
                                     errors: None,
@@ -528,7 +488,7 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                                     strict_eval: true,
                                 };
                                 let mut builder =
-                                    ColumnBuilder::with_capacity(args[0].data_type(), 2);
+                                    ColumnBuilder::with_capacity(args_expr[0].data_type(), 2);
                                 builder.push(min.as_ref());
                                 builder.push(max.as_ref());
 
@@ -544,13 +504,13 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                                     let col = result.as_column().unwrap();
                                     let d = if ctx.has_error(0) || ctx.has_error(1) {
                                         let (full_min, full_max) =
-                                            Domain::full(return_type).to_minmax();
+                                            Domain::full(&call.return_type).to_minmax();
                                         if full_min.is_null() || full_max.is_null() {
                                             return None;
                                         }
 
                                         let mut builder =
-                                            ColumnBuilder::with_capacity(return_type, 2);
+                                            ColumnBuilder::with_capacity(&call.return_type, 2);
 
                                         for (i, (v, f)) in
                                             col.iter().zip([full_min, full_max].iter()).enumerate()
@@ -570,7 +530,7 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                             }
                         }
                         (FunctionDomain::MayThrow, _) => None,
-                        (FunctionDomain::Full, _) => Some(Domain::full(return_type)),
+                        (FunctionDomain::Full, _) => Some(Domain::full(&call.return_type)),
                         (FunctionDomain::Domain(domain), _) => Some(domain),
                     }
                 });
@@ -578,91 +538,87 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                 if let Some(scalar) = func_domain.as_ref().and_then(Domain::as_singleton) {
                     return (
                         Expr::Constant(Constant {
-                            span: *span,
+                            span: call.span,
                             scalar,
-                            data_type: return_type.clone(),
+                            data_type: call.return_type,
                         }),
                         None,
+                        true,
                     );
                 }
+
+                let is_grouping = call.function.signature.name == "grouping";
+                call.args = args_expr;
+                let func_expr = Expr::FunctionCall(call);
 
                 // `grouping` is a placeholder before the aggregate rewriter rewrites it to
                 // `grouping<...>(_grouping_id)`. Folding it here can reach the dummy
                 // implementation and panic on invalid queries.
-                if function.signature.name == "grouping" {
-                    return (func_expr, func_domain);
+                if is_grouping {
+                    return (func_expr, func_domain, changed);
                 }
 
                 if all_args_is_scalar {
-                    let block = DataBlock::empty_with_rows(1);
-                    let evaluator = Evaluator::new(&block, self.func_ctx, self.fn_registry);
-                    // Since we know the expression is constant, it'll be safe to change its column index type.
-                    let func_expr = func_expr.project_column_ref(|_| unreachable!()).unwrap();
-                    if let Ok(Value::Scalar(scalar)) = evaluator.run(&func_expr) {
-                        return (
-                            Expr::Constant(Constant {
-                                span: *span,
-                                scalar,
-                                data_type: return_type.clone(),
-                            }),
-                            None,
-                        );
-                    }
+                    let (func_expr, folded) = self.try_fold_constant_expr(func_expr);
+                    return (
+                        func_expr,
+                        if folded { None } else { func_domain },
+                        changed || folded,
+                    );
                 }
 
-                (func_expr, func_domain)
+                (func_expr, func_domain, changed)
             }
-            Expr::LambdaFunctionCall(LambdaFunctionCall {
-                span,
-                name,
-                args,
-                lambda_expr,
-                lambda_display,
-                return_type,
-            }) => {
-                if args.len() > MAX_FUNCTION_ARGS_TO_FOLD {
-                    return (expr.clone(), None);
+            Expr::LambdaFunctionCall(mut call) => {
+                if call.args.len() > MAX_FUNCTION_ARGS_TO_FOLD {
+                    return (Expr::LambdaFunctionCall(call), None, false);
                 }
 
+                let mut changed = false;
+                let args = std::mem::take(&mut call.args);
                 let mut args_expr = Vec::with_capacity(args.len());
                 for arg in args {
-                    let (expr, _) = self.fold_once(arg);
-                    args_expr.push(expr);
+                    let (arg, _, arg_changed) = self.fold_once(arg);
+                    changed |= arg_changed;
+                    args_expr.push(arg);
                 }
                 let all_args_is_scalar = args_expr.iter().all(|arg| arg.as_constant().is_some());
-
-                let func_expr = Expr::LambdaFunctionCall(LambdaFunctionCall {
-                    span: *span,
-                    name: name.clone(),
-                    args: args_expr,
-                    lambda_expr: lambda_expr.clone(),
-                    lambda_display: lambda_display.clone(),
-                    return_type: return_type.clone(),
-                });
+                call.args = args_expr;
+                let func_expr = Expr::LambdaFunctionCall(call);
 
                 if all_args_is_scalar {
-                    let block = DataBlock::empty_with_rows(1);
-                    let evaluator = Evaluator::new(&block, self.func_ctx, self.fn_registry);
-                    // Since we know the expression is constant, it'll be safe to change its column index type.
-                    let func_expr = func_expr.project_column_ref(|_| unreachable!()).unwrap();
-                    if let Ok(Value::Scalar(scalar)) = evaluator.run(&func_expr) {
-                        return (
-                            Expr::Constant(Constant {
-                                span: *span,
-                                scalar,
-                                data_type: return_type.clone(),
-                            }),
-                            None,
-                        );
-                    }
+                    let (func_expr, folded) = self.try_fold_constant_expr(func_expr);
+                    return (func_expr, None, changed || folded);
                 }
-                (func_expr, None)
+                (func_expr, None, changed)
             }
         };
 
-        debug_assert_eq!(expr.data_type(), new_expr.data_type());
+        debug_assert_eq!(&data_type, new_expr.data_type());
 
-        (new_expr, domain)
+        (new_expr, domain, changed)
+    }
+
+    fn try_fold_constant_expr(&self, expr: Expr<Index>) -> (Expr<Index>, bool) {
+        let block = DataBlock::empty_with_rows(1);
+        let evaluator = Evaluator::new(&block, self.func_ctx, self.fn_registry);
+        // Since the expression is constant, it is safe to change its column index type.
+        let projected_expr = expr.project_column_ref(|_| unreachable!()).unwrap();
+        match evaluator.run(&projected_expr) {
+            Ok(Value::Scalar(scalar)) => {
+                let span = expr.span();
+                let data_type = expr.into_data_type();
+                (
+                    Expr::Constant(Constant {
+                        span,
+                        scalar,
+                        data_type,
+                    }),
+                    true,
+                )
+            }
+            _ => (expr, false),
+        }
     }
 
     fn calculate_cast(
@@ -863,7 +819,7 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
         }
 
         let (_, output_domain) = ConstantFolder::fold_with_domain(
-            &cast_expr,
+            cast_expr,
             &[(0, domain.clone())].into_iter().collect(),
             self.func_ctx,
             self.fn_registry,

--- a/src/query/expression/src/constant_folder.rs
+++ b/src/query/expression/src/constant_folder.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use databend_common_ast::Span;
@@ -50,14 +51,341 @@ pub struct ConstantFolder<'a, Index: ColumnIndex> {
     fn_registry: &'a FunctionRegistry,
 }
 
+enum FoldResult<'e, Index: ColumnIndex> {
+    Unchanged(Cow<'e, Expr<Index>>),
+    Changed(Expr<Index>),
+}
+
+impl<'e, Index: ColumnIndex> FoldResult<'e, Index> {
+    fn as_ref(&self) -> &Expr<Index> {
+        match self {
+            FoldResult::Unchanged(expr) => expr.as_ref(),
+            FoldResult::Changed(expr) => expr,
+        }
+    }
+
+    fn is_changed(&self) -> bool {
+        matches!(self, FoldResult::Changed(_))
+    }
+
+    fn into_expr(self) -> Expr<Index> {
+        match self {
+            FoldResult::Unchanged(expr) => expr.into_owned(),
+            FoldResult::Changed(expr) => expr,
+        }
+    }
+}
+
+enum ExprArgs<'e, Index: ColumnIndex> {
+    Borrowed(std::slice::Iter<'e, Expr<Index>>),
+    Owned(std::vec::IntoIter<Expr<Index>>),
+}
+
+impl<'e, Index: ColumnIndex> Iterator for ExprArgs<'e, Index> {
+    type Item = Cow<'e, Expr<Index>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            ExprArgs::Borrowed(args) => args.next().map(Cow::Borrowed),
+            ExprArgs::Owned(args) => args.next().map(Cow::Owned),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            ExprArgs::Borrowed(args) => args.size_hint(),
+            ExprArgs::Owned(args) => args.size_hint(),
+        }
+    }
+}
+
+impl<Index: ColumnIndex> ExactSizeIterator for ExprArgs<'_, Index> {}
+
+enum FunctionNode<'e, Index: ColumnIndex> {
+    Borrowed {
+        expr: &'e Expr<Index>,
+        call: &'e FunctionCall<Index>,
+    },
+    Owned(FunctionCall<Index>),
+}
+
+impl<'e, Index: ColumnIndex> FunctionNode<'e, Index> {
+    fn call(&self) -> &FunctionCall<Index> {
+        match self {
+            FunctionNode::Borrowed { call, .. } => call,
+            FunctionNode::Owned(call) => call,
+        }
+    }
+
+    fn args_len(&self) -> usize {
+        self.call().args.len()
+    }
+
+    fn into_args(self) -> (Self, ExprArgs<'e, Index>) {
+        match self {
+            FunctionNode::Borrowed { expr, call } => (
+                FunctionNode::Borrowed { expr, call },
+                ExprArgs::Borrowed(call.args.iter()),
+            ),
+            FunctionNode::Owned(mut call) => {
+                let args = ExprArgs::Owned(std::mem::take(&mut call.args).into_iter());
+                (FunctionNode::Owned(call), args)
+            }
+        }
+    }
+
+    fn into_cow(self) -> Cow<'e, Expr<Index>> {
+        match self {
+            FunctionNode::Borrowed { expr, .. } => Cow::Borrowed(expr),
+            FunctionNode::Owned(call) => Cow::Owned(Expr::FunctionCall(call)),
+        }
+    }
+
+    fn finish(self, args: impl IntoIterator<Item = Expr<Index>>) -> Expr<Index> {
+        let args = args.into_iter().collect();
+        match self {
+            FunctionNode::Borrowed { call, .. } => Expr::FunctionCall(FunctionCall {
+                span: call.span,
+                id: call.id.clone(),
+                function: call.function.clone(),
+                generics: call.generics.clone(),
+                args,
+                return_type: call.return_type.clone(),
+            }),
+            FunctionNode::Owned(mut call) => {
+                call.args = args;
+                Expr::FunctionCall(call)
+            }
+        }
+    }
+
+    fn borrowed_expr(&self) -> Option<&'e Expr<Index>> {
+        match self {
+            FunctionNode::Borrowed { expr, .. } => Some(expr),
+            FunctionNode::Owned(_) => None,
+        }
+    }
+
+    fn finish_fold(self, args: Vec<FoldResult<'e, Index>>, changed: bool) -> FoldResult<'e, Index> {
+        match (changed, self) {
+            (false, FunctionNode::Borrowed { expr, .. }) => {
+                FoldResult::Unchanged(Cow::Borrowed(expr))
+            }
+            (changed, node) => {
+                let expr = node.finish(args.into_iter().map(FoldResult::into_expr));
+                if changed {
+                    FoldResult::Changed(expr)
+                } else {
+                    FoldResult::Unchanged(Cow::Owned(expr))
+                }
+            }
+        }
+    }
+}
+
+enum LambdaNode<'e, Index: ColumnIndex> {
+    Borrowed {
+        expr: &'e Expr<Index>,
+        call: &'e LambdaFunctionCall<Index>,
+    },
+    Owned(LambdaFunctionCall<Index>),
+}
+
+impl<'e, Index: ColumnIndex> LambdaNode<'e, Index> {
+    fn args_len(&self) -> usize {
+        match self {
+            LambdaNode::Borrowed { call, .. } => call.args.len(),
+            LambdaNode::Owned(call) => call.args.len(),
+        }
+    }
+
+    fn into_args(self) -> (Self, ExprArgs<'e, Index>) {
+        match self {
+            LambdaNode::Borrowed { expr, call } => (
+                LambdaNode::Borrowed { expr, call },
+                ExprArgs::Borrowed(call.args.iter()),
+            ),
+            LambdaNode::Owned(mut call) => {
+                let args = ExprArgs::Owned(std::mem::take(&mut call.args).into_iter());
+                (LambdaNode::Owned(call), args)
+            }
+        }
+    }
+
+    fn into_cow(self) -> Cow<'e, Expr<Index>> {
+        match self {
+            LambdaNode::Borrowed { expr, .. } => Cow::Borrowed(expr),
+            LambdaNode::Owned(call) => Cow::Owned(Expr::LambdaFunctionCall(call)),
+        }
+    }
+
+    fn finish(self, args: impl IntoIterator<Item = Expr<Index>>) -> Expr<Index> {
+        let args = args.into_iter().collect();
+        match self {
+            LambdaNode::Borrowed { call, .. } => Expr::LambdaFunctionCall(LambdaFunctionCall {
+                span: call.span,
+                name: call.name.clone(),
+                args,
+                lambda_expr: call.lambda_expr.clone(),
+                lambda_display: call.lambda_display.clone(),
+                return_type: call.return_type.clone(),
+            }),
+            LambdaNode::Owned(mut call) => {
+                call.args = args;
+                Expr::LambdaFunctionCall(call)
+            }
+        }
+    }
+
+    fn borrowed_expr(&self) -> Option<&'e Expr<Index>> {
+        match self {
+            LambdaNode::Borrowed { expr, .. } => Some(expr),
+            LambdaNode::Owned(_) => None,
+        }
+    }
+
+    fn finish_fold(self, args: Vec<FoldResult<'e, Index>>, changed: bool) -> FoldResult<'e, Index> {
+        match (changed, self) {
+            (false, LambdaNode::Borrowed { expr, .. }) => {
+                FoldResult::Unchanged(Cow::Borrowed(expr))
+            }
+            (changed, node) => {
+                let expr = node.finish(args.into_iter().map(FoldResult::into_expr));
+                if changed {
+                    FoldResult::Changed(expr)
+                } else {
+                    FoldResult::Unchanged(Cow::Owned(expr))
+                }
+            }
+        }
+    }
+}
+
+enum CastNode<'e, Index: ColumnIndex> {
+    Borrowed(&'e Expr<Index>),
+    Owned {
+        span: Span,
+        is_try: bool,
+        dest_type: DataType,
+    },
+}
+
+impl<'e, Index: ColumnIndex> CastNode<'e, Index> {
+    fn parts(&self) -> (Span, bool, &DataType) {
+        match self {
+            CastNode::Borrowed(Expr::Cast(cast)) => (cast.span, cast.is_try, &cast.dest_type),
+            CastNode::Owned {
+                span,
+                is_try,
+                dest_type,
+            } => (*span, *is_try, dest_type),
+            CastNode::Borrowed(_) => unreachable!(),
+        }
+    }
+
+    fn finish(self, expr: Expr<Index>) -> Expr<Index> {
+        match self {
+            CastNode::Borrowed(Expr::Cast(cast)) => Expr::Cast(Cast {
+                span: cast.span,
+                is_try: cast.is_try,
+                expr: Box::new(expr),
+                dest_type: cast.dest_type.clone(),
+            }),
+            CastNode::Owned {
+                span,
+                is_try,
+                dest_type,
+            } => Expr::Cast(Cast {
+                span,
+                is_try,
+                expr: Box::new(expr),
+                dest_type,
+            }),
+            CastNode::Borrowed(_) => unreachable!(),
+        }
+    }
+
+    fn borrowed_expr(&self) -> Option<&'e Expr<Index>> {
+        match self {
+            CastNode::Borrowed(expr) => Some(expr),
+            CastNode::Owned { .. } => None,
+        }
+    }
+
+    fn finish_fold(self, expr: FoldResult<'e, Index>, changed: bool) -> FoldResult<'e, Index> {
+        if changed {
+            return FoldResult::Changed(self.finish(expr.into_expr()));
+        }
+
+        match self {
+            CastNode::Borrowed(expr) => FoldResult::Unchanged(Cow::Borrowed(expr)),
+            CastNode::Owned {
+                span,
+                is_try,
+                dest_type,
+            } => FoldResult::Unchanged(Cow::Owned(Expr::Cast(Cast {
+                span,
+                is_try,
+                expr: Box::new(expr.into_expr()),
+                dest_type,
+            }))),
+        }
+    }
+}
+
+enum FoldNode<'e, Index: ColumnIndex> {
+    Constant(Cow<'e, Expr<Index>>),
+    ColumnRef(Cow<'e, Expr<Index>>),
+    Cast(CastNode<'e, Index>, Cow<'e, Expr<Index>>),
+    FunctionCall(FunctionNode<'e, Index>),
+    LambdaFunctionCall(LambdaNode<'e, Index>),
+}
+
+impl<'e, Index: ColumnIndex> FoldNode<'e, Index> {
+    fn from_cow(expr: Cow<'e, Expr<Index>>) -> Self {
+        match expr {
+            Cow::Borrowed(expr @ Expr::Constant(_)) => FoldNode::Constant(Cow::Borrowed(expr)),
+            Cow::Owned(expr @ Expr::Constant(_)) => FoldNode::Constant(Cow::Owned(expr)),
+            Cow::Borrowed(expr @ Expr::ColumnRef(_)) => FoldNode::ColumnRef(Cow::Borrowed(expr)),
+            Cow::Owned(expr @ Expr::ColumnRef(_)) => FoldNode::ColumnRef(Cow::Owned(expr)),
+            Cow::Borrowed(expr @ Expr::Cast(cast)) => {
+                FoldNode::Cast(CastNode::Borrowed(expr), Cow::Borrowed(cast.expr.as_ref()))
+            }
+            Cow::Owned(Expr::Cast(cast)) => FoldNode::Cast(
+                CastNode::Owned {
+                    span: cast.span,
+                    is_try: cast.is_try,
+                    dest_type: cast.dest_type,
+                },
+                Cow::Owned(*cast.expr),
+            ),
+            Cow::Borrowed(expr @ Expr::FunctionCall(call)) => {
+                FoldNode::FunctionCall(FunctionNode::Borrowed { expr, call })
+            }
+            Cow::Owned(Expr::FunctionCall(call)) => {
+                FoldNode::FunctionCall(FunctionNode::Owned(call))
+            }
+            Cow::Borrowed(expr @ Expr::LambdaFunctionCall(call)) => {
+                FoldNode::LambdaFunctionCall(LambdaNode::Borrowed { expr, call })
+            }
+            Cow::Owned(Expr::LambdaFunctionCall(call)) => {
+                FoldNode::LambdaFunctionCall(LambdaNode::Owned(call))
+            }
+        }
+    }
+}
+
 impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
-    /// Fold a single expression, returning the new expression and the domain of the new expression.
-    pub fn fold(
-        expr: Expr<Index>,
+    /// Fold a single expression, returning the new expression and its domain.
+    ///
+    /// A borrowed input remains borrowed when folding does not rewrite it. An owned input is
+    /// consumed and rebuilt by moving its unchanged subtrees whenever possible.
+    pub fn fold<'e>(
+        expr: Cow<'e, Expr<Index>>,
         func_ctx: &'a FunctionContext,
         fn_registry: &'a FunctionRegistry,
-    ) -> (Expr<Index>, Option<Domain>) {
-        let input_domains = Self::full_input_domains(&expr);
+    ) -> (Cow<'e, Expr<Index>>, Option<Domain>) {
+        let input_domains = Self::full_input_domains(expr.as_ref());
 
         let folder = ConstantFolder {
             input_domains: &input_domains,
@@ -68,14 +396,16 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
         folder.fold_to_stable(expr)
     }
 
-    /// Fold a single expression with columns' domain, and then return the new expression and the
-    /// domain of the new expression.
-    pub fn fold_with_domain(
-        expr: Expr<Index>,
+    /// Fold a single expression with columns' domains, returning the new expression and its domain.
+    ///
+    /// A borrowed input remains borrowed when folding does not rewrite it. An owned input is
+    /// consumed and rebuilt by moving its unchanged subtrees whenever possible.
+    pub fn fold_with_domain<'e>(
+        expr: Cow<'e, Expr<Index>>,
         input_domains: &'a HashMap<Index, Domain>,
         func_ctx: &'a FunctionContext,
         fn_registry: &'a FunctionRegistry,
-    ) -> (Expr<Index>, Option<Domain>) {
+    ) -> (Cow<'e, Expr<Index>>, Option<Domain>) {
         let folder = ConstantFolder {
             input_domains,
             func_ctx,
@@ -97,16 +427,19 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
 
     /// Running `fold_once()` for only one time may not reach the simplest form of expression,
     /// therefore we need to call it repeatedly until the expression becomes stable.
-    fn fold_to_stable(&self, mut expr: Expr<Index>) -> (Expr<Index>, Option<Domain>) {
+    fn fold_to_stable<'e>(
+        &self,
+        mut expr: Cow<'e, Expr<Index>>,
+    ) -> (Cow<'e, Expr<Index>>, Option<Domain>) {
         const MAX_ITERATIONS: usize = 1024;
 
         let mut domain = None;
         for _ in 0..MAX_ITERATIONS {
-            let (new_expr, new_domain, changed) = self.fold_once(expr);
-            if !changed {
-                return (new_expr, new_domain);
+            let (result, new_domain) = self.fold_once(expr);
+            match result {
+                FoldResult::Unchanged(current) => return (current, new_domain),
+                FoldResult::Changed(replacement) => expr = Cow::Owned(replacement),
             }
-            expr = new_expr;
             domain = new_domain;
         }
 
@@ -118,95 +451,118 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
     /// Fold expression by one step, specifically, by reducing expression by domain calculation and then
     /// folding the function calls whose all arguments are constants.
     #[recursive::recursive]
-    fn fold_once(&self, expr: Expr<Index>) -> (Expr<Index>, Option<Domain>, bool) {
+    fn fold_once<'e>(&self, expr: Cow<'e, Expr<Index>>) -> (FoldResult<'e, Index>, Option<Domain>) {
         let data_type = expr.data_type().clone();
-        let (new_expr, domain, changed) = match expr {
-            Expr::Constant(constant) => {
+        let (result, domain) = match FoldNode::from_cow(expr) {
+            FoldNode::Constant(expr) => {
+                let Expr::Constant(constant) = expr.as_ref() else {
+                    unreachable!()
+                };
                 let domain = constant.scalar.as_ref().domain(&constant.data_type);
-                (Expr::Constant(constant), Some(domain), false)
+                (FoldResult::Unchanged(expr), Some(domain))
             }
-            Expr::ColumnRef(column_ref) => {
+            FoldNode::ColumnRef(expr) => {
+                let Expr::ColumnRef(column_ref) = expr.as_ref() else {
+                    unreachable!()
+                };
                 let domain = &self.input_domains[&column_ref.id];
                 if let Some(scalar) = domain.as_singleton() {
                     (
-                        Expr::Constant(Constant {
+                        FoldResult::Changed(Expr::Constant(Constant {
                             span: column_ref.span,
                             scalar,
-                            data_type: column_ref.data_type,
-                        }),
+                            data_type: column_ref.data_type.clone(),
+                        })),
                         Some(domain.clone()),
-                        true,
                     )
                 } else {
-                    (Expr::ColumnRef(column_ref), Some(domain.clone()), false)
+                    (FoldResult::Unchanged(expr), Some(domain.clone()))
                 }
             }
-            Expr::Cast(Cast {
-                span,
-                is_try,
-                expr,
-                dest_type,
-            }) => {
+            FoldNode::Cast(node, expr) => {
+                let (span, is_try, dest_type) = node.parts();
                 let src_type = expr.data_type().clone();
-                let (inner_expr, inner_domain, inner_changed) = self.fold_once(*expr);
+                let (inner_result, inner_domain) = self.fold_once(expr);
+                let inner_changed = inner_result.is_changed();
 
                 let new_domain = if is_try {
                     inner_domain.and_then(|inner_domain| {
-                        self.calculate_try_cast(span, &src_type, &dest_type, &inner_domain)
+                        self.calculate_try_cast(span, &src_type, dest_type, &inner_domain)
                     })
                 } else {
                     inner_domain.and_then(|inner_domain| {
-                        self.calculate_cast(span, &src_type, &dest_type, &inner_domain)
+                        self.calculate_cast(span, &src_type, dest_type, &inner_domain)
                     })
                 };
 
-                let inner_is_constant = inner_expr.as_constant().is_some();
-                let cast_expr = Expr::Cast(Cast {
-                    span,
-                    is_try,
-                    expr: Box::new(inner_expr),
-                    dest_type,
-                });
+                let inner_is_constant = inner_result.as_ref().as_constant().is_some();
+                if inner_is_constant {
+                    if !inner_changed && let Some(cast_expr) = node.borrowed_expr() {
+                        let (cast_expr, folded) =
+                            self.try_fold_constant_expr(Cow::Borrowed(cast_expr));
+                        if folded {
+                            return (FoldResult::Changed(cast_expr.into_owned()), None);
+                        }
+                    } else {
+                        let cast_expr = node.finish(inner_result.into_expr());
+                        let (cast_expr, folded) =
+                            self.try_fold_constant_expr(Cow::Owned(cast_expr));
+                        if folded {
+                            return (FoldResult::Changed(cast_expr.into_owned()), None);
+                        }
 
-                let (cast_expr, folded) = if inner_is_constant {
-                    self.try_fold_constant_expr(cast_expr)
-                } else {
-                    (cast_expr, false)
-                };
-                if folded {
-                    return (cast_expr, None, true);
+                        if let Some(scalar) = new_domain.as_ref().and_then(Domain::as_singleton) {
+                            let Expr::Cast(cast) = cast_expr.into_owned() else {
+                                unreachable!()
+                            };
+                            return (
+                                FoldResult::Changed(Expr::Constant(Constant {
+                                    span: cast.span,
+                                    scalar,
+                                    data_type: cast.dest_type,
+                                })),
+                                new_domain,
+                            );
+                        }
+
+                        let result = if inner_changed {
+                            FoldResult::Changed(cast_expr.into_owned())
+                        } else {
+                            FoldResult::Unchanged(cast_expr)
+                        };
+                        return (result, new_domain);
+                    }
                 }
 
                 if let Some(scalar) = new_domain.as_ref().and_then(Domain::as_singleton) {
-                    let span = cast_expr.span();
-                    let data_type = cast_expr.into_data_type();
                     (
-                        Expr::Constant(Constant {
+                        FoldResult::Changed(Expr::Constant(Constant {
                             span,
                             scalar,
-                            data_type,
-                        }),
+                            data_type: dest_type.clone(),
+                        })),
                         new_domain,
-                        true,
                     )
                 } else {
-                    (cast_expr, new_domain, inner_changed)
+                    (node.finish_fold(inner_result, inner_changed), new_domain)
                 }
             }
-            Expr::FunctionCall(mut call)
+            FoldNode::FunctionCall(node)
                 if matches!(
-                    call.function.signature.name.as_str(),
+                    node.call().function.signature.name.as_str(),
                     "and_filters" | "or_filters"
                 ) =>
             {
+                let call = node.call();
                 let is_or = call.function.signature.name.starts_with("or_");
+                let span = call.span;
 
-                if call.args.len() > MAX_FUNCTION_ARGS_TO_FOLD {
-                    return (Expr::FunctionCall(call), None, false);
+                if node.args_len() > MAX_FUNCTION_ARGS_TO_FOLD {
+                    return (FoldResult::Unchanged(node.into_cow()), None);
                 }
+                let (node, args) = node.into_args();
 
                 let mut changed = false;
-                let args = std::mem::take(&mut call.args);
                 let mut args_expr = Vec::with_capacity(args.len());
                 let mut result_domain = Some(BooleanDomain {
                     has_true: true,
@@ -214,24 +570,23 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                 });
 
                 for arg in args {
-                    let (arg, domain, arg_changed) = self.fold_once(arg);
-                    changed |= arg_changed;
+                    let (arg, domain) = self.fold_once(arg);
+                    changed |= arg.is_changed();
                     // A temporary hack to make `and_filters` shortcut on false.
                     // TODO(andylokandy): make it a rule in the optimizer.
                     if let Expr::Constant(Constant {
                         scalar: Scalar::Boolean(result),
                         ..
-                    }) = &arg
+                    }) = arg.as_ref()
                     {
                         if is_or == *result {
                             return (
-                                Expr::Constant(Constant {
-                                    span: call.span,
+                                FoldResult::Changed(Expr::Constant(Constant {
+                                    span,
                                     scalar: Scalar::Boolean(is_or),
                                     data_type: DataType::Boolean,
-                                }),
+                                })),
                                 None,
-                                true,
                             );
                         }
                     }
@@ -277,13 +632,12 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                     {
                         if is_or == result {
                             return (
-                                Expr::Constant(Constant {
-                                    span: call.span,
+                                FoldResult::Changed(Expr::Constant(Constant {
+                                    span,
                                     scalar: Scalar::Boolean(result),
                                     data_type: DataType::Boolean,
-                                }),
+                                })),
                                 None,
-                                true,
                             );
                         }
                     }
@@ -296,13 +650,12 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                     {
                         if is_mutually_exclusive {
                             return (
-                                Expr::Constant(Constant {
-                                    span: call.span,
+                                FoldResult::Changed(Expr::Constant(Constant {
+                                    span,
                                     scalar: Scalar::Boolean(false),
                                     data_type: DataType::Boolean,
-                                }),
+                                })),
                                 None,
-                                true,
                             );
                         }
                     }
@@ -313,47 +666,62 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                     .and_then(|domain| Domain::Boolean(*domain).as_singleton())
                 {
                     return (
-                        Expr::Constant(Constant {
-                            span: call.span,
+                        FoldResult::Changed(Expr::Constant(Constant {
+                            span,
                             scalar,
                             data_type: DataType::Boolean,
-                        }),
+                        })),
                         None,
-                        true,
                     );
                 }
 
-                let all_args_is_scalar = args_expr.iter().all(|arg| arg.as_constant().is_some());
-                call.args = args_expr;
-                let func_expr = Expr::FunctionCall(call);
+                let all_args_is_scalar = args_expr
+                    .iter()
+                    .all(|arg| arg.as_ref().as_constant().is_some());
 
                 if all_args_is_scalar {
-                    let (func_expr, folded) = self.try_fold_constant_expr(func_expr);
-                    return (
-                        func_expr,
+                    if !changed && let Some(func_expr) = node.borrowed_expr() {
+                        let (func_expr, folded) =
+                            self.try_fold_constant_expr(Cow::Borrowed(func_expr));
                         if folded {
-                            None
+                            return (FoldResult::Changed(func_expr.into_owned()), None);
+                        }
+                    } else {
+                        let func_expr =
+                            node.finish(args_expr.into_iter().map(FoldResult::into_expr));
+                        let (func_expr, folded) =
+                            self.try_fold_constant_expr(Cow::Owned(func_expr));
+                        let result = if folded || changed {
+                            FoldResult::Changed(func_expr.into_owned())
                         } else {
-                            result_domain.map(Domain::Boolean)
-                        },
-                        changed || folded,
-                    );
+                            FoldResult::Unchanged(func_expr)
+                        };
+                        return (
+                            result,
+                            if folded {
+                                None
+                            } else {
+                                result_domain.map(Domain::Boolean)
+                            },
+                        );
+                    }
                 }
 
-                (func_expr, result_domain.map(Domain::Boolean), changed)
+                let result = node.finish_fold(args_expr, changed);
+                (result, result_domain.map(Domain::Boolean))
             }
-            Expr::FunctionCall(mut call) => {
-                if call.args.len() > MAX_FUNCTION_ARGS_TO_FOLD {
-                    return (Expr::FunctionCall(call), None, false);
+            FoldNode::FunctionCall(node) => {
+                if node.args_len() > MAX_FUNCTION_ARGS_TO_FOLD {
+                    return (FoldResult::Unchanged(node.into_cow()), None);
                 }
+                let (node, args) = node.into_args();
 
                 let mut changed = false;
-                let args = std::mem::take(&mut call.args);
                 let mut args_expr = Vec::with_capacity(args.len());
                 let mut args_domain = Some(Vec::with_capacity(args.len()));
                 for arg in args {
-                    let (arg, domain, arg_changed) = self.fold_once(arg);
-                    changed |= arg_changed;
+                    let (arg, domain) = self.fold_once(arg);
+                    changed |= arg.is_changed();
                     args_expr.push(arg);
                     args_domain = args_domain.zip(domain).map(|(mut domains, domain)| {
                         domains.push(domain);
@@ -361,52 +729,86 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                     });
                 }
 
+                let call = node.call();
+
                 if call.function.signature.name == "if" {
                     if args_expr.len() < 3 || args_expr.len().is_multiple_of(2) {
-                        call.args = args_expr;
-                        return (Expr::FunctionCall(call), None, changed);
+                        let result = node.finish_fold(args_expr, changed);
+                        return (result, None);
                     }
 
-                    let mut simplified_args = Vec::with_capacity(args_expr.len());
+                    let mut simplified_indices = Vec::with_capacity(args_expr.len());
                     let mut found_true_branch = false;
                     for cond_idx in (0..args_expr.len() - 1).step_by(2) {
-                        match args_expr[cond_idx].as_constant().map(|c| &c.scalar) {
+                        match args_expr[cond_idx]
+                            .as_ref()
+                            .as_constant()
+                            .map(|c| &c.scalar)
+                        {
                             Some(Scalar::Boolean(true)) => {
-                                if simplified_args.is_empty() {
-                                    return (args_expr.remove(cond_idx + 1), None, true);
+                                if simplified_indices.is_empty() {
+                                    return (
+                                        FoldResult::Changed(
+                                            args_expr.remove(cond_idx + 1).into_expr(),
+                                        ),
+                                        None,
+                                    );
                                 }
-                                simplified_args.push(args_expr[cond_idx + 1].clone());
+                                simplified_indices.push(cond_idx + 1);
                                 found_true_branch = true;
                                 break;
                             }
                             Some(Scalar::Boolean(false) | Scalar::Null) => {}
                             _ => {
-                                simplified_args.push(args_expr[cond_idx].clone());
-                                simplified_args.push(args_expr[cond_idx + 1].clone());
+                                simplified_indices.push(cond_idx);
+                                simplified_indices.push(cond_idx + 1);
                             }
                         }
                     }
 
-                    if simplified_args.is_empty() {
-                        return (args_expr.pop().unwrap(), None, true);
+                    if simplified_indices.is_empty() {
+                        return (
+                            FoldResult::Changed(args_expr.pop().unwrap().into_expr()),
+                            None,
+                        );
                     }
                     if !found_true_branch {
-                        simplified_args.push(args_expr.last().unwrap().clone());
+                        simplified_indices.push(args_expr.len() - 1);
                     }
-                    if simplified_args.len() != args_expr.len() {
-                        if let Ok(func_expr) = check_function(
+                    if simplified_indices.len() != args_expr.len() {
+                        let mut original_args = args_expr.into_iter().map(Some).collect::<Vec<_>>();
+                        let simplified_args = simplified_indices
+                            .iter()
+                            .map(|&index| original_args[index].take().unwrap().into_expr())
+                            .collect::<Vec<_>>();
+                        match check_function(
                             call.span,
                             "if",
                             call.id.params(),
                             &simplified_args,
                             self.fn_registry,
                         ) {
-                            return (func_expr, None, true);
+                            Ok(Expr::FunctionCall(mut call)) => {
+                                call.args = simplified_args;
+                                return (FoldResult::Changed(Expr::FunctionCall(call)), None);
+                            }
+                            Ok(func_expr) => return (FoldResult::Changed(func_expr), None),
+                            Err(_) => {
+                                for (index, arg) in
+                                    simplified_indices.into_iter().zip(simplified_args)
+                                {
+                                    original_args[index] =
+                                        Some(FoldResult::Unchanged(Cow::Owned(arg)));
+                                }
+                                args_expr = original_args.into_iter().map(Option::unwrap).collect();
+                            }
                         }
                     }
                 }
 
-                let all_args_is_scalar = args_expr.iter().all(|arg| arg.as_constant().is_some());
+                let all_args_is_scalar = args_expr
+                    .iter()
+                    .all(|arg| arg.as_ref().as_constant().is_some());
                 let is_monotonicity = self
                     .fn_registry
                     .properties
@@ -414,7 +816,8 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                     .map(|p| {
                         args_expr.len() == 1
                             && (p.monotonicity
-                                || p.monotonicity_by_type.contains(args_expr[0].data_type()))
+                                || p.monotonicity_by_type
+                                    .contains(args_expr[0].as_ref().data_type()))
                     })
                     .unwrap_or_default();
                 let monotonicity_check = self
@@ -429,20 +832,19 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                     && args_expr.len() >= 2
                     && args_expr
                         .iter()
-                        .all(|arg| !arg.data_type().is_nullable_or_null())
+                        .all(|arg| !arg.as_ref().data_type().is_nullable_or_null())
                 {
                     if let Some(is_mutually_exclusive) =
                         self.check_mutually_exclusive_ranges(&args_expr)
                     {
                         if is_mutually_exclusive {
                             return (
-                                Expr::Constant(Constant {
+                                FoldResult::Changed(Expr::Constant(Constant {
                                     span: call.span,
                                     scalar: Scalar::Boolean(false),
                                     data_type: DataType::Boolean,
-                                }),
+                                })),
                                 None,
-                                true,
                             );
                         }
                     }
@@ -453,8 +855,8 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                         calc_domain, eval, ..
                     } => (calc_domain, eval),
                     FunctionEval::SRF { .. } => {
-                        call.args = args_expr;
-                        return (Expr::FunctionCall(call), None, changed);
+                        let result = node.finish_fold(args_expr, changed);
+                        return (result, None);
                     }
                 };
 
@@ -468,7 +870,7 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                     match (res, is_monotonic) {
                         (FunctionDomain::MayThrow | FunctionDomain::Full, true) => {
                             let domain = domains.first().unwrap();
-                            if args_expr[0].data_type().is_nullable_or_null() {
+                            if args_expr[0].as_ref().data_type().is_nullable_or_null() {
                                 return None;
                             }
 
@@ -487,8 +889,10 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
                                     suppress_error: false,
                                     strict_eval: true,
                                 };
-                                let mut builder =
-                                    ColumnBuilder::with_capacity(args_expr[0].data_type(), 2);
+                                let mut builder = ColumnBuilder::with_capacity(
+                                    args_expr[0].as_ref().data_type(),
+                                    2,
+                                );
                                 builder.push(min.as_ref());
                                 builder.push(max.as_ref());
 
@@ -537,88 +941,127 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
 
                 if let Some(scalar) = func_domain.as_ref().and_then(Domain::as_singleton) {
                     return (
-                        Expr::Constant(Constant {
+                        FoldResult::Changed(Expr::Constant(Constant {
                             span: call.span,
                             scalar,
-                            data_type: call.return_type,
-                        }),
+                            data_type: call.return_type.clone(),
+                        })),
                         None,
-                        true,
                     );
                 }
 
                 let is_grouping = call.function.signature.name == "grouping";
-                call.args = args_expr;
-                let func_expr = Expr::FunctionCall(call);
 
                 // `grouping` is a placeholder before the aggregate rewriter rewrites it to
                 // `grouping<...>(_grouping_id)`. Folding it here can reach the dummy
                 // implementation and panic on invalid queries.
                 if is_grouping {
-                    return (func_expr, func_domain, changed);
+                    let result = node.finish_fold(args_expr, changed);
+                    return (result, func_domain);
                 }
 
                 if all_args_is_scalar {
-                    let (func_expr, folded) = self.try_fold_constant_expr(func_expr);
-                    return (
-                        func_expr,
-                        if folded { None } else { func_domain },
-                        changed || folded,
-                    );
+                    if !changed && let Some(func_expr) = node.borrowed_expr() {
+                        let (func_expr, folded) =
+                            self.try_fold_constant_expr(Cow::Borrowed(func_expr));
+                        if folded {
+                            return (FoldResult::Changed(func_expr.into_owned()), None);
+                        }
+                    } else {
+                        let func_expr =
+                            node.finish(args_expr.into_iter().map(FoldResult::into_expr));
+                        let (func_expr, folded) =
+                            self.try_fold_constant_expr(Cow::Owned(func_expr));
+                        let result = if folded || changed {
+                            FoldResult::Changed(func_expr.into_owned())
+                        } else {
+                            FoldResult::Unchanged(func_expr)
+                        };
+                        return (result, if folded { None } else { func_domain });
+                    }
                 }
 
-                (func_expr, func_domain, changed)
+                let result = node.finish_fold(args_expr, changed);
+                (result, func_domain)
             }
-            Expr::LambdaFunctionCall(mut call) => {
-                if call.args.len() > MAX_FUNCTION_ARGS_TO_FOLD {
-                    return (Expr::LambdaFunctionCall(call), None, false);
+            FoldNode::LambdaFunctionCall(node) => {
+                if node.args_len() > MAX_FUNCTION_ARGS_TO_FOLD {
+                    return (FoldResult::Unchanged(node.into_cow()), None);
                 }
+                let (node, args) = node.into_args();
 
                 let mut changed = false;
-                let args = std::mem::take(&mut call.args);
                 let mut args_expr = Vec::with_capacity(args.len());
                 for arg in args {
-                    let (arg, _, arg_changed) = self.fold_once(arg);
-                    changed |= arg_changed;
+                    let (arg, _) = self.fold_once(arg);
+                    changed |= arg.is_changed();
                     args_expr.push(arg);
                 }
-                let all_args_is_scalar = args_expr.iter().all(|arg| arg.as_constant().is_some());
-                call.args = args_expr;
-                let func_expr = Expr::LambdaFunctionCall(call);
+                let all_args_is_scalar = args_expr
+                    .iter()
+                    .all(|arg| arg.as_ref().as_constant().is_some());
 
                 if all_args_is_scalar {
-                    let (func_expr, folded) = self.try_fold_constant_expr(func_expr);
-                    return (func_expr, None, changed || folded);
+                    if !changed && let Some(func_expr) = node.borrowed_expr() {
+                        let (func_expr, folded) =
+                            self.try_fold_constant_expr(Cow::Borrowed(func_expr));
+                        if folded {
+                            return (FoldResult::Changed(func_expr.into_owned()), None);
+                        }
+                    } else {
+                        let func_expr =
+                            node.finish(args_expr.into_iter().map(FoldResult::into_expr));
+                        let (func_expr, folded) =
+                            self.try_fold_constant_expr(Cow::Owned(func_expr));
+                        let result = if folded || changed {
+                            FoldResult::Changed(func_expr.into_owned())
+                        } else {
+                            FoldResult::Unchanged(func_expr)
+                        };
+                        return (result, None);
+                    }
                 }
-                (func_expr, None, changed)
+                let result = node.finish_fold(args_expr, changed);
+                (result, None)
             }
         };
 
-        debug_assert_eq!(&data_type, new_expr.data_type());
+        let result_type = match &result {
+            FoldResult::Unchanged(expr) => expr.data_type(),
+            FoldResult::Changed(expr) => expr.data_type(),
+        };
+        debug_assert_eq!(&data_type, result_type);
 
-        (new_expr, domain, changed)
+        (result, domain)
     }
 
-    fn try_fold_constant_expr(&self, expr: Expr<Index>) -> (Expr<Index>, bool) {
+    fn try_fold_constant_expr<'e>(
+        &self,
+        expr: Cow<'e, Expr<Index>>,
+    ) -> (Cow<'e, Expr<Index>>, bool) {
         let block = DataBlock::empty_with_rows(1);
         let evaluator = Evaluator::new(&block, self.func_ctx, self.fn_registry);
         // Since the expression is constant, it is safe to change its column index type.
-        let projected_expr = expr.project_column_ref(|_| unreachable!()).unwrap();
-        match evaluator.run(&projected_expr) {
-            Ok(Value::Scalar(scalar)) => {
-                let span = expr.span();
-                let data_type = expr.into_data_type();
-                (
-                    Expr::Constant(Constant {
-                        span,
-                        scalar,
-                        data_type,
-                    }),
-                    true,
-                )
-            }
-            _ => (expr, false),
-        }
+        let projected_expr = expr
+            .as_ref()
+            .project_column_ref(|_| unreachable!())
+            .unwrap();
+        let Ok(Value::Scalar(scalar)) = evaluator.run(&projected_expr) else {
+            return (expr, false);
+        };
+        let span = expr.span();
+        let data_type = match expr {
+            Cow::Borrowed(expr) => expr.data_type().clone(),
+            Cow::Owned(expr) => expr.into_data_type(),
+        };
+        (
+            Cow::Owned(Expr::Constant(Constant {
+                span,
+                scalar,
+                data_type,
+            })),
+            true,
+        )
     }
 
     fn calculate_cast(
@@ -819,7 +1262,7 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
         }
 
         let (_, output_domain) = ConstantFolder::fold_with_domain(
-            cast_expr,
+            Cow::Owned(cast_expr),
             &[(0, domain.clone())].into_iter().collect(),
             self.func_ctx,
             self.fn_registry,
@@ -832,13 +1275,13 @@ impl<'a, Index: ColumnIndex> ConstantFolder<'a, Index> {
     /// Returns Some(true) if the expressions are mutually exclusive (should return false)
     /// Returns Some(false) if they are not mutually exclusive
     /// Returns None if analysis is inconclusive
-    fn check_mutually_exclusive_ranges(&self, args: &[Expr<Index>]) -> Option<bool> {
+    fn check_mutually_exclusive_ranges(&self, args: &[FoldResult<'_, Index>]) -> Option<bool> {
         // Track constraints for each column
         let mut column_constraints: HashMap<Index, Vec<RangeConstraint<Index>>> = HashMap::new();
 
         // Extract constraints from each expression
         for arg in args {
-            if let Some(constraint) = RangeConstraint::try_from_expr(arg) {
+            if let Some(constraint) = RangeConstraint::try_from_expr(arg.as_ref()) {
                 column_constraints
                     .entry(constraint.column_id.clone())
                     .or_default()

--- a/src/query/expression/src/stat_evaluator.rs
+++ b/src/query/expression/src/stat_evaluator.rs
@@ -132,9 +132,12 @@ impl<'a> StatEvaluator<'a> {
             dest_type: cast.dest_type.clone(),
         });
         let input_domains = HashMap::from([(0, input.domain.clone())]);
-        let (_, Some(domain)) =
-            ConstantFolder::fold_with_domain(expr, &input_domains, self.func_ctx, self.fn_registry)
-        else {
+        let (_, Some(domain)) = ConstantFolder::fold_with_domain(
+            Cow::Owned(expr),
+            &input_domains,
+            self.func_ctx,
+            self.fn_registry,
+        ) else {
             return Ok(None);
         };
 

--- a/src/query/expression/src/stat_evaluator.rs
+++ b/src/query/expression/src/stat_evaluator.rs
@@ -132,12 +132,9 @@ impl<'a> StatEvaluator<'a> {
             dest_type: cast.dest_type.clone(),
         });
         let input_domains = HashMap::from([(0, input.domain.clone())]);
-        let (_, Some(domain)) = ConstantFolder::fold_with_domain(
-            &expr,
-            &input_domains,
-            self.func_ctx,
-            self.fn_registry,
-        ) else {
+        let (_, Some(domain)) =
+            ConstantFolder::fold_with_domain(expr, &input_domains, self.func_ctx, self.fn_registry)
+        else {
             return Ok(None);
         };
 

--- a/src/query/expression/src/type_check.rs
+++ b/src/query/expression/src/type_check.rs
@@ -233,16 +233,15 @@ pub fn wrap_nullable_for_try_cast(span: Span, ty: &DataType) -> Result<DataType>
 pub fn check_string<Index: ColumnIndex>(
     span: Span,
     func_ctx: &FunctionContext,
-    expr: &Expr<Index>,
+    expr: Expr<Index>,
     fn_registry: &FunctionRegistry,
 ) -> Result<String> {
-    let origin_ty = expr.data_type();
-    let (expr, _) = if origin_ty != &DataType::String {
+    let (expr, _) = if expr.data_type() != &DataType::String {
         ConstantFolder::fold(
-            &Expr::Cast(Cast {
+            Expr::Cast(Cast {
                 span,
                 is_try: false,
-                expr: Box::new(expr.clone()),
+                expr: Box::new(expr),
                 dest_type: DataType::String,
             }),
             func_ctx,
@@ -256,7 +255,7 @@ pub fn check_string<Index: ColumnIndex>(
         Expr::Constant(Constant {
             scalar: Scalar::String(string),
             ..
-        }) => Ok(string.clone()),
+        }) => Ok(string),
         _ => Err(
             ErrorCode::from_string_no_backtrace("expected string literal".to_string())
                 .set_span(span),
@@ -267,16 +266,16 @@ pub fn check_string<Index: ColumnIndex>(
 pub fn check_number<T: Number, Index: ColumnIndex>(
     span: Span,
     func_ctx: &FunctionContext,
-    expr: &Expr<Index>,
+    expr: Expr<Index>,
     fn_registry: &FunctionRegistry,
 ) -> Result<T> {
-    let origin_ty = expr.data_type();
-    let (expr, _) = if origin_ty != &DataType::Number(T::data_type()) {
+    let origin_ty = expr.data_type().clone();
+    let (expr, _) = if origin_ty != DataType::Number(T::data_type()) {
         ConstantFolder::fold(
-            &Expr::Cast(Cast {
+            Expr::Cast(Cast {
                 span,
                 is_try: false,
-                expr: Box::new(expr.clone()),
+                expr: Box::new(expr),
                 dest_type: DataType::Number(T::data_type()),
             }),
             func_ctx,

--- a/src/query/expression/src/type_check.rs
+++ b/src/query/expression/src/type_check.rs
@@ -238,18 +238,19 @@ pub fn check_string<Index: ColumnIndex>(
 ) -> Result<String> {
     let (expr, _) = if expr.data_type() != &DataType::String {
         ConstantFolder::fold(
-            Expr::Cast(Cast {
+            Cow::Owned(Expr::Cast(Cast {
                 span,
                 is_try: false,
                 expr: Box::new(expr),
                 dest_type: DataType::String,
-            }),
+            })),
             func_ctx,
             fn_registry,
         )
     } else {
-        ConstantFolder::fold(expr, func_ctx, fn_registry)
+        ConstantFolder::fold(Cow::Owned(expr), func_ctx, fn_registry)
     };
+    let expr = expr.into_owned();
 
     match expr {
         Expr::Constant(Constant {
@@ -272,18 +273,19 @@ pub fn check_number<T: Number, Index: ColumnIndex>(
     let origin_ty = expr.data_type().clone();
     let (expr, _) = if origin_ty != DataType::Number(T::data_type()) {
         ConstantFolder::fold(
-            Expr::Cast(Cast {
+            Cow::Owned(Expr::Cast(Cast {
                 span,
                 is_try: false,
                 expr: Box::new(expr),
                 dest_type: DataType::Number(T::data_type()),
-            }),
+            })),
             func_ctx,
             fn_registry,
         )
     } else {
-        ConstantFolder::fold(expr, func_ctx, fn_registry)
+        ConstantFolder::fold(Cow::Owned(expr), func_ctx, fn_registry)
     };
+    let expr = expr.into_owned();
 
     match expr {
         Expr::Constant(Constant {

--- a/src/query/expression/src/utils/filter_helper.rs
+++ b/src/query/expression/src/utils/filter_helper.rs
@@ -166,7 +166,7 @@ impl FilterHelpers {
                                 }
                             });
 
-                        let (folded_expr, _) = ConstantFolder::fold(&expr, func_ctx, fn_registry);
+                        let (folded_expr, _) = ConstantFolder::fold(expr, func_ctx, fn_registry);
 
                         if let Expr::Constant(Constant {
                             scalar: Scalar::Boolean(false),

--- a/src/query/expression/src/utils/filter_helper.rs
+++ b/src/query/expression/src/utils/filter_helper.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::HashSet;
 
 use databend_common_column::bitmap::Bitmap;
@@ -166,12 +167,13 @@ impl FilterHelpers {
                                 }
                             });
 
-                        let (folded_expr, _) = ConstantFolder::fold(expr, func_ctx, fn_registry);
+                        let (folded_expr, _) =
+                            ConstantFolder::fold(Cow::Owned(expr), func_ctx, fn_registry);
 
                         if let Expr::Constant(Constant {
                             scalar: Scalar::Boolean(false),
                             ..
-                        }) = folded_expr
+                        }) = folded_expr.as_ref()
                         {
                             if idx == 0 {
                                 results.push(value.clone());

--- a/src/query/expression/test-support/src/lib.rs
+++ b/src/query/expression/test-support/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
+
 use databend_common_ast::ast::BinaryOperator;
 use databend_common_ast::ast::ColumnRef;
 use databend_common_ast::ast::Expr;
@@ -186,9 +188,12 @@ fn transform_expr(
                 .map(|param| {
                     let raw_expr = transform_expr(param, &[], builtin_functions);
                     let expr = type_check::check(&raw_expr, builtin_functions).unwrap();
-                    let (expr, _) =
-                        ConstantFolder::fold(expr, &FunctionContext::default(), builtin_functions);
-                    expr.into_constant().unwrap().scalar
+                    let (expr, _) = ConstantFolder::fold(
+                        Cow::Owned(expr),
+                        &FunctionContext::default(),
+                        builtin_functions,
+                    );
+                    expr.into_owned().into_constant().unwrap().scalar
                 })
                 .collect(),
         },

--- a/src/query/expression/test-support/src/lib.rs
+++ b/src/query/expression/test-support/src/lib.rs
@@ -187,7 +187,7 @@ fn transform_expr(
                     let raw_expr = transform_expr(param, &[], builtin_functions);
                     let expr = type_check::check(&raw_expr, builtin_functions).unwrap();
                     let (expr, _) =
-                        ConstantFolder::fold(&expr, &FunctionContext::default(), builtin_functions);
+                        ConstantFolder::fold(expr, &FunctionContext::default(), builtin_functions);
                     expr.into_constant().unwrap().scalar
                 })
                 .collect(),

--- a/src/query/expression/tests/it/constant_folder.rs
+++ b/src/query/expression/tests/it/constant_folder.rs
@@ -198,7 +198,7 @@ fn if_expr(args: Vec<Expr<usize>>) -> Expr<usize> {
 }
 
 fn fold_with_registry(expr: &Expr<usize>, registry: &FunctionRegistry) -> Expr<usize> {
-    ConstantFolder::fold(expr, &FunctionContext::default(), registry).0
+    ConstantFolder::fold(expr.clone(), &FunctionContext::default(), registry).0
 }
 
 fn fold(expr: &Expr<usize>) -> Expr<usize> {
@@ -240,7 +240,7 @@ fn test_monotonic_nullable_domain_rejects_boundary_probe() {
     });
 
     let (folded, output_domain) = ConstantFolder::fold_with_domain(
-        &expr,
+        expr.clone(),
         &HashMap::from([(0, input_domain)]),
         &FunctionContext::default(),
         &registry,
@@ -288,7 +288,7 @@ fn test_monotonicity_check_gates_endpoint_domain() {
     // Accepted range: the fold probes the end points and derives an exact domain.
     let accepted = Domain::Number(NumberDomain::UInt64(SimpleDomain { min: 10, max: 20 }));
     let (_, output_domain) = ConstantFolder::fold_with_domain(
-        &expr,
+        expr.clone(),
         &HashMap::from([(0, accepted)]),
         &FunctionContext::default(),
         &registry,
@@ -304,7 +304,7 @@ fn test_monotonicity_check_gates_endpoint_domain() {
     // Rejected range: no end-point probing; the domain falls back to `Full`.
     let rejected = Domain::Number(NumberDomain::UInt64(SimpleDomain { min: 10, max: 200 }));
     let (_, output_domain) = ConstantFolder::fold_with_domain(
-        &expr,
+        expr,
         &HashMap::from([(0, rejected)]),
         &FunctionContext::default(),
         &registry,

--- a/src/query/expression/tests/it/constant_folder.rs
+++ b/src/query/expression/tests/it/constant_folder.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -198,7 +199,9 @@ fn if_expr(args: Vec<Expr<usize>>) -> Expr<usize> {
 }
 
 fn fold_with_registry(expr: &Expr<usize>, registry: &FunctionRegistry) -> Expr<usize> {
-    ConstantFolder::fold(expr.clone(), &FunctionContext::default(), registry).0
+    ConstantFolder::fold(Cow::Borrowed(expr), &FunctionContext::default(), registry)
+        .0
+        .into_owned()
 }
 
 fn fold(expr: &Expr<usize>) -> Expr<usize> {
@@ -240,13 +243,13 @@ fn test_monotonic_nullable_domain_rejects_boundary_probe() {
     });
 
     let (folded, output_domain) = ConstantFolder::fold_with_domain(
-        expr.clone(),
+        Cow::Borrowed(&expr),
         &HashMap::from([(0, input_domain)]),
         &FunctionContext::default(),
         &registry,
     );
 
-    assert_eq!(folded, expr);
+    assert_eq!(folded.as_ref(), &expr);
     assert_eq!(output_domain, None);
 }
 
@@ -288,7 +291,7 @@ fn test_monotonicity_check_gates_endpoint_domain() {
     // Accepted range: the fold probes the end points and derives an exact domain.
     let accepted = Domain::Number(NumberDomain::UInt64(SimpleDomain { min: 10, max: 20 }));
     let (_, output_domain) = ConstantFolder::fold_with_domain(
-        expr.clone(),
+        Cow::Borrowed(&expr),
         &HashMap::from([(0, accepted)]),
         &FunctionContext::default(),
         &registry,
@@ -304,7 +307,7 @@ fn test_monotonicity_check_gates_endpoint_domain() {
     // Rejected range: no end-point probing; the domain falls back to `Full`.
     let rejected = Domain::Number(NumberDomain::UInt64(SimpleDomain { min: 10, max: 200 }));
     let (_, output_domain) = ConstantFolder::fold_with_domain(
-        expr,
+        Cow::Owned(expr),
         &HashMap::from([(0, rejected)]),
         &FunctionContext::default(),
         &registry,

--- a/src/query/functions/src/aggregates/aggregator_common.rs
+++ b/src/query/functions/src/aggregates/aggregator_common.rs
@@ -196,7 +196,7 @@ pub(super) fn extract_number_param<T: Number>(param: Scalar) -> Result<T> {
     check_number::<T, usize>(
         None,
         &FunctionContext::default(),
-        &Constant {
+        Constant {
             span: None,
             data_type: param.as_ref().infer_data_type(),
             scalar: param,

--- a/src/query/functions/tests/it/scalars/datetime.rs
+++ b/src/query/functions/tests/it/scalars/datetime.rs
@@ -1324,12 +1324,12 @@ fn test_calendar_domain_fails_open_across_tz_fallback() {
         // November 1: any domain narrower than `Full` would exclude reachable
         // outputs and let pruning drop live rows.
         let (_, domain) =
-            ConstantFolder::fold_with_domain(&expr, &input, &st_johns, &BUILTIN_FUNCTIONS);
+            ConstantFolder::fold_with_domain(expr.clone(), &input, &st_johns, &BUILTIN_FUNCTIONS);
         assert_eq!(domain, Some(Domain::full(&return_type)), "{name}");
 
         // Under a fixed offset the same range is a single segment: the
         // projection collapses to one day and folds to a constant.
-        let (folded, _) = ConstantFolder::fold_with_domain(&expr, &input, &utc, &BUILTIN_FUNCTIONS);
+        let (folded, _) = ConstantFolder::fold_with_domain(expr, &input, &utc, &BUILTIN_FUNCTIONS);
         assert!(
             matches!(folded, Expr::Constant(_)),
             "{name}: expected constant fold under UTC, got {folded:?}"

--- a/src/query/functions/tests/it/scalars/datetime.rs
+++ b/src/query/functions/tests/it/scalars/datetime.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::io::Write;
 use std::str::FromStr;
 
@@ -1323,15 +1324,20 @@ fn test_calendar_domain_fails_open_across_tz_fallback() {
         // Both end points map to October 31, but the range internally touches
         // November 1: any domain narrower than `Full` would exclude reachable
         // outputs and let pruning drop live rows.
-        let (_, domain) =
-            ConstantFolder::fold_with_domain(expr.clone(), &input, &st_johns, &BUILTIN_FUNCTIONS);
+        let (_, domain) = ConstantFolder::fold_with_domain(
+            Cow::Borrowed(&expr),
+            &input,
+            &st_johns,
+            &BUILTIN_FUNCTIONS,
+        );
         assert_eq!(domain, Some(Domain::full(&return_type)), "{name}");
 
         // Under a fixed offset the same range is a single segment: the
         // projection collapses to one day and folds to a constant.
-        let (folded, _) = ConstantFolder::fold_with_domain(expr, &input, &utc, &BUILTIN_FUNCTIONS);
+        let (folded, _) =
+            ConstantFolder::fold_with_domain(Cow::Owned(expr), &input, &utc, &BUILTIN_FUNCTIONS);
         assert!(
-            matches!(folded, Expr::Constant(_)),
+            matches!(folded.as_ref(), Expr::Constant(_)),
             "{name}: expected constant fold under UTC, got {folded:?}"
         );
     }

--- a/src/query/functions/tests/it/scalars/mod.rs
+++ b/src/query/functions/tests/it/scalars/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::io::Write;
 
@@ -139,7 +140,7 @@ pub fn run_ast_with_context(file: &mut impl Write, text: impl AsRef<str>, mut ct
         let input_domains = ctx.input_domains();
 
         let (optimized_expr, output_domain) = ConstantFolder::fold_with_domain(
-            expr.clone(),
+            Cow::Borrowed(&expr),
             &input_domains,
             &ctx.func_ctx,
             &BUILTIN_FUNCTIONS,

--- a/src/query/functions/tests/it/scalars/mod.rs
+++ b/src/query/functions/tests/it/scalars/mod.rs
@@ -139,7 +139,7 @@ pub fn run_ast_with_context(file: &mut impl Write, text: impl AsRef<str>, mut ct
         let input_domains = ctx.input_domains();
 
         let (optimized_expr, output_domain) = ConstantFolder::fold_with_domain(
-            &expr,
+            expr.clone(),
             &input_domains,
             &ctx.func_ctx,
             &BUILTIN_FUNCTIONS,

--- a/src/query/service/src/physical_plans/physical_eval_scalar.rs
+++ b/src/query/service/src/physical_plans/physical_eval_scalar.rs
@@ -263,7 +263,7 @@ impl PhysicalPlanBuilder {
                     .scalar
                     .type_check(input_schema.as_ref())?
                     .project_column_ref(|index| input_schema.index_of(&index.to_string()))?;
-                let (expr, _) = ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
                 Ok((expr.as_remote_expr(), item.index))
             })
             .collect::<Result<Vec<_>>>()?;

--- a/src/query/service/src/physical_plans/physical_eval_scalar.rs
+++ b/src/query/service/src/physical_plans/physical_eval_scalar.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -263,7 +264,8 @@ impl PhysicalPlanBuilder {
                     .scalar
                     .type_check(input_schema.as_ref())?
                     .project_column_ref(|index| input_schema.index_of(&index.to_string()))?;
-                let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                let (expr, _) =
+                    ConstantFolder::fold(Cow::Owned(expr), &self.func_ctx, &BUILTIN_FUNCTIONS);
                 Ok((expr.as_remote_expr(), item.index))
             })
             .collect::<Result<Vec<_>>>()?;

--- a/src/query/service/src/physical_plans/physical_exchange.rs
+++ b/src/query/service/src/physical_plans/physical_exchange.rs
@@ -119,7 +119,7 @@ impl PhysicalPlanBuilder {
                     let expr = scalar
                         .type_check(input_schema.as_ref())?
                         .project_column_ref(|index| input_schema.index_of(&index.to_string()))?;
-                    let (expr, _) = ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                    let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
                     keys.push(expr.as_remote_expr());
                 }
                 FragmentKind::Normal
@@ -129,7 +129,7 @@ impl PhysicalPlanBuilder {
                     let expr = scalar
                         .type_check(input_schema.as_ref())?
                         .project_column_ref(|index| input_schema.index_of(&index.to_string()))?;
-                    let (expr, _) = ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                    let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
                     keys.push(expr.as_remote_expr());
                 }
                 FragmentKind::GlobalShuffle

--- a/src/query/service/src/physical_plans/physical_exchange.rs
+++ b/src/query/service/src/physical_plans/physical_exchange.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::borrow::Cow;
 
 use databend_common_catalog::plan::DataSourcePlan;
 use databend_common_exception::Result;
@@ -119,7 +120,8 @@ impl PhysicalPlanBuilder {
                     let expr = scalar
                         .type_check(input_schema.as_ref())?
                         .project_column_ref(|index| input_schema.index_of(&index.to_string()))?;
-                    let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                    let (expr, _) =
+                        ConstantFolder::fold(Cow::Owned(expr), &self.func_ctx, &BUILTIN_FUNCTIONS);
                     keys.push(expr.as_remote_expr());
                 }
                 FragmentKind::Normal
@@ -129,7 +131,8 @@ impl PhysicalPlanBuilder {
                     let expr = scalar
                         .type_check(input_schema.as_ref())?
                         .project_column_ref(|index| input_schema.index_of(&index.to_string()))?;
-                    let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                    let (expr, _) =
+                        ConstantFolder::fold(Cow::Owned(expr), &self.func_ctx, &BUILTIN_FUNCTIONS);
                     keys.push(expr.as_remote_expr());
                 }
                 FragmentKind::GlobalShuffle

--- a/src/query/service/src/physical_plans/physical_expression_scan.rs
+++ b/src/query/service/src/physical_plans/physical_expression_scan.rs
@@ -132,7 +132,7 @@ impl PhysicalPlanBuilder {
                                 input_schema.index_of(&index.to_string())
                             })?;
                         let (expr, _) =
-                            ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                            ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
                         Ok(expr.as_remote_expr())
                     })
                     .collect::<Result<Vec<_>>>()

--- a/src/query/service/src/physical_plans/physical_expression_scan.rs
+++ b/src/query/service/src/physical_plans/physical_expression_scan.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::borrow::Cow;
 
 use databend_common_exception::Result;
 use databend_common_expression::ConstantFolder;
@@ -131,8 +132,11 @@ impl PhysicalPlanBuilder {
                             .project_column_ref(|index| {
                                 input_schema.index_of(&index.to_string())
                             })?;
-                        let (expr, _) =
-                            ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                        let (expr, _) = ConstantFolder::fold(
+                            Cow::Owned(expr),
+                            &self.func_ctx,
+                            &BUILTIN_FUNCTIONS,
+                        );
                         Ok(expr.as_remote_expr())
                     })
                     .collect::<Result<Vec<_>>>()

--- a/src/query/service/src/physical_plans/physical_filter.rs
+++ b/src/query/service/src/physical_plans/physical_filter.rs
@@ -184,7 +184,7 @@ impl PhysicalPlanBuilder {
                         .type_check(input_schema.as_ref())?
                         .project_column_ref(|index| input_schema.index_of(&index.to_string()))?;
                     let expr = cast_expr_to_non_null_boolean(expr)?;
-                    let (expr, _) = ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                    let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
                     Ok(expr.as_remote_expr())
                 })
                 .collect::<Result<_>>()?,

--- a/src/query/service/src/physical_plans/physical_filter.rs
+++ b/src/query/service/src/physical_plans/physical_filter.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 
@@ -184,7 +185,8 @@ impl PhysicalPlanBuilder {
                         .type_check(input_schema.as_ref())?
                         .project_column_ref(|index| input_schema.index_of(&index.to_string()))?;
                     let expr = cast_expr_to_non_null_boolean(expr)?;
-                    let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                    let (expr, _) =
+                        ConstantFolder::fold(Cow::Owned(expr), &self.func_ctx, &BUILTIN_FUNCTIONS);
                     Ok(expr.as_remote_expr())
                 })
                 .collect::<Result<_>>()?,

--- a/src/query/service/src/physical_plans/physical_hash_join.rs
+++ b/src/query/service/src/physical_plans/physical_hash_join.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -899,13 +900,15 @@ impl PhysicalPlanBuilder {
 
             // Fold constants
             let (left_expr, _) =
-                ConstantFolder::fold(left_expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                ConstantFolder::fold(Cow::Owned(left_expr), &self.func_ctx, &BUILTIN_FUNCTIONS);
             let (right_expr, _) =
-                ConstantFolder::fold(right_expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                ConstantFolder::fold(Cow::Owned(right_expr), &self.func_ctx, &BUILTIN_FUNCTIONS);
 
             let left_expr_for_runtime_filter = left_expr_for_runtime_filter.map(|probe| {
                 probe.map_probe_key(|probe_key| {
-                    ConstantFolder::fold(probe_key, &self.func_ctx, &BUILTIN_FUNCTIONS).0
+                    ConstantFolder::fold(Cow::Owned(probe_key), &self.func_ctx, &BUILTIN_FUNCTIONS)
+                        .0
+                        .into_owned()
                 })
             });
 
@@ -1200,7 +1203,8 @@ impl PhysicalPlanBuilder {
                 let expr = scalar
                     .type_check(merged_schema.as_ref())?
                     .project_column_ref(|index| merged_schema.index_of(&index.to_string()))?;
-                let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                let (expr, _) =
+                    ConstantFolder::fold(Cow::Owned(expr), &self.func_ctx, &BUILTIN_FUNCTIONS);
                 Ok(expr.as_remote_expr())
             })
             .collect::<Result<_>>()?;

--- a/src/query/service/src/physical_plans/physical_hash_join.rs
+++ b/src/query/service/src/physical_plans/physical_hash_join.rs
@@ -899,13 +899,13 @@ impl PhysicalPlanBuilder {
 
             // Fold constants
             let (left_expr, _) =
-                ConstantFolder::fold(&left_expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                ConstantFolder::fold(left_expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
             let (right_expr, _) =
-                ConstantFolder::fold(&right_expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                ConstantFolder::fold(right_expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
 
             let left_expr_for_runtime_filter = left_expr_for_runtime_filter.map(|probe| {
                 probe.map_probe_key(|probe_key| {
-                    ConstantFolder::fold(&probe_key, &self.func_ctx, &BUILTIN_FUNCTIONS).0
+                    ConstantFolder::fold(probe_key, &self.func_ctx, &BUILTIN_FUNCTIONS).0
                 })
             });
 
@@ -1200,7 +1200,7 @@ impl PhysicalPlanBuilder {
                 let expr = scalar
                     .type_check(merged_schema.as_ref())?
                     .project_column_ref(|index| merged_schema.index_of(&index.to_string()))?;
-                let (expr, _) = ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
                 Ok(expr.as_remote_expr())
             })
             .collect::<Result<_>>()?;

--- a/src/query/service/src/physical_plans/physical_mutation.rs
+++ b/src/query/service/src/physical_plans/physical_mutation.rs
@@ -523,7 +523,7 @@ impl PhysicalPlanBuilder {
                     .scalar_expr_to_remote_expr(condition, output_schema.clone())?
                     .as_expr(&BUILTIN_FUNCTIONS);
                 let (expr, _) = ConstantFolder::fold(
-                    &expr,
+                    expr,
                     &self.ctx.get_function_context()?,
                     &BUILTIN_FUNCTIONS,
                 );
@@ -682,7 +682,7 @@ impl PhysicalPlanBuilder {
             .type_check(schema.as_ref())?
             .project_column_ref(|index| schema.index_of(&index.to_string()))?;
         let (filer, _) = ConstantFolder::fold(
-            &scalar_expr,
+            scalar_expr,
             &self.ctx.get_function_context().unwrap(),
             &BUILTIN_FUNCTIONS,
         );
@@ -909,7 +909,7 @@ pub fn generate_update_list(
                 .as_expr()?
                 .project_column_ref(|col| Ok(col.index.to_string()))?;
             let (expr, _) =
-                ConstantFolder::fold(&expr, &ctx.get_function_context()?, &BUILTIN_FUNCTIONS);
+                ConstantFolder::fold(expr, &ctx.get_function_context()?, &BUILTIN_FUNCTIONS);
             acc.push((*index, expr.as_remote_expr()));
             Ok::<_, ErrorCode>(acc)
         },
@@ -996,7 +996,7 @@ pub fn mutation_update_expr(
                 .type_check(input_schema.as_ref())?
                 .project_column_ref(|index| input_schema.index_of(&index.to_string()))?;
             let (expr, _) =
-                ConstantFolder::fold(&expr, &ctx.get_function_context()?, &BUILTIN_FUNCTIONS);
+                ConstantFolder::fold(expr, &ctx.get_function_context()?, &BUILTIN_FUNCTIONS);
             acc.push((*index, expr.as_remote_expr()));
             Ok::<_, ErrorCode>(acc)
         },
@@ -1044,7 +1044,7 @@ pub fn generate_stored_computed_list(
                     input_schema.index_of(&column_index.unwrap().to_string())
                 })?;
                 let (expr, _) =
-                    ConstantFolder::fold(&expr, &ctx.get_function_context()?, &BUILTIN_FUNCTIONS);
+                    ConstantFolder::fold(expr, &ctx.get_function_context()?, &BUILTIN_FUNCTIONS);
                 remote_exprs.push((i, expr.as_remote_expr()));
             }
         }

--- a/src/query/service/src/physical_plans/physical_mutation.rs
+++ b/src/query/service/src/physical_plans/physical_mutation.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -523,7 +524,7 @@ impl PhysicalPlanBuilder {
                     .scalar_expr_to_remote_expr(condition, output_schema.clone())?
                     .as_expr(&BUILTIN_FUNCTIONS);
                 let (expr, _) = ConstantFolder::fold(
-                    expr,
+                    Cow::Owned(expr),
                     &self.ctx.get_function_context()?,
                     &BUILTIN_FUNCTIONS,
                 );
@@ -682,7 +683,7 @@ impl PhysicalPlanBuilder {
             .type_check(schema.as_ref())?
             .project_column_ref(|index| schema.index_of(&index.to_string()))?;
         let (filer, _) = ConstantFolder::fold(
-            scalar_expr,
+            Cow::Owned(scalar_expr),
             &self.ctx.get_function_context().unwrap(),
             &BUILTIN_FUNCTIONS,
         );
@@ -908,8 +909,11 @@ pub fn generate_update_list(
             let expr = scalar
                 .as_expr()?
                 .project_column_ref(|col| Ok(col.index.to_string()))?;
-            let (expr, _) =
-                ConstantFolder::fold(expr, &ctx.get_function_context()?, &BUILTIN_FUNCTIONS);
+            let (expr, _) = ConstantFolder::fold(
+                Cow::Owned(expr),
+                &ctx.get_function_context()?,
+                &BUILTIN_FUNCTIONS,
+            );
             acc.push((*index, expr.as_remote_expr()));
             Ok::<_, ErrorCode>(acc)
         },
@@ -995,8 +999,11 @@ pub fn mutation_update_expr(
             let expr = scalar
                 .type_check(input_schema.as_ref())?
                 .project_column_ref(|index| input_schema.index_of(&index.to_string()))?;
-            let (expr, _) =
-                ConstantFolder::fold(expr, &ctx.get_function_context()?, &BUILTIN_FUNCTIONS);
+            let (expr, _) = ConstantFolder::fold(
+                Cow::Owned(expr),
+                &ctx.get_function_context()?,
+                &BUILTIN_FUNCTIONS,
+            );
             acc.push((*index, expr.as_remote_expr()));
             Ok::<_, ErrorCode>(acc)
         },
@@ -1043,8 +1050,11 @@ pub fn generate_stored_computed_list(
                     }
                     input_schema.index_of(&column_index.unwrap().to_string())
                 })?;
-                let (expr, _) =
-                    ConstantFolder::fold(expr, &ctx.get_function_context()?, &BUILTIN_FUNCTIONS);
+                let (expr, _) = ConstantFolder::fold(
+                    Cow::Owned(expr),
+                    &ctx.get_function_context()?,
+                    &BUILTIN_FUNCTIONS,
+                );
                 remote_exprs.push((i, expr.as_remote_expr()));
             }
         }

--- a/src/query/service/src/physical_plans/physical_mutation_source.rs
+++ b/src/query/service/src/physical_plans/physical_mutation_source.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use databend_common_base::runtime::Runtime;
@@ -333,7 +334,8 @@ pub fn create_push_down_filters(
         })?
         .unwrap();
     let expr = cast_expr_to_non_null_boolean(expr)?;
-    let (filter, _) = ConstantFolder::fold(expr, func_ctx, &BUILTIN_FUNCTIONS);
+    let (filter, _) = ConstantFolder::fold(Cow::Owned(expr), func_ctx, &BUILTIN_FUNCTIONS);
+    let filter = filter.into_owned();
     let remote_filter = filter.as_remote_expr();
 
     // prepare the inverse filter expression

--- a/src/query/service/src/physical_plans/physical_mutation_source.rs
+++ b/src/query/service/src/physical_plans/physical_mutation_source.rs
@@ -333,7 +333,7 @@ pub fn create_push_down_filters(
         })?
         .unwrap();
     let expr = cast_expr_to_non_null_boolean(expr)?;
-    let (filter, _) = ConstantFolder::fold(&expr, func_ctx, &BUILTIN_FUNCTIONS);
+    let (filter, _) = ConstantFolder::fold(expr, func_ctx, &BUILTIN_FUNCTIONS);
     let remote_filter = filter.as_remote_expr();
 
     // prepare the inverse filter expression

--- a/src/query/service/src/physical_plans/physical_project_set.rs
+++ b/src/query/service/src/physical_plans/physical_project_set.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::borrow::Cow;
 use std::collections::BTreeSet;
 
 use databend_common_catalog::plan::DataSourcePlan;
@@ -169,7 +170,8 @@ impl PhysicalPlanBuilder {
                     .scalar
                     .type_check(input_schema.as_ref())?
                     .project_column_ref(|index| input_schema.index_of(&index.to_string()))?;
-                let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                let (expr, _) =
+                    ConstantFolder::fold(Cow::Owned(expr), &self.func_ctx, &BUILTIN_FUNCTIONS);
                 Ok((expr.as_remote_expr(), item.index))
             })
             .collect::<Result<Vec<_>>>()?;

--- a/src/query/service/src/physical_plans/physical_project_set.rs
+++ b/src/query/service/src/physical_plans/physical_project_set.rs
@@ -169,7 +169,7 @@ impl PhysicalPlanBuilder {
                     .scalar
                     .type_check(input_schema.as_ref())?
                     .project_column_ref(|index| input_schema.index_of(&index.to_string()))?;
-                let (expr, _) = ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
                 Ok((expr.as_remote_expr(), item.index))
             })
             .collect::<Result<Vec<_>>>()?;

--- a/src/query/service/src/physical_plans/physical_spatial_join.rs
+++ b/src/query/service/src/physical_plans/physical_spatial_join.rs
@@ -309,7 +309,7 @@ fn remote_expr_for_schema(
     let expr = scalar
         .type_check(schema.as_ref())?
         .project_column_ref(|index| schema.index_of(&index.to_string()))?;
-    let (expr, _) = ConstantFolder::fold(&expr, func_ctx, &BUILTIN_FUNCTIONS);
+    let (expr, _) = ConstantFolder::fold(expr, func_ctx, &BUILTIN_FUNCTIONS);
     Ok(expr.as_remote_expr())
 }
 

--- a/src/query/service/src/physical_plans/physical_spatial_join.rs
+++ b/src/query/service/src/physical_plans/physical_spatial_join.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::borrow::Cow;
 
 use databend_common_exception::Result;
 use databend_common_expression::ConstantFolder;
@@ -309,7 +310,7 @@ fn remote_expr_for_schema(
     let expr = scalar
         .type_check(schema.as_ref())?
         .project_column_ref(|index| schema.index_of(&index.to_string()))?;
-    let (expr, _) = ConstantFolder::fold(expr, func_ctx, &BUILTIN_FUNCTIONS);
+    let (expr, _) = ConstantFolder::fold(Cow::Owned(expr), func_ctx, &BUILTIN_FUNCTIONS);
     Ok(expr.as_remote_expr())
 }
 

--- a/src/query/service/src/physical_plans/physical_table_scan.rs
+++ b/src/query/service/src/physical_plans/physical_table_scan.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
@@ -453,7 +454,8 @@ impl PhysicalPlanBuilder {
                     .as_raw_expr()
                     .type_check(&metadata)?
                     .project_column_ref(|col| Ok(col.column_name.clone()))?;
-                let (folded, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                let (folded, _) =
+                    ConstantFolder::fold(Cow::Owned(expr), &self.func_ctx, &BUILTIN_FUNCTIONS);
                 let remote = folded.as_remote_expr();
                 serialized.push(serde_json::to_string(&remote).map_err(|e| {
                     ErrorCode::Internal(format!(
@@ -567,8 +569,11 @@ impl PhysicalPlanBuilder {
                                 input_schema.index_of(&col.index.to_string())
                             })?;
                         let expr = cast_expr_to_non_null_boolean(expr)?;
-                        let (expr, _) =
-                            ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                        let (expr, _) = ConstantFolder::fold(
+                            Cow::Owned(expr),
+                            &self.func_ctx,
+                            &BUILTIN_FUNCTIONS,
+                        );
                         Ok(expr.as_remote_expr())
                     })
                     .collect::<Result<Vec<_>>>()?;
@@ -781,7 +786,8 @@ impl PhysicalPlanBuilder {
                         .type_check(&metadata)?
                         .project_column_ref(|col| Ok(col.column_name.clone()))?,
                 )?;
-                let (filter, _) = ConstantFolder::fold(filter, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                let (filter, _) =
+                    ConstantFolder::fold(Cow::Owned(filter), &self.func_ctx, &BUILTIN_FUNCTIONS);
                 let filter = filter.as_remote_expr();
                 let virtual_column_ids =
                     self.build_prewhere_virtual_column_ids(&prewhere.prewhere_columns);
@@ -891,7 +897,8 @@ impl PhysicalPlanBuilder {
             .unwrap();
 
         let expr = cast_expr_to_non_null_boolean(expr)?;
-        let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+        let (expr, _) = ConstantFolder::fold(Cow::Owned(expr), &self.func_ctx, &BUILTIN_FUNCTIONS);
+        let expr = expr.into_owned();
 
         let is_deterministic = expr.is_deterministic(&BUILTIN_FUNCTIONS);
         let inverted_filter =

--- a/src/query/service/src/physical_plans/physical_table_scan.rs
+++ b/src/query/service/src/physical_plans/physical_table_scan.rs
@@ -453,7 +453,7 @@ impl PhysicalPlanBuilder {
                     .as_raw_expr()
                     .type_check(&metadata)?
                     .project_column_ref(|col| Ok(col.column_name.clone()))?;
-                let (folded, _) = ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                let (folded, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
                 let remote = folded.as_remote_expr();
                 serialized.push(serde_json::to_string(&remote).map_err(|e| {
                     ErrorCode::Internal(format!(
@@ -568,7 +568,7 @@ impl PhysicalPlanBuilder {
                             })?;
                         let expr = cast_expr_to_non_null_boolean(expr)?;
                         let (expr, _) =
-                            ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                            ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
                         Ok(expr.as_remote_expr())
                     })
                     .collect::<Result<Vec<_>>>()?;
@@ -781,7 +781,7 @@ impl PhysicalPlanBuilder {
                         .type_check(&metadata)?
                         .project_column_ref(|col| Ok(col.column_name.clone()))?,
                 )?;
-                let (filter, _) = ConstantFolder::fold(&filter, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                let (filter, _) = ConstantFolder::fold(filter, &self.func_ctx, &BUILTIN_FUNCTIONS);
                 let filter = filter.as_remote_expr();
                 let virtual_column_ids =
                     self.build_prewhere_virtual_column_ids(&prewhere.prewhere_columns);
@@ -891,7 +891,7 @@ impl PhysicalPlanBuilder {
             .unwrap();
 
         let expr = cast_expr_to_non_null_boolean(expr)?;
-        let (expr, _) = ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+        let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
 
         let is_deterministic = expr.is_deterministic(&BUILTIN_FUNCTIONS);
         let inverted_filter =

--- a/src/query/service/src/physical_plans/physical_window.rs
+++ b/src/query/service/src/physical_plans/physical_window.rs
@@ -731,11 +731,8 @@ impl PhysicalPlanBuilder {
                         dest_type: common_ty.clone(),
                     };
                     let expr = type_check::check(&raw_expr, &BUILTIN_FUNCTIONS)?;
-                    let (expr, _) = ConstantFolder::fold(
-                        &expr,
-                        &FunctionContext::default(),
-                        &BUILTIN_FUNCTIONS,
-                    );
+                    let (expr, _) =
+                        ConstantFolder::fold(expr, &FunctionContext::default(), &BUILTIN_FUNCTIONS);
                     if let Expr::Constant(Constant {
                         scalar: new_scalar, ..
                     }) = expr

--- a/src/query/service/src/physical_plans/physical_window.rs
+++ b/src/query/service/src/physical_plans/physical_window.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::borrow::Cow;
 use std::sync::atomic;
 use std::sync::atomic::AtomicUsize;
 
@@ -731,8 +732,12 @@ impl PhysicalPlanBuilder {
                         dest_type: common_ty.clone(),
                     };
                     let expr = type_check::check(&raw_expr, &BUILTIN_FUNCTIONS)?;
-                    let (expr, _) =
-                        ConstantFolder::fold(expr, &FunctionContext::default(), &BUILTIN_FUNCTIONS);
+                    let (expr, _) = ConstantFolder::fold(
+                        Cow::Owned(expr),
+                        &FunctionContext::default(),
+                        &BUILTIN_FUNCTIONS,
+                    );
+                    let expr = expr.into_owned();
                     if let Expr::Constant(Constant {
                         scalar: new_scalar, ..
                     }) = expr

--- a/src/query/service/src/physical_plans/runtime_filter/builder.rs
+++ b/src/query/service/src/physical_plans/runtime_filter/builder.rs
@@ -421,7 +421,7 @@ fn normalize_probe_target(
     }
     let expr = check_cast(expr.span(), false, expr, target_type, &BUILTIN_FUNCTIONS)?;
     let expr =
-        databend_common_expression::ConstantFolder::fold(&expr, func_ctx, &BUILTIN_FUNCTIONS).0;
+        databend_common_expression::ConstantFolder::fold(expr, func_ctx, &BUILTIN_FUNCTIONS).0;
     Ok(Some(expr.as_remote_expr()))
 }
 

--- a/src/query/service/src/physical_plans/runtime_filter/builder.rs
+++ b/src/query/service/src/physical_plans/runtime_filter/builder.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -420,8 +421,12 @@ fn normalize_probe_target(
         return Ok(None);
     }
     let expr = check_cast(expr.span(), false, expr, target_type, &BUILTIN_FUNCTIONS)?;
-    let expr =
-        databend_common_expression::ConstantFolder::fold(expr, func_ctx, &BUILTIN_FUNCTIONS).0;
+    let expr = databend_common_expression::ConstantFolder::fold(
+        Cow::Owned(expr),
+        func_ctx,
+        &BUILTIN_FUNCTIONS,
+    )
+    .0;
     Ok(Some(expr.as_remote_expr()))
 }
 

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/convert.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/convert.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -274,6 +273,7 @@ async fn build_bloom_filter(
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
     use std::collections::HashMap;
 
     use databend_common_expression::ColumnBuilder;

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/convert.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/convert.rs
@@ -394,7 +394,7 @@ mod tests {
         input_domains.insert("column_a".to_string(), domain_value_2_10);
 
         let (folded_expr, _) = ConstantFolder::fold_with_domain(
-            &filter_expr,
+            filter_expr.clone(),
             &input_domains,
             &func_ctx,
             &BUILTIN_FUNCTIONS,
@@ -413,7 +413,7 @@ mod tests {
         input_domains_false.insert("column_a".to_string(), domain_value_2_9);
 
         let (folded_expr_false, _) = ConstantFolder::fold_with_domain(
-            &filter_expr,
+            filter_expr,
             &input_domains_false,
             &func_ctx,
             &BUILTIN_FUNCTIONS,
@@ -575,7 +575,7 @@ mod tests {
         input_domains.insert("column_b".to_string(), domain_value_500_600);
 
         let (folded_expr, _) = ConstantFolder::fold_with_domain(
-            &filter_expr,
+            filter_expr.clone(),
             &input_domains,
             &func_ctx,
             &BUILTIN_FUNCTIONS,
@@ -598,7 +598,7 @@ mod tests {
         input_domains_no_intersect.insert("column_b".to_string(), domain_value_2000_3000);
 
         let (folded_expr_false, _) = ConstantFolder::fold_with_domain(
-            &filter_expr,
+            filter_expr,
             &input_domains_no_intersect,
             &func_ctx,
             &BUILTIN_FUNCTIONS,

--- a/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/convert.rs
+++ b/src/query/service/src/pipelines/processors/transforms/hash_join/runtime_filter/convert.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -394,7 +395,7 @@ mod tests {
         input_domains.insert("column_a".to_string(), domain_value_2_10);
 
         let (folded_expr, _) = ConstantFolder::fold_with_domain(
-            filter_expr.clone(),
+            Cow::Borrowed(&filter_expr),
             &input_domains,
             &func_ctx,
             &BUILTIN_FUNCTIONS,
@@ -413,14 +414,14 @@ mod tests {
         input_domains_false.insert("column_a".to_string(), domain_value_2_9);
 
         let (folded_expr_false, _) = ConstantFolder::fold_with_domain(
-            filter_expr,
+            Cow::Owned(filter_expr),
             &input_domains_false,
             &func_ctx,
             &BUILTIN_FUNCTIONS,
         );
 
         // Range [2,9] does not intersect with {1, 10}, so it should fold to constant false
-        match folded_expr_false {
+        match folded_expr_false.as_ref() {
             Expr::Constant(Constant {
                 scalar: Scalar::Boolean(false),
                 ..
@@ -575,7 +576,7 @@ mod tests {
         input_domains.insert("column_b".to_string(), domain_value_500_600);
 
         let (folded_expr, _) = ConstantFolder::fold_with_domain(
-            filter_expr.clone(),
+            Cow::Borrowed(&filter_expr),
             &input_domains,
             &func_ctx,
             &BUILTIN_FUNCTIONS,
@@ -598,7 +599,7 @@ mod tests {
         input_domains_no_intersect.insert("column_b".to_string(), domain_value_2000_3000);
 
         let (folded_expr_false, _) = ConstantFolder::fold_with_domain(
-            filter_expr,
+            Cow::Owned(filter_expr),
             &input_domains_no_intersect,
             &func_ctx,
             &BUILTIN_FUNCTIONS,
@@ -606,7 +607,7 @@ mod tests {
 
         // Range [2000, 3000] does not intersect with {0, 1, 2, ..., 1023},
         // so it should fold to constant false
-        match folded_expr_false {
+        match folded_expr_false.as_ref() {
             Expr::Constant(Constant {
                 scalar: Scalar::Boolean(false),
                 ..

--- a/src/query/service/src/table_functions/numbers/numbers_table.rs
+++ b/src/query/service/src/table_functions/numbers/numbers_table.rs
@@ -73,7 +73,7 @@ impl NumbersTable {
         let total = check_number::<_, usize>(
             None,
             &FunctionContext::default(),
-            &Expr::constant(args[0].clone(), None),
+            Expr::constant(args.into_iter().next().unwrap(), None),
             &BUILTIN_FUNCTIONS,
         )?;
         let engine = match table_func_name {

--- a/src/query/service/src/table_functions/srf/range.rs
+++ b/src/query/service/src/table_functions/srf/range.rs
@@ -221,11 +221,11 @@ struct RangeSource<const INCLUSIVE: bool> {
     step: i64,
 }
 
-fn get_i64_number(scalar: &Scalar) -> Result<i64> {
+fn get_i64_number(scalar: Scalar) -> Result<i64> {
     check_number::<i64, usize>(
         None,
         &FunctionContext::default(),
-        &Expr::constant(scalar.clone(), None),
+        Expr::constant(scalar, None),
         &BUILTIN_FUNCTIONS,
     )
 }
@@ -239,9 +239,9 @@ impl<const INCLUSIVE: bool> RangeSource<INCLUSIVE> {
         end: Scalar,
         step: Scalar,
     ) -> Result<ProcessorPtr> {
-        let start = get_i64_number(&start)?;
-        let end = get_i64_number(&end)?;
-        let step = get_i64_number(&step)?;
+        let start = get_i64_number(start)?;
+        let end = get_i64_number(end)?;
+        let step = get_i64_number(step)?;
         let series_type = series_type_from_data_type(&data_type).ok_or_else(|| {
             ErrorCode::BadArguments(format!(
                 "Unsupported data type for generate_series: {:?}",

--- a/src/query/sql/src/planner/binder/binder.rs
+++ b/src/query/sql/src/planner/binder/binder.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::mem;
@@ -978,9 +979,12 @@ impl Binder {
             let scalar = wrap_cast(&scalar, &DataType::String);
             let expr = scalar.as_expr()?;
 
-            let (new_expr, _) =
-                ConstantFolder::fold(expr, &self.ctx.get_function_context()?, &BUILTIN_FUNCTIONS);
-            match new_expr {
+            let (new_expr, _) = ConstantFolder::fold(
+                Cow::Owned(expr),
+                &self.ctx.get_function_context()?,
+                &BUILTIN_FUNCTIONS,
+            );
+            match new_expr.into_owned() {
                 Expr::Constant(Constant { scalar, .. }) => {
                     let value = scalar.into_string().unwrap();
                     if variable.to_lowercase().as_str() == "timezone" {

--- a/src/query/sql/src/planner/binder/binder.rs
+++ b/src/query/sql/src/planner/binder/binder.rs
@@ -979,7 +979,7 @@ impl Binder {
             let expr = scalar.as_expr()?;
 
             let (new_expr, _) =
-                ConstantFolder::fold(&expr, &self.ctx.get_function_context()?, &BUILTIN_FUNCTIONS);
+                ConstantFolder::fold(expr, &self.ctx.get_function_context()?, &BUILTIN_FUNCTIONS);
             match new_expr {
                 Expr::Constant(Constant { scalar, .. }) => {
                     let value = scalar.into_string().unwrap();

--- a/src/query/sql/src/planner/binder/default_expr.rs
+++ b/src/query/sql/src/planner/binder/default_expr.rs
@@ -157,7 +157,7 @@ impl DefaultExprBinder {
         } else if scalar_expr.is_deterministic() {
             let expr = scalar_expr.as_expr()?;
             let (fold_to_constant, _) =
-                ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
             (fold_to_constant, true)
         } else {
             (scalar_expr.as_expr()?, false)

--- a/src/query/sql/src/planner/binder/default_expr.rs
+++ b/src/query/sql/src/planner/binder/default_expr.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use databend_common_ast::ast::Expr as AExpr;
@@ -157,8 +158,8 @@ impl DefaultExprBinder {
         } else if scalar_expr.is_deterministic() {
             let expr = scalar_expr.as_expr()?;
             let (fold_to_constant, _) =
-                ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
-            (fold_to_constant, true)
+                ConstantFolder::fold(Cow::Owned(expr), &self.func_ctx, &BUILTIN_FUNCTIONS);
+            (fold_to_constant.into_owned(), true)
         } else {
             (scalar_expr.as_expr()?, false)
         };

--- a/src/query/sql/src/planner/binder/project.rs
+++ b/src/query/sql/src/planner/binder/project.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -689,10 +690,13 @@ impl Binder {
             )?;
             let (scalar, _) = *type_checker.resolve(&expr)?;
             let expr = scalar.as_expr()?;
-            let (new_expr, _) =
-                ConstantFolder::fold(expr, &self.ctx.get_function_context()?, &BUILTIN_FUNCTIONS);
+            let (new_expr, _) = ConstantFolder::fold(
+                Cow::Owned(expr),
+                &self.ctx.get_function_context()?,
+                &BUILTIN_FUNCTIONS,
+            );
 
-            match new_expr {
+            match new_expr.into_owned() {
                 databend_common_expression::Expr::Constant(Constant {
                     scalar: Scalar::Array(Column::Boolean(bitmap)),
                     ..
@@ -720,7 +724,7 @@ impl Binder {
                         output.items.push(item);
                     }
                 }
-                _ => {
+                new_expr => {
                     return Err(ErrorCode::SemanticError(format!(
                         "Column lambda expression must be constant folded: {:?}",
                         new_expr

--- a/src/query/sql/src/planner/binder/project.rs
+++ b/src/query/sql/src/planner/binder/project.rs
@@ -690,7 +690,7 @@ impl Binder {
             let (scalar, _) = *type_checker.resolve(&expr)?;
             let expr = scalar.as_expr()?;
             let (new_expr, _) =
-                ConstantFolder::fold(&expr, &self.ctx.get_function_context()?, &BUILTIN_FUNCTIONS);
+                ConstantFolder::fold(expr, &self.ctx.get_function_context()?, &BUILTIN_FUNCTIONS);
 
             match new_expr {
                 databend_common_expression::Expr::Constant(Constant {

--- a/src/query/sql/src/planner/binder/set.rs
+++ b/src/query/sql/src/planner/binder/set.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
+
 use databend_common_ast::ast::Expr;
 use databend_common_ast::ast::Identifier;
 use databend_common_ast::ast::SetType;
@@ -65,13 +67,14 @@ impl Binder {
                         let (scalar, _) = *type_checker.resolve(expr.as_ref())?;
                         let expr = scalar.as_expr()?;
                         let (new_expr, _) = ConstantFolder::fold(
-                            expr,
+                            Cow::Owned(expr),
                             &self.ctx.get_function_context()?,
                             &BUILTIN_FUNCTIONS,
                         );
-                        let Constant { scalar, .. } = new_expr.into_constant().map_err(|_| {
-                            ErrorCode::SemanticError("value must be constant value")
-                        })?;
+                        let Constant { scalar, .. } =
+                            new_expr.into_owned().into_constant().map_err(|_| {
+                                ErrorCode::SemanticError("value must be constant value")
+                            })?;
                         results.push(scalar);
                     }
                     SetScalarsOrQuery::VarValue(results)

--- a/src/query/sql/src/planner/binder/set.rs
+++ b/src/query/sql/src/planner/binder/set.rs
@@ -65,7 +65,7 @@ impl Binder {
                         let (scalar, _) = *type_checker.resolve(expr.as_ref())?;
                         let expr = scalar.as_expr()?;
                         let (new_expr, _) = ConstantFolder::fold(
-                            &expr,
+                            expr,
                             &self.ctx.get_function_context()?,
                             &BUILTIN_FUNCTIONS,
                         );

--- a/src/query/sql/src/planner/binder/statement_settings.rs
+++ b/src/query/sql/src/planner/binder/statement_settings.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use chrono_tz::Tz;
@@ -74,11 +75,11 @@ impl Binder {
                                 let (scalar, _) = *type_checker.resolve(expr.as_ref())?;
                                 let expr = scalar.as_expr()?;
                                 let (new_expr, _) = ConstantFolder::fold(
-                                    expr,
+                                    Cow::Owned(expr),
                                     &self.ctx.get_function_context()?,
                                     &BUILTIN_FUNCTIONS,
                                 );
-                                match new_expr {
+                                match new_expr.into_owned() {
                                     Expr::Constant(Constant { scalar, .. }) => {
                                         let scalar = cast_scalar(
                                             None,

--- a/src/query/sql/src/planner/binder/statement_settings.rs
+++ b/src/query/sql/src/planner/binder/statement_settings.rs
@@ -74,7 +74,7 @@ impl Binder {
                                 let (scalar, _) = *type_checker.resolve(expr.as_ref())?;
                                 let expr = scalar.as_expr()?;
                                 let (new_expr, _) = ConstantFolder::fold(
-                                    &expr,
+                                    expr,
                                     &self.ctx.get_function_context()?,
                                     &BUILTIN_FUNCTIONS,
                                 );

--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::default::Default;
@@ -720,11 +721,11 @@ impl Binder {
         let box (scalar, _) = type_checker.resolve(expr)?;
         let scalar_expr = scalar.as_expr()?;
         let (new_expr, _) = ConstantFolder::fold(
-            scalar_expr,
+            Cow::Owned(scalar_expr),
             &self.ctx.get_function_context()?,
             &BUILTIN_FUNCTIONS,
         );
-        Ok(new_expr)
+        Ok(new_expr.into_owned())
     }
 
     pub(crate) fn resolve_data_travel_point(

--- a/src/query/sql/src/planner/binder/table.rs
+++ b/src/query/sql/src/planner/binder/table.rs
@@ -720,7 +720,7 @@ impl Binder {
         let box (scalar, _) = type_checker.resolve(expr)?;
         let scalar_expr = scalar.as_expr()?;
         let (new_expr, _) = ConstantFolder::fold(
-            &scalar_expr,
+            scalar_expr,
             &self.ctx.get_function_context()?,
             &BUILTIN_FUNCTIONS,
         );
@@ -793,7 +793,7 @@ impl Binder {
                 let v: i64 = check_number(
                     None,
                     &FunctionContext::default(),
-                    &new_expr,
+                    new_expr,
                     &BUILTIN_FUNCTIONS,
                 )?;
                 if v > 0 {

--- a/src/query/sql/src/planner/binder/table_args.rs
+++ b/src/query/sql/src/planner/binder/table_args.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -123,9 +124,13 @@ fn try_fold_to_scalar(
     subquery_executor: &Option<Arc<dyn QueryExecutor>>,
 ) -> Result<Scalar> {
     let expr = scalar.as_expr()?;
-    let (expr, _) = ConstantFolder::fold(expr, &scalar_binder.get_func_ctx()?, &BUILTIN_FUNCTIONS);
+    let (expr, _) = ConstantFolder::fold(
+        Cow::Owned(expr),
+        &scalar_binder.get_func_ctx()?,
+        &BUILTIN_FUNCTIONS,
+    );
 
-    match expr.into_constant() {
+    match expr.into_owned().into_constant() {
         Ok(Constant { scalar, .. }) => Ok(scalar),
         Err(_) => {
             if contains_subquery(ast_expr) {

--- a/src/query/sql/src/planner/binder/table_args.rs
+++ b/src/query/sql/src/planner/binder/table_args.rs
@@ -123,7 +123,7 @@ fn try_fold_to_scalar(
     subquery_executor: &Option<Arc<dyn QueryExecutor>>,
 ) -> Result<Scalar> {
     let expr = scalar.as_expr()?;
-    let (expr, _) = ConstantFolder::fold(&expr, &scalar_binder.get_func_ctx()?, &BUILTIN_FUNCTIONS);
+    let (expr, _) = ConstantFolder::fold(expr, &scalar_binder.get_func_ctx()?, &BUILTIN_FUNCTIONS);
 
     match expr.into_constant() {
         Ok(Constant { scalar, .. }) => Ok(scalar),

--- a/src/query/sql/src/planner/optimizer/ir/stats/selectivity.rs
+++ b/src/query/sql/src/planner/optimizer/ir/stats/selectivity.rs
@@ -137,7 +137,7 @@ impl SelectivityEstimator {
         let expr = scalar_expr.as_expr()?;
         let input_domains = self.build_input_domains(&expr)?;
         let (expr, output_domain) =
-            ConstantFolder::fold_with_domain(&expr, &input_domains, &func_ctx, &BUILTIN_FUNCTIONS);
+            ConstantFolder::fold_with_domain(expr, &input_domains, &func_ctx, &BUILTIN_FUNCTIONS);
 
         // ConstantFolder owns expression/domain reasoning: boolean shortcuts and
         // contradictions visible from input column domains. It can still leave

--- a/src/query/sql/src/planner/optimizer/ir/stats/selectivity.rs
+++ b/src/query/sql/src/planner/optimizer/ir/stats/selectivity.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use databend_common_exception::ErrorCode;
@@ -136,14 +137,18 @@ impl SelectivityEstimator {
         };
         let expr = scalar_expr.as_expr()?;
         let input_domains = self.build_input_domains(&expr)?;
-        let (expr, output_domain) =
-            ConstantFolder::fold_with_domain(expr, &input_domains, &func_ctx, &BUILTIN_FUNCTIONS);
+        let (expr, output_domain) = ConstantFolder::fold_with_domain(
+            Cow::Owned(expr),
+            &input_domains,
+            &func_ctx,
+            &BUILTIN_FUNCTIONS,
+        );
 
         // ConstantFolder owns expression/domain reasoning: boolean shortcuts and
         // contradictions visible from input column domains. It can still leave
         // SQL-truthy constants such as `WHERE 1`, so handle constant predicates
         // here before falling through to estimation rules.
-        if let Expr::Constant(constant) = &expr {
+        if let Expr::Constant(constant) = expr.as_ref() {
             return match constant_filter_truthiness(&constant.scalar) {
                 Some(true) => Ok(self.cardinality.value()),
                 Some(false) => {

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/decorrelate.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
@@ -625,9 +626,12 @@ impl SubqueryDecorrelatorOptimizer {
                 let mut constant_scalar = None;
                 if scalar_expr.used_columns().is_empty() && !scalar_expr.has_subquery() {
                     let func_ctx = self.ctx.get_function_context()?;
-                    let (folded, _) =
-                        ConstantFolder::fold(scalar_expr.as_expr()?, &func_ctx, &BUILTIN_FUNCTIONS);
-                    if let EExpr::Constant(constant) = folded {
+                    let (folded, _) = ConstantFolder::fold(
+                        Cow::Owned(scalar_expr.as_expr()?),
+                        &func_ctx,
+                        &BUILTIN_FUNCTIONS,
+                    );
+                    if let EExpr::Constant(constant) = folded.into_owned() {
                         constant_scalar = Some(ScalarExpr::TypedConstantExpr(
                             ConstantExpr {
                                 span: scalar_expr.span(),

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/decorrelate.rs
@@ -625,11 +625,8 @@ impl SubqueryDecorrelatorOptimizer {
                 let mut constant_scalar = None;
                 if scalar_expr.used_columns().is_empty() && !scalar_expr.has_subquery() {
                     let func_ctx = self.ctx.get_function_context()?;
-                    let (folded, _) = ConstantFolder::fold(
-                        &scalar_expr.as_expr()?,
-                        &func_ctx,
-                        &BUILTIN_FUNCTIONS,
-                    );
+                    let (folded, _) =
+                        ConstantFolder::fold(scalar_expr.as_expr()?, &func_ctx, &BUILTIN_FUNCTIONS);
                     if let EExpr::Constant(constant) = folded {
                         constant_scalar = Some(ScalarExpr::TypedConstantExpr(
                             ConstantExpr {

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_push_down_filter_window_top_n.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/filter_rules/rule_push_down_filter_window_top_n.rs
@@ -270,7 +270,7 @@ fn extract_i32(expr: &ScalarExpr) -> Option<i32> {
     check_number(
         None,
         &FunctionContext::default(),
-        &expr.as_expr().ok()?,
+        expr.as_expr().ok()?,
         &BUILTIN_FUNCTIONS,
     )
     .ok()

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/push_down_filter_join/outer_join_to_inner_join.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/push_down_filter_join/outer_join_to_inner_join.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -241,7 +242,7 @@ pub fn can_filter_null(
         let columns = null_scalar_expr.columns_and_data_types(metadata);
         let expr = convert_scalar_expr_to_expr(null_scalar_expr, columns)?;
         let func_ctx = &FunctionContext::default();
-        let (expr, _) = ConstantFolder::fold(expr, func_ctx, &BUILTIN_FUNCTIONS);
+        let (expr, _) = ConstantFolder::fold(Cow::Owned(expr), func_ctx, &BUILTIN_FUNCTIONS);
         if expr.contains_column_ref() {
             return Ok(false);
         }

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/push_down_filter_join/outer_join_to_inner_join.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/join_rules/push_down_filter_join/outer_join_to_inner_join.rs
@@ -241,7 +241,7 @@ pub fn can_filter_null(
         let columns = null_scalar_expr.columns_and_data_types(metadata);
         let expr = convert_scalar_expr_to_expr(null_scalar_expr, columns)?;
         let func_ctx = &FunctionContext::default();
-        let (expr, _) = ConstantFolder::fold(&expr, func_ctx, &BUILTIN_FUNCTIONS);
+        let (expr, _) = ConstantFolder::fold(expr, func_ctx, &BUILTIN_FUNCTIONS);
         if expr.contains_column_ref() {
             return Ok(false);
         }

--- a/src/query/sql/src/planner/plans/window.rs
+++ b/src/query/sql/src/planner/plans/window.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::sync::Arc;
@@ -401,8 +402,12 @@ enum FoldedConstantStat {
 
 fn fold_constant_stat(expr: &ScalarExpr) -> Result<Option<FoldedConstantStat>> {
     let expr = expr.as_expr()?;
-    let (expr, _) = ConstantFolder::fold(expr, &FunctionContext::default(), &BUILTIN_FUNCTIONS);
-    let Ok(constant) = expr.into_constant() else {
+    let (expr, _) = ConstantFolder::fold(
+        Cow::Owned(expr),
+        &FunctionContext::default(),
+        &BUILTIN_FUNCTIONS,
+    );
+    let Ok(constant) = expr.into_owned().into_constant() else {
         return Ok(None);
     };
     if constant.scalar == Scalar::Null {

--- a/src/query/sql/src/planner/plans/window.rs
+++ b/src/query/sql/src/planner/plans/window.rs
@@ -401,7 +401,7 @@ enum FoldedConstantStat {
 
 fn fold_constant_stat(expr: &ScalarExpr) -> Result<Option<FoldedConstantStat>> {
     let expr = expr.as_expr()?;
-    let (expr, _) = ConstantFolder::fold(&expr, &FunctionContext::default(), &BUILTIN_FUNCTIONS);
+    let (expr, _) = ConstantFolder::fold(expr, &FunctionContext::default(), &BUILTIN_FUNCTIONS);
     let Ok(constant) = expr.into_constant() else {
         return Ok(None);
     };

--- a/src/query/sql/src/planner/semantic/type_check/aggregate.rs
+++ b/src/query/sql/src/planner/semantic/type_check/aggregate.rs
@@ -414,7 +414,7 @@ where A: TypeCheckAdapter
             let max_num_buckets: u64 = check_number(
                 None,
                 &FunctionContext::default(),
-                &arguments[1].as_expr()?,
+                arguments[1].as_expr()?,
                 &BUILTIN_FUNCTIONS,
             )?;
 

--- a/src/query/sql/src/planner/semantic/type_check/core_expr.rs
+++ b/src/query/sql/src/planner/semantic/type_check/core_expr.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
+
 use databend_common_ast::Span;
 use databend_common_ast::ast::Expr;
 use databend_common_ast::ast::FunctionCall as ASTFunctionCall;
@@ -715,8 +717,10 @@ where A: TypeCheckAdapter
         for (display_name, param) in params {
             let box (scalar, _) = self.resolve_core(arena, *param)?;
             let expr = scalar.as_expr()?;
-            let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+            let (expr, _) =
+                ConstantFolder::fold(Cow::Owned(expr), &self.func_ctx, &BUILTIN_FUNCTIONS);
             let constant = expr
+                .into_owned()
                 .into_constant()
                 .map_err(|_| {
                     ErrorCode::SemanticError(format!(

--- a/src/query/sql/src/planner/semantic/type_check/core_expr.rs
+++ b/src/query/sql/src/planner/semantic/type_check/core_expr.rs
@@ -715,7 +715,7 @@ where A: TypeCheckAdapter
         for (display_name, param) in params {
             let box (scalar, _) = self.resolve_core(arena, *param)?;
             let expr = scalar.as_expr()?;
-            let (expr, _) = ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+            let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
             let constant = expr
                 .into_constant()
                 .map_err(|_| {

--- a/src/query/sql/src/planner/semantic/type_check/date.rs
+++ b/src/query/sql/src/planner/semantic/type_check/date.rs
@@ -421,7 +421,7 @@ impl<'a, A> TypeChecker<'a, A> {
 
     fn interval_contains_only_date_parts(&self, interval_expr: &ScalarExpr) -> Result<bool> {
         let expr = interval_expr.as_expr()?;
-        let (folded, _) = ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+        let (folded, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
         if let EExpr::Constant(Constant {
             scalar: Scalar::Interval(value),
             ..

--- a/src/query/sql/src/planner/semantic/type_check/date.rs
+++ b/src/query/sql/src/planner/semantic/type_check/date.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
+
 use databend_common_ast::Span;
 use databend_common_ast::ast::BinaryOperator;
 use databend_common_ast::ast::Expr;
@@ -421,11 +423,12 @@ impl<'a, A> TypeChecker<'a, A> {
 
     fn interval_contains_only_date_parts(&self, interval_expr: &ScalarExpr) -> Result<bool> {
         let expr = interval_expr.as_expr()?;
-        let (folded, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+        let (folded, _) =
+            ConstantFolder::fold(Cow::Owned(expr), &self.func_ctx, &BUILTIN_FUNCTIONS);
         if let EExpr::Constant(Constant {
             scalar: Scalar::Interval(value),
             ..
-        }) = folded
+        }) = folded.as_ref()
         {
             return Ok(value.microseconds() == 0);
         }

--- a/src/query/sql/src/planner/semantic/type_check/in_list.rs
+++ b/src/query/sql/src/planner/semantic/type_check/in_list.rs
@@ -164,7 +164,7 @@ where A: super::TypeCheckAdapter
             let scalar = if *data_type != common_type {
                 let cast = wrap_cast(&scalar, &common_type);
                 let expr = cast.as_expr()?;
-                let (expr, _) = ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
                 match expr.into_constant() {
                     Ok(constant) => ScalarExpr::ConstantExpr(ConstantExpr {
                         span: scalar.span(),

--- a/src/query/sql/src/planner/semantic/type_check/in_list.rs
+++ b/src/query/sql/src/planner/semantic/type_check/in_list.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
+
 use databend_common_ast::Span;
 use databend_common_ast::ast::Expr;
 use databend_common_exception::ErrorCode;
@@ -164,8 +166,9 @@ where A: super::TypeCheckAdapter
             let scalar = if *data_type != common_type {
                 let cast = wrap_cast(&scalar, &common_type);
                 let expr = cast.as_expr()?;
-                let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
-                match expr.into_constant() {
+                let (expr, _) =
+                    ConstantFolder::fold(Cow::Owned(expr), &self.func_ctx, &BUILTIN_FUNCTIONS);
+                match expr.into_owned().into_constant() {
                     Ok(constant) => ScalarExpr::ConstantExpr(ConstantExpr {
                         span: scalar.span(),
                         value: constant.scalar,

--- a/src/query/sql/src/planner/semantic/type_check/lambda.rs
+++ b/src/query/sql/src/planner/semantic/type_check/lambda.rs
@@ -446,7 +446,7 @@ where A: super::TypeCheckAdapter
                 let expr = lambda_expr
                     .type_check(&lambda_schema)?
                     .project_column_ref(|index| lambda_schema.index_of(&index.to_string()))?;
-                let (expr, _) = ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
                 let remote_lambda_expr = expr.as_remote_expr();
                 let lambda_display = format!("{:?} -> {}", params, expr.sql_display());
 
@@ -618,7 +618,7 @@ where A: super::TypeCheckAdapter
         let expr = lambda_scalar
             .type_check(&lambda_schema)?
             .project_column_ref(|index| lambda_schema.index_of(&index.to_string()))?;
-        let (expr, _) = ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+        let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
         let remote_lambda_expr = expr.as_remote_expr();
         let lambda_display = format!("{:?} -> {}", params, expr.sql_display());
 

--- a/src/query/sql/src/planner/semantic/type_check/lambda.rs
+++ b/src/query/sql/src/planner/semantic/type_check/lambda.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::HashSet;
 
 use databend_common_ast::Span;
@@ -446,7 +447,8 @@ where A: super::TypeCheckAdapter
                 let expr = lambda_expr
                     .type_check(&lambda_schema)?
                     .project_column_ref(|index| lambda_schema.index_of(&index.to_string()))?;
-                let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                let (expr, _) =
+                    ConstantFolder::fold(Cow::Owned(expr), &self.func_ctx, &BUILTIN_FUNCTIONS);
                 let remote_lambda_expr = expr.as_remote_expr();
                 let lambda_display = format!("{:?} -> {}", params, expr.sql_display());
 
@@ -618,7 +620,7 @@ where A: super::TypeCheckAdapter
         let expr = lambda_scalar
             .type_check(&lambda_schema)?
             .project_column_ref(|index| lambda_schema.index_of(&index.to_string()))?;
-        let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+        let (expr, _) = ConstantFolder::fold(Cow::Owned(expr), &self.func_ctx, &BUILTIN_FUNCTIONS);
         let remote_lambda_expr = expr.as_remote_expr();
         let lambda_display = format!("{:?} -> {}", params, expr.sql_display());
 

--- a/src/query/sql/src/planner/semantic/type_check/resolve.rs
+++ b/src/query/sql/src/planner/semantic/type_check/resolve.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
+
 use databend_common_ast::Span;
 use databend_common_ast::ast::BinaryOperator;
 use databend_common_ast::ast::Expr;
@@ -155,7 +157,8 @@ where A: TypeCheckAdapter
         }
 
         let span = expr.span();
-        let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+        let (expr, _) = ConstantFolder::fold(Cow::Owned(expr), &self.func_ctx, &BUILTIN_FUNCTIONS);
+        let expr = expr.into_owned();
         let EExpr::Constant(expr::Constant { scalar, .. }) = expr else {
             return Err(expr);
         };

--- a/src/query/sql/src/planner/semantic/type_check/resolve.rs
+++ b/src/query/sql/src/planner/semantic/type_check/resolve.rs
@@ -148,30 +148,27 @@ where A: TypeCheckAdapter
 
     pub(super) fn try_fold_constant<Index: ColumnIndex>(
         &self,
-        expr: &EExpr<Index>,
-        enable_shrink: bool,
-    ) -> Option<Box<(ScalarExpr, DataType)>> {
-        if expr.is_deterministic(&BUILTIN_FUNCTIONS) && enable_shrink {
-            if let (EExpr::Constant(expr::Constant { scalar, .. }), _) =
-                ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS)
-            {
-                let scalar = if enable_shrink {
-                    shrink_scalar(scalar)
-                } else {
-                    scalar
-                };
-                let ty = scalar.as_ref().infer_data_type();
-                return Some(Box::new((
-                    ConstantExpr {
-                        span: expr.span(),
-                        value: scalar,
-                    }
-                    .into(),
-                    ty,
-                )));
-            }
+        expr: EExpr<Index>,
+    ) -> std::result::Result<Box<(ScalarExpr, DataType)>, EExpr<Index>> {
+        if !expr.is_deterministic(&BUILTIN_FUNCTIONS) {
+            return Err(expr);
         }
 
-        None
+        let span = expr.span();
+        let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+        let EExpr::Constant(expr::Constant { scalar, .. }) = expr else {
+            return Err(expr);
+        };
+
+        let scalar = shrink_scalar(scalar);
+        let ty = scalar.as_ref().infer_data_type();
+        Ok(Box::new((
+            ConstantExpr {
+                span,
+                value: scalar,
+            }
+            .into(),
+            ty,
+        )))
     }
 }

--- a/src/query/sql/src/planner/semantic/type_check/scalar_function.rs
+++ b/src/query/sql/src/planner/semantic/type_check/scalar_function.rs
@@ -632,6 +632,7 @@ where A: TypeCheckAdapter
 
         let expr = type_check::check(&raw_expr, &BUILTIN_FUNCTIONS)?;
         let expr = type_check::rewrite_function_to_cast(expr);
+        let is_top_level_cast = matches!(&expr, expr::Expr::Cast(_));
 
         // Run constant folding for arguments of the scalar function.
         // This will be helpful to simplify some constant expressions, especially
@@ -676,13 +677,16 @@ where A: TypeCheckAdapter
             Err(expr) => expr,
         };
 
-        if let expr::Expr::Cast(expr::Cast {
-            span,
-            is_try,
-            dest_type,
-            ..
-        }) = expr
-        {
+        if is_top_level_cast {
+            let expr::Expr::Cast(expr::Cast {
+                span,
+                is_try,
+                dest_type,
+                ..
+            }) = expr
+            else {
+                unreachable!("a partially folded top-level cast must remain a cast");
+            };
             assert_eq!(folded_args.len(), 1);
             return Ok(Box::new((
                 CastExpr {

--- a/src/query/sql/src/planner/semantic/type_check/scalar_function.rs
+++ b/src/query/sql/src/planner/semantic/type_check/scalar_function.rs
@@ -390,10 +390,6 @@ where A: TypeCheckAdapter
         };
         let checked_expr = type_check::check(&raw_expr, &BUILTIN_FUNCTIONS)?;
 
-        if let Some(constant) = self.try_fold_constant(&checked_expr, false) {
-            return Ok(constant);
-        }
-
         // cast variant to other type should nest wrap nullable,
         // as we cast JSON null to SQL NULL.
         let target_type = if data_type.remove_nullable() == DataType::Variant {
@@ -507,7 +503,7 @@ where A: TypeCheckAdapter
                 let scale: i64 = check_number(
                     expr.span(),
                     &FunctionContext::default(),
-                    &expr,
+                    expr,
                     &BUILTIN_FUNCTIONS,
                 )?;
                 scale.clamp(-76, 76)
@@ -538,7 +534,7 @@ where A: TypeCheckAdapter
                     let param: u8 = check_number(
                         expr.span(),
                         &FunctionContext::default(),
-                        &expr,
+                        expr,
                         &BUILTIN_FUNCTIONS,
                     )?;
                     params.push(Scalar::Number(NumberScalar::UInt8(param)));
@@ -592,7 +588,7 @@ where A: TypeCheckAdapter
                           default: i64|
              -> Result<i64> {
                 Ok(args.get(index).map(|arg| {
-                    match ConstantFolder::fold(&arg.as_expr()?, &func_ctx, &BUILTIN_FUNCTIONS).0 {
+                    match ConstantFolder::fold(arg.as_expr()?, &func_ctx, &BUILTIN_FUNCTIONS).0 {
                         EExpr::Constant(Constant {
                             scalar,
                             ..
@@ -643,61 +639,64 @@ where A: TypeCheckAdapter
         // will be folded from `timestamp > to_timestamp('2001-01-01')` to `timestamp > 978307200000000`
         // Note: check function may reorder the args
 
-        let mut folded_args = match &expr {
-            expr::Expr::FunctionCall(expr::FunctionCall {
-                function,
-                args: checked_args,
-                ..
-            }) => checked_args
-                .iter()
-                .zip(
-                    function
-                        .signature
-                        .args_type
-                        .iter()
-                        .map(DataType::is_generic),
-                )
-                .zip(args)
-                .map(|((checked_arg, is_generic), arg)| {
-                    if !arg.evaluable() {
-                        return arg;
-                    }
-                    match self.try_fold_constant(checked_arg, !is_generic) {
-                        Some(box (constant, _)) => constant,
-                        _ => arg,
-                    }
-                })
-                .collect(),
-            _ => args,
-        };
-
         if !expr.is_deterministic(&BUILTIN_FUNCTIONS) {
             self.adapter.set_result_cache_uncacheable();
         }
 
-        if let Some(constant) = self.try_fold_constant(&expr, true) {
-            return Ok(constant);
-        }
+        let expr = match self.try_fold_constant(expr) {
+            Ok(constant) => return Ok(constant),
+            Err(expr) => expr,
+        };
 
-        if let expr::Expr::Cast(expr::Cast {
-            span,
-            is_try,
-            dest_type,
-            ..
-        }) = expr
-        {
-            assert_eq!(folded_args.len(), 1);
-            return Ok(Box::new((
-                CastExpr {
-                    span,
-                    is_try,
-                    argument: Box::new(folded_args.pop().unwrap()),
-                    target_type: Box::new(dest_type.clone()),
-                }
-                .into(),
+        let (mut folded_args, return_type) = match expr {
+            expr::Expr::FunctionCall(expr::FunctionCall {
+                function,
+                args: checked_args,
+                return_type,
+                ..
+            }) => {
+                let folded_args = checked_args
+                    .into_iter()
+                    .zip(
+                        function
+                            .signature
+                            .args_type
+                            .iter()
+                            .map(DataType::is_generic),
+                    )
+                    .zip(args)
+                    .map(|((checked_arg, is_generic), arg)| {
+                        if !arg.evaluable() || is_generic {
+                            return arg;
+                        }
+                        match self.try_fold_constant(checked_arg) {
+                            Ok(box (constant, _)) => constant,
+                            Err(_) => arg,
+                        }
+                    })
+                    .collect();
+                (folded_args, return_type)
+            }
+            expr::Expr::Cast(expr::Cast {
+                span,
+                is_try,
                 dest_type,
-            )));
-        }
+                ..
+            }) => {
+                assert_eq!(args.len(), 1);
+                return Ok(Box::new((
+                    CastExpr {
+                        span,
+                        is_try,
+                        argument: Box::new(args.into_iter().next().unwrap()),
+                        target_type: Box::new(dest_type.clone()),
+                    }
+                    .into(),
+                    dest_type,
+                )));
+            }
+            expr => (args, expr.into_data_type()),
+        };
 
         // reorder
         if func_name == "eq"
@@ -708,7 +707,6 @@ where A: TypeCheckAdapter
             folded_args.swap(0, 1);
         }
 
-        let return_type = expr.data_type().clone();
         Ok(Box::new((
             FunctionCall {
                 span,

--- a/src/query/sql/src/planner/semantic/type_check/scalar_function.rs
+++ b/src/query/sql/src/planner/semantic/type_check/scalar_function.rs
@@ -639,6 +639,34 @@ where A: TypeCheckAdapter
         // will be folded from `timestamp > to_timestamp('2001-01-01')` to `timestamp > 978307200000000`
         // Note: check function may reorder the args
 
+        let mut folded_args = match &expr {
+            expr::Expr::FunctionCall(expr::FunctionCall {
+                function,
+                args: checked_args,
+                ..
+            }) => checked_args
+                .iter()
+                .zip(
+                    function
+                        .signature
+                        .args_type
+                        .iter()
+                        .map(DataType::is_generic),
+                )
+                .zip(args)
+                .map(|((checked_arg, is_generic), arg)| {
+                    if !arg.evaluable() || is_generic {
+                        return arg;
+                    }
+                    match self.try_fold_constant(checked_arg.clone()) {
+                        Ok(box (constant, _)) => constant,
+                        Err(_) => arg,
+                    }
+                })
+                .collect(),
+            _ => args,
+        };
+
         if !expr.is_deterministic(&BUILTIN_FUNCTIONS) {
             self.adapter.set_result_cache_uncacheable();
         }
@@ -648,55 +676,25 @@ where A: TypeCheckAdapter
             Err(expr) => expr,
         };
 
-        let (mut folded_args, return_type) = match expr {
-            expr::Expr::FunctionCall(expr::FunctionCall {
-                function,
-                args: checked_args,
-                return_type,
-                ..
-            }) => {
-                let folded_args = checked_args
-                    .into_iter()
-                    .zip(
-                        function
-                            .signature
-                            .args_type
-                            .iter()
-                            .map(DataType::is_generic),
-                    )
-                    .zip(args)
-                    .map(|((checked_arg, is_generic), arg)| {
-                        if !arg.evaluable() || is_generic {
-                            return arg;
-                        }
-                        match self.try_fold_constant(checked_arg) {
-                            Ok(box (constant, _)) => constant,
-                            Err(_) => arg,
-                        }
-                    })
-                    .collect();
-                (folded_args, return_type)
-            }
-            expr::Expr::Cast(expr::Cast {
-                span,
-                is_try,
+        if let expr::Expr::Cast(expr::Cast {
+            span,
+            is_try,
+            dest_type,
+            ..
+        }) = expr
+        {
+            assert_eq!(folded_args.len(), 1);
+            return Ok(Box::new((
+                CastExpr {
+                    span,
+                    is_try,
+                    argument: Box::new(folded_args.pop().unwrap()),
+                    target_type: Box::new(dest_type.clone()),
+                }
+                .into(),
                 dest_type,
-                ..
-            }) => {
-                assert_eq!(args.len(), 1);
-                return Ok(Box::new((
-                    CastExpr {
-                        span,
-                        is_try,
-                        argument: Box::new(args.into_iter().next().unwrap()),
-                        target_type: Box::new(dest_type.clone()),
-                    }
-                    .into(),
-                    dest_type,
-                )));
-            }
-            expr => (args, expr.into_data_type()),
-        };
+            )));
+        }
 
         // reorder
         if func_name == "eq"
@@ -707,6 +705,7 @@ where A: TypeCheckAdapter
             folded_args.swap(0, 1);
         }
 
+        let return_type = expr.into_data_type();
         Ok(Box::new((
             FunctionCall {
                 span,

--- a/src/query/sql/src/planner/semantic/type_check/scalar_function.rs
+++ b/src/query/sql/src/planner/semantic/type_check/scalar_function.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
+
 use databend_common_ast::Span;
 use databend_common_ast::ast::ColumnID;
 use databend_common_ast::ast::ColumnRef;
@@ -588,7 +590,14 @@ where A: TypeCheckAdapter
                           default: i64|
              -> Result<i64> {
                 Ok(args.get(index).map(|arg| {
-                    match ConstantFolder::fold(arg.as_expr()?, &func_ctx, &BUILTIN_FUNCTIONS).0 {
+                    match ConstantFolder::fold(
+                        Cow::Owned(arg.as_expr()?),
+                        &func_ctx,
+                        &BUILTIN_FUNCTIONS,
+                    )
+                    .0
+                    .into_owned()
+                    {
                         EExpr::Constant(Constant {
                             scalar,
                             ..

--- a/src/query/sql/src/planner/semantic/type_check/special_function.rs
+++ b/src/query/sql/src/planner/semantic/type_check/special_function.rs
@@ -545,7 +545,7 @@ where A: TypeCheckAdapter
                 )
                 .set_span(span));
             }
-            check_number(span, &self.func_ctx, &expr, &BUILTIN_FUNCTIONS)?
+            check_number(span, &self.func_ctx, expr, &BUILTIN_FUNCTIONS)?
         } else {
             -1
         };

--- a/src/query/sql/src/planner/semantic/type_check/udf.rs
+++ b/src/query/sql/src/planner/semantic/type_check/udf.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::time::Duration;
@@ -966,9 +967,12 @@ where A: UdfAdapter
                     ));
                 }
                 let expr = argument.scalar.as_expr()?;
-                let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
-                let Ok(Some(location)) =
-                    expr.into_constant().map(|c| c.scalar.as_string().cloned())
+                let (expr, _) =
+                    ConstantFolder::fold(Cow::Owned(expr), &self.func_ctx, &BUILTIN_FUNCTIONS);
+                let Ok(Some(location)) = expr
+                    .into_owned()
+                    .into_constant()
+                    .map(|c| c.scalar.as_string().cloned())
                 else {
                     return Err(ErrorCode::SemanticError(format!(
                         "invalid parameter {argument} for udf function, expected constant string",

--- a/src/query/sql/src/planner/semantic/type_check/udf.rs
+++ b/src/query/sql/src/planner/semantic/type_check/udf.rs
@@ -966,7 +966,7 @@ where A: UdfAdapter
                     ));
                 }
                 let expr = argument.scalar.as_expr()?;
-                let (expr, _) = ConstantFolder::fold(&expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                let (expr, _) = ConstantFolder::fold(expr, &self.func_ctx, &BUILTIN_FUNCTIONS);
                 let Ok(Some(location)) =
                     expr.into_constant().map(|c| c.scalar.as_string().cloned())
                 else {

--- a/src/query/sql/src/planner/semantic/type_check/vector.rs
+++ b/src/query/sql/src/planner/semantic/type_check/vector.rs
@@ -52,16 +52,16 @@ where A: TypeCheckAdapter
     fn try_fold_cast_to_vector(&self, expr: &ScalarExpr) -> Option<Vec<F32>> {
         if expr.evaluable() {
             let checked_expr = expr.as_expr().ok()?;
-            let folded = self.try_fold_constant(&checked_expr, true)?;
-            let constant = match &folded.0 {
+            let box (folded, _) = self.try_fold_constant(checked_expr).ok()?;
+            let constant = match folded {
                 ScalarExpr::ConstantExpr(constant) | ScalarExpr::TypedConstantExpr(constant, _) => {
-                    constant.clone()
+                    constant
                 }
                 _ => return None,
             };
 
             if let Scalar::Vector(VectorScalar::Float32(values)) = constant.value {
-                return Some(values.clone());
+                return Some(values);
             }
         }
         None

--- a/src/query/sql/src/planner/semantic/type_check/window.rs
+++ b/src/query/sql/src/planner/semantic/type_check/window.rs
@@ -558,7 +558,7 @@ where A: TypeCheckAdapter
             | CoreWindowFrameBound::Preceding(Some(expr)) => {
                 let box (expr, _) = self.resolve_core(arena, *expr)?;
                 let (expr, _) =
-                    ConstantFolder::fold(&expr.as_expr()?, &self.func_ctx, &BUILTIN_FUNCTIONS);
+                    ConstantFolder::fold(expr.as_expr()?, &self.func_ctx, &BUILTIN_FUNCTIONS);
                 match expr.into_constant() {
                     Ok(expr::Constant { scalar, .. }) => Ok(Some(scalar)),
                     Err(expr) => Err(ErrorCode::SemanticError(
@@ -701,7 +701,7 @@ where A: TypeCheckAdapter
                 EExpr::Constant(_) => Some(check_number::<i64, _>(
                     off.span(),
                     &self.func_ctx,
-                    &off,
+                    off,
                     &BUILTIN_FUNCTIONS,
                 )?),
                 _ => {
@@ -800,7 +800,7 @@ where A: TypeCheckAdapter
                     EExpr::Constant(_) => check_number::<u64, _>(
                         n_expr.span(),
                         &self.func_ctx,
-                        &n_expr,
+                        n_expr,
                         &BUILTIN_FUNCTIONS,
                     )?,
                     _ => {
@@ -838,7 +838,7 @@ where A: TypeCheckAdapter
         let return_type = DataType::Number(NumberDataType::UInt64);
         let n = match n_expr {
             EExpr::Constant(_) => {
-                check_number::<u64, _>(n_expr.span(), &self.func_ctx, &n_expr, &BUILTIN_FUNCTIONS)?
+                check_number::<u64, _>(n_expr.span(), &self.func_ctx, n_expr, &BUILTIN_FUNCTIONS)?
             }
             _ => {
                 return Err(ErrorCode::InvalidArgument(

--- a/src/query/sql/src/planner/semantic/type_check/window.rs
+++ b/src/query/sql/src/planner/semantic/type_check/window.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
+
 use databend_common_ast::Span;
 use databend_common_ast::ast::Expr;
 use databend_common_ast::ast::FunctionCall as ASTFunctionCall;
@@ -557,9 +559,12 @@ where A: TypeCheckAdapter
             CoreWindowFrameBound::Following(Some(expr))
             | CoreWindowFrameBound::Preceding(Some(expr)) => {
                 let box (expr, _) = self.resolve_core(arena, *expr)?;
-                let (expr, _) =
-                    ConstantFolder::fold(expr.as_expr()?, &self.func_ctx, &BUILTIN_FUNCTIONS);
-                match expr.into_constant() {
+                let (expr, _) = ConstantFolder::fold(
+                    Cow::Owned(expr.as_expr()?),
+                    &self.func_ctx,
+                    &BUILTIN_FUNCTIONS,
+                );
+                match expr.into_owned().into_constant() {
                     Ok(expr::Constant { scalar, .. }) => Ok(Some(scalar)),
                     Err(expr) => Err(ErrorCode::SemanticError(
                         "Only constant is allowed in RANGE offset".to_string(),

--- a/src/query/sql/tests/it/semantic/type_check/scalar_function.rs
+++ b/src/query/sql/tests/it/semantic/type_check/scalar_function.rs
@@ -21,6 +21,12 @@ async fn test_type_check_scalar_function_rules() -> Result<()> {
             setup_sqls: &[],
             sql: "if(false, 1, number > 0, 2, 3)",
         },
+        SqlTestCase {
+            name: "partially_folded_if_with_nested_cast",
+            description: "A nested cast selected by constant folding must not be treated as a top-level cast rewrite.",
+            setup_sqls: &[],
+            sql: "if(true, CAST(number AS BIGINT), 0)",
+        },
     ];
 
     run_type_check_cases("scalar_function.txt", &cases).await

--- a/src/query/sql/tests/it/semantic/type_check/scalar_function.rs
+++ b/src/query/sql/tests/it/semantic/type_check/scalar_function.rs
@@ -15,6 +15,12 @@ async fn test_type_check_scalar_function_rules() -> Result<()> {
             setup_sqls: &[],
             sql: "to_decimal(number, number)",
         },
+        SqlTestCase {
+            name: "partially_folded_if_keeps_argument_alignment",
+            description: "Removing constant IF branches must preserve alignment with planner arguments.",
+            setup_sqls: &[],
+            sql: "if(false, 1, number > 0, 2, 3)",
+        },
     ];
 
     run_type_check_cases("scalar_function.txt", &cases).await

--- a/src/query/sql/tests/it/semantic/type_check/scalar_function.txt
+++ b/src/query/sql/tests/it/semantic/type_check/scalar_function.txt
@@ -11,3 +11,10 @@ sql: to_decimal(number, number)
 status: error
 code: 1065
 message: Invalid arguments for `to_decimal`, precision is only allowed to be a constant
+
+=== partially_folded_if_keeps_argument_alignment ===
+description: Removing constant IF branches must preserve alignment with planner arguments.
+sql: if(false, 1, number > 0, 2, 3)
+status: ok
+scalar: if(false, 1, gt(number (#0), 0), 2, 3)
+type: UInt8

--- a/src/query/sql/tests/it/semantic/type_check/scalar_function.txt
+++ b/src/query/sql/tests/it/semantic/type_check/scalar_function.txt
@@ -18,3 +18,10 @@ sql: if(false, 1, number > 0, 2, 3)
 status: ok
 scalar: if(false, 1, gt(number (#0), 0), 2, 3)
 type: UInt8
+
+=== partially_folded_if_with_nested_cast ===
+description: A nested cast selected by constant folding must not be treated as a top-level cast rewrite.
+sql: if(true, CAST(number AS BIGINT), 0)
+status: ok
+scalar: if(true, CAST(number (#0) AS Int64 NULL), 0)
+type: Int64 NULL

--- a/src/query/storages/common/index/src/bloom_index.rs
+++ b/src/query/storages/common/index/src/bloom_index.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -278,7 +279,14 @@ impl BloomIndex {
             column_stats,
             data_schema,
         )?;
-        match ConstantFolder::fold_with_domain(expr, &domains, &self.func_ctx, &BUILTIN_FUNCTIONS).0
+        match ConstantFolder::fold_with_domain(
+            Cow::Owned(expr),
+            &domains,
+            &self.func_ctx,
+            &BUILTIN_FUNCTIONS,
+        )
+        .0
+        .as_ref()
         {
             Expr::Constant(Constant {
                 scalar: Scalar::Boolean(false),
@@ -1336,7 +1344,7 @@ impl EqVisitor for RewriteVisitor<'_> {
 
         // check domain for possible overflow
         if ConstantFolder::<String>::fold_with_domain(
-            cast.clone(),
+            Cow::Borrowed(cast),
             self.domains,
             &FunctionContext::default(),
             &BUILTIN_FUNCTIONS,

--- a/src/query/storages/common/index/src/bloom_index.rs
+++ b/src/query/storages/common/index/src/bloom_index.rs
@@ -278,8 +278,7 @@ impl BloomIndex {
             column_stats,
             data_schema,
         )?;
-        match ConstantFolder::fold_with_domain(&expr, &domains, &self.func_ctx, &BUILTIN_FUNCTIONS)
-            .0
+        match ConstantFolder::fold_with_domain(expr, &domains, &self.func_ctx, &BUILTIN_FUNCTIONS).0
         {
             Expr::Constant(Constant {
                 scalar: Scalar::Boolean(false),
@@ -1337,7 +1336,7 @@ impl EqVisitor for RewriteVisitor<'_> {
 
         // check domain for possible overflow
         if ConstantFolder::<String>::fold_with_domain(
-            cast,
+            cast.clone(),
             self.domains,
             &FunctionContext::default(),
             &BUILTIN_FUNCTIONS,

--- a/src/query/storages/common/index/src/eliminate_cast.rs
+++ b/src/query/storages/common/index/src/eliminate_cast.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use databend_common_ast::Span;
@@ -114,12 +115,13 @@ impl RewriteVisitor<'_> {
 
                 Ok(Some(
                     ConstantFolder::fold_with_domain(
-                        func_expr,
+                        Cow::Owned(func_expr),
                         &self.input_domains,
                         self.func_ctx,
                         self.fn_registry,
                     )
-                    .0,
+                    .0
+                    .into_owned(),
                 ))
             }
         }
@@ -160,12 +162,13 @@ impl RewriteVisitor<'_> {
 
         Ok(Some(
             ConstantFolder::fold_with_domain(
-                func_expr,
+                Cow::Owned(func_expr),
                 &self.input_domains,
                 self.func_ctx,
                 self.fn_registry,
             )
-            .0,
+            .0
+            .into_owned(),
         ))
     }
 
@@ -194,7 +197,7 @@ impl RewriteVisitor<'_> {
 
         // check domain for possible overflow
         ConstantFolder::<String>::fold_with_domain(
-            cast.clone().into(),
+            Cow::Owned(cast.clone().into()),
             &self.input_domains,
             self.func_ctx,
             &BUILTIN_FUNCTIONS,
@@ -210,13 +213,15 @@ pub(super) fn cast_const(
     constant: Constant,
 ) -> Option<Scalar> {
     let (_, Some(domain)) = ConstantFolder::<String>::fold(
-        Cast {
-            span: None,
-            is_try: false,
-            expr: Box::new(constant.into()),
-            dest_type,
-        }
-        .into(),
+        Cow::Owned(
+            Cast {
+                span: None,
+                is_try: false,
+                expr: Box::new(constant.into()),
+                dest_type,
+            }
+            .into(),
+        ),
         func_ctx,
         &BUILTIN_FUNCTIONS,
     ) else {

--- a/src/query/storages/common/index/src/eliminate_cast.rs
+++ b/src/query/storages/common/index/src/eliminate_cast.rs
@@ -114,7 +114,7 @@ impl RewriteVisitor<'_> {
 
                 Ok(Some(
                     ConstantFolder::fold_with_domain(
-                        &func_expr,
+                        func_expr,
                         &self.input_domains,
                         self.func_ctx,
                         self.fn_registry,
@@ -160,7 +160,7 @@ impl RewriteVisitor<'_> {
 
         Ok(Some(
             ConstantFolder::fold_with_domain(
-                &func_expr,
+                func_expr,
                 &self.input_domains,
                 self.func_ctx,
                 self.fn_registry,
@@ -194,7 +194,7 @@ impl RewriteVisitor<'_> {
 
         // check domain for possible overflow
         ConstantFolder::<String>::fold_with_domain(
-            &cast.clone().into(),
+            cast.clone().into(),
             &self.input_domains,
             self.func_ctx,
             &BUILTIN_FUNCTIONS,
@@ -210,7 +210,7 @@ pub(super) fn cast_const(
     constant: Constant,
 ) -> Option<Scalar> {
     let (_, Some(domain)) = ConstantFolder::<String>::fold(
-        &Cast {
+        Cast {
             span: None,
             is_try: false,
             expr: Box::new(constant.into()),

--- a/src/query/storages/common/index/src/range_index.rs
+++ b/src/query/storages/common/index/src/range_index.rs
@@ -166,7 +166,7 @@ impl RangeIndex {
         };
 
         let (new_expr, _) = ConstantFolder::fold_with_domain(
-            expr.into_owned(),
+            expr,
             &visitor.input_domains,
             &self.func_ctx,
             &BUILTIN_FUNCTIONS,
@@ -174,7 +174,7 @@ impl RangeIndex {
 
         // Only return false, which means to skip this block, when the expression is folded to a constant false.
         Ok(!matches!(
-            new_expr,
+            new_expr.as_ref(),
             Expr::Constant(Constant {
                 scalar: Scalar::Boolean(false),
                 ..

--- a/src/query/storages/common/index/src/range_index.rs
+++ b/src/query/storages/common/index/src/range_index.rs
@@ -166,7 +166,7 @@ impl RangeIndex {
         };
 
         let (new_expr, _) = ConstantFolder::fold_with_domain(
-            &expr,
+            expr.into_owned(),
             &visitor.input_domains,
             &self.func_ctx,
             &BUILTIN_FUNCTIONS,

--- a/src/query/storages/common/index/tests/it/bloom_pruner.rs
+++ b/src/query/storages/common/index/tests/it/bloom_pruner.rs
@@ -190,7 +190,7 @@ fn test_bloom_filter_rewrites_string_literal_integer_comparison() {
             schema,
         )
         .unwrap();
-    let folded = ConstantFolder::fold_with_domain(&expr, &domains, &func_ctx, &BUILTIN_FUNCTIONS).0;
+    let folded = ConstantFolder::fold_with_domain(expr, &domains, &func_ctx, &BUILTIN_FUNCTIONS).0;
 
     assert!(matches!(
         folded,
@@ -681,7 +681,7 @@ fn eval_index_expr(
     writeln!(file, "expr     : {expr}").unwrap();
 
     let func_ctx = FunctionContext::default();
-    let (fold_expr, _) = ConstantFolder::fold(&expr, &func_ctx, &BUILTIN_FUNCTIONS);
+    let (fold_expr, _) = ConstantFolder::fold(expr.clone(), &func_ctx, &BUILTIN_FUNCTIONS);
     let expr = if fold_expr != expr {
         writeln!(file, "fold_expr: {fold_expr}").unwrap();
         fold_expr
@@ -765,14 +765,20 @@ fn eval_index_expr(
             schema,
         )
         .unwrap();
-    let result =
-        match ConstantFolder::fold_with_domain(&expr, &domains, &func_ctx, &BUILTIN_FUNCTIONS).0 {
-            Expr::Constant(Constant {
-                scalar: Scalar::Boolean(false),
-                ..
-            }) => FilterEvalResult::MustFalse,
-            _ => FilterEvalResult::Uncertain,
-        };
+    let result = match ConstantFolder::fold_with_domain(
+        expr.clone(),
+        &domains,
+        &func_ctx,
+        &BUILTIN_FUNCTIONS,
+    )
+    .0
+    {
+        Expr::Constant(Constant {
+            scalar: Scalar::Boolean(false),
+            ..
+        }) => FilterEvalResult::MustFalse,
+        _ => FilterEvalResult::Uncertain,
+    };
     let domains = BTreeMap::from_iter(domains);
 
     writeln!(file, "filter   : {expr}").unwrap();

--- a/src/query/storages/common/index/tests/it/bloom_pruner.rs
+++ b/src/query/storages/common/index/tests/it/bloom_pruner.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::io::Write;
@@ -190,10 +191,12 @@ fn test_bloom_filter_rewrites_string_literal_integer_comparison() {
             schema,
         )
         .unwrap();
-    let folded = ConstantFolder::fold_with_domain(expr, &domains, &func_ctx, &BUILTIN_FUNCTIONS).0;
+    let folded =
+        ConstantFolder::fold_with_domain(Cow::Owned(expr), &domains, &func_ctx, &BUILTIN_FUNCTIONS)
+            .0;
 
     assert!(matches!(
-        folded,
+        folded.as_ref(),
         Expr::Constant(Constant {
             scalar: Scalar::Boolean(false),
             ..
@@ -681,10 +684,10 @@ fn eval_index_expr(
     writeln!(file, "expr     : {expr}").unwrap();
 
     let func_ctx = FunctionContext::default();
-    let (fold_expr, _) = ConstantFolder::fold(expr.clone(), &func_ctx, &BUILTIN_FUNCTIONS);
+    let (fold_expr, _) = ConstantFolder::fold(Cow::Borrowed(&expr), &func_ctx, &BUILTIN_FUNCTIONS);
     let expr = if fold_expr != expr {
         writeln!(file, "fold_expr: {fold_expr}").unwrap();
-        fold_expr
+        fold_expr.into_owned()
     } else {
         expr
     };
@@ -766,12 +769,13 @@ fn eval_index_expr(
         )
         .unwrap();
     let result = match ConstantFolder::fold_with_domain(
-        expr.clone(),
+        Cow::Borrowed(&expr),
         &domains,
         &func_ctx,
         &BUILTIN_FUNCTIONS,
     )
     .0
+    .as_ref()
     {
         Expr::Constant(Constant {
             scalar: Scalar::Boolean(false),

--- a/src/query/storages/common/index/tests/it/bloom_pruner.rs
+++ b/src/query/storages/common/index/tests/it/bloom_pruner.rs
@@ -685,11 +685,12 @@ fn eval_index_expr(
 
     let func_ctx = FunctionContext::default();
     let (fold_expr, _) = ConstantFolder::fold(Cow::Borrowed(&expr), &func_ctx, &BUILTIN_FUNCTIONS);
-    let expr = if fold_expr != expr {
-        writeln!(file, "fold_expr: {fold_expr}").unwrap();
-        fold_expr.into_owned()
-    } else {
-        expr
+    let expr = match fold_expr {
+        Cow::Borrowed(_) => expr,
+        Cow::Owned(fold_expr) => {
+            writeln!(file, "fold_expr: {fold_expr}").unwrap();
+            fold_expr
+        }
     };
 
     let bloom_fields = bloom_columns.values().cloned().collect::<Vec<_>>();

--- a/src/query/storages/common/index/tests/it/range_pruner.rs
+++ b/src/query/storages/common/index/tests/it/range_pruner.rs
@@ -510,7 +510,7 @@ fn run_text_spatial(
 
     let columns = [("g", DataType::Geometry)];
     let expr = parse_expr(text, &columns);
-    let (folded_expr, _) = ConstantFolder::fold(&expr, &func_ctx, &BUILTIN_FUNCTIONS);
+    let (folded_expr, _) = ConstantFolder::fold(expr.clone(), &func_ctx, &BUILTIN_FUNCTIONS);
     let index = RangeIndex::try_create(func_ctx, &folded_expr, schema, Default::default()).unwrap();
 
     writeln!(file, "text      : {text}").unwrap();

--- a/src/query/storages/common/index/tests/it/range_pruner.rs
+++ b/src/query/storages/common/index/tests/it/range_pruner.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::io::Write;
 use std::sync::Arc;
@@ -510,7 +511,8 @@ fn run_text_spatial(
 
     let columns = [("g", DataType::Geometry)];
     let expr = parse_expr(text, &columns);
-    let (folded_expr, _) = ConstantFolder::fold(expr.clone(), &func_ctx, &BUILTIN_FUNCTIONS);
+    let (folded_expr, _) =
+        ConstantFolder::fold(Cow::Borrowed(&expr), &func_ctx, &BUILTIN_FUNCTIONS);
     let index = RangeIndex::try_create(func_ctx, &folded_expr, schema, Default::default()).unwrap();
 
     writeln!(file, "text      : {text}").unwrap();

--- a/src/query/storages/common/pruner/src/internal_column_pruner.rs
+++ b/src/query/storages/common/pruner/src/internal_column_pruner.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -67,14 +68,14 @@ impl InternalColumnPruner {
             input_domains.insert(col_name.to_string(), domain);
 
             let (folded_expr, _) = ConstantFolder::fold_with_domain(
-                self.expr.clone(),
+                Cow::Borrowed(&self.expr),
                 &input_domains,
                 &self.func_ctx,
                 &BUILTIN_FUNCTIONS,
             );
 
             !matches!(
-                folded_expr,
+                folded_expr.as_ref(),
                 Expr::Constant(Constant {
                     scalar: Scalar::Boolean(false),
                     ..

--- a/src/query/storages/common/pruner/src/internal_column_pruner.rs
+++ b/src/query/storages/common/pruner/src/internal_column_pruner.rs
@@ -67,7 +67,7 @@ impl InternalColumnPruner {
             input_domains.insert(col_name.to_string(), domain);
 
             let (folded_expr, _) = ConstantFolder::fold_with_domain(
-                &self.expr,
+                self.expr.clone(),
                 &input_domains,
                 &self.func_ctx,
                 &BUILTIN_FUNCTIONS,

--- a/src/query/storages/fuse/src/pruning/expr_runtime_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/expr_runtime_pruner.rs
@@ -309,7 +309,7 @@ fn prune_by_statistics(
             input_domains.insert(name.to_string(), domain.clone());
 
             let (new_expr, _) = ConstantFolder::fold_with_domain(
-                filter,
+                filter.clone(),
                 &input_domains,
                 func_ctx,
                 &BUILTIN_FUNCTIONS,

--- a/src/query/storages/fuse/src/pruning/expr_runtime_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/expr_runtime_pruner.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
@@ -309,13 +310,13 @@ fn prune_by_statistics(
             input_domains.insert(name.to_string(), domain.clone());
 
             let (new_expr, _) = ConstantFolder::fold_with_domain(
-                filter.clone(),
+                Cow::Borrowed(filter),
                 &input_domains,
                 func_ctx,
                 &BUILTIN_FUNCTIONS,
             );
             return matches!(
-                new_expr,
+                new_expr.as_ref(),
                 Expr::Constant(Constant {
                     scalar: Scalar::Boolean(false),
                     ..

--- a/src/query/storages/fuse/src/pruning/partition_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/partition_pruner.rs
@@ -64,7 +64,7 @@ impl PartitionPruner {
             .into_iter()
             .map(|expr| {
                 ConstantFolder::fold(
-                    &expr.as_expr(&BUILTIN_FUNCTIONS),
+                    expr.as_expr(&BUILTIN_FUNCTIONS),
                     &func_ctx,
                     &BUILTIN_FUNCTIONS,
                 )
@@ -95,7 +95,7 @@ impl PartitionPruner {
         let filter = visit_expr(&self.filter, &mut visitor)
             .unwrap()
             .unwrap_or_else(|| self.filter.clone());
-        let (filter, _) = ConstantFolder::fold(&filter, &self.func_ctx, &BUILTIN_FUNCTIONS);
+        let (filter, _) = ConstantFolder::fold(filter, &self.func_ctx, &BUILTIN_FUNCTIONS);
 
         !matches!(
             filter,
@@ -185,7 +185,7 @@ impl PartitionPredicateRewriter<'_> {
             return true;
         };
         let (equality, _) = ConstantFolder::fold_with_domain(
-            &equality,
+            equality,
             input_domains,
             self.func_ctx,
             &BUILTIN_FUNCTIONS,

--- a/src/query/storages/fuse/src/pruning/partition_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/partition_pruner.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use databend_common_expression::Constant;
@@ -64,11 +65,12 @@ impl PartitionPruner {
             .into_iter()
             .map(|expr| {
                 ConstantFolder::fold(
-                    expr.as_expr(&BUILTIN_FUNCTIONS),
+                    Cow::Owned(expr.as_expr(&BUILTIN_FUNCTIONS)),
                     &func_ctx,
                     &BUILTIN_FUNCTIONS,
                 )
                 .0
+                .into_owned()
             })
             .collect();
 
@@ -95,10 +97,11 @@ impl PartitionPruner {
         let filter = visit_expr(&self.filter, &mut visitor)
             .unwrap()
             .unwrap_or_else(|| self.filter.clone());
-        let (filter, _) = ConstantFolder::fold(filter, &self.func_ctx, &BUILTIN_FUNCTIONS);
+        let (filter, _) =
+            ConstantFolder::fold(Cow::Owned(filter), &self.func_ctx, &BUILTIN_FUNCTIONS);
 
         !matches!(
-            filter,
+            filter.as_ref(),
             Expr::Constant(Constant {
                 scalar: Scalar::Boolean(false),
                 ..
@@ -185,13 +188,13 @@ impl PartitionPredicateRewriter<'_> {
             return true;
         };
         let (equality, _) = ConstantFolder::fold_with_domain(
-            equality,
+            Cow::Owned(equality),
             input_domains,
             self.func_ctx,
             &BUILTIN_FUNCTIONS,
         );
         !matches!(
-            equality,
+            equality.as_ref(),
             Expr::Constant(Constant {
                 scalar: Scalar::Boolean(false),
                 ..

--- a/src/query/storages/fuse/src/pruning/spatial_index_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/spatial_index_pruner.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -158,13 +159,13 @@ impl SpatialIndexPruner {
         }
 
         let (folded, _) = ConstantFolder::fold_with_domain(
-            self.expr.clone(),
+            Cow::Borrowed(&self.expr),
             &domains,
             &self.func_ctx,
             &BUILTIN_FUNCTIONS,
         );
         Ok(matches!(
-            folded,
+            folded.as_ref(),
             Expr::Constant(Constant {
                 scalar: Scalar::Boolean(false),
                 ..

--- a/src/query/storages/fuse/src/pruning/spatial_index_pruner.rs
+++ b/src/query/storages/fuse/src/pruning/spatial_index_pruner.rs
@@ -158,7 +158,7 @@ impl SpatialIndexPruner {
         }
 
         let (folded, _) = ConstantFolder::fold_with_domain(
-            &self.expr,
+            self.expr.clone(),
             &domains,
             &self.func_ctx,
             &BUILTIN_FUNCTIONS,

--- a/src/query/storages/fuse/src/statistics/cluster_statistics.rs
+++ b/src/query/storages/fuse/src/statistics/cluster_statistics.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -732,7 +733,7 @@ pub(crate) fn get_min_max_stats(
             .collect();
 
         let (_, domain_opt) = ConstantFolder::fold_with_domain(
-            prepared_expr.expr.clone(),
+            Cow::Borrowed(&prepared_expr.expr),
             &input_domains,
             &func_ctx,
             &BUILTIN_FUNCTIONS,

--- a/src/query/storages/fuse/src/statistics/cluster_statistics.rs
+++ b/src/query/storages/fuse/src/statistics/cluster_statistics.rs
@@ -732,7 +732,7 @@ pub(crate) fn get_min_max_stats(
             .collect();
 
         let (_, domain_opt) = ConstantFolder::fold_with_domain(
-            &prepared_expr.expr,
+            prepared_expr.expr.clone(),
             &input_domains,
             &func_ctx,
             &BUILTIN_FUNCTIONS,

--- a/src/query/storages/system/src/locks_table.rs
+++ b/src/query/storages/system/src/locks_table.rs
@@ -100,15 +100,16 @@ impl AsyncSystemTable for LocksTable {
                     )?;
 
                     for scalars in leveld_results {
-                        for r in scalars.iter() {
+                        for r in scalars {
+                            let data_type = r.as_ref().infer_data_type();
                             let e = Expr::Constant(Constant {
                                 span: None,
-                                scalar: r.clone(),
-                                data_type: r.as_ref().infer_data_type(),
+                                scalar: r,
+                                data_type,
                             });
 
                             if let Ok(s) =
-                                check_number::<u64, usize>(None, &func_ctx, &e, &BUILTIN_FUNCTIONS)
+                                check_number::<u64, usize>(None, &func_ctx, e, &BUILTIN_FUNCTIONS)
                             {
                                 table_ids.push(s);
                             }

--- a/src/query/storages/system/src/tables_table.rs
+++ b/src/query/storages/system/src/tables_table.rs
@@ -641,31 +641,33 @@ where TablesTable<WITH_HISTORY, WITHOUT_VIEW>: HistoryAware
                     &BUILTIN_FUNCTIONS,
                 )?;
 
-                for (i, scalars) in leveld_results.iter().enumerate() {
+                for (i, scalars) in leveld_results.into_iter().enumerate() {
                     if i == 3 {
-                        for r in scalars.iter() {
+                        for r in scalars {
+                            let data_type = r.as_ref().infer_data_type();
                             let e = Expr::Constant(Constant {
                                 span: None,
-                                scalar: r.clone(),
-                                data_type: r.as_ref().infer_data_type(),
+                                scalar: r,
+                                data_type,
                             });
 
                             if let Ok(s) =
-                                check_number::<u64, usize>(None, &func_ctx, &e, &BUILTIN_FUNCTIONS)
+                                check_number::<u64, usize>(None, &func_ctx, e, &BUILTIN_FUNCTIONS)
                             {
                                 tables_ids.push(s);
                             }
                         }
                     } else {
-                        for r in scalars.iter() {
+                        for r in scalars {
+                            let data_type = r.as_ref().infer_data_type();
                             let e = Expr::Constant(Constant {
                                 span: None,
-                                scalar: r.clone(),
-                                data_type: r.as_ref().infer_data_type(),
+                                scalar: r,
+                                data_type,
                             });
 
                             if let Ok(s) =
-                                check_string::<usize>(None, &func_ctx, &e, &BUILTIN_FUNCTIONS)
+                                check_string::<usize>(None, &func_ctx, e, &BUILTIN_FUNCTIONS)
                             {
                                 match i {
                                     0 => catalog_name.push(s),

--- a/src/query/storages/system/src/util.rs
+++ b/src/query/storages/system/src/util.rs
@@ -52,15 +52,16 @@ pub fn extract_leveled_strings(
     let leveld_results =
         FilterHelpers::find_leveled_eq_filters(expr, level_names, func_ctx, &BUILTIN_FUNCTIONS)?;
 
-    for (i, scalars) in leveld_results.iter().enumerate() {
-        for r in scalars.iter() {
+    for (i, scalars) in leveld_results.into_iter().enumerate() {
+        for r in scalars {
+            let data_type = r.as_ref().infer_data_type();
             let e = Expr::Constant(Constant {
                 span: None,
-                scalar: r.clone(),
-                data_type: r.as_ref().infer_data_type(),
+                scalar: r,
+                data_type,
             });
 
-            if let Ok(s) = check_string::<usize>(None, func_ctx, &e, &BUILTIN_FUNCTIONS) {
+            if let Ok(s) = check_string::<usize>(None, func_ctx, e, &BUILTIN_FUNCTIONS) {
                 match i {
                     0 => res1.push(s),
                     1 => res2.push(s),

--- a/src/query/task_support/src/system_tables/task_history.rs
+++ b/src/query/task_support/src/system_tables/task_history.rs
@@ -319,15 +319,16 @@ fn extract_leveled_strings(
     let leveled_results =
         FilterHelpers::find_leveled_eq_filters(expr, level_names, func_ctx, &BUILTIN_FUNCTIONS)?;
 
-    for (i, scalars) in leveled_results.iter().enumerate() {
-        for r in scalars.iter() {
+    for (i, scalars) in leveled_results.into_iter().enumerate() {
+        for r in scalars {
+            let data_type = r.as_ref().infer_data_type();
             let e = Expr::Constant(Constant {
                 span: None,
-                scalar: r.clone(),
-                data_type: r.as_ref().infer_data_type(),
+                scalar: r,
+                data_type,
             });
 
-            if let Ok(s) = check_string::<usize>(None, func_ctx, &e, &BUILTIN_FUNCTIONS) {
+            if let Ok(s) = check_string::<usize>(None, func_ctx, e, &BUILTIN_FUNCTIONS) {
                 match i {
                     0 => res1.push(s),
                     1 => res2.push(s),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Make ConstantFolder fold and fold_with_domain consume Expr values instead of cloning borrowed expression trees
- Return explicit changed state from fold_once, removing fixpoint-wide expression equality comparisons
- Reuse owned Cast, FunctionCall, and LambdaFunctionCall nodes while rebuilding folded expressions
- Migrate callers to move expressions when ownership is available and keep explicit clones only where expressions are intentionally replayed
- Propagate the owned flow through check_string, check_number, and SQL constant-folding helpers

The fixpoint behavior is preserved because one fold can still enable another. This is an ownership and allocation refactor with no intended SQL behavior change.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent assisted with ownership-flow analysis, implementation, call-site migration, and local validation; the responsible human reviewed and directed the final diff
- Responsible human: @KKould
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20373)
<!-- Reviewable:end -->
