### PR TITLE
refactor(storage): stream vacuum2 block gc

### DIFF
--- a/.github/actions/test_unit/action.yml
+++ b/.github/actions/test_unit/action.yml
@@ -33,8 +33,7 @@ runs:
           --no-fail-fast \
           --hide-progress-bar \
           --run-ignored only \
-          -p databend-enterprise-query \
-          --lib \
+          --workspace \
           real_s3::streaming_block_gc_across_list_pages
       env:
         DATABEND_TEST_S3_BUCKET: databend-ci

--- a/.github/actions/test_unit/action.yml
+++ b/.github/actions/test_unit/action.yml
@@ -32,10 +32,10 @@ runs:
         cargo nextest run \
           --no-fail-fast \
           --hide-progress-bar \
-          --run-ignored ignored-only \
+          --run-ignored only \
           -p databend-enterprise-query \
           --lib \
-          -E 'test(/::real_s3::/)'
+          real_s3::streaming_block_gc_across_list_pages
       env:
         DATABEND_TEST_S3_BUCKET: databend-ci
         DATABEND_TEST_S3_REGION: us-east-2

--- a/.github/actions/test_unit/action.yml
+++ b/.github/actions/test_unit/action.yml
@@ -14,7 +14,7 @@ runs:
       uses: ./.github/actions/setup_build_tool
       with:
         target: ${{ inputs.target }}
-        bypass_env_vars: RUSTFLAGS,RUSTDOCFLAGS,RUST_TEST_THREADS,RUST_LOG,RUST_BACKTRACE,RUST_MIN_STACK
+        bypass_env_vars: RUSTFLAGS,RUSTDOCFLAGS,RUST_TEST_THREADS,RUST_LOG,RUST_BACKTRACE,RUST_MIN_STACK,DATABEND_TEST_S3_BUCKET,DATABEND_TEST_S3_REGION,DATABEND_TEST_S3_ROOT
 
     - shell: bash
       run: |
@@ -24,6 +24,24 @@ runs:
         RUST_LOG: ERROR
         RUST_MIN_STACK: 33554432
         # RUST_BACKTRACE: 1
+
+    - name: Test vacuum2 streaming GC against AWS S3
+      if: env.RUNNER_PROVIDER == 'aws'
+      shell: bash
+      run: |
+        cargo nextest run \
+          --no-fail-fast \
+          --hide-progress-bar \
+          --run-ignored ignored-only \
+          -p databend-enterprise-query \
+          --lib \
+          -E 'test(/::real_s3::/)'
+      env:
+        DATABEND_TEST_S3_BUCKET: databend-ci
+        DATABEND_TEST_S3_REGION: us-east-2
+        DATABEND_TEST_S3_ROOT: stateful/vacuum2-ci/github-${{ github.run_id }}-${{ github.run_attempt }}
+        RUST_LOG: ERROR
+        RUST_MIN_STACK: 33554432
 
     - name: Upload failure
       if: failure()

