### PR TITLE
fix(query): re-sort re-aggregated MV blocks before recluster serialization

### DIFF
--- a/src/query/service/src/physical_plans/physical_recluster.rs
+++ b/src/query/service/src/physical_plans/physical_recluster.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::sync::Arc;
 
 use databend_common_base::runtime::GLOBAL_MEM_STAT;
 use databend_common_catalog::plan::BlockMetaOptions;
@@ -277,11 +278,25 @@ impl IPhysicalPlan for Recluster {
                     cluster_stats_gen.extra_key_num,
                 )?;
 
-                add_aggregate_state_reaggregate_transform(
+                let reaggregated = add_aggregate_state_reaggregate_transform(
                     &mut builder.main_pipeline,
                     table.engine(),
                     table.schema().as_ref(),
                 )?;
+                // Re-aggregation flushes rows in hash-table order, which
+                // breaks the ordering the merge sort just established.
+                // Re-sort each block before serialization: serialize-time
+                // cluster statistics read the first and last rows of a
+                // sorted block. Compact relies on the partial sort inside
+                // `cluster_gen_for_append` for the same guarantee.
+                if reaggregated {
+                    let resort_descs: Arc<[_]> = cluster_stats_gen.sort_descs().into();
+                    if !resort_descs.is_empty() {
+                        builder.main_pipeline.add_transformer(move || {
+                            TransformSortPartial::new(LimitType::None, resort_descs.clone())
+                        });
+                    }
+                }
 
                 builder.main_pipeline.add_transform(
                     |transform_input_port, transform_output_port| {

--- a/src/query/storages/fuse/src/operations/common/processors/transform_reaggregate_aggregate_state.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/transform_reaggregate_aggregate_state.rs
@@ -41,6 +41,17 @@ use databend_common_pipeline_transforms::processors::Transform;
 /// gathers neighboring rows into the same block. Re-aggregating that block
 /// collapses duplicate groups without rewriting the whole materialized view.
 /// Non-aggregate MVs keep `_mv_source_row_id` and skip this transform.
+///
+/// The output preserves the input column layout: the materialized view
+/// physical schema always stores aggregate state columns before group
+/// columns, matching the `[states..., groups...]` layout produced by
+/// `Payload::aggregate_flush`, and evaluated cluster key columns stay
+/// appended after the table columns as trailing group keys.
+///
+/// The output row order is unspecified: rows are flushed in hash-table
+/// order. Write paths serializing clustered data must sort each block
+/// afterwards, as compact does inside `cluster_gen_for_append` and recluster
+/// does with an explicit partial sort before `TransformSerializeBlock`.
 #[derive(Clone)]
 pub struct TransformReaggregateAggregateStateBlock {
     table_column_count: usize,
@@ -163,19 +174,25 @@ impl Transform for TransformReaggregateAggregateStateBlock {
 /// Re-aggregate that block so equal group keys collapse before serialization.
 ///
 /// Non-aggregate materialized views keep `_mv_source_row_id` and are left unchanged.
+///
+/// Returns whether the transform was added. Re-aggregation flushes rows in
+/// hash-table order, so write paths that do not already sort each block
+/// before serialization (recluster: serialize-time cluster statistics read
+/// the first and last rows of a sorted block) must re-establish the
+/// cluster-key order afterwards.
 pub fn add_aggregate_state_reaggregate_transform(
     pipeline: &mut Pipeline,
     engine: &str,
     table_schema: &TableSchema,
-) -> Result<()> {
+) -> Result<bool> {
     if !is_materialized_view_engine(engine) {
-        return Ok(());
+        return Ok(false);
     }
     let Some(transform) = TransformReaggregateAggregateStateBlock::try_create(table_schema)? else {
-        return Ok(());
+        return Ok(false);
     };
     pipeline.add_transformer(move || transform.clone());
-    Ok(())
+    Ok(true)
 }
 
 #[cfg(test)]
@@ -247,6 +264,53 @@ mod tests {
         let output = transform.transform(input)?;
         assert_eq!(output.num_rows(), 1);
         assert_eq!(output.num_columns(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn reaggregate_preserves_column_layout() -> Result<()> {
+        // Materialized view physical schemas store aggregate state columns
+        // before group columns; the transform output must keep that layout.
+        let function = AggregateFunctionFactory::instance().get(
+            "sum_state",
+            vec![],
+            vec![DataType::Number(NumberDataType::Int32)],
+            vec![],
+        )?;
+        let schema = TableSchema::new(vec![
+            TableField::new("total", infer_schema_type(&function.return_type()?)?),
+            TableField::new("category", TableDataType::String),
+        ]);
+        let mut transform = TransformReaggregateAggregateStateBlock::try_create(&schema)?
+            .expect("aggregate state schema should build a reaggregate transform");
+
+        // Two runs of the same group keys, concatenated the way a
+        // recluster-merged block interleaves rows from different source blocks.
+        let groups: Vec<String> = (0..64).map(|i| format!("key_{i:03}")).collect();
+        let group_refs: Vec<&str> = groups.iter().map(|group| group.as_str()).collect();
+        let values_a: Vec<i32> = (0..64).collect();
+        let values_b: Vec<i32> = (0..64).map(|i| i * 10).collect();
+        let first = sum_state_block(&group_refs, &values_a)?;
+        let second = sum_state_block(&group_refs, &values_b)?;
+        let input = DataBlock::concat(&[first, second])?;
+        assert_eq!(input.num_rows(), 128);
+        // Flushed state columns use the state's physical serialization type.
+        let state_type = input.get_by_offset(0).data_type();
+
+        let output = transform.transform(input)?;
+        assert_eq!(output.num_rows(), 64);
+        assert_eq!(output.num_columns(), 2);
+        // Column layout preserved: state column first, group column second.
+        assert_eq!(output.get_by_offset(0).data_type(), state_type);
+        assert_eq!(output.get_by_offset(1).data_type(), DataType::String);
+        // The flushed row order is unspecified; compare the group key set.
+        let group_column = output.get_by_offset(1).clone().into_column().unwrap();
+        let mut flushed: Vec<String> = (0..output.num_rows())
+            .map(|row| group_column.index(row).unwrap().to_string())
+            .collect();
+        flushed.sort();
+        let expected: Vec<String> = groups.iter().map(|group| format!("'{group}'")).collect();
+        assert_eq!(flushed, expected);
         Ok(())
     }
 

--- a/tests/sqllogictests/suites/ee/07_ee_materialized_view/07_0000_materialized_view.test
+++ b/tests/sqllogictests/suites/ee/07_ee_materialized_view/07_0000_materialized_view.test
@@ -422,6 +422,82 @@ drop materialized view compact_group_mv
 statement ok
 drop table compact_group_source
 
+# Recluster merges duplicate group keys and must re-sort each re-aggregated
+# block before serialization: cluster statistics read the first and last rows
+# of a sorted block, and wrong bounds would let cluster-key filters prune
+# blocks that still contain live rows.
+statement ok
+create table recluster_source (category string, amount int) change_tracking = true
+
+statement ok
+create materialized view recluster_mv (category, total_amount) cluster by (category) as
+select category, sum(amount) as total_amount
+from recluster_source
+group by category
+
+statement ok
+insert into recluster_source values ('a', 1), ('b', 2), ('c', 3), ('d', 4), ('e', 5), ('f', 6)
+
+statement ok
+refresh materialized view recluster_mv
+
+statement ok
+insert into recluster_source values ('a', 10), ('b', 20), ('c', 30), ('d', 40), ('e', 50), ('f', 60)
+
+statement ok
+refresh materialized view recluster_mv
+
+query I
+select block_count
+from fuse_snapshot('test_materialized_view', 'recluster_mv')
+order by timestamp desc
+limit 1
+----
+2
+
+statement ok
+alter materialized view recluster_mv recluster final
+
+query I
+select block_count
+from fuse_snapshot('test_materialized_view', 'recluster_mv')
+order by timestamp desc
+limit 1
+----
+1
+
+query I
+select row_count from fuse_block('test_materialized_view', 'recluster_mv')
+----
+6
+
+# Cluster-key point lookups reach the re-aggregated block through pruning.
+query TI
+select category, total_amount from recluster_mv where category = 'a'
+----
+a 11
+
+query TI
+select category, total_amount from recluster_mv where category = 'f'
+----
+f 66
+
+query TI
+select category, total_amount from recluster_mv order by category
+----
+a 11
+b 22
+c 33
+d 44
+e 55
+f 66
+
+statement ok
+drop materialized view recluster_mv
+
+statement ok
+drop table recluster_source
+
 statement ok
 unset enable_compact_after_write
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Recluster runs `TransformReaggregateAggregateStateBlock` (which collapses duplicate group keys of aggregating materialized views) **after** the merge sort, and the transform flushes rows in hash-table order. Linear cluster statistics take the **first row as min and the last row as max** of each serialized block (`clusters_statistics`), so the scrambled rows produced wrong cluster bounds — and via `cache_column_min_max` also wrong reusable column bounds. Cluster-key filters could then prune blocks that still contain live rows and silently return wrong results.

The compact path is unaffected: it re-aggregates before `cluster_gen_for_append`, whose `TransformSortPartial` re-sorts each block before serialization.

Changes:

- Document the transform output contract: the column layout is preserved (the MV physical schema always stores aggregate state columns before group columns, matching the `[states..., groups...]` layout of `Payload::aggregate_flush`), while the row order is unspecified.
- `add_aggregate_state_reaggregate_transform` now returns whether the transform was added.
- Recluster re-sorts each re-aggregated block with a partial sort before `TransformSerializeBlock`, matching the guarantee compact already gets. The hash-table configuration is left untouched.
- Unit test for the column-layout contract; ee sqllogictest covering recluster of a clustered aggregate MV with cluster-key point lookups (fails without the fix: the wrong bounds prune the only block).

## Tests

- [x] Unit Test
- [x] Logic Test

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

## AI assistance

- AI usage: Coding agent assisted with root-cause analysis of the recluster/re-aggregation ordering interaction, the fix in `physical_recluster.rs` and the transform docs/return value, and the unit/logic tests.
- Responsible human: @zhang2014
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20378)
<!-- Reviewable:end -->
