### PR TITLE
fix(query): record early client close as LogType::Closed

### DIFF
--- a/src/query/service/src/interpreters/common/query_log.rs
+++ b/src/query/service/src/interpreters/common/query_log.rs
@@ -53,28 +53,13 @@ fn error_fields<C>(log_type: LogType, err: Option<ErrorCode<C>>) -> (LogType, i3
     match err {
         None => (log_type, 0, "".to_string(), "".to_string()),
         Some(e) => {
-            if e.code() == ErrorCode::ABORTED_QUERY {
-                (
-                    LogType::Aborted,
-                    e.code().into(),
-                    e.to_string(),
-                    e.backtrace_str(),
-                )
-            } else if e.code() == ErrorCode::ABORTED_QUERY {
-                (
-                    LogType::Closed,
-                    e.code().into(),
-                    e.to_string(),
-                    e.backtrace_str(),
-                )
-            } else {
-                (
-                    LogType::Error,
-                    e.code().into(),
-                    e.to_string(),
-                    e.backtrace_str(),
-                )
-            }
+            let log_type = match e.code() {
+                ErrorCode::ABORTED_QUERY => LogType::Aborted,
+                ErrorCode::CLOSED_QUERY => LogType::Closed,
+                _ => LogType::Error,
+            };
+
+            (log_type, e.code().into(), e.to_string(), e.backtrace_str())
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

`error_fields` in `query_log.rs` checked `ErrorCode::ABORTED_QUERY` twice, so the `LogType::Closed` branch was dead code:

```rust
if e.code() == ErrorCode::ABORTED_QUERY {
    (LogType::Aborted, ...)
} else if e.code() == ErrorCode::ABORTED_QUERY {   // duplicate, meant CLOSED_QUERY
    (LogType::Closed, ...)
```

As a result, when a client closes a result set early (`result_set.close()` -> `/final`, `exception_code=1044`), the record fell through to the `else` branch and was written as `log_type=3` (`Error`) instead of `log_type=5` (`Closed`). Observed in `query_history`: rows with `exception_code=1044` but `log_type=3`.

That makes a normal early close indistinguishable from a genuine query failure, so audits and alerting count expected client-side closes as errors. The `LogType` enum comment already documents `Closed = 5` as "close early because client does not need more data: explicit or implicit result_set.close() -> /final", so this is the implementation diverging from the documented intent.

The duplicated condition was introduced in #15206, which added the `LogType::Closed` branch but copied the `ABORTED_QUERY` predicate, so `Closed` has never been reachable.

## Changes

Replaced the if/else-if chain with a `match` on `e.code()`, mapping `CLOSED_QUERY` to `LogType::Closed`. This also removes the triplicated tuple construction, since only the log type varied between branches.

`ErrorCode::ClosedQuery` has a single construction site, `CloseReason::Finalized` in `http_query.rs`, which is the `/final` path.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Explain why_

The change is a one-line predicate correction on an error-code-to-enum mapping. A unit test over `error_fields` would only restate the `match` arms, so it would not add meaningful coverage. Verified by compiling and running the existing `query_log` unit tests:

```
cargo test -p databend-query --lib interpreters::common::query_log
# 5 passed; 0 failed
```

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

## Rollout notes

Behavior change in `system.query_log` / `query_history`: early-close records move from `log_type=3` to `log_type=5`. Anything downstream that counts `log_type=3` as errors will see that count drop, which is the intended correction. Historical rows are not backfilled.

## AI assistance

- AI usage: An AI coding agent diagnosed the duplicated condition and applied the fix; I reviewed the final diff.
- Responsible human: @youngsofun
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20376)
<!-- Reviewable:end -->