--- a/src/query/ee/src/storages/fuse/operations/vacuum_table_v2.rs
+++ b/src/query/ee/src/storages/fuse/operations/vacuum_table_v2.rs
@@ -615,9 +615,14 @@ fn slice_summary<T: std::fmt::Debug>(s: &[T]) -> String {
 
 #[cfg(test)]
 mod tests {
+    use chrono::TimeZone;
     use databend_common_meta_app::schema::TableIndexType;
+    use databend_query::test_kits::TestFixture;
+    use futures_util::StreamExt;
+    use opendal::services::Memory;
 
     use super::*;
+    use crate::test_kits::context::EESetup;
 
     #[test]
     fn test_collect_block_index_locations_keeps_per_block_order() {
@@ -653,5 +658,188 @@ mod tests {
             ),
             TableMetaLocationGenerator::gen_bloom_index_location_from_block_location(&blocks[1]),
         ]);
+    }
+
+    mod memory {
+        use super::*;
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn streaming_block_gc_keeps_protected_and_cutoff_blocks() -> anyhow::Result<()> {
+            const CANDIDATE_BLOCKS: usize = VACUUM2_BLOCK_DELETE_CHUNK_SIZE + 2;
+            const BLOCK_PREFIX: &str = "1/2/_b/";
+
+            let fixture = TestFixture::setup_with_custom(EESetup::new()).await?;
+            let query_ctx = fixture.new_query_ctx().await?;
+            let ctx: Arc<dyn TableContext> = query_ctx;
+            let dal = Operator::new(Memory::default())?.finish();
+
+            let gc_root_timestamp = Utc
+                .with_ymd_and_hms(2025, 1, 2, 0, 0, 0)
+                .single()
+                .expect("valid gc-root timestamp");
+            let old_timestamp = gc_root_timestamp - chrono::Duration::minutes(2);
+            let mut candidates = Vec::with_capacity(CANDIDATE_BLOCKS);
+            for i in 0..CANDIDATE_BLOCKS {
+                let timestamp = old_timestamp + chrono::Duration::milliseconds(i as i64);
+                let uuid =
+                    databend_storages_common_table_meta::meta::uuid_from_date_time(timestamp);
+                let path = format!("{}h{}_v2.parquet", BLOCK_PREFIX, uuid.simple());
+                dal.write(&path, vec![i as u8]).await?;
+                candidates.push(path);
+            }
+
+            let protected_block = candidates[0].clone();
+            let after_cutoff_uuid = databend_storages_common_table_meta::meta::uuid_from_date_time(
+                gc_root_timestamp + chrono::Duration::seconds(1),
+            );
+            let after_cutoff_block =
+                format!("{}h{}_v2.parquet", BLOCK_PREFIX, after_cutoff_uuid.simple());
+            dal.write(&after_cutoff_block, vec![1]).await?;
+
+            let protected_blocks = HashSet::from([protected_block.clone()]);
+            let inverted_indexes = BTreeMap::new();
+            let block_gc = BlockGcContext {
+                dal: &dal,
+                ctx: &ctx,
+                table_desc: "streaming-gc-test",
+                block_location_prefix: BLOCK_PREFIX,
+                until: FuseTable::vacuum2_until_prefix(BLOCK_PREFIX, gc_root_timestamp),
+                gc_root_timestamp,
+                gc_root_meta_ts: gc_root_timestamp,
+                gc_root_blocks: &protected_blocks,
+                table_agg_index_ids: &[],
+                inverted_indexes: &inverted_indexes,
+                start: std::time::Instant::now(),
+            };
+            assert_ne!(dal.info().scheme(), Scheme::Fs);
+
+            let mut removed_files = Vec::new();
+            let stats = purge_blocks_before_gc_root(&block_gc, &mut removed_files).await?;
+
+            assert_eq!(stats.scanned_blocks, CANDIDATE_BLOCKS);
+            assert_eq!(stats.removed_blocks, CANDIDATE_BLOCKS - 1);
+            // Each removed block also contributes its derived bloom-index path.
+            assert_eq!(stats.removed_files, (CANDIDATE_BLOCKS - 1) * 2);
+            assert!(dal.exists(&protected_block).await?);
+            assert!(dal.exists(&after_cutoff_block).await?);
+            for path in candidates.iter().skip(1) {
+                assert!(!dal.exists(path).await?, "garbage block survived: {path}");
+            }
+
+            Ok(())
+        }
+    }
+
+    mod real_s3 {
+        use opendal::services::S3;
+
+        use super::*;
+
+        /// Exercises the AWS S3 continuation-token boundary while vacuum deletes the page that
+        /// was just listed. CI supplies credentials through the runner's AWS credential chain.
+        #[tokio::test(flavor = "multi_thread")]
+        #[ignore = "requires an explicitly configured real AWS S3 bucket"]
+        async fn streaming_block_gc_across_list_pages() -> anyhow::Result<()> {
+            const CANDIDATE_BLOCKS: usize = VACUUM2_BLOCK_DELETE_CHUNK_SIZE + 2;
+            const BLOCK_PREFIX: &str = "1/2/_b/";
+
+            let bucket = std::env::var("DATABEND_TEST_S3_BUCKET")?;
+            let region = std::env::var("DATABEND_TEST_S3_REGION")?;
+            let configured_root = std::env::var("DATABEND_TEST_S3_ROOT").unwrap_or_default();
+            let test_id =
+                databend_storages_common_table_meta::meta::uuid_from_date_time(Utc::now())
+                    .simple()
+                    .to_string();
+            let configured_root = configured_root.trim_matches('/');
+            let test_root = if configured_root.is_empty() {
+                format!("vacuum2/{test_id}/")
+            } else {
+                format!("{configured_root}/vacuum2/{test_id}/")
+            };
+
+            let builder = S3::default()
+                .bucket(&bucket)
+                .root(&test_root)
+                .region(&region);
+            let dal = Operator::new(builder)?.finish();
+
+            let fixture = TestFixture::setup_with_custom(EESetup::new()).await?;
+            let query_ctx = fixture.new_query_ctx().await?;
+            let ctx: Arc<dyn TableContext> = query_ctx;
+
+            let test_result: anyhow::Result<()> = async {
+                let gc_root_timestamp = Utc
+                    .with_ymd_and_hms(2025, 1, 2, 0, 0, 0)
+                    .single()
+                    .expect("valid gc-root timestamp");
+                let old_timestamp = gc_root_timestamp - chrono::Duration::minutes(2);
+                let candidates = futures_util::stream::iter(0..CANDIDATE_BLOCKS)
+                    .map(|i| {
+                        let dal = dal.clone();
+                        async move {
+                            let timestamp =
+                                old_timestamp + chrono::Duration::milliseconds(i as i64);
+                            let uuid =
+                                databend_storages_common_table_meta::meta::uuid_from_date_time(
+                                    timestamp,
+                                );
+                            let path = format!("{}h{}_v2.parquet", BLOCK_PREFIX, uuid.simple());
+                            dal.write(&path, vec![i as u8]).await?;
+                            Ok::<_, opendal::Error>(path)
+                        }
+                    })
+                    .buffered(32)
+                    .try_collect::<Vec<_>>()
+                    .await?;
+
+                // AWS S3 returns at most 1000 keys per ListObjectsV2 page. Vacuum deletes those
+                // first 1000 keys before requesting the page containing this protected key.
+                let protected_block = candidates.last().unwrap().clone();
+                let after_cutoff_uuid =
+                    databend_storages_common_table_meta::meta::uuid_from_date_time(
+                        gc_root_timestamp + chrono::Duration::seconds(1),
+                    );
+                let after_cutoff_block =
+                    format!("{}h{}_v2.parquet", BLOCK_PREFIX, after_cutoff_uuid.simple());
+                dal.write(&after_cutoff_block, vec![1]).await?;
+
+                let protected_blocks = HashSet::from([protected_block.clone()]);
+                let inverted_indexes = BTreeMap::new();
+                let block_gc = BlockGcContext {
+                    dal: &dal,
+                    ctx: &ctx,
+                    table_desc: "real-s3-streaming-gc-test",
+                    block_location_prefix: BLOCK_PREFIX,
+                    until: FuseTable::vacuum2_until_prefix(BLOCK_PREFIX, gc_root_timestamp),
+                    gc_root_timestamp,
+                    gc_root_meta_ts: gc_root_timestamp,
+                    gc_root_blocks: &protected_blocks,
+                    table_agg_index_ids: &[],
+                    inverted_indexes: &inverted_indexes,
+                    start: std::time::Instant::now(),
+                };
+                anyhow::ensure!(dal.info().scheme() == Scheme::S3, "expected an S3 operator");
+
+                let mut removed_files = Vec::new();
+                let stats = purge_blocks_before_gc_root(&block_gc, &mut removed_files).await?;
+
+                anyhow::ensure!(stats.scanned_blocks == CANDIDATE_BLOCKS);
+                anyhow::ensure!(stats.removed_blocks == CANDIDATE_BLOCKS - 1);
+                anyhow::ensure!(stats.removed_files == (CANDIDATE_BLOCKS - 1) * 2);
+                anyhow::ensure!(dal.exists(&protected_block).await?);
+                anyhow::ensure!(dal.exists(&after_cutoff_block).await?);
+                for path in candidates.iter().take(CANDIDATE_BLOCKS - 1) {
+                    anyhow::ensure!(!dal.exists(path).await?, "garbage block survived: {path}");
+                }
+
+                Ok(())
+            }
+            .await;
+
+            let cleanup_result = dal.remove_all("").await;
+            test_result?;
+            cleanup_result?;
+            Ok(())
+        }
     }
 }

