### PR TITLE
fix(query): preserve nullable reflexive equality filters

### DIFF
--- a/src/query/sql/src/planner/optimizer/optimizers/operator/filter/infer_filter.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/filter/infer_filter.rs
@@ -189,6 +189,16 @@ impl<'a> InferFilterOptimizer<'a> {
     }
 
     pub fn add_equal_expr(&mut self, left: &ScalarExpr, right: &ScalarExpr) -> bool {
+        if left == right {
+            // Returning true tells the caller that this predicate has been absorbed and
+            // can be removed. However, a reflexive equality only forms a singleton
+            // equivalence class, so derive_predicates() will not reconstruct `expr = expr`.
+            // Removing it is valid for a non-nullable operand, but for a nullable operand
+            // the predicate is still needed to reject NULL rows. Return false so the caller
+            // keeps the original predicate.
+            return !left.data_type().is_nullable_or_null();
+        }
+
         let left_ty = left.data_type();
         let right_ty = right.data_type();
         if !common_super_type_with_conversion(left_ty.as_ref(), right_ty.as_ref())

--- a/src/query/sql/test-support/data/cases/regressions/20379_non_nullable_reflexive_equality.yaml
+++ b/src/query/sql/test-support/data/cases/regressions/20379_non_nullable_reflexive_equality.yaml
@@ -1,0 +1,7 @@
+name: "20379_non_nullable_reflexive_equality"
+description: "Non-nullable reflexive equality should still be eliminated during filter inference"
+
+sql: |
+  SELECT value
+  FROM (VALUES (1), (2)) AS t(value)
+  WHERE value = value;

--- a/src/query/sql/test-support/data/results/regressions/20379_non_nullable_reflexive_equality_optimized.txt
+++ b/src/query/sql/test-support/data/results/regressions/20379_non_nullable_reflexive_equality_optimized.txt
@@ -1,0 +1,5 @@
+Exchange(Merge)
+└── ConstantTableScan
+    ├── columns: [value (#0)]
+    └── num_rows: [2]
+

--- a/src/query/sql/test-support/data/results/regressions/20379_non_nullable_reflexive_equality_physical.txt
+++ b/src/query/sql/test-support/data/results/regressions/20379_non_nullable_reflexive_equality_physical.txt
@@ -1,0 +1,7 @@
+Exchange
+├── output columns: [value (#0)]
+├── exchange type: Merge
+└── ConstantTableScan
+    ├── output columns: [value (#0)]
+    └── column 0: [1, 2]
+

--- a/src/query/sql/test-support/data/results/regressions/20379_non_nullable_reflexive_equality_raw.txt
+++ b/src/query/sql/test-support/data/results/regressions/20379_non_nullable_reflexive_equality_raw.txt
@@ -1,0 +1,8 @@
+EvalScalar
+├── scalars: [value (#0) AS (#0)]
+└── Filter
+    ├── filters: [eq(value (#0), value (#0))]
+    └── ConstantTableScan
+        ├── columns: [value (#0)]
+        └── num_rows: [2]
+

--- a/src/query/sql/test-support/data/results/tpcds/Q01_optimized.txt
+++ b/src/query/sql/test-support/data/results/tpcds/Q01_optimized.txt
@@ -56,7 +56,7 @@ TopN
                 │       │       │                                       │       └── limit: NONE
                 │       │       │                                       └── Scan
                 │       │       │                                           ├── table: default.store_returns (#4)
-                │       │       │                                           ├── filters: []
+                │       │       │                                           ├── filters: [eq(store_returns.sr_store_sk (#103), store_returns.sr_store_sk (#103))]
                 │       │       │                                           ├── order by: []
                 │       │       │                                           └── limit: NONE
                 │       │       └── Scan

--- a/src/query/sql/test-support/data/results/tpcds/Q01_physical.txt
+++ b/src/query/sql/test-support/data/results/tpcds/Q01_physical.txt
@@ -111,7 +111,7 @@ TopN(Final)
             │       │       │                                       ├── read size: 0
             │       │       │                                       ├── partitions total: 0
             │       │       │                                       ├── partitions scanned: 0
-            │       │       │                                       ├── push downs: [filters: [], limit: NONE]
+            │       │       │                                       ├── push downs: [filters: [is_true(store_returns.sr_store_sk (#103) = store_returns.sr_store_sk (#103))], limit: NONE]
             │       │       │                                       ├── apply join filters: [#1]
             │       │       │                                       └── estimated rows: 0.00
             │       │       └── TableScan(Probe)

--- a/src/query/sql/tests/it/planner.rs
+++ b/src/query/sql/tests/it/planner.rs
@@ -138,6 +138,12 @@ const LITE_REPLAY_CASE_SPECS: &[LiteReplayCaseSpec] = &[
         default_node_num: 1,
     },
     LiteReplayCaseSpec {
+        name: "20379_non_nullable_reflexive_equality",
+        warehouse_distribution: false,
+        optimizer_skip_list: &[],
+        default_node_num: 1,
+    },
+    LiteReplayCaseSpec {
         name: "q17_histogram_join_order",
         warehouse_distribution: true,
         optimizer_skip_list: &[],

--- a/tests/sqllogictests/suites/query/issues/issue_20379.test
+++ b/tests/sqllogictests/suites/query/issues/issue_20379.test
@@ -1,0 +1,28 @@
+# GitHub issue: https://github.com/databendlabs/databend/issues/20379
+# Reflexive equality is not a tautology for nullable operands because NULL = NULL is NULL.
+
+statement ok
+DROP TABLE IF EXISTS issue_20379_reflexive_equality
+
+statement ok
+CREATE TABLE issue_20379_reflexive_equality(c TIMESTAMP NULL)
+
+statement ok
+INSERT INTO issue_20379_reflexive_equality VALUES
+    ('2020-01-01 10:00:00'),
+    ('2020-05-05 08:30:00'),
+    (NULL)
+
+# The all-NULL group must not pass HAVING.
+query I
+SELECT count(*) FROM (
+    SELECT c
+    FROM issue_20379_reflexive_equality
+    GROUP BY c
+    HAVING min(c) = min(c)
+)
+----
+2
+
+statement ok
+DROP TABLE issue_20379_reflexive_equality


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Fixes #20379.
- Preserve nullable reflexive equality predicates during filter inference so `NULL` semantics are not lost.
- Continue eliminating non-nullable reflexive equalities and keep the existing inference path unchanged for other equality predicates.
- Add a named optimizer replay case with raw, optimized, and physical goldens to explicitly protect elimination of non-nullable `x = x`.
- Update the TPC-DS Q01 logical and physical optimizer snapshots to retain the nullable self-equality filter pushed to the scan. This PR prioritizes semantic correctness and intentionally keeps that filter for now; a follow-up PR can optimize nullable `x = x` into `x IS NOT NULL`, or eliminate it when it can prove the predicate is redundant.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation performed:

- `cargo fmt --all -- --check`
- `TEST_SUBDIR=regressions cargo test --package databend-common-sql --test it -- planner::test_lite_replay_service_optimizer_cases --exact --nocapture`
- `TEST_SUBDIR=regressions cargo test --package databend-query --test it -- sql::planner::optimizer::optimizer_test::test_optimizer --exact --nocapture`
- `TEST_SUBDIR=tpcds cargo test --package databend-common-sql --test it -- planner::test_lite_replay_service_optimizer_cases --exact --nocapture`
- `cargo clippy --package databend-common-sql --tests -- -D warnings`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## Risk and performance

The optimizer only retains the original `x = x` predicate when `x` is nullable. Non-nullable self-equalities still take the existing elimination path, and other equality inference is unchanged. Retaining the nullable predicate can also push the required NULL rejection closer to a scan.

## AI assistance

- AI usage: A coding agent diagnosed the filter-inference bug, drafted the minimal optimizer fix, investigated affected optimizer snapshots, and added logic and optimizer regression coverage.
- Responsible human: @youngsofun
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20390)
<!-- Reviewable:end -->
