### PR TITLE
fix(query): flatten lambdas in correlated subqueries

### DIFF
--- a/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/flatten_scalar.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/flatten_scalar.rs
@@ -24,8 +24,11 @@ use crate::plans::AggregateFunctionScalarSortDesc;
 use crate::plans::BoundColumnRef;
 use crate::plans::CastExpr;
 use crate::plans::FunctionCall;
+use crate::plans::LambdaFunc;
 use crate::plans::ScalarExpr;
+use crate::plans::UDAFCall;
 use crate::plans::UDFCall;
+use crate::plans::UDFLambdaCall;
 
 impl SubqueryDecorrelatorOptimizer {
     #[recursive::recursive]
@@ -55,7 +58,7 @@ impl SubqueryDecorrelatorOptimizer {
                 }
                 Ok(scalar.clone())
             }
-            ScalarExpr::ConstantExpr(_) => Ok(scalar.clone()),
+            ScalarExpr::ConstantExpr(_) | ScalarExpr::TypedConstantExpr(_, _) => Ok(scalar.clone()),
             ScalarExpr::AggregateFunction(agg) => {
                 let mut args = Vec::with_capacity(agg.args.len());
                 for arg in &agg.args {
@@ -99,6 +102,21 @@ impl SubqueryDecorrelatorOptimizer {
                     return_type: func.return_type.clone(),
                 }))
             }
+            ScalarExpr::LambdaFunction(lambda) => {
+                let args = lambda
+                    .args
+                    .iter()
+                    .map(|arg| self.flatten_scalar(arg, correlated_columns, derived_columns))
+                    .collect::<Result<Vec<_>>>()?;
+                Ok(ScalarExpr::LambdaFunction(LambdaFunc {
+                    span: lambda.span,
+                    func_name: lambda.func_name.clone(),
+                    args,
+                    lambda_expr: lambda.lambda_expr.clone(),
+                    lambda_display: lambda.lambda_display.clone(),
+                    return_type: lambda.return_type.clone(),
+                }))
+            }
             ScalarExpr::CastExpr(cast_expr) => {
                 let scalar =
                     self.flatten_scalar(&cast_expr.argument, correlated_columns, derived_columns)?;
@@ -127,8 +145,40 @@ impl SubqueryDecorrelatorOptimizer {
                     arguments,
                 }))
             }
-            _ => Err(ErrorCode::Internal(
-                "Invalid scalar for flattening subquery",
+            ScalarExpr::UDAFCall(udaf) => {
+                let arguments = udaf
+                    .arguments
+                    .iter()
+                    .map(|arg| self.flatten_scalar(arg, correlated_columns, derived_columns))
+                    .collect::<Result<Vec<_>>>()?;
+                Ok(ScalarExpr::UDAFCall(UDAFCall {
+                    span: udaf.span,
+                    name: udaf.name.clone(),
+                    display_name: udaf.display_name.clone(),
+                    arg_types: udaf.arg_types.clone(),
+                    state_fields: udaf.state_fields.clone(),
+                    return_type: udaf.return_type.clone(),
+                    arguments,
+                    udf_type: udaf.udf_type.clone(),
+                }))
+            }
+            ScalarExpr::UDFLambdaCall(udf) => {
+                let scalar =
+                    self.flatten_scalar(&udf.scalar, correlated_columns, derived_columns)?;
+                Ok(ScalarExpr::UDFLambdaCall(UDFLambdaCall {
+                    span: udf.span,
+                    func_name: udf.func_name.clone(),
+                    scalar: Box::new(scalar),
+                }))
+            }
+            ScalarExpr::WindowFunction(_) => Err(ErrorCode::SemanticError(
+                "Window functions are not supported while flattening correlated subqueries",
+            )),
+            ScalarExpr::SubqueryExpr(_) => Err(ErrorCode::Internal(
+                "Nested subqueries must be decorrelated before flattening correlated subqueries",
+            )),
+            ScalarExpr::AsyncFunctionCall(_) => Err(ErrorCode::SemanticError(
+                "Async functions are not supported while flattening correlated subqueries",
             )),
         }
     }

