### PR TITLE
fix(query): expose unpivot columns in query block

### DIFF
--- a/src/query/sql/src/planner/binder/bind_query/bind_select.rs
+++ b/src/query/sql/src/planner/binder/bind_query/bind_select.rs
@@ -20,7 +20,6 @@ use databend_common_ast::ast::BinaryOperator;
 use databend_common_ast::ast::ColumnID;
 use databend_common_ast::ast::ColumnRef;
 use databend_common_ast::ast::Expr;
-use databend_common_ast::ast::Expr::Array;
 use databend_common_ast::ast::FunctionCall;
 use databend_common_ast::ast::GroupBy;
 use databend_common_ast::ast::Identifier;
@@ -39,7 +38,6 @@ use databend_common_ast::ast::SelectTarget;
 use databend_common_ast::ast::SetExpr;
 use databend_common_ast::ast::TableAlias;
 use databend_common_ast::ast::TableReference;
-use databend_common_ast::ast::UnpivotName;
 use databend_common_ast::visit::VisitControl;
 use databend_common_ast::visit::Visitor;
 use databend_common_ast::visit::Walk;
@@ -579,38 +577,6 @@ impl SelectRewriter {
             alias,
         }
     }
-
-    fn expr_literal_array_from_unpivot_names(names: &[UnpivotName]) -> Expr {
-        Array {
-            span: Span::default(),
-            exprs: names
-                .iter()
-                .map(|name| Expr::Literal {
-                    span: name.ident.span,
-                    value: Literal::String(
-                        name.alias.as_ref().unwrap_or(&name.ident.name).to_string(),
-                    ),
-                })
-                .collect(),
-        }
-    }
-
-    fn expr_column_ref_array_from_vec_ident(exprs: Vec<Identifier>) -> Expr {
-        Array {
-            span: Span::default(),
-            exprs: exprs
-                .into_iter()
-                .map(|expr| Expr::ColumnRef {
-                    span: None,
-                    column: ColumnRef {
-                        database: None,
-                        table: None,
-                        column: ColumnID::Name(expr),
-                    },
-                })
-                .collect(),
-        }
-    }
 }
 
 impl SelectRewriter {
@@ -642,7 +608,6 @@ impl SelectRewriter {
 
     fn rewrite(&mut self, stmt: &SelectStmt) -> Result<Option<SelectStmt>> {
         self.rewrite_pivot(stmt)?;
-        self.rewrite_unpivot(stmt)?;
         Ok(self.new_stmt.take())
     }
 
@@ -973,46 +938,6 @@ impl SelectRewriter {
         }
 
         Ok(source_query)
-    }
-
-    fn rewrite_unpivot(&mut self, stmt: &SelectStmt) -> Result<()> {
-        if stmt.from.len() != 1 {
-            return Ok(());
-        }
-        let Some(unpivot) = stmt.from[0].unpivot() else {
-            return Ok(());
-        };
-        let mut new_select_list = stmt.select_list.clone();
-        let columns = unpivot
-            .column_names
-            .iter()
-            .map(|name| name.ident.to_owned())
-            .collect::<Vec<_>>();
-        if let Some(star) = new_select_list.iter_mut().find(|target| target.is_star()) {
-            star.exclude(columns.clone());
-        };
-        new_select_list.push(Self::target_func_from_name_args(
-            Identifier::from_name(stmt.span, "unnest"),
-            vec![Self::expr_literal_array_from_unpivot_names(
-                &unpivot.column_names,
-            )],
-            Some(unpivot.unpivot_column.clone()),
-        ));
-        new_select_list.push(Self::target_func_from_name_args(
-            Identifier::from_name(stmt.span, "unnest"),
-            vec![Self::expr_column_ref_array_from_vec_ident(columns)],
-            Some(unpivot.value_column.clone()),
-        ));
-
-        if let Some(ref mut new_stmt) = self.new_stmt {
-            new_stmt.select_list = new_select_list;
-        } else {
-            self.new_stmt = Some(SelectStmt {
-                select_list: new_select_list,
-                ..stmt.clone()
-            });
-        };
-        Ok(())
     }
 }
 

