### PR TITLE
fix(meta): avoid embedded service port races

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4583,7 +4583,6 @@ name = "databend-common-meta-schema-api-test-suite"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "chrono",
  "databend-common-base",
  "databend-common-exception",
@@ -4593,7 +4592,6 @@ dependencies = [
  "databend-common-proto-conv",
  "databend-meta-client 260205.13.2",
  "fastrace",
- "futures-util",
  "log",
  "maplit",
 ]
@@ -4633,6 +4631,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "tonic 0.13.1",
  "tonic 0.14.5",
 ]
 
@@ -6279,6 +6278,7 @@ dependencies = [
  "hyper-util",
  "tokio",
  "tonic 0.13.1",
+ "tower 0.5.2",
 ]
 
 [[package]]

--- a/src/common/grpc/src/client_conf.rs
+++ b/src/common/grpc/src/client_conf.rs
@@ -16,6 +16,12 @@ use std::time::Duration;
 
 use semver::Version;
 
+pub const IN_PROCESS_GRPC_SCHEME: &str = "in-process://";
+
+pub fn is_in_process_grpc_address(addr: &str) -> bool {
+    addr.starts_with(IN_PROCESS_GRPC_SCHEME)
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct RpcClientTlsConfig {
     pub rpc_tls_server_root_ca_cert: String,

--- a/src/common/grpc/src/lib.rs
+++ b/src/common/grpc/src/lib.rs
@@ -14,8 +14,10 @@
 
 #![allow(clippy::uninlined_format_args)]
 
+pub use client_conf::IN_PROCESS_GRPC_SCHEME;
 pub use client_conf::RpcClientConf;
 pub use client_conf::RpcClientTlsConfig;
+pub use client_conf::is_in_process_grpc_address;
 pub use dns_resolver::ConnectionFactory;
 pub use dns_resolver::DNSResolver;
 pub use dns_resolver::DNSService;

--- a/src/meta/runtime/Cargo.toml
+++ b/src/meta/runtime/Cargo.toml
@@ -18,6 +18,7 @@ fastrace = { workspace = true }
 hyper-util = { workspace = true }
 tokio = { workspace = true }
 tonic_013 = { package = "tonic", version = "0.13.1", features = ["transport", "tls-native-roots"] }
+tower = { workspace = true }
 
 [lints]
 workspace = true

--- a/src/meta/runtime/src/in_process_grpc.rs
+++ b/src/meta/runtime/src/in_process_grpc.rs
@@ -1,0 +1,241 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::io;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::LazyLock;
+use std::sync::Mutex;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::task::Context;
+use std::task::Poll;
+use std::time::Duration;
+
+use databend_common_grpc::IN_PROCESS_GRPC_SCHEME;
+use databend_meta::runtime_api::BoxFuture;
+use databend_meta::runtime_api::Channel;
+use databend_meta::runtime_api::ChannelError;
+use databend_meta::runtime_api::TlsConfig;
+use hyper_util::rt::TokioIo;
+use tokio::io::AsyncRead;
+use tokio::io::AsyncWrite;
+use tokio::io::DuplexStream;
+use tokio::io::ReadBuf;
+use tokio::sync::mpsc;
+use tonic_013::transport::Endpoint;
+use tonic_013::transport::server::Connected;
+use tonic_013::transport::server::TcpConnectInfo;
+use tower::service_fn;
+
+const IN_PROCESS_GRPC_BUFFER_SIZE: usize = 64 * 1024;
+
+type InProcessGrpcSender = mpsc::UnboundedSender<InProcessGrpcStream>;
+
+static NEXT_IN_PROCESS_GRPC_ENDPOINT_ID: AtomicU64 = AtomicU64::new(1);
+static IN_PROCESS_GRPC_ENDPOINTS: LazyLock<Mutex<HashMap<String, InProcessGrpcSender>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// One server side of an in-process gRPC connection.
+///
+/// Tonic normally derives the peer address from a TCP stream. Embedded meta
+/// clients still call `get_client_info()`, so this stream supplies a synthetic
+/// loopback address to preserve that API contract without opening a socket.
+pub struct InProcessGrpcStream {
+    inner: DuplexStream,
+}
+
+impl AsyncRead for InProcessGrpcStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for InProcessGrpcStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+impl Connected for InProcessGrpcStream {
+    type ConnectInfo = TcpConnectInfo;
+
+    fn connect_info(&self) -> Self::ConnectInfo {
+        let loopback = SocketAddr::from(([127, 0, 0, 1], 0));
+        TcpConnectInfo {
+            local_addr: Some(loopback),
+            remote_addr: Some(loopback),
+        }
+    }
+}
+
+/// Registered endpoint for gRPC communication inside one process.
+///
+/// The endpoint owns the server-side receiver and unregisters its address on
+/// drop. Every tonic connection gets a new duplex stream, so reconnects and
+/// the meta client's connection TTL retain their normal behavior.
+pub struct InProcessGrpcEndpoint {
+    address: String,
+    incoming: Option<mpsc::UnboundedReceiver<InProcessGrpcStream>>,
+}
+
+impl InProcessGrpcEndpoint {
+    pub fn new() -> Self {
+        let id = NEXT_IN_PROCESS_GRPC_ENDPOINT_ID.fetch_add(1, Ordering::Relaxed);
+        let address = format!("{IN_PROCESS_GRPC_SCHEME}{id}");
+        let (sender, incoming) = mpsc::unbounded_channel();
+
+        IN_PROCESS_GRPC_ENDPOINTS
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(address.clone(), sender);
+
+        Self {
+            address,
+            incoming: Some(incoming),
+        }
+    }
+
+    pub fn address(&self) -> &str {
+        &self.address
+    }
+
+    pub fn take_incoming(&mut self) -> mpsc::UnboundedReceiver<InProcessGrpcStream> {
+        self.incoming
+            .take()
+            .expect("in-process gRPC incoming stream can only be taken once")
+    }
+}
+
+impl Default for InProcessGrpcEndpoint {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for InProcessGrpcEndpoint {
+    fn drop(&mut self) {
+        IN_PROCESS_GRPC_ENDPOINTS
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(&self.address);
+    }
+}
+
+pub(crate) fn connect_in_process_grpc(
+    addr: String,
+    timeout: Option<Duration>,
+    tls_config: Option<TlsConfig>,
+) -> BoxFuture<'static, Result<Channel, ChannelError>> {
+    let sender = IN_PROCESS_GRPC_ENDPOINTS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&addr)
+        .cloned();
+
+    Box::pin(async move {
+        if tls_config.is_some() {
+            return Err(ChannelError::TlsConfig {
+                action: "connecting to an in-process gRPC channel with".to_string(),
+                message: "TLS is not supported".to_string(),
+            });
+        }
+
+        let sender = sender.ok_or_else(|| ChannelError::CannotConnect {
+            uri: addr.clone(),
+            message: "in-process gRPC endpoint is not registered".to_string(),
+        })?;
+
+        let mut endpoint = Endpoint::from_static("http://[::]:0");
+        if let Some(timeout) = timeout {
+            endpoint = endpoint.timeout(timeout);
+        }
+
+        let connector = service_fn(move |_| {
+            let sender = sender.clone();
+            async move {
+                let (client, server) = tokio::io::duplex(IN_PROCESS_GRPC_BUFFER_SIZE);
+                sender
+                    .send(InProcessGrpcStream { inner: server })
+                    .map_err(|_| {
+                        io::Error::new(
+                            io::ErrorKind::ConnectionRefused,
+                            "in-process gRPC endpoint closed",
+                        )
+                    })?;
+                Ok::<_, io::Error>(TokioIo::new(client))
+            }
+        });
+
+        endpoint
+            .connect_with_connector(connector)
+            .await
+            .map_err(|e| ChannelError::CannotConnect {
+                uri: addr,
+                message: e.to_string(),
+            })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_endpoint_unregisters_on_drop() {
+        let endpoint = InProcessGrpcEndpoint::new();
+        let address = endpoint.address().to_string();
+
+        assert!(
+            IN_PROCESS_GRPC_ENDPOINTS
+                .lock()
+                .unwrap()
+                .contains_key(&address)
+        );
+        drop(endpoint);
+        assert!(
+            !IN_PROCESS_GRPC_ENDPOINTS
+                .lock()
+                .unwrap()
+                .contains_key(&address)
+        );
+    }
+
+    #[test]
+    fn test_stream_supplies_loopback_connection_info() {
+        let (_, server) = tokio::io::duplex(1);
+        let stream = InProcessGrpcStream { inner: server };
+        let info = stream.connect_info();
+
+        assert_eq!(info.local_addr(), Some(([127, 0, 0, 1], 0).into()));
+        assert_eq!(info.remote_addr(), Some(([127, 0, 0, 1], 0).into()));
+    }
+}

--- a/src/meta/runtime/src/lib.rs
+++ b/src/meta/runtime/src/lib.rs
@@ -21,6 +21,7 @@
 //! core decoupled from the query runtime.
 
 mod client_bridge;
+mod in_process_grpc;
 mod metrics;
 
 use std::future::Future;
@@ -31,6 +32,7 @@ use std::time::Duration;
 
 use databend_common_base::runtime;
 use databend_common_grpc::DNSService;
+use databend_common_grpc::is_in_process_grpc_address;
 use databend_meta::runtime_api::BoxFuture;
 use databend_meta::runtime_api::Channel;
 use databend_meta::runtime_api::ChannelError;
@@ -41,6 +43,9 @@ use databend_meta::runtime_api::TlsConfig;
 use databend_meta::runtime_api::TrackingData;
 use fastrace::collector::SpanContext;
 use hyper_util::client::legacy::connect::HttpConnector;
+pub use in_process_grpc::InProcessGrpcEndpoint;
+pub use in_process_grpc::InProcessGrpcStream;
+use in_process_grpc::connect_in_process_grpc;
 pub use metrics::DatabendMetrics;
 use tonic_013::transport::Certificate;
 use tonic_013::transport::ClientTlsConfig;
@@ -189,6 +194,10 @@ impl SpawnApi for DatabendRuntime {
         timeout: Option<Duration>,
         tls_config: Option<TlsConfig>,
     ) -> BoxFuture<'static, Result<Channel, ChannelError>> {
+        if is_in_process_grpc_address(&addr) {
+            return connect_in_process_grpc(addr, timeout, tls_config);
+        }
+
         Box::pin(async move {
             let uri = format!(
                 "{}://{}",

--- a/src/meta/schema-api-test-suite/Cargo.toml
+++ b/src/meta/schema-api-test-suite/Cargo.toml
@@ -8,7 +8,6 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-async-trait = { workspace = true }
 chrono = { workspace = true }
 databend-common-base = { workspace = true }
 databend-common-exception = { workspace = true }
@@ -18,7 +17,6 @@ databend-common-meta-app = { workspace = true }
 databend-common-proto-conv = { workspace = true }
 databend-meta-client = { workspace = true }
 fastrace = { workspace = true }
-futures-util = { workspace = true }
 log = { workspace = true }
 maplit = { workspace = true }
 

--- a/src/meta/store/Cargo.toml
+++ b/src/meta/store/Cargo.toml
@@ -23,6 +23,7 @@ tempfile = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tonic = { workspace = true }
+tonic_013 = { package = "tonic", version = "0.13.1", features = ["transport"] }
 
 [lints]
 workspace = true

--- a/src/meta/store/src/lib.rs
+++ b/src/meta/store/src/lib.rs
@@ -89,11 +89,9 @@ impl MetaStore {
     }
 
     /// Create a local meta service for testing.
-    ///
-    /// It is required to assign a base port as the port number range.
     pub async fn new_local_testing<RT: RuntimeApi>() -> Self {
         MetaStore::L(Arc::new(
-            LocalMetaService::new::<RT>("MetaStore-new-local-testing")
+            LocalMetaService::new_testing::<RT>("MetaStore-new-local-testing")
                 .await
                 .unwrap(),
         ))
@@ -217,20 +215,24 @@ impl MetaStoreProvider {
 
     pub async fn create_meta_store<RT: RuntimeApi>(&self) -> Result<MetaStore, CreationError> {
         if self.rpc_conf.local_mode() {
-            info!(
-                conf :? =(&self.rpc_conf);
-                "use embedded meta, data will be removed when process exits"
-            );
-
-            // NOTE: This can only be used for test: data will be removed when program quit.
-            Ok(MetaStore::L(Arc::new(
-                LocalMetaService::new_with_fixed_dir::<RT>(
-                    self.rpc_conf.embedded_dir.clone(),
-                    "MetaStoreProvider-created",
-                )
-                .await
-                .unwrap(),
-            )))
+            let local = match &self.rpc_conf.embedded_dir {
+                Some(dir) => {
+                    info!(conf :? =(&self.rpc_conf), path = dir; "use persistent embedded meta");
+                    LocalMetaService::new_with_fixed_dir::<RT>(
+                        dir.clone(),
+                        "MetaStoreProvider-created",
+                    )
+                    .await
+                }
+                None => {
+                    info!(
+                        conf :? =(&self.rpc_conf);
+                        "use temporary embedded meta; data will be removed when the service exits"
+                    );
+                    LocalMetaService::new_testing::<RT>("MetaStoreProvider-created").await
+                }
+            };
+            Ok(MetaStore::L(Arc::new(local.unwrap())))
         } else {
             info!(conf :? =(&self.rpc_conf); "use remote meta");
             let client = MetaGrpcClient::try_new(&self.rpc_conf)?;

--- a/src/meta/store/src/local.rs
+++ b/src/meta/store/src/local.rs
@@ -15,23 +15,39 @@
 use std::fmt;
 use std::fs;
 use std::ops::Deref;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
 use databend_base::testutil::next_port;
-use databend_meta::api::GrpcServer;
+use databend_meta::api::grpc::grpc_service::MetaServiceImpl;
 use databend_meta::configs;
+use databend_meta::meta_node::meta_handle::MetaHandle;
 use databend_meta::meta_node::meta_worker::MetaWorker;
 use databend_meta::runtime_api::RuntimeApi;
+use databend_meta::types::protobuf::meta_service_server::MetaServiceServer;
 use databend_meta_client::ClientHandle;
 use databend_meta_client::DEFAULT_GRPC_MESSAGE_SIZE;
 use databend_meta_client::MetaGrpcClient;
 use databend_meta_client::errors::CreationError;
 use databend_meta_runtime::DatabendRuntime;
+use databend_meta_runtime::InProcessGrpcEndpoint;
+use futures::StreamExt;
+use log::error;
 use log::info;
 use log::warn;
+use tokio::sync::oneshot;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use tonic_013::transport::Server;
 
-/// A container for a locally started meta service, mainly for testing purpose.
+struct InProcessGrpcServer<RT: RuntimeApi> {
+    _endpoint: InProcessGrpcEndpoint,
+    _meta_handle: Arc<MetaHandle<RT>>,
+    _shutdown_tx: oneshot::Sender<()>,
+    _join_handle: tokio::task::JoinHandle<()>,
+}
+
+/// A container for a locally started embedded meta service.
 ///
 /// The service will be shutdown if this struct is dropped.
 /// It deref to `ClientHandle` thus it can be used as a client.
@@ -43,6 +59,8 @@ pub struct LocalMetaService {
 
     pub config: configs::MetaServiceConfig,
 
+    grpc_addr: String,
+
     /// Kept alive for shutdown; dropped when `LocalMetaService` is dropped.
     _grpc_server: Option<Box<dyn Send + Sync>>,
 
@@ -51,15 +69,10 @@ pub struct LocalMetaService {
 
 impl fmt::Display for LocalMetaService {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let grpc_addr = self
-            .config
-            .grpc
-            .api_address()
-            .unwrap_or_else(|| "-".to_string());
         write!(
             f,
             "LocalMetaService({}: raft={} grpc={})",
-            self.name, self.config.raft_config.raft_api_port, grpc_addr
+            self.name, self.config.raft_config.raft_api_port, self.grpc_addr
         )
     }
 }
@@ -85,48 +98,65 @@ impl Drop for LocalMetaService {
 }
 
 impl LocalMetaService {
-    pub async fn new<RT: RuntimeApi>(name: impl fmt::Display) -> anyhow::Result<LocalMetaService> {
-        Self::new_with_fixed_dir::<RT>(None, name).await
-    }
-
-    /// Create a new Config for test, with unique port assigned
-    ///
-    /// It brings up a meta-service process with the port number based on the base_port.
-    /// If it is None, 19_000 is used.
-    /// If dir is not empty, we should persistent the dir without cleanup, this could be used in databend-local and bendpy
-    pub async fn new_with_fixed_dir<RT: RuntimeApi>(
-        dir: Option<String>,
+    /// Create an isolated embedded meta service for tests.
+    pub async fn new_testing<RT: RuntimeApi>(
         name: impl fmt::Display,
     ) -> anyhow::Result<LocalMetaService> {
         let name = name.to_string();
-        let (temp_dir, dir_path) = if let Some(dir_path) = dir {
-            (None, dir_path)
-        } else {
-            let temp_dir = tempfile::tempdir().unwrap();
-            let dir_path = format!("{}", temp_dir.path().display());
-            (Some(temp_dir), dir_path)
-        };
-
+        let temp_dir = tempfile::tempdir()?;
         let raft_port = next_port();
+        let raft_dir = temp_dir
+            .path()
+            .join(format!("{name}-{raft_port}"))
+            .join("raft_dir");
+
+        Self::create::<RT>(Some(temp_dir), name, raft_dir, raft_port).await
+    }
+
+    /// Create an embedded meta service backed by a persistent directory.
+    ///
+    /// Client RPCs use an in-process gRPC channel. Raft still starts the
+    /// listener required by `databend-meta`, but binds port 0 atomically.
+    /// The supplied directory is stable across restarts. The logical Raft port
+    /// remains the config ID even though the actual listener now binds port 0.
+    pub async fn new_with_fixed_dir<RT: RuntimeApi>(
+        dir: String,
+        name: impl fmt::Display,
+    ) -> anyhow::Result<LocalMetaService> {
+        let name = name.to_string();
+        let raft_port = next_port();
+        let raft_dir = PathBuf::from(dir).join("raft_dir");
+
+        Self::create::<RT>(None, name, raft_dir, raft_port).await
+    }
+
+    async fn create<RT: RuntimeApi>(
+        temp_dir: Option<tempfile::TempDir>,
+        name: String,
+        raft_dir: PathBuf,
+        raft_port: u16,
+    ) -> anyhow::Result<LocalMetaService> {
         let mut config = configs::MetaServiceConfig::default();
 
         config.raft_config.id = 0;
 
         config.raft_config.config_id = raft_port.to_string();
 
-        // Use a unique dir for each instance.
-        config.raft_config.raft_dir = format!("{}/{}-{}/raft_dir", dir_path, name, raft_port);
+        config.raft_config.raft_dir = raft_dir.to_string_lossy().into_owned();
 
         // By default, create a meta node instead of open an existent one.
         config.raft_config.single = true;
 
-        config.raft_config.raft_api_port = raft_port;
+        // A single embedded node does not make Raft RPCs. Let the OS assign the
+        // listener port atomically instead of probing a free port and racing a
+        // later bind in databend-meta.
+        config.raft_config.raft_api_port = 0;
         config.raft_config.raft_listen_host = "127.0.0.1".to_string();
         config.raft_config.raft_advertise_host = "localhost".to_string();
 
         let host = "127.0.0.1";
 
-        // Use OS-assigned port for gRPC
+        // The in-process server uses this config for gRPC limits, not for listening.
         config.grpc = configs::GrpcConfig::new_local(host);
 
         info!("new LocalMetaService({}) with config: {:?}", name, config);
@@ -141,18 +171,15 @@ impl LocalMetaService {
         let meta_handle = MetaWorker::create_meta_worker(config.clone(), Arc::new(runtime)).await?;
         let meta_handle = Arc::new(meta_handle);
 
-        let mut grpc_server = GrpcServer::create(&config, meta_handle);
-        grpc_server.do_start().await?;
-
-        // Update config with the actual bound port
-        config.grpc = grpc_server.grpc_config().clone();
-
-        let client = Self::grpc_client(&config).await?;
+        let grpc_server = Self::start_in_process_grpc_server::<RT>(&config, meta_handle);
+        let grpc_addr = grpc_server._endpoint.address().to_string();
+        let client = Self::grpc_client(&grpc_addr).await?;
 
         let local = LocalMetaService {
             _temp_dir: temp_dir,
             name,
             config,
+            grpc_addr,
             _grpc_server: Some(Box::new(grpc_server)),
             client,
         };
@@ -175,12 +202,50 @@ impl LocalMetaService {
         }
     }
 
-    async fn grpc_client(
+    fn start_in_process_grpc_server<RT: RuntimeApi>(
         config: &configs::MetaServiceConfig,
-    ) -> Result<Arc<ClientHandle<DatabendRuntime>>, CreationError> {
-        let addr = config.grpc.api_address().expect("gRPC port should be set");
+        meta_handle: Arc<MetaHandle<RT>>,
+    ) -> InProcessGrpcServer<RT> {
+        let mut endpoint = InProcessGrpcEndpoint::new();
+        let incoming =
+            UnboundedReceiverStream::new(endpoint.take_incoming()).map(Ok::<_, std::io::Error>);
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+        let grpc_impl = MetaServiceImpl::create(
+            *databend_meta::version::version(),
+            Arc::downgrade(&meta_handle),
+        );
+        let max_msg_size = config.grpc.max_message_size();
+        let grpc_service = MetaServiceServer::new(grpc_impl)
+            .max_decoding_message_size(max_msg_size)
+            .max_encoding_message_size(max_msg_size);
+
+        let join_handle = RT::spawn(
+            async move {
+                let result = Server::builder()
+                    .add_service(grpc_service)
+                    .serve_with_incoming_shutdown(incoming, async move {
+                        let _ = shutdown_rx.await;
+                    })
+                    .await;
+                if let Err(cause) = result {
+                    error!("embedded meta in-process gRPC server stopped: {cause}");
+                }
+            },
+            Some("embedded-meta-in-process-grpc".to_string()),
+        );
+
+        InProcessGrpcServer {
+            _endpoint: endpoint,
+            _meta_handle: meta_handle,
+            _shutdown_tx: shutdown_tx,
+            _join_handle: join_handle,
+        }
+    }
+
+    async fn grpc_client(addr: &str) -> Result<Arc<ClientHandle<DatabendRuntime>>, CreationError> {
         let client = MetaGrpcClient::<DatabendRuntime>::try_create(
-            vec![addr],
+            vec![addr.to_string()],
             "root",
             "xxx",
             None,
@@ -190,5 +255,55 @@ impl LocalMetaService {
         )?;
 
         Ok(client)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_meta::runtime_api::TokioRuntime;
+    use databend_meta_client::kvapi::KVApi;
+    use databend_meta_client::kvapi::KvApiExt;
+    use databend_meta_client::types::UpsertKV;
+
+    use super::*;
+    use crate::MetaStore;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_fixed_dir_survives_restart() -> anyhow::Result<()> {
+        let root = tempfile::tempdir()?;
+        let dir = root.path().join("meta");
+        let dir = dir.to_string_lossy().into_owned();
+        let key = "fixed-dir-restart";
+        let value = b"persistent-value";
+
+        let first =
+            LocalMetaService::new_with_fixed_dir::<TokioRuntime>(dir.clone(), "persistent-test")
+                .await?;
+        let first_raft_dir = first.config.raft_config.raft_dir.clone();
+        let logical_raft_port = first.config.raft_config.config_id.parse::<u16>()?;
+        assert_eq!(first.config.raft_config.raft_api_port, 0);
+        assert_eq!(
+            first_raft_dir,
+            root.path().join("meta/raft_dir").to_string_lossy()
+        );
+        assert_ne!(logical_raft_port, 0);
+        let first = MetaStore::L(Arc::new(first));
+        first.upsert_kv(UpsertKV::update(key, value)).await?;
+        drop(first);
+
+        // Dropping the service signals its background server and Meta worker.
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let second =
+            LocalMetaService::new_with_fixed_dir::<TokioRuntime>(dir, "persistent-test").await?;
+        assert_eq!(second.config.raft_config.raft_dir, first_raft_dir);
+
+        let second = MetaStore::L(Arc::new(second));
+        let stored = second
+            .get_kv(key)
+            .await?
+            .expect("persisted value must exist");
+        assert_eq!(stored.data, value);
+        Ok(())
     }
 }

--- a/src/meta/store/tests/it/kv_api.rs
+++ b/src/meta/store/tests/it/kv_api.rs
@@ -23,7 +23,16 @@ struct MetaNodeUnitTestBuilder {}
 #[async_trait]
 impl kvapi::ApiBuilder<MetaStore> for MetaNodeUnitTestBuilder {
     async fn build(&self) -> MetaStore {
-        MetaStore::new_local_testing::<TokioRuntime>().await
+        let store = MetaStore::new_local_testing::<TokioRuntime>().await;
+        let MetaStore::L(local) = &store else {
+            unreachable!("new_local_testing must return a local store")
+        };
+
+        assert_eq!(local.config.raft_config.raft_api_port, 0);
+        assert!(local.config.grpc.api_address().is_none());
+        assert_eq!(store.get_local_addr().await.unwrap(), "127.0.0.1:0");
+
+        store
     }
 
     async fn build_cluster(&self) -> Vec<MetaStore> {

--- a/src/query/config/src/global.rs
+++ b/src/query/config/src/global.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use databend_common_base::base::BuildInfoRef;
 use databend_common_base::base::GlobalInstance;
 use databend_common_exception::Result;
+use databend_common_grpc::is_in_process_grpc_address;
 use databend_common_storage::EndpointUrlPolicyRegistry;
 
 use crate::InnerConfig;
@@ -29,7 +30,13 @@ impl GlobalConfig {
         GlobalInstance::set(Arc::new(config.clone()));
         GlobalInstance::set(Arc::new(version));
         let mut endpoint_url_policy = config.storage.endpoint_url_policy.clone();
-        endpoint_url_policy.protected_sockets = config.meta.endpoints.clone();
+        endpoint_url_policy.protected_sockets = config
+            .meta
+            .endpoints
+            .iter()
+            .filter(|endpoint| !is_in_process_grpc_address(endpoint))
+            .cloned()
+            .collect();
         EndpointUrlPolicyRegistry::init(endpoint_url_policy)?;
         Ok(())
     }

--- a/src/query/management/tests/it/warehouse.rs
+++ b/src/query/management/tests/it/warehouse.rs
@@ -1564,7 +1564,7 @@ async fn nodes(lift: Duration, size: usize) -> Result<(MetaStore, WarehouseMgr, 
 
 async fn new_cluster_api(lift: Duration) -> Result<(MetaStore, WarehouseMgr)> {
     let test_api = MetaStore::L(Arc::new(
-        LocalMetaService::new::<DatabendRuntime>("management-test")
+        LocalMetaService::new_testing::<DatabendRuntime>("management-test")
             .await
             .unwrap(),
     ));


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Avoid port allocation races when starting embedded Meta services.
- Route embedded Meta client RPCs through an in-process gRPC channel instead of a loopback TCP listener.
- Let the OS atomically allocate the required single-node Raft listener port by binding to port `0`.
- Preserve `get_client_info()` behavior by supplying synthetic loopback connection information for in-process streams.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

<!--
See AI_POLICY.md. Agent-opened PRs are welcome; a responsible human on the author side must own the change.
The responsible human is NOT the reviewer — it is the submitter-side owner who has read the diff,
can explain each change, and will answer questions during review.
Write "None" for AI usage if no AI was involved.
-->

- AI usage: An AI coding agent assisted with implementation.
- Responsible human: @forsaken628 
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20391)
<!-- Reviewable:end -->
