### PR TITLE
fix(query): preserve cast comparison operand order

### DIFF
--- a/src/query/sql/src/planner/optimizer/optimizers/operator/filter/common.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/filter/common.rs
@@ -63,160 +63,85 @@ pub fn check_float_range(min: f64, max: f64, value: &Scalar) -> (bool, f64) {
 }
 
 pub fn remove_trivial_type_cast(left: ScalarExpr, right: ScalarExpr) -> (ScalarExpr, ScalarExpr) {
-    match (&left, &right) {
+    let (argument, span, value, cast_on_left) = match (&left, &right) {
         (
             ScalarExpr::CastExpr(CastExpr { argument, .. }),
             ScalarExpr::ConstantExpr(ConstantExpr { span, value }),
-        )
-        | (
+        ) => (argument, span, value, true),
+        (
             ScalarExpr::ConstantExpr(ConstantExpr { span, value }),
             ScalarExpr::CastExpr(CastExpr { argument, .. }),
-        ) => {
-            if let ScalarExpr::BoundColumnRef(BoundColumnRef { column, .. }) = &(**argument) {
-                match *column.data_type {
-                    DataType::Number(NumberDataType::UInt8)
-                    | DataType::Nullable(box DataType::Number(NumberDataType::UInt8)) => {
-                        let (is_trivial, v) = check_uint_range(u8::MAX as u64, value);
-                        if is_trivial {
-                            return (
-                                (**argument).clone(),
-                                ScalarExpr::ConstantExpr(ConstantExpr {
-                                    span: *span,
-                                    value: Scalar::Number(NumberScalar::UInt8(v as u8)),
-                                }),
-                            );
-                        }
-                    }
-                    DataType::Number(NumberDataType::UInt16)
-                    | DataType::Nullable(box DataType::Number(NumberDataType::UInt16)) => {
-                        let (is_trivial, v) = check_uint_range(u16::MAX as u64, value);
-                        if is_trivial {
-                            return (
-                                (**argument).clone(),
-                                ScalarExpr::ConstantExpr(ConstantExpr {
-                                    span: *span,
-                                    value: Scalar::Number(NumberScalar::UInt16(v as u16)),
-                                }),
-                            );
-                        }
-                    }
-                    DataType::Number(NumberDataType::UInt32)
-                    | DataType::Nullable(box DataType::Number(NumberDataType::UInt32)) => {
-                        let (is_trivial, v) = check_uint_range(u32::MAX as u64, value);
-                        if is_trivial {
-                            return (
-                                (**argument).clone(),
-                                ScalarExpr::ConstantExpr(ConstantExpr {
-                                    span: *span,
-                                    value: Scalar::Number(NumberScalar::UInt32(v as u32)),
-                                }),
-                            );
-                        }
-                    }
-                    DataType::Number(NumberDataType::UInt64)
-                    | DataType::Nullable(box DataType::Number(NumberDataType::UInt64)) => {
-                        let (is_trivial, v) = check_uint_range(u64::MAX, value);
-                        if is_trivial {
-                            return (
-                                (**argument).clone(),
-                                ScalarExpr::ConstantExpr(ConstantExpr {
-                                    span: *span,
-                                    value: Scalar::Number(NumberScalar::UInt64(v)),
-                                }),
-                            );
-                        }
-                    }
-                    DataType::Number(NumberDataType::Int8)
-                    | DataType::Nullable(box DataType::Number(NumberDataType::Int8)) => {
-                        let (is_trivial, v) =
-                            check_int_range(i8::MIN as i64, i8::MAX as i64, value);
-                        if is_trivial {
-                            return (
-                                (**argument).clone(),
-                                ScalarExpr::ConstantExpr(ConstantExpr {
-                                    span: *span,
-                                    value: Scalar::Number(NumberScalar::Int8(v as i8)),
-                                }),
-                            );
-                        }
-                    }
-                    DataType::Number(NumberDataType::Int16)
-                    | DataType::Nullable(box DataType::Number(NumberDataType::Int16)) => {
-                        let (is_trivial, v) =
-                            check_int_range(i16::MIN as i64, i16::MAX as i64, value);
-                        if is_trivial {
-                            return (
-                                (**argument).clone(),
-                                ScalarExpr::ConstantExpr(ConstantExpr {
-                                    span: *span,
-                                    value: Scalar::Number(NumberScalar::Int16(v as i16)),
-                                }),
-                            );
-                        }
-                    }
-                    DataType::Number(NumberDataType::Int32)
-                    | DataType::Nullable(box DataType::Number(NumberDataType::Int32)) => {
-                        let (is_trivial, v) =
-                            check_int_range(i32::MIN as i64, i32::MAX as i64, value);
-                        if is_trivial {
-                            return (
-                                (**argument).clone(),
-                                ScalarExpr::ConstantExpr(ConstantExpr {
-                                    span: *span,
-                                    value: Scalar::Number(NumberScalar::Int32(v as i32)),
-                                }),
-                            );
-                        }
-                    }
-                    DataType::Number(NumberDataType::Int64)
-                    | DataType::Nullable(box DataType::Number(NumberDataType::Int64)) => {
-                        let (is_trivial, v) = check_int_range(i64::MIN, i64::MAX, value);
-                        if is_trivial {
-                            return (
-                                (**argument).clone(),
-                                ScalarExpr::ConstantExpr(ConstantExpr {
-                                    span: *span,
-                                    value: Scalar::Number(v.into()),
-                                }),
-                            );
-                        }
-                    }
-                    DataType::Number(NumberDataType::Float32)
-                    | DataType::Nullable(box DataType::Number(NumberDataType::Float32)) => {
-                        let (is_trivial, v) =
-                            check_float_range(f32::MIN as f64, f32::MAX as f64, value);
-                        if is_trivial {
-                            return (
-                                (**argument).clone(),
-                                ScalarExpr::ConstantExpr(ConstantExpr {
-                                    span: *span,
-                                    value: Scalar::Number(NumberScalar::Float32(OrderedFloat(
-                                        v as f32,
-                                    ))),
-                                }),
-                            );
-                        }
-                    }
-                    DataType::Number(NumberDataType::Float64)
-                    | DataType::Nullable(box DataType::Number(NumberDataType::Float64)) => {
-                        let (is_trivial, v) = check_float_range(f64::MIN, f64::MAX, value);
-                        if is_trivial {
-                            return (
-                                (**argument).clone(),
-                                ScalarExpr::ConstantExpr(ConstantExpr {
-                                    span: *span,
-                                    value: Scalar::Number(NumberScalar::Float64(OrderedFloat(v))),
-                                }),
-                            );
-                        }
-                    }
-                    _ => (),
-                };
-                (left, right)
-            } else {
-                (left, right)
-            }
+        ) => (argument, span, value, false),
+        _ => return (left, right),
+    };
+
+    let ScalarExpr::BoundColumnRef(BoundColumnRef { column, .. }) = &**argument else {
+        return (left, right);
+    };
+
+    let converted_value = match *column.data_type {
+        DataType::Number(NumberDataType::UInt8)
+        | DataType::Nullable(box DataType::Number(NumberDataType::UInt8)) => {
+            let (is_trivial, value) = check_uint_range(u8::MAX as u64, value);
+            is_trivial.then(|| Scalar::Number(NumberScalar::UInt8(value as u8)))
         }
-        _ => (left, right),
+        DataType::Number(NumberDataType::UInt16)
+        | DataType::Nullable(box DataType::Number(NumberDataType::UInt16)) => {
+            let (is_trivial, value) = check_uint_range(u16::MAX as u64, value);
+            is_trivial.then(|| Scalar::Number(NumberScalar::UInt16(value as u16)))
+        }
+        DataType::Number(NumberDataType::UInt32)
+        | DataType::Nullable(box DataType::Number(NumberDataType::UInt32)) => {
+            let (is_trivial, value) = check_uint_range(u32::MAX as u64, value);
+            is_trivial.then(|| Scalar::Number(NumberScalar::UInt32(value as u32)))
+        }
+        DataType::Number(NumberDataType::UInt64)
+        | DataType::Nullable(box DataType::Number(NumberDataType::UInt64)) => {
+            let (is_trivial, value) = check_uint_range(u64::MAX, value);
+            is_trivial.then(|| Scalar::Number(NumberScalar::UInt64(value)))
+        }
+        DataType::Number(NumberDataType::Int8)
+        | DataType::Nullable(box DataType::Number(NumberDataType::Int8)) => {
+            let (is_trivial, value) = check_int_range(i8::MIN as i64, i8::MAX as i64, value);
+            is_trivial.then(|| Scalar::Number(NumberScalar::Int8(value as i8)))
+        }
+        DataType::Number(NumberDataType::Int16)
+        | DataType::Nullable(box DataType::Number(NumberDataType::Int16)) => {
+            let (is_trivial, value) = check_int_range(i16::MIN as i64, i16::MAX as i64, value);
+            is_trivial.then(|| Scalar::Number(NumberScalar::Int16(value as i16)))
+        }
+        DataType::Number(NumberDataType::Int32)
+        | DataType::Nullable(box DataType::Number(NumberDataType::Int32)) => {
+            let (is_trivial, value) = check_int_range(i32::MIN as i64, i32::MAX as i64, value);
+            is_trivial.then(|| Scalar::Number(NumberScalar::Int32(value as i32)))
+        }
+        DataType::Number(NumberDataType::Int64)
+        | DataType::Nullable(box DataType::Number(NumberDataType::Int64)) => {
+            let (is_trivial, value) = check_int_range(i64::MIN, i64::MAX, value);
+            is_trivial.then(|| Scalar::Number(value.into()))
+        }
+        DataType::Number(NumberDataType::Float32)
+        | DataType::Nullable(box DataType::Number(NumberDataType::Float32)) => {
+            let (is_trivial, value) = check_float_range(f32::MIN as f64, f32::MAX as f64, value);
+            is_trivial.then(|| Scalar::Number(NumberScalar::Float32(OrderedFloat(value as f32))))
+        }
+        DataType::Number(NumberDataType::Float64)
+        | DataType::Nullable(box DataType::Number(NumberDataType::Float64)) => {
+            let (is_trivial, value) = check_float_range(f64::MIN, f64::MAX, value);
+            is_trivial.then(|| Scalar::Number(NumberScalar::Float64(OrderedFloat(value))))
+        }
+        _ => None,
+    };
+
+    let Some(value) = converted_value else {
+        return (left, right);
+    };
+    let constant = ScalarExpr::ConstantExpr(ConstantExpr { span: *span, value });
+
+    // Preserve operand order because this helper does not own the comparison operator.
+    if cast_on_left {
+        ((**argument).clone(), constant)
+    } else {
+        (constant, (**argument).clone())
     }
 }

--- a/tests/sqllogictests/suites/query/filter.test
+++ b/tests/sqllogictests/suites/query/filter.test
@@ -239,3 +239,33 @@ drop table if exists t;
 
 statement ok
 drop table if exists t2;
+
+# issue 20359
+
+statement ok
+create or replace table t(v int);
+
+statement ok
+insert into t values (5), (10), (15), (25);
+
+query I
+select v from t where 10 <= cast(v as int32) group by v order by v;
+----
+10
+15
+25
+
+query I
+select v from t where 10 < try_cast(v as int32) group by v order by v;
+----
+15
+25
+
+query I
+select v from t where cast(v as int32) <= 10 group by v order by v;
+----
+5
+10
+
+statement ok
+drop table t;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

`remove_trivial_type_cast` matched both operand orders of a comparison in a single or-pattern arm and always returned `(column, constant)`. Because the helper only rewrites operands and never sees the comparison operator, `10 <= CAST(v AS INT32)` was rewritten to `v <= 10`, silently inverting the predicate direction. Only the WHERE-filter path was affected, since that is where `InferFilterOptimizer` and `EquivalentConstantsVisitor` call this helper.

The fix tracks which side held the cast and restores that side when returning, so operand order is preserved and the operator stays valid. The per-type range checks are unchanged; the match arms now produce an `Option<Scalar>` instead of early-returning, which removes the duplicated construction code.

- fixes: #20359

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Logic test in `tests/sqllogictests/suites/query/filter.test` covers the issue query `10 <= cast(v as int32)`, the `try_cast` spelling, and the already-correct `cast(v as int32) <= 10` direction to guard the operand order in both directions.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: Root cause analysis of the operand-order bug in the filter optimizer helper, the rewrite of `remove_trivial_type_cast`, and the accompanying sqllogic test.
- Responsible human: @youngsofun
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20375)
<!-- Reviewable:end -->