--- a/src/query/ee/src/storages/fuse/operations/vacuum_table_v2.rs
+++ b/src/query/ee/src/storages/fuse/operations/vacuum_table_v2.rs
@@ -29,15 +29,65 @@ use databend_common_meta_app::schema::TableIndex;
 use databend_common_storages_fuse::FuseTable;
 use databend_common_storages_fuse::io::SegmentsIO;
 use databend_common_storages_fuse::io::TableMetaLocationGenerator;
+use databend_common_storages_fuse::operations::is_gc_candidate_segment_block;
 use databend_storages_common_cache::CacheAccessor;
 use databend_storages_common_cache::CacheManager;
 use databend_storages_common_io::Files;
 use databend_storages_common_table_meta::meta::CompactSegmentInfo;
 use databend_storages_common_table_meta::meta::Location;
+use futures_util::TryStreamExt;
 use log::info;
+use opendal::Operator;
+use opendal::Scheme;
 
 const VACUUM2_BLOCK_DELETE_CHUNK_SIZE: usize = 1000;
 const VACUUM2_SEGMENT_READ_CHUNK_SIZE: usize = 1000;
+
+/// Block GC progress counters used for status reporting.
+struct BlockGcStats {
+    /// Number of candidate block objects before protected-block filtering.
+    ///
+    /// This excludes directory entries and entries that are not eligible by the
+    /// vacuum2 cutoff/safety rule, but includes blocks that are later kept
+    /// because they are still referenced by the protected block set.
+    scanned_blocks: usize,
+    /// Number of data block objects successfully removed.
+    removed_blocks: usize,
+    /// Number of objects successfully removed, including data blocks and their
+    /// derived index files.
+    removed_files: usize,
+}
+
+/// Shared context for block-level GC.
+///
+/// Keep the safety-critical inputs in one place so the FS and object-store
+/// paths use the same gc-root cutoff, protected block set, and index metadata.
+struct BlockGcContext<'a> {
+    /// Operator used to list, stat, and delete block-related objects.
+    dal: &'a Operator,
+    /// Query context used for settings, abort checks, and status reporting.
+    ctx: &'a Arc<dyn TableContext>,
+    /// Table description used only in status/error messages.
+    table_desc: &'a str,
+    /// Prefix of the table block object directory, i.e. `_b/`.
+    block_location_prefix: &'a str,
+    /// Timestamp-derived vacuum2 object-key cutoff. Objects at or after this
+    /// prefix must not be vacuumed.
+    until: String,
+    /// GC-root snapshot timestamp used to build `until` and for status reporting.
+    gc_root_timestamp: DateTime<Utc>,
+    /// GC-root object metadata timestamp used by the common vacuum safety helper
+    /// for legacy object-key handling.
+    gc_root_meta_ts: DateTime<Utc>,
+    /// Protected data block paths that are still referenced by the gc root or refs.
+    gc_root_blocks: &'a HashSet<String>,
+    /// Aggregating index ids used to derive index object paths from data blocks.
+    table_agg_index_ids: &'a [u64],
+    /// Inverted index metadata used to derive index object paths from data blocks.
+    inverted_indexes: &'a BTreeMap<String, TableIndex>,
+    /// Start time of the block GC phase, used only for status reporting.
+    start: std::time::Instant,
+}
 
 /// GC root context derived from the owner table before ref-aware cleanup starts.
 ///
@@ -173,40 +223,6 @@ pub async fn do_vacuum2(
     ));
 
     let start = std::time::Instant::now();