--- a/src/query/sql/src/planner/binder/bind_table_reference/bind.rs
+++ b/src/query/sql/src/planner/binder/bind_table_reference/bind.rs
@@ -25,7 +25,7 @@ impl Binder {
         bind_context: &mut BindContext,
         table_ref: &TableReference,
     ) -> Result<(SExpr, BindContext)> {
-        match table_ref {
+        let (s_expr, bind_context) = match table_ref {
             TableReference::Table {
                 span,
                 table,
@@ -76,6 +76,12 @@ impl Binder {
                 alias,
             } => self.bind_location(bind_context, location, options, alias),
             TableReference::Join { join, .. } => self.bind_join(bind_context, join),
+        }?;
+
+        if let Some(unpivot) = table_ref.unpivot() {
+            self.bind_unpivot(s_expr, bind_context, unpivot)
+        } else {
+            Ok((s_expr, bind_context))
         }
     }
 }

--- a/src/query/sql/src/planner/binder/bind_table_reference/bind_unpivot.rs
+++ b/src/query/sql/src/planner/binder/bind_table_reference/bind_unpivot.rs
@@ -1,0 +1,176 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use databend_common_ast::Span;
+use databend_common_ast::ast::ColumnID;
+use databend_common_ast::ast::ColumnRef;
+use databend_common_ast::ast::Expr;
+use databend_common_ast::ast::FunctionCall;
+use databend_common_ast::ast::Identifier;
+use databend_common_ast::ast::Literal;
+use databend_common_ast::ast::SelectTarget;
+use databend_common_ast::ast::Unpivot;
+use databend_common_exception::Result;
+
+use crate::BindContext;
+use crate::ColumnBinding;
+use crate::ColumnSet;
+use crate::Visibility;
+use crate::binder::Binder;
+use crate::binder::ColumnBindingBuilder;
+use crate::optimizer::ir::SExpr;
+use crate::plans::EvalScalar;
+use crate::plans::ScalarItem;
+
+impl Binder {
+    pub(crate) fn bind_unpivot(
+        &mut self,
+        s_expr: SExpr,
+        mut bind_context: BindContext,
+        unpivot: &Unpivot,
+    ) -> Result<(SExpr, BindContext)> {
+        let targets = Self::unpivot_targets(unpivot);
+        let mut generated = self.normalize_select_list(&mut bind_context, &targets)?;
+        self.analyze_project_set_select(&mut bind_context, &mut generated)?;
+
+        let mut source_indices = ColumnSet::new();
+        for srf in &bind_context.srf_info.srfs {
+            srf.scalar.collect_used_columns(&mut source_indices);
+        }
+        let (database_name, table_name, table_index) =
+            Self::common_source_identity(&bind_context.columns, &source_indices);
+
+        let s_expr = self.bind_project_set(&mut bind_context, s_expr, false)?;
+        bind_context.srf_info = Default::default();
+        bind_context
+            .columns
+            .retain(|column| !source_indices.contains(&column.index));
+
+        let mut items = Vec::with_capacity(generated.items.len());
+        for item in generated.items {
+            let data_type = item.scalar.data_type().into_owned();
+            let index = self
+                .metadata
+                .write()
+                .add_derived_column(item.alias.clone(), data_type.clone());
+            let column = ColumnBindingBuilder::new(
+                item.alias,
+                index,
+                Box::new(data_type),
+                Visibility::Visible,
+            )
+            .database_name(database_name.clone())
+            .table_name(table_name.clone())
+            .table_index(table_index)
+            .build();
+            items.push(ScalarItem {
+                scalar: item.scalar,
+                index,
+            });
+            bind_context.add_column_binding(column);
+        }
+
+        let eval_scalar = EvalScalar { items };
+        let s_expr = SExpr::create_unary(Arc::new(eval_scalar.into()), Arc::new(s_expr));
+        Ok((s_expr, bind_context))
+    }
+
+    fn unpivot_targets(unpivot: &Unpivot) -> [SelectTarget; 2] {
+        let name_values = Expr::Array {
+            span: Span::default(),
+            exprs: unpivot
+                .column_names
+                .iter()
+                .map(|name| Expr::Literal {
+                    span: name.ident.span,
+                    value: Literal::String(
+                        name.alias.as_ref().unwrap_or(&name.ident.name).to_string(),
+                    ),
+                })
+                .collect(),
+        };
+        let column_values = Expr::Array {
+            span: Span::default(),
+            exprs: unpivot
+                .column_names
+                .iter()
+                .map(|name| Expr::ColumnRef {
+                    span: None,
+                    column: ColumnRef {
+                        database: None,
+                        table: None,
+                        column: ColumnID::Name(name.ident.clone()),
+                    },
+                })
+                .collect(),
+        };
+
+        [
+            Self::unpivot_target(name_values, unpivot.unpivot_column.clone()),
+            Self::unpivot_target(column_values, unpivot.value_column.clone()),
+        ]
+    }
+
+    fn unpivot_target(argument: Expr, alias: Identifier) -> SelectTarget {
+        SelectTarget::AliasedExpr {
+            expr: Box::new(Expr::FunctionCall {
+                span: Span::default(),
+                func: FunctionCall {
+                    distinct: false,
+                    name: Identifier::from_name(Span::default(), "unnest"),
+                    args: vec![argument],
+                    params: vec![],
+                    order_by: vec![],
+                    filter: None,
+                    window: None,
+                    lambda: None,
+                },
+            }),
+            alias: Some(alias),
+        }
+    }
+
+    fn common_source_identity(
+        columns: &[ColumnBinding],
+        source_indices: &ColumnSet,
+    ) -> (Option<String>, Option<String>, Option<crate::IndexType>) {
+        let Some(first) = columns
+            .iter()
+            .find(|column| source_indices.contains(&column.index))
+        else {
+            return (None, None, None);
+        };
+        let database_name = columns
+            .iter()
+            .filter(|column| source_indices.contains(&column.index))
+            .all(|column| column.database_name == first.database_name)
+            .then(|| first.database_name.clone())
+            .flatten();
+        let table_name = columns
+            .iter()
+            .filter(|column| source_indices.contains(&column.index))
+            .all(|column| column.table_name == first.table_name)
+            .then(|| first.table_name.clone())
+            .flatten();
+        let table_index = columns
+            .iter()
+            .filter(|column| source_indices.contains(&column.index))
+            .all(|column| column.table_index == first.table_index)
+            .then_some(first.table_index)
+            .flatten();
+        (database_name, table_name, table_index)
+    }
+}

--- a/src/query/sql/src/planner/binder/bind_table_reference/mod.rs
+++ b/src/query/sql/src/planner/binder/bind_table_reference/mod.rs
@@ -23,6 +23,7 @@ mod bind_obfuscate;
 mod bind_subquery;
 mod bind_table;
 mod bind_table_function;
+mod bind_unpivot;
 
 pub use bind_asof_join::is_range_join_condition;
 pub use bind_join::JoinConditions;

--- a/src/query/sql/tests/it/planner.rs
+++ b/src/query/sql/tests/it/planner.rs
@@ -517,6 +517,35 @@ async fn test_srf_rejects_window_argument_before_project_set_binding() -> Result
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_unpivot_binds_as_table_reference_output() -> Result<()> {
+    let ctx = LiteTableContext::create().await?;
+    ctx.register_setup_sql(
+        "CREATE TABLE repro(game_id UINT64, level UINT32, game_cnt DECIMAL(18, 2), rtp DECIMAL(18, 2))",
+    )
+    .await?;
+    ctx.register_setup_sql("CREATE TABLE all_values(jan INT, feb INT)")
+        .await?;
+
+    for sql in [
+        "SELECT game_id, level, metric, value FROM repro UNPIVOT(value FOR metric IN (game_cnt, rtp))",
+        "SELECT game_id, metric, value FROM repro UNPIVOT(value FOR metric IN (game_cnt, rtp)) WHERE metric = 'rtp'",
+        "SELECT src.game_id, src.metric, src.value FROM repro AS src(game_id, level, game_cnt, rtp) UNPIVOT(value FOR metric IN (game_cnt, rtp)) WHERE src.metric = 'rtp'",
+        "SELECT default.repro.* FROM default.repro UNPIVOT(value FOR metric IN (game_cnt, rtp)) WHERE default.repro.metric = 'rtp'",
+        "SELECT repro.game_id FROM (SELECT * FROM repro) UNPIVOT(value FOR metric IN (game_cnt, rtp))",
+        "SELECT _row_id, metric, value FROM all_values UNPIVOT(value FOR metric IN (jan, feb))",
+    ] {
+        ctx.bind_sql(sql).await?;
+    }
+
+    let err = ctx
+        .bind_sql("SELECT game_cnt FROM repro UNPIVOT(value FOR metric IN (game_cnt, rtp))")
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), 1065, "unexpected error: {err:?}");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_lambda_udf_resolves_own_parameters() -> Result<()> {
     let ctx = LiteTableContext::create().await?;
     ctx.register_setup_sql("CREATE FUNCTION f1 AS (p) -> (p)")

--- a/tests/sqllogictests/suites/query/unpivot.test
+++ b/tests/sqllogictests/suites/query/unpivot.test
@@ -26,6 +26,86 @@ ORDER BY empid;
 3	cars	April	50
 
 query ITTI
+SELECT empid, dept, month, sales
+FROM monthly_sales_1
+UNPIVOT(sales FOR month IN (jan AS 'Jan', feb AS '2', mar 'MARCH', april))
+ORDER BY empid;
+----
+1 electronics Jan 100
+1 electronics 2 200
+1 electronics MARCH 300
+1 electronics april 100
+2 clothes Jan 100
+2 clothes 2 300
+2 clothes MARCH 150
+2 clothes april 200
+3 cars Jan 200
+3 cars 2 400
+3 cars MARCH 100
+3 cars april 50
+
+query ITI
+SELECT empid, month, sales
+FROM monthly_sales_1
+UNPIVOT(sales FOR month IN (jan AS 'Jan', feb AS '2', mar 'MARCH', april))
+WHERE month = '2'
+ORDER BY empid;
+----
+1 2 200
+2 2 300
+3 2 400
+
+query ITI
+SELECT m.empid, m.month, m.sales
+FROM monthly_sales_1 AS m(empid, dept, jan, feb, mar, april)
+UNPIVOT(sales FOR month IN (jan, feb, mar, april))
+WHERE m.month = 'feb'
+ORDER BY m.empid;
+----
+1 feb 200
+2 feb 300
+3 feb 400
+
+query ITTI
+SELECT default.monthly_sales_1.*
+FROM default.monthly_sales_1
+UNPIVOT(sales FOR month IN (jan, feb, mar, april))
+WHERE default.monthly_sales_1.month = 'feb'
+ORDER BY default.monthly_sales_1.empid;
+----
+1 electronics feb 200
+2 clothes feb 300
+3 cars feb 400
+
+query I
+SELECT monthly_sales_1.empid
+FROM (SELECT * FROM monthly_sales_1)
+UNPIVOT(sales FOR month IN (jan, feb, mar, april))
+ORDER BY monthly_sales_1.empid, month;
+----
+1
+1
+1
+1
+2
+2
+2
+2
+3
+3
+3
+3
+
+query TI
+SELECT month, sales
+FROM (SELECT 10 AS jan, 20 AS feb)
+UNPIVOT(sales FOR month IN (jan, feb))
+ORDER BY month;
+----
+feb 20
+jan 10
+
+query ITTI
 SELECT empid,dept,month,sales FROM (
     SELECT * FROM monthly_sales_1
         UNPIVOT(sales FOR month IN (jan as 'Jan', feb As '2', mar 'MARCH', april))


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Fix explicit projection of columns generated by UNPIVOT in the same query block
- Make UNPIVOT-generated columns available to downstream clauses such as WHERE
- Fixes #20382

## Changes

UNPIVOT previously appended its generated columns as aliases in the user SELECT list. Sibling projection expressions could not resolve those aliases, so explicit references such as metric and value failed to bind.

The rewrite now builds an inner derived table that removes the source columns and produces the UNPIVOT name/value columns. The original SELECT and filtering clauses bind against that derived table, matching FROM-clause visibility semantics.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent investigated the binder root cause, drafted the UNPIVOT rewrite and regression tests, and prepared the PR description
- Responsible human: @KKould
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20396)
<!-- Reviewable:end -->