--- a/src/query/sql/tests/it/optimizer/decorrelate_correlated_aliases.rs
+++ b/src/query/sql/tests/it/optimizer/decorrelate_correlated_aliases.rs
@@ -19,6 +19,33 @@ use crate::framework::golden::open_golden_file;
 use crate::framework::golden::setup_context;
 use crate::framework::golden::write_case_header;
 
+const TEST_UDAF_SQL: &str = r#"
+CREATE OR REPLACE FUNCTION weighted_avg (a INT, b INT) STATE { sum INT, weight INT } RETURNS FLOAT
+LANGUAGE javascript AS $$
+export function create_state() {
+    return {sum: 0, weight: 0};
+}
+export function accumulate(state, value, weight) {
+    state.sum += value * weight;
+    state.weight += weight;
+    return state;
+}
+export function retract(state, value, weight) {
+    state.sum -= value * weight;
+    state.weight -= weight;
+    return state;
+}
+export function merge(state1, state2) {
+    state1.sum += state2.sum;
+    state1.weight += state2.weight;
+    return state1;
+}
+export function finish(state) {
+    return state.sum / state.weight;
+}
+$$
+"#;
+
 async fn write_optimized_case(file: &mut impl std::io::Write, case: &SqlTestCase) -> Result<()> {
     let ctx = setup_context(case).await?;
     ctx.set_cluster_node_num(1);
@@ -82,6 +109,109 @@ async fn test_decorrelate_correlated_alias_regressions() -> Result<()> {
             ) AS s
             WHERE s.a = t1.a
         )
+    "#,
+        },
+        SqlTestCase {
+            name: "lambda_argument_survives_correlated_exists_decorrelation",
+            description: "Lambda-function arguments must be flattened when a correlated EXISTS projection is decorrelated.",
+            setup_sqls: &[],
+            sql: r#"
+        SELECT ref0
+        FROM (
+            SELECT t1.c0array AS ref0,
+                   EXISTS (
+                       SELECT 1
+                       FROM (VALUES (['baz', 'ab', 'baz'])) AS t66(c0array)
+                       WHERE t66.c0array = t1.c0array
+                         AND array_any(array_filter(t66.c0array, x -> x = 'baz')) = 'baz'
+                   ) AS ref1
+            FROM (VALUES (['other'])) AS t1(c0array)
+        ) AS s
+        WHERE ref1
+    "#,
+        },
+        SqlTestCase {
+            name: "correlated_lambda_argument_uses_derived_column",
+            description: "A correlated column used as a lambda-function argument must be remapped to its derived column during decorrelation.",
+            setup_sqls: &[],
+            sql: r#"
+        SELECT ref0
+        FROM (
+            SELECT t1.c0array AS ref0,
+                   EXISTS (
+                       SELECT 1
+                       FROM (VALUES (1)) AS t66(c)
+                       WHERE t66.c = 1
+                         AND array_any(array_filter(t1.c0array, x -> x = 'baz')) = 'baz'
+                   ) AS ref1
+            FROM (VALUES (['baz', 'ab'])) AS t1(c0array)
+        ) AS s
+        WHERE ref1
+    "#,
+        },
+        SqlTestCase {
+            name: "typed_constant_survives_correlated_exists_decorrelation",
+            description: "A folded scalar subquery constant must remain valid while its containing correlated EXISTS is decorrelated.",
+            setup_sqls: &[
+                "CREATE TABLE typed_constant_outer(a INT)",
+                "CREATE TABLE typed_constant_inner(b INT)",
+            ],
+            sql: r#"
+        SELECT ref0
+        FROM (
+            SELECT o.a AS ref0,
+                   EXISTS (
+                       SELECT 1
+                       FROM typed_constant_inner AS i
+                       WHERE i.b = o.a AND (SELECT true)
+                   ) AS ref1
+            FROM typed_constant_outer AS o
+        ) AS s
+        WHERE ref1
+    "#,
+        },
+        SqlTestCase {
+            name: "lambda_udf_survives_correlated_exists_decorrelation",
+            description: "An expanded SQL lambda UDF must remain valid inside a decorrelated EXISTS predicate.",
+            setup_sqls: &[
+                "CREATE TABLE lambda_udf_outer(a INT)",
+                "CREATE TABLE lambda_udf_inner(b INT)",
+                "CREATE FUNCTION is_positive AS (x) -> x > 0",
+            ],
+            sql: r#"
+        SELECT ref0
+        FROM (
+            SELECT o.a AS ref0,
+                   EXISTS (
+                       SELECT 1
+                       FROM lambda_udf_inner AS i
+                       WHERE i.b = o.a AND is_positive(i.b)
+                   ) AS ref1
+            FROM lambda_udf_outer AS o
+        ) AS s
+        WHERE ref1
+    "#,
+        },
+        SqlTestCase {
+            name: "udaf_survives_correlated_scalar_subquery_decorrelation",
+            description: "A UDAF and its arguments must remain valid when a correlated scalar subquery is decorrelated.",
+            setup_sqls: &[
+                "CREATE TABLE udaf_outer(a INT)",
+                "CREATE TABLE udaf_inner(b INT)",
+                TEST_UDAF_SQL,
+            ],
+            sql: r#"
+        SELECT ref0
+        FROM (
+            SELECT o.a AS ref0,
+                   (
+                       SELECT weighted_avg(i.b, 1)
+                       FROM udaf_inner AS i
+                       WHERE i.b = o.a
+                   ) AS ref1
+            FROM udaf_outer AS o
+        ) AS s
+        WHERE ref1 > 0
     "#,
         },
     ];