-    let blocks_before_gc_root = fuse_table
-        .list_files_until_timestamp(
-            fuse_table.meta_location_generator().block_location_prefix(),
-            gc_root_timestamp,
-            false,
-            Some(gc_root_meta_ts),
-        )
-        .await?
-        .into_iter()
-        .map(|v| v.path().to_owned())
-        .collect::<Vec<_>>();
-
-    ctx.set_status_info(&format!(
-        "Listed blocks before gc_root for table {}, elapsed: {:?}, block_dir: {:?}, gc_root_timestamp: {:?}, blocks: {:?}",
-        table_info.desc,
-        start.elapsed(),
-        fuse_table.meta_location_generator().block_location_prefix(),
-        gc_root_timestamp,
-        slice_summary(&blocks_before_gc_root)
-    ));
-
-    let start = std::time::Instant::now();
-    let blocks_to_gc: Vec<String> = blocks_before_gc_root
-        .into_iter()
-        .filter(|b| !gc_root_blocks.contains(b))
-        .collect();
-    ctx.set_status_info(&format!(
-        "Filtered blocks_to_gc for table {}, elapsed: {:?}, blocks_to_gc: {:?}",
-        table_info.desc,
-        start.elapsed(),
-        slice_summary(&blocks_to_gc)
-    ));
-
-    let start = std::time::Instant::now();
     let catalog = ctx.get_default_catalog()?;
     let table_agg_index_ids = catalog
         .list_index_ids_by_table_id(ListIndexesByIdReq::new(
@@ -216,37 +232,45 @@ pub async fn do_vacuum2(
         .await?;
     let inverted_indexes = &table_info.meta.indexes;
 
-    let op = Files::create(ctx.clone(), fuse_table.get_operator());
-    let mut files_to_gc = Vec::with_capacity(
-        blocks_to_gc.len() * (table_agg_index_ids.len() + inverted_indexes.len() + 2)
-            + stats_to_gc.len()
-            + segments_to_gc.len()
-            + snapshots_to_gc.len(),
-    );
+    let mut removed_files = Vec::new();
 
     // order is important
     // indexes should be removed before their blocks, because index locations to gc are generated from block locations.
-    purge_block_chunks(
-        &op,
-        &ctx,
-        table_info.desc.as_str(),
-        &blocks_to_gc,
-        &table_agg_index_ids,
+    let block_location_prefix = fuse_table.meta_location_generator().block_location_prefix();
+    let block_gc_ctx = BlockGcContext {
+        dal: fuse_table.get_operator_ref(),
+        ctx: &ctx,
+        table_desc: table_info.desc.as_str(),
+        block_location_prefix,
+        until: FuseTable::vacuum2_until_prefix(block_location_prefix, gc_root_timestamp),
+        gc_root_timestamp,
+        gc_root_meta_ts,
+        gc_root_blocks: &gc_root_blocks,
+        table_agg_index_ids: &table_agg_index_ids,
         inverted_indexes,
-        &mut files_to_gc,
         start,
-    )
-    .await?;
+    };
+    let block_gc_stats = purge_blocks_before_gc_root(&block_gc_ctx, &mut removed_files).await?;
+    ctx.set_status_info(&format!(
+        "Filtered and removed blocks for table {}, elapsed: {:?}, blocks scanned: {}, blocks removed: {}, files removed: {}",
+        table_info.desc,
+        start.elapsed(),
+        block_gc_stats.scanned_blocks,
+        block_gc_stats.removed_blocks,
+        block_gc_stats.removed_files,
+    ));
+
+    let file_remover = Files::create(ctx.clone(), fuse_table.get_operator());
 
     // segment stats should be removed before segments.
     if !stats_to_gc.is_empty() {
-        op.remove_file_in_batch(&stats_to_gc).await?;
-        files_to_gc.extend(stats_to_gc.iter().cloned());
+        file_remover.remove_file_in_batch(&stats_to_gc).await?;
+        removed_files.extend(stats_to_gc.iter().cloned());
     }
 
     if !segments_to_gc.is_empty() {
-        op.remove_file_in_batch(&segments_to_gc).await?;
-        files_to_gc.extend(segments_to_gc.iter().cloned());
+        file_remover.remove_file_in_batch(&segments_to_gc).await?;
+        removed_files.extend(segments_to_gc.iter().cloned());
     }
 
     // Evict snapshot caches from the local node.
@@ -263,8 +287,8 @@ pub async fn do_vacuum2(
             snapshot_cache.evict(path);
         }
     }
-    op.remove_file_in_batch(&snapshots_to_gc).await?;
-    files_to_gc.extend(snapshots_to_gc.iter().cloned());
+    file_remover.remove_file_in_batch(&snapshots_to_gc).await?;
+    removed_files.extend(snapshots_to_gc.iter().cloned());
 
     // Legacy branch/tag refs were removed without compatibility guarantees.
     // Vacuum2 cleans up the old ref snapshot prefix opportunistically, and the
@@ -275,68 +299,230 @@ pub async fn do_vacuum2(
     let _ = fuse_table.get_operator().remove_all(legacy_ref_dir).await;
 
     ctx.set_status_info(&format!(
-        "Removed files for table {}, elapsed: {:?}, files_to_gc: {:?}",
+        "Removed files for table {}, elapsed: {:?}, removed_files: {:?}",
         table_info.desc,
         start.elapsed(),
-        slice_summary(&files_to_gc),
+        slice_summary(&removed_files),
     ));
 
-    Ok(files_to_gc)
+    Ok(removed_files)
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn purge_block_chunks(
-    op: &Files,
-    ctx: &Arc<dyn TableContext>,
-    table_desc: &str,
-    blocks_to_gc: &[String],
-    table_agg_index_ids: &[u64],
-    inverted_indexes: &BTreeMap<String, TableIndex>,
-    files_to_gc: &mut Vec<String>,
-    start: std::time::Instant,
+async fn purge_blocks_before_gc_root(
+    block_gc: &BlockGcContext<'_>,
+    removed_files: &mut Vec<String>,
+) -> Result<BlockGcStats> {
+    info!("Listing block files until prefix: {}", block_gc.until);
+
+    match block_gc.dal.info().scheme() {
+        Scheme::Fs => purge_blocks_before_gc_root_fs(block_gc, removed_files).await,
+        _ => purge_blocks_before_gc_root_object_store_streaming(block_gc, removed_files).await,
+    }
+}
+
+async fn purge_blocks_before_gc_root_fs(
+    block_gc: &BlockGcContext<'_>,
+    removed_files: &mut Vec<String>,
+) -> Result<BlockGcStats> {
+    let file_remover = Files::create(Arc::clone(block_gc.ctx), block_gc.dal.clone());
+    let blocks_before_gc_root = list_gc_candidate_paths_until_prefix_fs(
+        block_gc.dal,
+        block_gc.block_location_prefix,
+        &block_gc.until,
+        block_gc.gc_root_meta_ts,
+    )
+    .await?;
+    let scanned_blocks = blocks_before_gc_root.len();
+    block_gc.ctx.set_status_info(&format!(
+        "Listed block paths before gc_root for table {}, elapsed: {:?}, block_location_prefix: {:?}, gc_root_timestamp: {:?}, blocks: {:?}",
+        block_gc.table_desc,
+        block_gc.start.elapsed(),
+        block_gc.block_location_prefix,
+        block_gc.gc_root_timestamp,
+        slice_summary(&blocks_before_gc_root)
+    ));
+
+    let mut stats = BlockGcStats {
+        scanned_blocks,
+        removed_blocks: 0,
+        removed_files: 0,
+    };
+    let mut block_chunk = Vec::with_capacity(VACUUM2_BLOCK_DELETE_CHUNK_SIZE);
+    for block_path in blocks_before_gc_root {
+        if !block_gc.gc_root_blocks.contains(&block_path) {
+            block_chunk.push(block_path);
+            if block_chunk.len() == VACUUM2_BLOCK_DELETE_CHUNK_SIZE {
+                purge_block_chunk(
+                    &file_remover,
+                    block_gc,
+                    &block_chunk,
+                    removed_files,
+                    &mut stats,
+                )
+                .await?;
+                block_chunk.clear();
+            }
+        }
+    }
+    if !block_chunk.is_empty() {
+        purge_block_chunk(
+            &file_remover,
+            block_gc,
+            &block_chunk,
+            removed_files,
+            &mut stats,
+        )
+        .await?;
+    }
+
+    Ok(stats)
+}
+
+async fn purge_blocks_before_gc_root_object_store_streaming(
+    block_gc: &BlockGcContext<'_>,
+    removed_files: &mut Vec<String>,
+) -> Result<BlockGcStats> {
+    let file_remover = Files::create(Arc::clone(block_gc.ctx), block_gc.dal.clone());
+    let mut lister = block_gc.dal.lister(block_gc.block_location_prefix).await?;
+    let mut block_chunk = Vec::with_capacity(VACUUM2_BLOCK_DELETE_CHUNK_SIZE);
+    let mut stats = BlockGcStats {
+        scanned_blocks: 0,
+        removed_blocks: 0,
+        removed_files: 0,
+    };
+
+    block_gc.ctx.set_status_info(&format!(
+        "Streaming block paths before gc_root for table {}, block_location_prefix: {:?}, gc_root_timestamp: {:?}",
+        block_gc.table_desc, block_gc.block_location_prefix, block_gc.gc_root_timestamp
+    ));
+
+    while let Some(entry) = lister.try_next().await? {
+        if entry.metadata().is_dir() {
+            continue;
+        }
+
+        let path = entry.path();
+        if path >= block_gc.until.as_str() {
+            info!("entry path: {} >= until: {}", path, block_gc.until);
+            break;
+        }
+
+        if !is_gc_candidate_segment_block(&entry, block_gc.dal, block_gc.gc_root_meta_ts).await? {
+            continue;
+        }
+
+        stats.scanned_blocks += 1;
+        if block_gc.gc_root_blocks.contains(path) {
+            continue;
+        }
+
+        block_chunk.push(path.to_owned());
+        if block_chunk.len() == VACUUM2_BLOCK_DELETE_CHUNK_SIZE {
+            purge_block_chunk(
+                &file_remover,
+                block_gc,
+                &block_chunk,
+                removed_files,
+                &mut stats,
+            )
+            .await?;
+            block_chunk.clear();
+        }
+    }
+
+    if !block_chunk.is_empty() {
+        purge_block_chunk(
+            &file_remover,
+            block_gc,
+            &block_chunk,
+            removed_files,
+            &mut stats,
+        )
+        .await?;
+    }
+
+    Ok(stats)
+}
+
+async fn list_gc_candidate_paths_until_prefix_fs(
+    dal: &Operator,
+    path: &str,
+    until: &str,
+    gc_root_meta_ts: DateTime<Utc>,
+) -> Result<Vec<String>> {
+    let mut lister = dal.lister(path).await?;
+    let mut entries = Vec::new();
+    while let Some(item) = lister.try_next().await? {
+        if item.metadata().is_file() {
+            entries.push(item);
+        }
+    }
+    entries.sort_by(|l, r| l.path().cmp(r.path()));
+
+    let mut res = Vec::new();
+    for entry in entries {
+        if entry.path() >= until {
+            info!("entry path: {} >= until: {}", entry.path(), until);
+            break;
+        }
+        if is_gc_candidate_segment_block(&entry, dal, gc_root_meta_ts).await? {
+            res.push(entry.path().to_owned());
+        }
+    }
+    Ok(res)
+}
+
+async fn purge_block_chunk(
+    file_remover: &Files,
+    block_gc: &BlockGcContext<'_>,
+    block_chunk: &[String],
+    removed_files: &mut Vec<String>,
+    stats: &mut BlockGcStats,
 ) -> Result<()> {
-    if blocks_to_gc.is_empty() {
-        return Ok(());
+    if let Err(err) = block_gc.ctx.check_aborting() {
+        return Err(err.with_context(format!(
+            "aborted while removing block chunk for table {}, blocks removed: {}, current chunk size: {}",
+            block_gc.table_desc,
+            stats.removed_blocks,
+            block_chunk.len()
+        )));
     }
 
-    let total_chunks = blocks_to_gc.len().div_ceil(VACUUM2_BLOCK_DELETE_CHUNK_SIZE);
-    for (chunk_idx, block_chunk) in blocks_to_gc
-        .chunks(VACUUM2_BLOCK_DELETE_CHUNK_SIZE)
-        .enumerate()
-    {
-        if let Err(err) = ctx.check_aborting() {
-            return Err(err.with_context("failed to vacuum block chunk"));
-        }
+    let chunk_idx = stats.removed_blocks / VACUUM2_BLOCK_DELETE_CHUNK_SIZE + 1;
+    let indexes_to_gc = collect_block_index_locations(
+        block_chunk,
+        block_gc.table_agg_index_ids,
+        block_gc.inverted_indexes,
+    );
+    block_gc.ctx.set_status_info(&format!(
+        "Collected indexes_to_gc for table {}, elapsed: {:?}, block chunk: {}, blocks in chunk: {}, indexes_to_gc: {:?}",
+        block_gc.table_desc,
+        block_gc.start.elapsed(),
+        chunk_idx,
+        block_chunk.len(),
+        slice_summary(&indexes_to_gc)
+    ));
 
-        let indexes_to_gc =
-            collect_block_index_locations(block_chunk, table_agg_index_ids, inverted_indexes);
-        ctx.set_status_info(&format!(
-            "Collected indexes_to_gc for table {}, elapsed: {:?}, block chunk: {}/{}, blocks in chunk: {}, indexes_to_gc: {:?}",
-            table_desc,
-            start.elapsed(),
-            chunk_idx + 1,
-            total_chunks,
-            block_chunk.len(),
-            slice_summary(&indexes_to_gc)
-        ));
-
-        if !indexes_to_gc.is_empty() {
-            op.remove_file_in_batch(&indexes_to_gc).await?;
-            files_to_gc.extend(indexes_to_gc);
-        }
-
-        op.remove_file_in_batch(block_chunk).await?;
-        files_to_gc.extend(block_chunk.iter().cloned());
-
-        ctx.set_status_info(&format!(
-            "Removed block chunk for table {}, elapsed: {:?}, block chunk: {}/{}, blocks removed in chunk: {}",
-            table_desc,
-            start.elapsed(),
-            chunk_idx + 1,
-            total_chunks,
-            block_chunk.len(),
-        ));
+    if !indexes_to_gc.is_empty() {
+        file_remover.remove_file_in_batch(&indexes_to_gc).await?;
+        stats.removed_files += indexes_to_gc.len();
+        removed_files.extend(indexes_to_gc);
     }
+
+    file_remover.remove_file_in_batch(block_chunk).await?;
+    stats.removed_blocks += block_chunk.len();
+    stats.removed_files += block_chunk.len();
+    removed_files.extend(block_chunk.iter().cloned());
+
+    block_gc.ctx.set_status_info(&format!(
+        "Removed block chunk for table {}, elapsed: {:?}, block chunk: {}, blocks scanned: {}, blocks removed in chunk: {}, total blocks removed: {}",
+        block_gc.table_desc,
+        block_gc.start.elapsed(),
+        chunk_idx,
+        stats.scanned_blocks,
+        block_chunk.len(),
+        stats.removed_blocks,
+    ));
 
     Ok(())
 }

--- a/src/query/ee/tests/it/storages/fuse/operations/vacuum2.rs
+++ b/src/query/ee/tests/it/storages/fuse/operations/vacuum2.rs
@@ -12,15 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
 use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
 
+use databend_common_catalog::session_type::SessionType;
+use databend_common_catalog::table::Table;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
+use databend_common_expression::DataBlock;
+use databend_common_storages_fuse::FuseTable;
+use databend_common_storages_fuse::io::SegmentsIO;
 use databend_enterprise_query::test_kits::context::EESetup;
 use databend_query::sessions::QueryContext;
 use databend_query::sessions::TableContextTableAccess;
 use databend_query::test_kits::TestFixture;
+use databend_query::test_kits::execute_command;
 use databend_storages_common_io::dedup_file_locations;
+use databend_storages_common_table_meta::meta::CompactSegmentInfo;
+use futures::TryStreamExt;
 
 // TODO investigate this
 // NOTE: SHOULD specify flavor = "multi_thread", otherwise query execution might be hanged
@@ -114,6 +125,246 @@ async fn test_vacuum2_all() -> anyhow::Result<()> {
 
     check_files_left(&ctx, storage_root, "db1", "t1").await?;
     check_files_left(&ctx, storage_root, "default", "t1").await?;
+
+    Ok(())
+}
+
+/// Regression test for chunked reads of protected gc-root segments.
+///
+/// `do_vacuum2` reads the gc-root's protected segments in chunks of
+/// `VACUUM2_SEGMENT_READ_CHUNK_SIZE` (1000) rather than all at once, so that peak
+/// memory does not scale with the number of protected segments. Every chunk must
+/// contribute its block locations to the protected set: if a single chunk were
+/// skipped or its results dropped, the blocks it protects would be misclassified
+/// as garbage and deleted, silently corrupting a live table.
+///
+/// This test forces the segment count past the chunk boundary (one block per
+/// segment, one row per block) and then asserts every block still referenced by
+/// the surviving snapshot is present on storage after vacuum.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_vacuum2_protected_segments_span_multiple_chunks() -> anyhow::Result<()> {
+    // Must exceed the chunk size used by do_vacuum2, so the read loop runs more
+    // than one iteration and a lost chunk would be observable.
+    const SEGMENT_COUNT: usize = 1001;
+
+    let ee_setup = EESetup::new();
+    let fixture = TestFixture::setup_with_custom(ee_setup).await?;
+
+    let session = fixture.default_session();
+    // Retention 0 so the previous snapshot becomes collectable immediately.
+    session.get_settings().set_data_retention_time_in_days(0)?;
+    // Auto compaction would merge the many tiny segments back together and
+    // defeat the point of the test.
+    session
+        .get_settings()
+        .set_auto_compaction_imperfect_blocks_threshold(0)?;
+
+    let ctx = fixture.new_query_ctx().await?;
+    fixture.create_default_database().await?;
+    let db_name = fixture.default_db_name();
+    let tbl_name = "t_chunked";
+
+    fixture
+        .execute_command(&format!(
+            "create table {}.{} (c int) row_per_block=1 block_per_segment=1",
+            db_name, tbl_name
+        ))
+        .await?;
+
+    // One row per block and one block per segment, so each row lands in its own
+    // segment and the gc-root ends up with SEGMENT_COUNT protected segments.
+    fixture
+        .execute_command(&format!(
+            "insert into {}.{} select number from numbers({})",
+            db_name, tbl_name, SEGMENT_COUNT
+        ))
+        .await?;
+
+    // A second write creates a newer snapshot, so the first one becomes eligible
+    // for collection and vacuum has actual work to do.
+    fixture
+        .execute_command(&format!("insert into {}.{} values (-1)", db_name, tbl_name))
+        .await?;
+
+    // Confirm the setup actually crossed the chunk boundary. If table option
+    // semantics change and segments get merged, the test would silently stop
+    // covering the multi-chunk path, so fail loudly instead.
+    let table = ctx
+        .get_default_catalog()?
+        .get_table(&ctx.get_tenant(), &db_name, tbl_name)
+        .await?;
+    let fuse_table = FuseTable::try_from_table(table.as_ref())?;
+    let snapshot = fuse_table
+        .read_table_snapshot()
+        .await?
+        .expect("snapshot should exist after inserts");
+    assert!(
+        snapshot.segments.len() > 1000,
+        "expected more than 1000 protected segments to cross the chunk boundary, got {}",
+        snapshot.segments.len()
+    );
+
+    // Blocks referenced by the surviving snapshot: none of these may be removed.
+    let segments_io =
+        SegmentsIO::create(ctx.clone(), fuse_table.get_operator(), fuse_table.schema());
+    let mut live_blocks = Vec::new();
+    for chunk in snapshot.segments.chunks(500) {
+        let segments = segments_io
+            .read_segments::<Arc<CompactSegmentInfo>>(chunk, false)
+            .await?;
+        for segment in segments {
+            for block in segment?.block_metas()?.iter() {
+                live_blocks.push(block.location.0.clone());
+            }
+        }
+    }
+    assert_eq!(live_blocks.len(), SEGMENT_COUNT + 1);
+
+    fixture
+        .execute_command(&format!(
+            "call system$fuse_vacuum2('{}', '{}')",
+            db_name, tbl_name
+        ))
+        .await?;
+
+    // The core assertion: every block still referenced by the live snapshot must
+    // survive. Dropping any protected-segment chunk during the read would leave
+    // that chunk's blocks unprotected and delete them here.
+    let operator = fuse_table.get_operator();
+    let mut missing = Vec::new();
+    for loc in &live_blocks {
+        if !operator.exists(loc).await? {
+            missing.push(loc.clone());
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "vacuum deleted {} live block(s) still referenced by the current snapshot; \
+         first few: {:?}",
+        missing.len(),
+        &missing[..missing.len().min(5)]
+    );
+
+    // Sanity check that the table is still readable end to end and no rows were
+    // lost: scanning every row would fail outright if a live block was deleted.
+    let stream = fixture
+        .execute_query(&format!("select c from {}.{}", db_name, tbl_name))
+        .await?;
+    let blocks: Vec<DataBlock> = stream.try_collect().await?;
+    let scanned_rows: usize = blocks.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(scanned_rows, SEGMENT_COUNT + 1);
+
+    Ok(())
+}
+
+/// An old transaction may have written block objects before a newer snapshot becomes the
+/// vacuum gc-root. Vacuum may delete those uncommitted objects, but the old transaction must
+/// then fail to commit so no committed snapshot can reference a deleted block.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_vacuum2_rejects_transaction_whose_blocks_were_collected() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup_with_custom(EESetup::new()).await?;
+    fixture
+        .default_session()
+        .get_settings()
+        .set_data_retention_time_in_days(0)?;
+    fixture.create_default_database().await?;
+
+    let db_name = fixture.default_db_name();
+    let tbl_name = "t_concurrent_txn";
+    fixture
+        .execute_command(&format!("create table {db_name}.{tbl_name} (c int)"))
+        .await?;
+    fixture
+        .execute_command(&format!("insert into {db_name}.{tbl_name} values (1)"))
+        .await?;
+
+    let catalog_ctx = fixture.new_query_ctx().await?;
+    let table = catalog_ctx
+        .get_default_catalog()?
+        .get_table(&fixture.default_tenant(), &db_name, tbl_name)
+        .await?;
+    let fuse_table = FuseTable::try_from_table(table.as_ref())?;
+    let operator = fuse_table.get_operator();
+    let block_prefix = fuse_table
+        .meta_location_generator()
+        .block_location_prefix()
+        .to_string();
+    let blocks_before_txn = operator
+        .list(&block_prefix)
+        .await?
+        .into_iter()
+        .filter(|entry| entry.metadata().is_file())
+        .map(|entry| entry.path().to_string())
+        .collect::<HashSet<_>>();
+
+    let txn_session = fixture.new_session_with_type(SessionType::Dummy).await?;
+    txn_session
+        .get_settings()
+        .set_data_retention_time_in_days(0)?;
+    let txn_ctx = txn_session
+        .create_query_context(&databend_common_version::BUILD_INFO)
+        .await?;
+    execute_command(txn_ctx.clone(), "begin").await?;
+    execute_command(
+        txn_ctx.clone(),
+        &format!("insert into {db_name}.{tbl_name} values (2)"),
+    )
+    .await?;
+
+    let blocks_after_txn = operator
+        .list(&block_prefix)
+        .await?
+        .into_iter()
+        .filter(|entry| entry.metadata().is_file())
+        .map(|entry| entry.path().to_string())
+        .collect::<HashSet<_>>();
+    let txn_blocks = blocks_after_txn
+        .difference(&blocks_before_txn)
+        .cloned()
+        .collect::<Vec<_>>();
+    assert!(
+        !txn_blocks.is_empty(),
+        "transaction insert should write at least one uncommitted block"
+    );
+
+    // Ensure the next committed snapshot has a strictly later logical timestamp than the
+    // transaction's block objects and can therefore become their gc-root cutoff.
+    tokio::time::sleep(Duration::from_millis(2)).await;
+    fixture
+        .execute_command(&format!("insert into {db_name}.{tbl_name} values (3)"))
+        .await?;
+    fixture
+        .execute_command(&format!(
+            "call system$fuse_vacuum2('{db_name}', '{tbl_name}')"
+        ))
+        .await?;
+
+    for path in &txn_blocks {
+        assert!(
+            !operator.exists(path).await?,
+            "vacuum should collect uncommitted block older than the gc-root: {path}"
+        );
+    }
+
+    let commit_error = execute_command(txn_ctx, "commit")
+        .await
+        .expect_err("transaction must not commit a snapshot referencing collected blocks");
+    assert!(
+        matches!(
+            commit_error.code(),
+            ErrorCode::STORAGE_NOT_FOUND
+                | ErrorCode::TABLE_VERSION_MISMATCHED
+                | ErrorCode::UNRESOLVABLE_CONFLICT
+        ),
+        "unexpected transaction rejection after vacuum collected its blocks: {commit_error}"
+    );
+
+    let stream = fixture
+        .execute_query(&format!("select c from {db_name}.{tbl_name}"))
+        .await?;
+    let blocks: Vec<DataBlock> = stream.try_collect().await?;
+    let committed_rows: usize = blocks.iter().map(|block| block.num_rows()).sum();
+    assert_eq!(committed_rows, 2);
 
     Ok(())
 }

--- a/src/query/storages/fuse/src/operations/mod.rs
+++ b/src/query/storages/fuse/src/operations/mod.rs
@@ -67,6 +67,7 @@ pub use snapshot_hint::*;
 pub use table_index::do_refresh_table_index;
 pub use util::*;
 pub use vacuum::ASSUMPTION_MAX_TXN_DURATION;
+pub use vacuum::is_gc_candidate_segment_block;
 pub use vacuum::vacuum_tables_from_info;
 pub use virtual_column::VirtualColumnVacuumResult;
 pub use virtual_column::cleanup_vacuum_virtual_column_files;

--- a/src/query/storages/fuse/src/operations/vacuum.rs
+++ b/src/query/storages/fuse/src/operations/vacuum.rs
@@ -165,7 +165,7 @@ async fn fs_list_until_prefix(
 }
 
 /// Check if an entry is a candidate for garbage collection
-async fn is_gc_candidate_segment_block(
+pub async fn is_gc_candidate_segment_block(
     entry: &Entry,
     op: &Operator,
     gc_root_meta_ts: DateTime<Utc>,
@@ -214,6 +214,18 @@ impl FuseTable {
         }
     }
 
+    pub fn vacuum2_until_prefix(path: &str, until: DateTime<Utc>) -> String {
+        let uuid = uuid_from_date_time(until);
+        let uuid_str = uuid.simple().to_string();
+
+        // extract the most significant 48 bits, which is 12 characters
+        let timestamp_component = &uuid_str[..12];
+        format!(
+            "{}{}{}",
+            path, VACUUM2_OBJECT_KEY_PREFIX, timestamp_component
+        )
+    }
+
     /// List files until a specific timestamp
     ///
     /// This implementation uses UUID v7 timestamp extraction for precise filtering.
@@ -225,15 +237,7 @@ impl FuseTable {
         need_one_more: bool,
         gc_root_meta_ts: Option<DateTime<Utc>>,
     ) -> Result<Vec<Entry>> {
-        let uuid = uuid_from_date_time(until);
-        let uuid_str = uuid.simple().to_string();
-
-        // extract the most significant 48 bits, which is 12 characters
-        let timestamp_component = &uuid_str[..12];
-        let until = format!(
-            "{}{}{}",
-            path, VACUUM2_OBJECT_KEY_PREFIX, timestamp_component
-        );
+        let until = Self::vacuum2_until_prefix(path, until);
         self.list_files_until_prefix(path, &until, need_one_more, gc_root_meta_ts)
             .await
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Reduce peak memory usage in `fuse_vacuum2` block garbage collection for very large tables.

This PR is a follow-up to the protected-segment chunking change. It avoids materializing all candidate block listing results in memory before deletion while preserving the existing `vacuumed` result contract.

The main memory reduction is to avoid keeping all listed block `Entry` values and intermediate block path vectors in memory at once. This matters for very large `_b/` directories because each OpenDAL `Entry` carries both the object path and metadata; the metadata portion is significant and should not be treated as negligible when millions of entries are listed.

This PR intentionally preserves the existing result contract and still returns the complete list of removed files. The remaining memory pressure from retaining all removed file paths for the result set will be addressed in a follow-up PR with an explicit API/behavior design.

Changes:
- Stream block listing for non-FS object stores and stop at the same vacuum2 timestamp-derived `until` prefix as before.
- Filter and remove block chunks while listing, instead of building full `Vec<Entry>` / candidate block path vectors.
- Preserve the existing FS behavior by sorting listed entries before applying the `until` boundary, because FS listing order is not guaranteed.
- Reuse the existing common fuse vacuum candidate safety helper for block eligibility checks, including conservative legacy-object `last_modified` handling.
- Preserve the complete returned `vacuumed` file list.

Safety notes:
- The deletion condition remains candidate-before-gc-root AND not referenced by the protected block set.
- Index files are still removed before their data blocks for each delete chunk.
- Errors while proving legacy-object eligibility are still propagated instead of ignored by reusing the existing common vacuum logic.

## Tests

- [x] Unit Test
  - `cargo test -p databend-enterprise-query vacuum_table_v2 --lib -- --nocapture`
- [x] Logic Test
  - `cargo test -p databend-enterprise-query --test it storages::fuse::operations::vacuum2 -- --nocapture`
- [x] Build/Check
  - `cargo check -p databend-common-storages-fuse`
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: Assisted with diagnosing the vacuum2 memory path, implementing streaming block GC, reviewing conservative error handling, adding focused tests, and preparing this PR.
- Responsible human: @dantengsky
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20402)
<!-- Reviewable:end -->
