### PR TITLE
fix(storage): bound parquet row group bytes

### DIFF
--- a/src/query/storages/stage/src/append/parquet_file/writer_processor.rs
+++ b/src/query/storages/stage/src/append/parquet_file/writer_processor.rs
@@ -55,8 +55,10 @@ struct ParquetEncoder {
 }
 
 const MAX_BUFFER_SIZE: usize = 64 * 1024 * 1024;
-// this is number of rows, not size
+// Maximum number of rows in a Parquet row group.
 const MAX_ROW_GROUP_SIZE: usize = 1024 * 1024;
+// Maximum estimated encoded size of a Parquet row group.
+const MAX_ROW_GROUP_BYTES: usize = 128 * 1024 * 1024;
 
 /// Return an Arrow schema with canonical names for Parquet map entries.
 ///
@@ -198,6 +200,7 @@ fn create_writer(
         .set_compression(compression)
         .set_created_by(create_by)
         .set_max_row_group_row_count(Some(MAX_ROW_GROUP_SIZE))
+        .set_max_row_group_bytes(Some(MAX_ROW_GROUP_BYTES))
         .set_statistics_enabled(EnabledStatistics::Chunk)
         // RLE_DICTIONARY was added in Parquet 2.0 even though arrow-rs may use it with
         // WriterVersion::PARQUET_1_0. Disable dictionaries to keep value encodings at 1.0.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Bound Parquet row groups produced by `COPY INTO <location>` by both row count and estimated encoded bytes
- Flush a row group when it reaches 128 MiB instead of allowing wide schemas to accumulate until the 1,048,576-row limit
- Reduce peak memory for wide-table Parquet unloads without changing the configured output file size

Previously, Parquet unload only bounded row groups by row count. A wide table could therefore accumulate a very large in-progress row group in every parallel writer before reaching 1,048,576 rows.

This change sets `max_row_group_bytes` to 128 MiB while retaining the existing row-count limit. The limit controls the row-group encoding working set; completed row groups still accumulate in the existing file buffer until the target file size is reached.


## Tests

- [ ] Unit Test
- [ ] Logic Test
- [x] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent assisted with root-cause analysis, the row-group limit change, and the SQL A/B benchmark; the responsible human reviewed the final diff and requested PR submission
- Responsible human: @dqhl76
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20387)
<!-- Reviewable:end -->