--- a/src/query/sql/tests/it/optimizer/decorrelate_correlated_aliases.txt
+++ b/src/query/sql/tests/it/optimizer/decorrelate_correlated_aliases.txt
@@ -155,3 +155,359 @@ Exchange(Merge)
                 └── num_rows: [1]
 
 
+=== lambda_argument_survives_correlated_exists_decorrelation ===
+description: Lambda-function arguments must be flattened when a correlated EXISTS projection is decorrelated.
+sql: 
+        SELECT ref0
+        FROM (
+            SELECT t1.c0array AS ref0,
+                   EXISTS (
+                       SELECT 1
+                       FROM (VALUES (['baz', 'ab', 'baz'])) AS t66(c0array)
+                       WHERE t66.c0array = t1.c0array
+                         AND array_any(array_filter(t66.c0array, x -> x = 'baz')) = 'baz'
+                   ) AS ref1
+            FROM (VALUES (['other'])) AS t1(c0array)
+        ) AS s
+        WHERE ref1
+    
+raw_plan:
+EvalScalar
+├── scalars: [c0array (#0) AS (#0)]
+└── Filter
+    ├── filters: [ref1 (#3)]
+    └── EvalScalar
+        ├── scalars: [c0array (#0) AS (#0), SUBQUERY AS (#2) AS (#3)]
+        ├── subquerys
+        │   └── Subquery (Exists)
+        │       ├── output_column: 1 (#2)
+        │       └── EvalScalar
+        │           ├── scalars: [1 AS (#2)]
+        │           └── Filter
+        │               ├── filters: [eq(c0array (#1), c0array (#0)), eq(array_any(array_filter(c0array (#1), ["x"] -> x (#2) = 'baz')), 'baz')]
+        │               └── ConstantTableScan
+        │                   ├── columns: [c0array (#1)]
+        │                   └── num_rows: [1]
+        └── ConstantTableScan
+            ├── columns: [c0array (#0)]
+            └── num_rows: [1]
+
+optimized_plan:
+Exchange(Merge)
+└── EvalScalar
+    ├── scalars: [c0array (#0) AS (#0), ref1 (#3) AS (#5)]
+    └── EvalScalar
+        ├── scalars: [c0array (#0) AS (#0), is_true(marker (#4)) AS (#3)]
+        └── Filter
+            ├── filters: [is_true(marker (#4))]
+            └── Join(RightMark)
+                ├── build keys: [c0array (#1)]
+                ├── probe keys: [c0array (#0)]
+                ├── other filters: []
+                ├── Exchange(Broadcast)
+                │   └── EvalScalar
+                │       ├── scalars: [c0array (#1) AS (#1), 1 AS (#2)]
+                │       └── Filter
+                │           ├── filters: [eq(array_any(array_filter(c0array (#1), ["x"] -> x (#2) = 'baz')), 'baz')]
+                │           └── ConstantTableScan
+                │               ├── columns: [c0array (#1)]
+                │               └── num_rows: [1]
+                └── ConstantTableScan
+                    ├── columns: [c0array (#0)]
+                    └── num_rows: [1]
+
+
+=== correlated_lambda_argument_uses_derived_column ===
+description: A correlated column used as a lambda-function argument must be remapped to its derived column during decorrelation.
+sql: 
+        SELECT ref0
+        FROM (
+            SELECT t1.c0array AS ref0,
+                   EXISTS (
+                       SELECT 1
+                       FROM (VALUES (1)) AS t66(c)
+                       WHERE t66.c = 1
+                         AND array_any(array_filter(t1.c0array, x -> x = 'baz')) = 'baz'
+                   ) AS ref1
+            FROM (VALUES (['baz', 'ab'])) AS t1(c0array)
+        ) AS s
+        WHERE ref1
+    
+raw_plan:
+EvalScalar
+├── scalars: [c0array (#0) AS (#0)]
+└── Filter
+    ├── filters: [ref1 (#3)]
+    └── EvalScalar
+        ├── scalars: [c0array (#0) AS (#0), SUBQUERY AS (#2) AS (#3)]
+        ├── subquerys
+        │   └── Subquery (Exists)
+        │       ├── output_column: 1 (#2)
+        │       └── EvalScalar
+        │           ├── scalars: [1 AS (#2)]
+        │           └── Filter
+        │               ├── filters: [eq(c (#1), 1), eq(array_any(array_filter(c0array (#0), ["x"] -> x (#2) = 'baz')), 'baz')]
+        │               └── ConstantTableScan
+        │                   ├── columns: [c (#1)]
+        │                   └── num_rows: [1]
+        └── ConstantTableScan
+            ├── columns: [c0array (#0)]
+            └── num_rows: [1]
+
+optimized_plan:
+Exchange(Merge)
+└── EvalScalar
+    ├── scalars: [c0array (#0) AS (#0), ref1 (#3) AS (#7)]
+    └── EvalScalar
+        ├── scalars: [c0array (#0) AS (#0), is_true(marker (#5)) AS (#3)]
+        └── Filter
+            ├── filters: [is_true(marker (#5))]
+            └── Join(RightMark)
+                ├── build keys: [c0array (#4)]
+                ├── probe keys: [c0array (#0)]
+                ├── other filters: []
+                ├── Exchange(Broadcast)
+                │   └── EvalScalar
+                │       ├── scalars: [1 AS (#2), c0array (#4) AS (#4), c (#1) AS (#6)]
+                │       └── Join(Cross)
+                │           ├── build keys: []
+                │           ├── probe keys: []
+                │           ├── other filters: []
+                │           ├── Exchange(Broadcast)
+                │           │   └── Filter
+                │           │       ├── filters: [eq(c (#1), 1)]
+                │           │       └── ConstantTableScan
+                │           │           ├── columns: [c (#1)]
+                │           │           └── num_rows: [1]
+                │           └── Aggregate(Final)
+                │               ├── group items: [c0array (#4) AS (#4)]
+                │               ├── aggregate functions: []
+                │               └── Aggregate(Partial)
+                │                   ├── group items: [c0array (#4) AS (#4)]
+                │                   ├── aggregate functions: []
+                │                   └── Exchange(Hash)
+                │                       ├── Exchange(Hash): keys: [c0array (#4)]
+                │                       └── Filter
+                │                           ├── filters: [eq(array_any(array_filter(c0array (#4), ["x"] -> x (#2) = 'baz')), 'baz')]
+                │                           └── ConstantTableScan
+                │                               ├── columns: [c0array (#4)]
+                │                               └── num_rows: [1]
+                └── ConstantTableScan
+                    ├── columns: [c0array (#0)]
+                    └── num_rows: [1]
+
+
+=== typed_constant_survives_correlated_exists_decorrelation ===
+description: A folded scalar subquery constant must remain valid while its containing correlated EXISTS is decorrelated.
+sql: 
+        SELECT ref0
+        FROM (
+            SELECT o.a AS ref0,
+                   EXISTS (
+                       SELECT 1
+                       FROM typed_constant_inner AS i
+                       WHERE i.b = o.a AND (SELECT true)
+                   ) AS ref1
+            FROM typed_constant_outer AS o
+        ) AS s
+        WHERE ref1
+    
+raw_plan:
+EvalScalar
+├── scalars: [typed_constant_outer.a (#0) AS (#0)]
+└── Filter
+    ├── filters: [ref1 (#4)]
+    └── EvalScalar
+        ├── scalars: [typed_constant_outer.a (#0) AS (#0), SUBQUERY AS (#3) AS (#4)]
+        ├── subquerys
+        │   └── Subquery (Exists)
+        │       ├── output_column: 1 (#3)
+        │       └── EvalScalar
+        │           ├── scalars: [1 AS (#3)]
+        │           └── Filter
+        │               ├── filters: [eq(typed_constant_inner.b (#1), typed_constant_outer.a (#0)), SUBQUERY AS (#2)]
+        │               ├── subquerys
+        │               │   └── Subquery (Scalar)
+        │               │       ├── output_column: TRUE (#2)
+        │               │       └── EvalScalar
+        │               │           ├── scalars: [true AS (#2)]
+        │               │           └── DummyTableScan(DummyTableScan { source_table_indexes: [] })
+        │               └── Scan
+        │                   ├── table: default.typed_constant_inner (#1)
+        │                   ├── filters: []
+        │                   ├── order by: []
+        │                   └── limit: NONE
+        └── Scan
+            ├── table: default.typed_constant_outer (#0)
+            ├── filters: []
+            ├── order by: []
+            └── limit: NONE
+
+optimized_plan:
+EvalScalar
+├── scalars: [typed_constant_outer.a (#0) AS (#0), ref1 (#4) AS (#6)]
+└── EvalScalar
+    ├── scalars: [typed_constant_outer.a (#0) AS (#0), is_true(marker (#5)) AS (#4)]
+    └── Filter
+        ├── filters: [is_true(marker (#5))]
+        └── Join(RightMark)
+            ├── build keys: [typed_constant_inner.b (#1)]
+            ├── probe keys: [typed_constant_outer.a (#0)]
+            ├── other filters: []
+            ├── EvalScalar
+            │   ├── scalars: [typed_constant_inner.b (#1) AS (#1), 1 AS (#3)]
+            │   └── Filter
+            │       ├── filters: [eq(typed_constant_inner.b (#1), typed_constant_inner.b (#1)), true]
+            │       └── Scan
+            │           ├── table: default.typed_constant_inner (#1)
+            │           ├── filters: [eq(typed_constant_inner.b (#1), typed_constant_inner.b (#1)), true]
+            │           ├── order by: []
+            │           └── limit: NONE
+            └── Scan
+                ├── table: default.typed_constant_outer (#0)
+                ├── filters: []
+                ├── order by: []
+                └── limit: NONE
+
+
+=== lambda_udf_survives_correlated_exists_decorrelation ===
+description: An expanded SQL lambda UDF must remain valid inside a decorrelated EXISTS predicate.
+sql: 
+        SELECT ref0
+        FROM (
+            SELECT o.a AS ref0,
+                   EXISTS (
+                       SELECT 1
+                       FROM lambda_udf_inner AS i
+                       WHERE i.b = o.a AND is_positive(i.b)
+                   ) AS ref1
+            FROM lambda_udf_outer AS o
+        ) AS s
+        WHERE ref1
+    
+raw_plan:
+EvalScalar
+├── scalars: [lambda_udf_outer.a (#0) AS (#0)]
+└── Filter
+    ├── filters: [ref1 (#3)]
+    └── EvalScalar
+        ├── scalars: [lambda_udf_outer.a (#0) AS (#0), SUBQUERY AS (#2) AS (#3)]
+        ├── subquerys
+        │   └── Subquery (Exists)
+        │       ├── output_column: 1 (#2)
+        │       └── EvalScalar
+        │           ├── scalars: [1 AS (#2)]
+        │           └── Filter
+        │               ├── filters: [eq(lambda_udf_inner.b (#1), lambda_udf_outer.a (#0)), is_positive(gt(lambda_udf_inner.b (#1), 0))]
+        │               └── Scan
+        │                   ├── table: default.lambda_udf_inner (#1)
+        │                   ├── filters: []
+        │                   ├── order by: []
+        │                   └── limit: NONE
+        └── Scan
+            ├── table: default.lambda_udf_outer (#0)
+            ├── filters: []
+            ├── order by: []
+            └── limit: NONE
+
+optimized_plan:
+EvalScalar
+├── scalars: [lambda_udf_outer.a (#0) AS (#0), ref1 (#3) AS (#5)]
+└── EvalScalar
+    ├── scalars: [lambda_udf_outer.a (#0) AS (#0), is_true(marker (#4)) AS (#3)]
+    └── Filter
+        ├── filters: [is_true(marker (#4))]
+        └── Join(RightMark)
+            ├── build keys: [lambda_udf_inner.b (#1)]
+            ├── probe keys: [lambda_udf_outer.a (#0)]
+            ├── other filters: []
+            ├── EvalScalar
+            │   ├── scalars: [lambda_udf_inner.b (#1) AS (#1), 1 AS (#2)]
+            │   └── Filter
+            │       ├── filters: [eq(lambda_udf_inner.b (#1), lambda_udf_inner.b (#1)), is_positive(gt(lambda_udf_inner.b (#1), 0))]
+            │       └── Scan
+            │           ├── table: default.lambda_udf_inner (#1)
+            │           ├── filters: [eq(lambda_udf_inner.b (#1), lambda_udf_inner.b (#1)), is_positive(gt(lambda_udf_inner.b (#1), 0))]
+            │           ├── order by: []
+            │           └── limit: NONE
+            └── Scan
+                ├── table: default.lambda_udf_outer (#0)
+                ├── filters: []
+                ├── order by: []
+                └── limit: NONE
+
+
+=== udaf_survives_correlated_scalar_subquery_decorrelation ===
+description: A UDAF and its arguments must remain valid when a correlated scalar subquery is decorrelated.
+sql: 
+        SELECT ref0
+        FROM (
+            SELECT o.a AS ref0,
+                   (
+                       SELECT weighted_avg(i.b, 1)
+                       FROM udaf_inner AS i
+                       WHERE i.b = o.a
+                   ) AS ref1
+            FROM udaf_outer AS o
+        ) AS s
+        WHERE ref1 > 0
+    
+raw_plan:
+EvalScalar
+├── scalars: [udaf_outer.a (#0) AS (#0)]
+└── Filter
+    ├── filters: [gt(ref1 (#4), 0)]
+    └── EvalScalar
+        ├── scalars: [udaf_outer.a (#0) AS (#0), SUBQUERY AS (#3) AS (#4)]
+        ├── subquerys
+        │   └── Subquery (Scalar)
+        │       ├── output_column: weighted_avg(i.b, 1) (#3)
+        │       └── EvalScalar
+        │           ├── scalars: [weighted_avg(i.b, 1) (#3) AS (#3)]
+        │           └── Aggregate(Initial)
+        │               ├── group items: []
+        │               ├── aggregate functions: [weighted_avg(i.b, 1) AS (#3)]
+        │               └── EvalScalar
+        │                   ├── scalars: [udaf_inner.b (#1) AS (#1), CAST(1 AS Int32 NULL) AS (#2)]
+        │                   └── Filter
+        │                       ├── filters: [eq(udaf_inner.b (#1), udaf_outer.a (#0))]
+        │                       └── Scan
+        │                           ├── table: default.udaf_inner (#1)
+        │                           ├── filters: []
+        │                           ├── order by: []
+        │                           └── limit: NONE
+        └── Scan
+            ├── table: default.udaf_outer (#0)
+            ├── filters: []
+            ├── order by: []
+            └── limit: NONE
+
+optimized_plan:
+EvalScalar
+├── scalars: [udaf_outer.a (#0) AS (#0), weighted_avg(i.b, 1) (#3) AS (#4), weighted_avg(i.b, 1) (#3) AS (#5)]
+└── Join(Inner)
+    ├── build keys: [udaf_outer.a (#0)]
+    ├── probe keys: [udaf_inner.b (#1)]
+    ├── other filters: []
+    ├── Scan
+    │   ├── table: default.udaf_outer (#0)
+    │   ├── filters: []
+    │   ├── order by: []
+    │   └── limit: NONE
+    └── Filter
+        ├── filters: [gt(weighted_avg(i.b, 1) (#3), 0)]
+        └── Aggregate(Final)
+            ├── group items: [udaf_inner.b (#1) AS (#1)]
+            ├── aggregate functions: [weighted_avg(i.b, 1) AS (#3)]
+            └── Aggregate(Partial)
+                ├── group items: [udaf_inner.b (#1) AS (#1)]
+                ├── aggregate functions: [weighted_avg(i.b, 1) AS (#3)]
+                └── EvalScalar
+                    ├── scalars: [udaf_inner.b (#1) AS (#1), CAST(1 AS Int32 NULL) AS (#2)]
+                    └── Scan
+                        ├── table: default.udaf_inner (#1)
+                        ├── filters: [eq(udaf_inner.b (#1), udaf_inner.b (#1))]
+                        ├── order by: []
+                        └── limit: NONE
+
+

--- a/tests/sqllogictests/suites/query/subquery.test
+++ b/tests/sqllogictests/suites/query/subquery.test
@@ -1303,3 +1303,42 @@ use default;
 
 statement ok
 drop database issue_13716_subquery;
+
+# https://github.com/databendlabs/databend/issues/20380
+# Lambda-function arguments must be flattened while decorrelating a correlated subquery.
+statement ok
+create or replace database issue_20380_subquery;
+
+statement ok
+use issue_20380_subquery;
+
+statement ok
+create table t1(c0array array(varchar) null);
+
+statement ok
+create table t66(c0array array(varchar) null);
+
+statement ok
+insert into t1 values (['other']);
+
+statement ok
+insert into t66 values (['baz', 'ab', 'baz']);
+
+query ?
+select ref0 from (
+    select t1.c0array as ref0,
+           exists (
+               select 1 from t66
+               where t66.c0array = t1.c0array
+                 and array_any(array_filter(t66.c0array, x -> x = 'baz')) = 'baz'
+           ) as ref1
+    from t1
+) as s
+where ref1;
+----
+
+statement ok
+use default;
+
+statement ok
+drop database issue_20380_subquery;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Fix correlated subquery decorrelation when predicates contain lambda functions or other scalar-expression variants that were not handled by `flatten_scalar`
- Recursively remap correlated columns in `LambdaFunction`, `UDFLambdaCall`, and `UDAFCall` arguments, and preserve `TypedConstantExpr`
- Return semantic errors for unsupported window and async functions while retaining an internal error for a nested-subquery planner invariant violation
- Add optimizer golden coverage proving a lambda argument is remapped from the outer column to its derived column, plus regressions for typed constants, SQL lambda UDFs, and UDAFs
- fixes: #20380

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validated with:

- `cargo test -p databend-common-sql --test it optimizer::decorrelate_correlated_aliases::test_decorrelate_correlated_alias_regressions -- --exact --nocapture`
- `cargo check -p databend-common-sql`
- `cargo clippy -p databend-common-sql -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent investigated the decorrelator failure, drafted scalar-expression flattening support, and added optimizer golden and SQL logic regressions
- Responsible human: @youngsofun
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20389)
<!-- Reviewable:end -->
