### PR TITLE
fix(query): derive stats for integer string cast round trips

### DIFF
--- a/src/query/expression/src/stat_evaluator.rs
+++ b/src/query/expression/src/stat_evaluator.rs
@@ -43,6 +43,7 @@ use super::stat_distribution::StatCount;
 use super::stat_distribution::StatEstimate;
 use super::stat_distribution::StatUnaryArg;
 use crate::Constant;
+use crate::types::DataType;
 
 pub struct StatEvaluator<'a> {
     func_ctx: &'a FunctionContext,
@@ -107,12 +108,38 @@ impl<'a> StatEvaluator<'a> {
         cast: &Cast<I>,
         input_stats: &'s HashMap<I, ArgStat<'_>>,
     ) -> Result<Option<ReturnStat>> {
-        let src_type = cast.expr.data_type();
-        if cast.is_try || !classify_conversion(src_type, &cast.dest_type).is_lossless_injective() {
+        if cast.is_try {
             return Ok(None);
         }
 
-        let Some(input) = self.eval(&cast.expr, input_stats)? else {
+        let mut src_expr = cast.expr.as_ref();
+        let mut src_type = src_expr.data_type();
+        if !classify_conversion(src_type, &cast.dest_type).is_lossless_injective() {
+            // Integer/string comparisons are coerced through Decimal. If the string
+            // operand itself is a non-TRY cast from an integer, this round trip is
+            // equivalent to a direct lossless integer-to-decimal cast. Evaluating
+            // the intermediate string domain is both unnecessary and generally
+            // impossible because numeric bounds are not lexical string bounds.
+            let Expr::Cast(string_cast) = src_expr else {
+                return Ok(None);
+            };
+            let integer_type = string_cast.expr.data_type();
+            let is_integer_string_round_trip = !string_cast.is_try
+                && matches!(
+                    integer_type.remove_nullable(),
+                    DataType::Number(number) if number.is_integer()
+                )
+                && matches!(string_cast.dest_type.remove_nullable(), DataType::String)
+                && matches!(cast.dest_type.remove_nullable(), DataType::Decimal(_))
+                && classify_conversion(integer_type, &cast.dest_type).is_lossless_injective();
+            if !is_integer_string_round_trip {
+                return Ok(None);
+            }
+            src_expr = string_cast.expr.as_ref();
+            src_type = integer_type;
+        }
+
+        let Some(input) = self.eval(src_expr, input_stats)? else {
             return Ok(None);
         };
         let input = input.as_ref();

--- a/src/query/sql/src/planner/plans/eval_scalar.rs
+++ b/src/query/sql/src/planner/plans/eval_scalar.rs
@@ -301,6 +301,7 @@ mod tests {
     use databend_common_expression::stat_distribution::NdvEstimate;
     use databend_common_expression::stat_distribution::StatCount;
     use databend_common_expression::types::DataType;
+    use databend_common_expression::types::DecimalSize;
     use databend_common_expression::types::NumberDataType;
     use databend_common_expression::types::NumberScalar;
     use databend_common_statistics::StatBounds;
@@ -516,5 +517,32 @@ mod tests {
         ));
         assert!(!stats.statistics.column_stats.contains_key(&Symbol::new(2)));
         assert!(stats.statistics.column_stats.contains_key(&Symbol::new(0)));
+    }
+
+    #[test]
+    fn test_derive_stats_for_integer_string_decimal_round_trip() {
+        let decimal = DataType::Decimal(DecimalSize::new(38, 5).unwrap());
+        let integer_to_string = ScalarExpr::CastExpr(CastExpr {
+            span: None,
+            is_try: false,
+            argument: Box::new(column(0)),
+            target_type: Box::new(DataType::String),
+        });
+        let stats = derive(
+            vec![ScalarItem {
+                scalar: ScalarExpr::CastExpr(CastExpr {
+                    span: None,
+                    is_try: false,
+                    argument: Box::new(integer_to_string),
+                    target_type: Box::new(decimal),
+                }),
+                index: Symbol::new(1),
+            }],
+            HashMap::from([(Symbol::new(0), column_stat(1, 3, 3.0))]),
+        );
+
+        let derived = &stats.statistics.column_stats[&Symbol::new(1)];
+        assert_eq!(derived.ndv(), NdvEstimate::exact(3.0));
+        assert_eq!(derived.null_count(), StatCount::exact(0));
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Fix a join cardinality regression introduced by #20317 when an integer join key is explicitly cast through `STRING`
- Derive statistics for a safe `integer -> string -> decimal` round trip as the equivalent lossless integer-to-decimal cast, avoiding fallback to Cartesian-product cardinality
- Add unit coverage for the expression-statistics path; the existing standalone `join.test` case covers the SQL plan regression

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent investigated the CI regression, identified the conflicting statistics and join-key changes, and drafted the focused implementation and unit test
- Responsible human: @youngsofun
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20392)
<!-- Reviewable:end -->
