### PR TITLE
fix(query): match nullable scalar correlation keys

### DIFF
--- a/src/query/sql/src/planner/optimizer/optimizers/hyper_dp/dphyp.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/hyper_dp/dphyp.rs
@@ -27,7 +27,6 @@ use super::algorithm::JoinEdgeRef;
 use super::algorithm::JoinNode;
 use super::algorithm::JoinOrderModel;
 use crate::IndexType;
-use crate::ScalarExpr;
 use crate::optimizer::Optimizer;
 use crate::optimizer::OptimizerContext;
 use crate::optimizer::ir::RelExpr;
@@ -59,7 +58,7 @@ pub struct DPhpyOptimizer {
 
 struct DPhypJoinOrderModel<'a> {
     join_relations: &'a [JoinRelation],
-    join_conditions: &'a [(ScalarExpr, ScalarExpr)],
+    join_conditions: &'a [JoinEquiCondition],
 }
 
 impl DPhypJoinOrderModel<'_> {
@@ -71,17 +70,14 @@ impl DPhypJoinOrderModel<'_> {
     ) -> SExpr {
         let left_expr = left.state().clone();
         let right_expr = right.state().clone();
-        let mut left_conditions = Vec::with_capacity(edge_refs.len());
-        let mut right_conditions = Vec::with_capacity(edge_refs.len());
+        let mut conditions = Vec::with_capacity(edge_refs.len());
 
         for edge_ref in edge_refs {
-            let (mut left_condition, mut right_condition) =
-                self.join_conditions[edge_ref.id].clone();
+            let mut condition = self.join_conditions[edge_ref.id].clone();
             if edge_ref.reversed {
-                std::mem::swap(&mut left_condition, &mut right_condition);
+                std::mem::swap(&mut condition.left, &mut condition.right);
             }
-            left_conditions.push(left_condition);
-            right_conditions.push(right_condition);
+            conditions.push(condition);
         }
 
         let join_type = if edge_refs.is_empty() {
@@ -90,11 +86,7 @@ impl DPhypJoinOrderModel<'_> {
             JoinType::Inner
         };
         let rel_op = RelOperator::Join(Join {
-            equi_conditions: JoinEquiCondition::new_conditions(
-                left_conditions,
-                right_conditions,
-                vec![],
-            ),
+            equi_conditions: conditions,
             non_equi_conditions: vec![],
             join_type,
             marker_index: None,
@@ -269,7 +261,7 @@ impl DPhpyOptimizer {
     async fn process_join_node(
         &mut self,
         s_expr: &SExpr,
-        join_conditions: &mut Vec<(ScalarExpr, ScalarExpr)>,
+        join_conditions: &mut Vec<JoinEquiCondition>,
     ) -> Result<(Arc<SExpr>, bool)> {
         let op = match s_expr.plan() {
             RelOperator::Join(op) => op,
@@ -304,7 +296,7 @@ impl DPhpyOptimizer {
                 break;
             }
 
-            join_conditions.push((condition.left.clone(), condition.right.clone()));
+            join_conditions.push(condition.clone());
         }
 
         // Add non-equi conditions to filters
@@ -571,7 +563,7 @@ impl DPhpyOptimizer {
     async fn process_unary_node(
         &mut self,
         s_expr: &SExpr,
-        join_conditions: &mut Vec<(ScalarExpr, ScalarExpr)>,
+        join_conditions: &mut Vec<JoinEquiCondition>,
         join_child: bool,
         join_relation: Option<&SExpr>,
     ) -> Result<(Arc<SExpr>, bool)> {
@@ -611,7 +603,7 @@ impl DPhpyOptimizer {
     async fn get_base_relations(
         &mut self,
         s_expr: &SExpr,
-        join_conditions: &mut Vec<(ScalarExpr, ScalarExpr)>,
+        join_conditions: &mut Vec<JoinEquiCondition>,
         join_child: bool,
         join_relation: Option<&SExpr>,
         is_subquery: bool,
@@ -673,7 +665,6 @@ impl DPhpyOptimizer {
         }
 
         // Firstly, we need to extract all join conditions and base tables
-        // `join_condition` is pair, left is left_condition, right is right_condition
         let mut join_conditions = vec![];
         let (s_expr, optimized) = self
             .get_base_relations(s_expr, &mut join_conditions, false, None, false)
@@ -715,18 +706,18 @@ impl DPhpyOptimizer {
     fn build_join_order_edges(
         &self,
         hyper_dp: &mut HyperDp<'_, DPhypJoinOrderModel<'_>>,
-        join_conditions: &[(ScalarExpr, ScalarExpr)],
+        join_conditions: &[JoinEquiCondition],
     ) -> Result<bool> {
-        for (edge_id, (left_condition, right_condition)) in join_conditions.iter().enumerate() {
+        for (edge_id, condition) in join_conditions.iter().enumerate() {
             let mut left_relation_set = HashSet::new();
             let mut right_relation_set = HashSet::new();
 
-            let left_used_tables = left_condition.used_tables()?;
+            let left_used_tables = condition.left.used_tables()?;
             for table in left_used_tables.iter() {
                 left_relation_set.insert(self.table_index_map[table]);
             }
 
-            let right_used_tables = right_condition.used_tables()?;
+            let right_used_tables = condition.right.used_tables()?;
             for table in right_used_tables.iter() {
                 right_relation_set.insert(self.table_index_map[table]);
             }
@@ -904,7 +895,7 @@ mod tests {
     use crate::plans::MaterializedCTERef;
     use crate::plans::Sequence;
 
-    fn bool_constant(value: bool) -> ScalarExpr {
+    fn bool_constant(value: bool) -> crate::ScalarExpr {
         ConstantExpr {
             span: None,
             value: Scalar::Boolean(value),

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/decorrelate.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/decorrelate.rs
@@ -275,6 +275,12 @@ impl SubqueryDecorrelatorOptimizer {
                     &mut left_conditions,
                 )?;
 
+                // These conditions reconnect the flattened subquery result to the outer row.
+                // They are internal correlation keys rather than user-written equality
+                // predicates, so NULL correlation groups must match each other.
+                let is_null_equal =
+                    Self::nullable_condition_indexes(&left_conditions, &right_conditions);
+
                 let join_type = if matches!(subquery.contain_agg, Some(true)) && {
                     let rel_expr = RelExpr::with_s_expr(&subquery.subquery);
                     rel_expr
@@ -292,7 +298,7 @@ impl SubqueryDecorrelatorOptimizer {
                     equi_conditions: JoinEquiCondition::new_conditions(
                         left_conditions,
                         right_conditions,
-                        vec![],
+                        is_null_equal,
                     ),
                     non_equi_conditions: vec![],
                     join_type,
@@ -339,16 +345,8 @@ impl SubqueryDecorrelatorOptimizer {
                     &mut left_conditions,
                     &mut right_conditions,
                 )?;
-                let mut is_null_equal = Vec::new();
-                for (i, (l, r)) in left_conditions
-                    .iter()
-                    .zip(right_conditions.iter())
-                    .enumerate()
-                {
-                    if l.data_type().is_nullable() || r.data_type().is_nullable() {
-                        is_null_equal.push(i);
-                    }
-                }
+                let is_null_equal =
+                    Self::nullable_condition_indexes(&left_conditions, &right_conditions);
 
                 let marker_index = if let Some(idx) = subquery.projection_index {
                     idx
@@ -404,16 +402,8 @@ impl SubqueryDecorrelatorOptimizer {
                     &mut right_conditions,
                 )?;
 
-                let mut is_null_equal = Vec::new();
-                for (i, (l, r)) in left_conditions
-                    .iter()
-                    .zip(right_conditions.iter())
-                    .enumerate()
-                {
-                    if l.data_type().is_nullable() || r.data_type().is_nullable() {
-                        is_null_equal.push(i);
-                    }
-                }
+                let is_null_equal =
+                    Self::nullable_condition_indexes(&left_conditions, &right_conditions);
 
                 let output_column = subquery.output_column.clone();
                 let column_name = format!("subquery_{}", output_column.index);
@@ -520,6 +510,20 @@ impl SubqueryDecorrelatorOptimizer {
             right_conditions.push(right_column);
         }
         Ok(())
+    }
+
+    pub(crate) fn nullable_condition_indexes(
+        left_conditions: &[ScalarExpr],
+        right_conditions: &[ScalarExpr],
+    ) -> Vec<usize> {
+        left_conditions
+            .iter()
+            .zip(right_conditions)
+            .enumerate()
+            .filter_map(|(index, (left, right))| {
+                (left.data_type().is_nullable() || right.data_type().is_nullable()).then_some(index)
+            })
+            .collect()
     }
 
     // Check if need to join outer and inner table

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/subquery_decorrelator.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/subquery_decorrelator.rs
@@ -736,16 +736,8 @@ impl SubqueryDecorrelatorOptimizer {
                     )
                 };
 
-                let mut is_null_equal = Vec::new();
-                for (i, (l, r)) in left_conditions
-                    .iter()
-                    .zip(right_conditions.iter())
-                    .enumerate()
-                {
-                    if l.data_type().is_nullable() || r.data_type().is_nullable() {
-                        is_null_equal.push(i);
-                    }
-                }
+                let is_null_equal =
+                    Self::nullable_condition_indexes(&left_conditions, &right_conditions);
 
                 // Consider the sql: select * from t1 where t1.a = any(select t2.a from t2);
                 // Will be transferred to:select t1.a, t2.a, marker_index from t1, t2 where t2.a = t1.a;

--- a/src/query/sql/test-support/data/results/tpcds/Q01_optimized.txt
+++ b/src/query/sql/test-support/data/results/tpcds/Q01_optimized.txt
@@ -15,80 +15,80 @@ TopN
                 ├── other filters: []
                 ├── Exchange(Broadcast)
                 │   └── Join(Inner)
-                │       ├── build keys: [store_returns.sr_store_sk (#103)]
+                │       ├── build keys: [store.s_store_sk (#49)]
                 │       ├── probe keys: [store_returns.sr_store_sk (#7)]
-                │       ├── other filters: [gt(Sum(sr_return_amt) (#48), sum(ctr_total_return) / if(count(ctr_total_return) = 0, 1, count(ctr_total_return)) * 1.2 (#147))]
+                │       ├── other filters: []
                 │       ├── Exchange(Broadcast)
-                │       │   └── Join(Inner)
-                │       │       ├── build keys: [store_returns.sr_store_sk (#103)]
-                │       │       ├── probe keys: [store.s_store_sk (#49)]
-                │       │       ├── other filters: []
-                │       │       ├── Exchange(Broadcast)
-                │       │       │   └── EvalScalar
-                │       │       │       ├── scalars: [store_returns.sr_store_sk (#103) AS (#103), multiply(divide(sum(ctr_total_return) (#145), if(eq(count(ctr_total_return) (#146), 0), 1, count(ctr_total_return) (#146))), 1.2) AS (#147)]
-                │       │       │       └── Aggregate(Final)
-                │       │       │           ├── group items: [store_returns.sr_store_sk (#103) AS (#103)]
-                │       │       │           ├── aggregate functions: [sum(Sum(sr_return_amt) (#144)) AS (#145), count(Sum(sr_return_amt) (#144)) AS (#146)]
-                │       │       │           └── Aggregate(Partial)
-                │       │       │               ├── group items: [store_returns.sr_store_sk (#103) AS (#103)]
-                │       │       │               ├── aggregate functions: [sum(Sum(sr_return_amt) (#144)) AS (#145), count(Sum(sr_return_amt) (#144)) AS (#146)]
-                │       │       │               └── Exchange(Hash)
-                │       │       │                   ├── Exchange(Hash): keys: [store_returns.sr_store_sk (#103)]
-                │       │       │                   └── Aggregate(Final)
-                │       │       │                       ├── group items: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103)]
-                │       │       │                       ├── aggregate functions: [sum(store_returns.sr_return_amt (#107)) AS (#144)]
-                │       │       │                       └── Aggregate(Partial)
-                │       │       │                           ├── group items: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103)]
-                │       │       │                           ├── aggregate functions: [sum(store_returns.sr_return_amt (#107)) AS (#144)]
-                │       │       │                           └── Exchange(Hash)
-                │       │       │                               ├── Exchange(Hash): keys: [store_returns.sr_customer_sk (#99)]
-                │       │       │                               └── EvalScalar
-                │       │       │                                   ├── scalars: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103), store_returns.sr_return_amt (#107) AS (#107), store_returns.sr_returned_date_sk (#96) AS (#151), date_dim.d_date_sk (#116) AS (#152), date_dim.d_year (#122) AS (#153)]
-                │       │       │                                   └── Join(Inner)
-                │       │       │                                       ├── build keys: [date_dim.d_date_sk (#116)]
-                │       │       │                                       ├── probe keys: [store_returns.sr_returned_date_sk (#96)]
-                │       │       │                                       ├── other filters: []
-                │       │       │                                       ├── Exchange(Broadcast)
-                │       │       │                                       │   └── Scan
-                │       │       │                                       │       ├── table: default.date_dim (#5)
-                │       │       │                                       │       ├── filters: [eq(date_dim.d_year (#122), 2001)]
-                │       │       │                                       │       ├── order by: []
-                │       │       │                                       │       └── limit: NONE
-                │       │       │                                       └── Scan
-                │       │       │                                           ├── table: default.store_returns (#4)
-                │       │       │                                           ├── filters: []
-                │       │       │                                           ├── order by: []
-                │       │       │                                           └── limit: NONE
-                │       │       └── Scan
-                │       │           ├── table: default.store (#2)
-                │       │           ├── filters: [eq(store.s_state (#73), 'TN')]
-                │       │           ├── order by: []
-                │       │           └── limit: NONE
-                │       └── Aggregate(Final)
-                │           ├── group items: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7)]
-                │           ├── aggregate functions: [sum(store_returns.sr_return_amt (#11)) AS (#48)]
-                │           └── Aggregate(Partial)
+                │       │   └── Scan
+                │       │       ├── table: default.store (#2)
+                │       │       ├── filters: [eq(store.s_state (#73), 'TN')]
+                │       │       ├── order by: []
+                │       │       └── limit: NONE
+                │       └── Join(Inner)
+                │           ├── build keys: [store_returns.sr_store_sk (#103)]
+                │           ├── probe keys: [store_returns.sr_store_sk (#7)]
+                │           ├── other filters: [gt(Sum(sr_return_amt) (#48), sum(ctr_total_return) / if(count(ctr_total_return) = 0, 1, count(ctr_total_return)) * 1.2 (#147))]
+                │           ├── Exchange(Broadcast)
+                │           │   └── EvalScalar
+                │           │       ├── scalars: [store_returns.sr_store_sk (#103) AS (#103), multiply(divide(sum(ctr_total_return) (#145), if(eq(count(ctr_total_return) (#146), 0), 1, count(ctr_total_return) (#146))), 1.2) AS (#147)]
+                │           │       └── Aggregate(Final)
+                │           │           ├── group items: [store_returns.sr_store_sk (#103) AS (#103)]
+                │           │           ├── aggregate functions: [sum(Sum(sr_return_amt) (#144)) AS (#145), count(Sum(sr_return_amt) (#144)) AS (#146)]
+                │           │           └── Aggregate(Partial)
+                │           │               ├── group items: [store_returns.sr_store_sk (#103) AS (#103)]
+                │           │               ├── aggregate functions: [sum(Sum(sr_return_amt) (#144)) AS (#145), count(Sum(sr_return_amt) (#144)) AS (#146)]
+                │           │               └── Exchange(Hash)
+                │           │                   ├── Exchange(Hash): keys: [store_returns.sr_store_sk (#103)]
+                │           │                   └── Aggregate(Final)
+                │           │                       ├── group items: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103)]
+                │           │                       ├── aggregate functions: [sum(store_returns.sr_return_amt (#107)) AS (#144)]
+                │           │                       └── Aggregate(Partial)
+                │           │                           ├── group items: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103)]
+                │           │                           ├── aggregate functions: [sum(store_returns.sr_return_amt (#107)) AS (#144)]
+                │           │                           └── Exchange(Hash)
+                │           │                               ├── Exchange(Hash): keys: [store_returns.sr_customer_sk (#99)]
+                │           │                               └── EvalScalar
+                │           │                                   ├── scalars: [store_returns.sr_customer_sk (#99) AS (#99), store_returns.sr_store_sk (#103) AS (#103), store_returns.sr_return_amt (#107) AS (#107), store_returns.sr_returned_date_sk (#96) AS (#151), date_dim.d_date_sk (#116) AS (#152), date_dim.d_year (#122) AS (#153)]
+                │           │                                   └── Join(Inner)
+                │           │                                       ├── build keys: [date_dim.d_date_sk (#116)]
+                │           │                                       ├── probe keys: [store_returns.sr_returned_date_sk (#96)]
+                │           │                                       ├── other filters: []
+                │           │                                       ├── Exchange(Broadcast)
+                │           │                                       │   └── Scan
+                │           │                                       │       ├── table: default.date_dim (#5)
+                │           │                                       │       ├── filters: [eq(date_dim.d_year (#122), 2001)]
+                │           │                                       │       ├── order by: []
+                │           │                                       │       └── limit: NONE
+                │           │                                       └── Scan
+                │           │                                           ├── table: default.store_returns (#4)
+                │           │                                           ├── filters: []
+                │           │                                           ├── order by: []
+                │           │                                           └── limit: NONE
+                │           └── Aggregate(Final)
                 │               ├── group items: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7)]
                 │               ├── aggregate functions: [sum(store_returns.sr_return_amt (#11)) AS (#48)]
-                │               └── Exchange(Hash)
-                │                   ├── Exchange(Hash): keys: [store_returns.sr_customer_sk (#3)]
-                │                   └── EvalScalar
-                │                       ├── scalars: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7), store_returns.sr_return_amt (#11) AS (#11), store_returns.sr_returned_date_sk (#0) AS (#148), date_dim.d_date_sk (#20) AS (#149), date_dim.d_year (#26) AS (#150)]
-                │                       └── Join(Inner)
-                │                           ├── build keys: [date_dim.d_date_sk (#20)]
-                │                           ├── probe keys: [store_returns.sr_returned_date_sk (#0)]
-                │                           ├── other filters: []
-                │                           ├── Exchange(Broadcast)
-                │                           │   └── Scan
-                │                           │       ├── table: default.date_dim (#1)
-                │                           │       ├── filters: [eq(date_dim.d_year (#26), 2001)]
-                │                           │       ├── order by: []
-                │                           │       └── limit: NONE
-                │                           └── Scan
-                │                               ├── table: default.store_returns (#0)
-                │                               ├── filters: []
-                │                               ├── order by: []
-                │                               └── limit: NONE
+                │               └── Aggregate(Partial)
+                │                   ├── group items: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7)]
+                │                   ├── aggregate functions: [sum(store_returns.sr_return_amt (#11)) AS (#48)]
+                │                   └── Exchange(Hash)
+                │                       ├── Exchange(Hash): keys: [store_returns.sr_customer_sk (#3)]
+                │                       └── EvalScalar
+                │                           ├── scalars: [store_returns.sr_customer_sk (#3) AS (#3), store_returns.sr_store_sk (#7) AS (#7), store_returns.sr_return_amt (#11) AS (#11), store_returns.sr_returned_date_sk (#0) AS (#148), date_dim.d_date_sk (#20) AS (#149), date_dim.d_year (#26) AS (#150)]
+                │                           └── Join(Inner)
+                │                               ├── build keys: [date_dim.d_date_sk (#20)]
+                │                               ├── probe keys: [store_returns.sr_returned_date_sk (#0)]
+                │                               ├── other filters: []
+                │                               ├── Exchange(Broadcast)
+                │                               │   └── Scan
+                │                               │       ├── table: default.date_dim (#1)
+                │                               │       ├── filters: [eq(date_dim.d_year (#26), 2001)]
+                │                               │       ├── order by: []
+                │                               │       └── limit: NONE
+                │                               └── Scan
+                │                                   ├── table: default.store_returns (#0)
+                │                                   ├── filters: []
+                │                                   ├── order by: []
+                │                                   └── limit: NONE
                 └── Scan
                     ├── table: default.customer (#3)
                     ├── filters: []

--- a/src/query/sql/test-support/data/results/tpcds/Q01_physical.txt
+++ b/src/query/sql/test-support/data/results/tpcds/Q01_physical.txt
@@ -29,148 +29,147 @@ TopN(Final)
             │   └── HashJoin
             │       ├── output columns: [store_returns.sr_customer_sk (#3)]
             │       ├── join type: INNER
-            │       ├── build keys: [sr_store_sk (#103)]
-            │       ├── probe keys: [sr_store_sk (#7)]
+            │       ├── build keys: [store.s_store_sk (#49)]
+            │       ├── probe keys: [ctr1.ctr_store_sk (#7)]
             │       ├── keys is null equal: [false]
-            │       ├── filters: [ctr1.ctr_total_return (#48) > scalar_subquery_147 (#147)]
+            │       ├── filters: []
             │       ├── build join filters:
-            │       │   └── filter id:3, build key:sr_store_sk (#103), probe targets:[sr_store_sk (#7)@scan0], filter type:bloom,inlist,min_max
+            │       │   └── filter id:3, build key:store.s_store_sk (#49), probe targets:[ctr1.ctr_store_sk (#7)@scan0, sr_store_sk (#103)@scan4], filter type:bloom,inlist,min_max
             │       ├── estimated rows: 348605.57
             │       ├── Exchange(Build)
-            │       │   ├── output columns: [sum(ctr_total_return) / if(count(ctr_total_return) = 0, 1, count(ctr_total_return)) * 1.2 (#147), store_returns.sr_store_sk (#103)]
+            │       │   ├── output columns: [store.s_store_sk (#49)]
             │       │   ├── exchange type: Broadcast
-            │       │   └── HashJoin
-            │       │       ├── output columns: [sum(ctr_total_return) / if(count(ctr_total_return) = 0, 1, count(ctr_total_return)) * 1.2 (#147), store_returns.sr_store_sk (#103)]
-            │       │       ├── join type: INNER
-            │       │       ├── build keys: [sr_store_sk (#103)]
-            │       │       ├── probe keys: [store.s_store_sk (#49)]
-            │       │       ├── keys is null equal: [false]
-            │       │       ├── filters: []
-            │       │       ├── build join filters:
-            │       │       │   └── filter id:2, build key:sr_store_sk (#103), probe targets:[store.s_store_sk (#49)@scan2], filter type:bloom,inlist,min_max
-            │       │       ├── estimated rows: 7.96
-            │       │       ├── Exchange(Build)
-            │       │       │   ├── output columns: [store_returns.sr_store_sk (#103), sum(ctr_total_return) / if(count(ctr_total_return) = 0, 1, count(ctr_total_return)) * 1.2 (#147)]
-            │       │       │   ├── exchange type: Broadcast
-            │       │       │   └── EvalScalar
-            │       │       │       ├── output columns: [store_returns.sr_store_sk (#103), sum(ctr_total_return) / if(count(ctr_total_return) = 0, 1, count(ctr_total_return)) * 1.2 (#147)]
-            │       │       │       ├── expressions: [sum(ctr_total_return) (#145) / CAST(if(CAST(count(ctr_total_return) (#146) = 0 AS Boolean NULL), 1, count(ctr_total_return) (#146)) AS UInt64 NULL) * 1.2]
-            │       │       │       ├── estimated rows: 1.00
-            │       │       │       └── AggregateFinal
-            │       │       │           ├── output columns: [sum(ctr_total_return) (#145), count(ctr_total_return) (#146), store_returns.sr_store_sk (#103)]
-            │       │       │           ├── group by: [sr_store_sk]
-            │       │       │           ├── aggregate functions: [sum(Sum(sr_return_amt)), count(Sum(sr_return_amt))]
-            │       │       │           ├── estimated rows: 1.00
-            │       │       │           └── Exchange
-            │       │       │               ├── output columns: [sum(ctr_total_return) (#145), count(ctr_total_return) (#146), store_returns.sr_store_sk (#103)]
-            │       │       │               ├── exchange type: Hash(0)
-            │       │       │               └── AggregatePartial
-            │       │       │                   ├── group by: [sr_store_sk]
-            │       │       │                   ├── aggregate functions: [sum(Sum(sr_return_amt)), count(Sum(sr_return_amt))]
-            │       │       │                   ├── estimated rows: 1.00
-            │       │       │                   └── AggregateFinal
-            │       │       │                       ├── output columns: [Sum(sr_return_amt) (#144), store_returns.sr_customer_sk (#99), store_returns.sr_store_sk (#103)]
-            │       │       │                       ├── group by: [sr_customer_sk, sr_store_sk]
-            │       │       │                       ├── aggregate functions: [sum(sr_return_amt)]
-            │       │       │                       ├── estimated rows: 1.00
-            │       │       │                       └── Exchange
-            │       │       │                           ├── output columns: [Sum(sr_return_amt) (#144), store_returns.sr_customer_sk (#99), store_returns.sr_store_sk (#103)]
-            │       │       │                           ├── exchange type: Hash(0, 1)
-            │       │       │                           └── AggregatePartial
-            │       │       │                               ├── group by: [sr_customer_sk, sr_store_sk]
-            │       │       │                               ├── aggregate functions: [sum(sr_return_amt)]
-            │       │       │                               ├── estimated rows: 1.00
-            │       │       │                               └── HashJoin
-            │       │       │                                   ├── output columns: [store_returns.sr_customer_sk (#99), store_returns.sr_store_sk (#103), store_returns.sr_return_amt (#107)]
-            │       │       │                                   ├── join type: INNER
-            │       │       │                                   ├── build keys: [date_dim.d_date_sk (#116)]
-            │       │       │                                   ├── probe keys: [store_returns.sr_returned_date_sk (#96)]
-            │       │       │                                   ├── keys is null equal: [false]
-            │       │       │                                   ├── filters: []
-            │       │       │                                   ├── build join filters:
-            │       │       │                                   │   └── filter id:1, build key:date_dim.d_date_sk (#116), probe targets:[store_returns.sr_returned_date_sk (#96)@scan4], filter type:bloom,inlist,min_max
-            │       │       │                                   ├── estimated rows: 0.00
-            │       │       │                                   ├── Exchange(Build)
-            │       │       │                                   │   ├── output columns: [date_dim.d_date_sk (#116)]
-            │       │       │                                   │   ├── exchange type: Broadcast
-            │       │       │                                   │   └── TableScan
-            │       │       │                                   │       ├── table: default.default.date_dim
-            │       │       │                                   │       ├── scan id: 5
-            │       │       │                                   │       ├── output columns: [d_date_sk (#116)]
-            │       │       │                                   │       ├── read rows: 0
-            │       │       │                                   │       ├── read size: 0
-            │       │       │                                   │       ├── partitions total: 0
-            │       │       │                                   │       ├── partitions scanned: 0
-            │       │       │                                   │       ├── push downs: [filters: [is_true(date_dim.d_year (#122) = 2001)], limit: NONE]
-            │       │       │                                   │       └── estimated rows: 0.00
-            │       │       │                                   └── TableScan(Probe)
-            │       │       │                                       ├── table: default.default.store_returns
-            │       │       │                                       ├── scan id: 4
-            │       │       │                                       ├── output columns: [sr_returned_date_sk (#96), sr_customer_sk (#99), sr_store_sk (#103), sr_return_amt (#107)]
-            │       │       │                                       ├── read rows: 0
-            │       │       │                                       ├── read size: 0
-            │       │       │                                       ├── partitions total: 0
-            │       │       │                                       ├── partitions scanned: 0
-            │       │       │                                       ├── push downs: [filters: [], limit: NONE]
-            │       │       │                                       ├── apply join filters: [#1]
-            │       │       │                                       └── estimated rows: 0.00
-            │       │       └── TableScan(Probe)
-            │       │           ├── table: default.default.store
-            │       │           ├── scan id: 2
-            │       │           ├── output columns: [s_store_sk (#49)]
-            │       │           ├── read rows: 0
-            │       │           ├── read size: 0
-            │       │           ├── partitions total: 0
-            │       │           ├── partitions scanned: 0
-            │       │           ├── push downs: [filters: [is_true(store.s_state (#73) = 'TN')], limit: NONE]
-            │       │           ├── apply join filters: [#2]
-            │       │           └── estimated rows: 7.96
-            │       └── AggregateFinal(Probe)
-            │           ├── output columns: [Sum(sr_return_amt) (#48), store_returns.sr_customer_sk (#3), store_returns.sr_store_sk (#7)]
-            │           ├── group by: [sr_customer_sk, sr_store_sk]
-            │           ├── aggregate functions: [sum(sr_return_amt)]
+            │       │   └── TableScan
+            │       │       ├── table: default.default.store
+            │       │       ├── scan id: 2
+            │       │       ├── output columns: [s_store_sk (#49)]
+            │       │       ├── read rows: 0
+            │       │       ├── read size: 0
+            │       │       ├── partitions total: 0
+            │       │       ├── partitions scanned: 0
+            │       │       ├── push downs: [filters: [is_true(store.s_state (#73) = 'TN')], limit: NONE]
+            │       │       └── estimated rows: 7.96
+            │       └── HashJoin(Probe)
+            │           ├── output columns: [store_returns.sr_customer_sk (#3), store_returns.sr_store_sk (#7)]
+            │           ├── join type: INNER
+            │           ├── build keys: [sr_store_sk (#103)]
+            │           ├── probe keys: [sr_store_sk (#7)]
+            │           ├── keys is null equal: [true]
+            │           ├── filters: [ctr1.ctr_total_return (#48) > scalar_subquery_147 (#147)]
+            │           ├── build join filters:
+            │           │   └── filter id:2, build key:sr_store_sk (#103), probe targets:[sr_store_sk (#7)@scan0], filter type:
             │           ├── estimated rows: 43794.67
-            │           └── Exchange
+            │           ├── Exchange(Build)
+            │           │   ├── output columns: [store_returns.sr_store_sk (#103), sum(ctr_total_return) / if(count(ctr_total_return) = 0, 1, count(ctr_total_return)) * 1.2 (#147)]
+            │           │   ├── exchange type: Broadcast
+            │           │   └── EvalScalar
+            │           │       ├── output columns: [store_returns.sr_store_sk (#103), sum(ctr_total_return) / if(count(ctr_total_return) = 0, 1, count(ctr_total_return)) * 1.2 (#147)]
+            │           │       ├── expressions: [sum(ctr_total_return) (#145) / CAST(if(CAST(count(ctr_total_return) (#146) = 0 AS Boolean NULL), 1, count(ctr_total_return) (#146)) AS UInt64 NULL) * 1.2]
+            │           │       ├── estimated rows: 1.00
+            │           │       └── AggregateFinal
+            │           │           ├── output columns: [sum(ctr_total_return) (#145), count(ctr_total_return) (#146), store_returns.sr_store_sk (#103)]
+            │           │           ├── group by: [sr_store_sk]
+            │           │           ├── aggregate functions: [sum(Sum(sr_return_amt)), count(Sum(sr_return_amt))]
+            │           │           ├── estimated rows: 1.00
+            │           │           └── Exchange
+            │           │               ├── output columns: [sum(ctr_total_return) (#145), count(ctr_total_return) (#146), store_returns.sr_store_sk (#103)]
+            │           │               ├── exchange type: Hash(0)
+            │           │               └── AggregatePartial
+            │           │                   ├── group by: [sr_store_sk]
+            │           │                   ├── aggregate functions: [sum(Sum(sr_return_amt)), count(Sum(sr_return_amt))]
+            │           │                   ├── estimated rows: 1.00
+            │           │                   └── AggregateFinal
+            │           │                       ├── output columns: [Sum(sr_return_amt) (#144), store_returns.sr_customer_sk (#99), store_returns.sr_store_sk (#103)]
+            │           │                       ├── group by: [sr_customer_sk, sr_store_sk]
+            │           │                       ├── aggregate functions: [sum(sr_return_amt)]
+            │           │                       ├── estimated rows: 1.00
+            │           │                       └── Exchange
+            │           │                           ├── output columns: [Sum(sr_return_amt) (#144), store_returns.sr_customer_sk (#99), store_returns.sr_store_sk (#103)]
+            │           │                           ├── exchange type: Hash(0, 1)
+            │           │                           └── AggregatePartial
+            │           │                               ├── group by: [sr_customer_sk, sr_store_sk]
+            │           │                               ├── aggregate functions: [sum(sr_return_amt)]
+            │           │                               ├── estimated rows: 1.00
+            │           │                               └── HashJoin
+            │           │                                   ├── output columns: [store_returns.sr_customer_sk (#99), store_returns.sr_store_sk (#103), store_returns.sr_return_amt (#107)]
+            │           │                                   ├── join type: INNER
+            │           │                                   ├── build keys: [date_dim.d_date_sk (#116)]
+            │           │                                   ├── probe keys: [store_returns.sr_returned_date_sk (#96)]
+            │           │                                   ├── keys is null equal: [false]
+            │           │                                   ├── filters: []
+            │           │                                   ├── build join filters:
+            │           │                                   │   └── filter id:1, build key:date_dim.d_date_sk (#116), probe targets:[store_returns.sr_returned_date_sk (#96)@scan4], filter type:bloom,inlist,min_max
+            │           │                                   ├── estimated rows: 0.00
+            │           │                                   ├── Exchange(Build)
+            │           │                                   │   ├── output columns: [date_dim.d_date_sk (#116)]
+            │           │                                   │   ├── exchange type: Broadcast
+            │           │                                   │   └── TableScan
+            │           │                                   │       ├── table: default.default.date_dim
+            │           │                                   │       ├── scan id: 5
+            │           │                                   │       ├── output columns: [d_date_sk (#116)]
+            │           │                                   │       ├── read rows: 0
+            │           │                                   │       ├── read size: 0
+            │           │                                   │       ├── partitions total: 0
+            │           │                                   │       ├── partitions scanned: 0
+            │           │                                   │       ├── push downs: [filters: [is_true(date_dim.d_year (#122) = 2001)], limit: NONE]
+            │           │                                   │       └── estimated rows: 0.00
+            │           │                                   └── TableScan(Probe)
+            │           │                                       ├── table: default.default.store_returns
+            │           │                                       ├── scan id: 4
+            │           │                                       ├── output columns: [sr_returned_date_sk (#96), sr_customer_sk (#99), sr_store_sk (#103), sr_return_amt (#107)]
+            │           │                                       ├── read rows: 0
+            │           │                                       ├── read size: 0
+            │           │                                       ├── partitions total: 0
+            │           │                                       ├── partitions scanned: 0
+            │           │                                       ├── push downs: [filters: [], limit: NONE]
+            │           │                                       ├── apply join filters: [#3, #1]
+            │           │                                       └── estimated rows: 0.00
+            │           └── AggregateFinal(Probe)
             │               ├── output columns: [Sum(sr_return_amt) (#48), store_returns.sr_customer_sk (#3), store_returns.sr_store_sk (#7)]
-            │               ├── exchange type: Hash(0, 1)
-            │               └── AggregatePartial
-            │                   ├── group by: [sr_customer_sk, sr_store_sk]
-            │                   ├── aggregate functions: [sum(sr_return_amt)]
-            │                   ├── estimated rows: 43794.67
-            │                   └── HashJoin
-            │                       ├── output columns: [store_returns.sr_customer_sk (#3), store_returns.sr_store_sk (#7), store_returns.sr_return_amt (#11)]
-            │                       ├── join type: INNER
-            │                       ├── build keys: [date_dim.d_date_sk (#20)]
-            │                       ├── probe keys: [store_returns.sr_returned_date_sk (#0)]
-            │                       ├── keys is null equal: [false]
-            │                       ├── filters: []
-            │                       ├── build join filters:
-            │                       │   └── filter id:0, build key:date_dim.d_date_sk (#20), probe targets:[store_returns.sr_returned_date_sk (#0)@scan0], filter type:bloom,inlist,min_max
-            │                       ├── estimated rows: 131384.01
-            │                       ├── Exchange(Build)
-            │                       │   ├── output columns: [date_dim.d_date_sk (#20)]
-            │                       │   ├── exchange type: Broadcast
-            │                       │   └── TableScan
-            │                       │       ├── table: default.default.date_dim
-            │                       │       ├── scan id: 1
-            │                       │       ├── output columns: [d_date_sk (#20)]
-            │                       │       ├── read rows: 0
-            │                       │       ├── read size: 0
-            │                       │       ├── partitions total: 0
-            │                       │       ├── partitions scanned: 0
-            │                       │       ├── push downs: [filters: [is_true(date_dim.d_year (#26) = 2001)], limit: NONE]
-            │                       │       └── estimated rows: 363.43
-            │                       └── TableScan(Probe)
-            │                           ├── table: default.default.store_returns
-            │                           ├── scan id: 0
-            │                           ├── output columns: [sr_returned_date_sk (#0), sr_customer_sk (#3), sr_store_sk (#7), sr_return_amt (#11)]
-            │                           ├── read rows: 0
-            │                           ├── read size: 0
-            │                           ├── partitions total: 0
-            │                           ├── partitions scanned: 0
-            │                           ├── push downs: [filters: [], limit: NONE]
-            │                           ├── apply join filters: [#3, #0]
-            │                           └── estimated rows: 28792282.00
+            │               ├── group by: [sr_customer_sk, sr_store_sk]
+            │               ├── aggregate functions: [sum(sr_return_amt)]
+            │               ├── estimated rows: 43794.67
+            │               └── Exchange
+            │                   ├── output columns: [Sum(sr_return_amt) (#48), store_returns.sr_customer_sk (#3), store_returns.sr_store_sk (#7)]
+            │                   ├── exchange type: Hash(0, 1)
+            │                   └── AggregatePartial
+            │                       ├── group by: [sr_customer_sk, sr_store_sk]
+            │                       ├── aggregate functions: [sum(sr_return_amt)]
+            │                       ├── estimated rows: 43794.67
+            │                       └── HashJoin
+            │                           ├── output columns: [store_returns.sr_customer_sk (#3), store_returns.sr_store_sk (#7), store_returns.sr_return_amt (#11)]
+            │                           ├── join type: INNER
+            │                           ├── build keys: [date_dim.d_date_sk (#20)]
+            │                           ├── probe keys: [store_returns.sr_returned_date_sk (#0)]
+            │                           ├── keys is null equal: [false]
+            │                           ├── filters: []
+            │                           ├── build join filters:
+            │                           │   └── filter id:0, build key:date_dim.d_date_sk (#20), probe targets:[store_returns.sr_returned_date_sk (#0)@scan0], filter type:bloom,inlist,min_max
+            │                           ├── estimated rows: 131384.01
+            │                           ├── Exchange(Build)
+            │                           │   ├── output columns: [date_dim.d_date_sk (#20)]
+            │                           │   ├── exchange type: Broadcast
+            │                           │   └── TableScan
+            │                           │       ├── table: default.default.date_dim
+            │                           │       ├── scan id: 1
+            │                           │       ├── output columns: [d_date_sk (#20)]
+            │                           │       ├── read rows: 0
+            │                           │       ├── read size: 0
+            │                           │       ├── partitions total: 0
+            │                           │       ├── partitions scanned: 0
+            │                           │       ├── push downs: [filters: [is_true(date_dim.d_year (#26) = 2001)], limit: NONE]
+            │                           │       └── estimated rows: 363.43
+            │                           └── TableScan(Probe)
+            │                               ├── table: default.default.store_returns
+            │                               ├── scan id: 0
+            │                               ├── output columns: [sr_returned_date_sk (#0), sr_customer_sk (#3), sr_store_sk (#7), sr_return_amt (#11)]
+            │                               ├── read rows: 0
+            │                               ├── read size: 0
+            │                               ├── partitions total: 0
+            │                               ├── partitions scanned: 0
+            │                               ├── push downs: [filters: [], limit: NONE]
+            │                               ├── apply join filters: [#3, #2, #0]
+            │                               └── estimated rows: 28792282.00
             └── TableScan(Probe)
                 ├── table: default.default.customer
                 ├── scan id: 3

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -930,13 +930,13 @@ explain select * from a where a.id = (select id from b where a.id = b.id);
 HashJoin
 ├── output columns: [a.id (#0), a.c1 (#1)]
 ├── join type: INNER
-├── build keys: [scalar_subquery_2 (#2), id (#2)]
-├── probe keys: [a.id (#0), a.id (#0)]
-├── keys is null equal: [false, false]
+├── build keys: [id (#2), scalar_subquery_2 (#2)]
+├── probe keys: [id (#0), a.id (#0)]
+├── keys is null equal: [true, false]
 ├── filters: []
 ├── build join filters:
-│   ├── filter id:0, build key:scalar_subquery_2 (#2), probe targets:[a.id (#0)@scan0], filter type:bloom,inlist,min_max
-│   └── filter id:1, build key:id (#2), probe targets:[a.id (#0)@scan0], filter type:bloom,inlist,min_max
+│   ├── filter id:0, build key:id (#2), probe targets:[id (#0)@scan0], filter type:
+│   └── filter id:1, build key:scalar_subquery_2 (#2), probe targets:[a.id (#0)@scan0], filter type:bloom,inlist,min_max
 ├── estimated rows: 0.40
 ├── TableScan(Build)
 │   ├── table: default.default.b
@@ -1327,10 +1327,10 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [a (#0)]
 ├── probe keys: [a (#3)]
-├── keys is null equal: [false]
+├── keys is null equal: [true]
 ├── filters: [t2.c (#2) > scalar_subquery_5 (#5)]
 ├── build join filters:
-│   └── filter id:0, build key:a (#0), probe targets:[a (#3)@scan1], filter type:bloom,inlist,min_max
+│   └── filter id:0, build key:a (#0), probe targets:[a (#3)@scan1], filter type:
 ├── estimated rows: 0.00
 ├── TableScan(Build)
 │   ├── table: default.default.t2
@@ -1375,10 +1375,10 @@ HashJoin
 ├── join type: INNER
 ├── build keys: [a (#0)]
 ├── probe keys: [a (#3)]
-├── keys is null equal: [false]
+├── keys is null equal: [true]
 ├── filters: [t2.c (#2) > scalar_subquery_5 (#5)]
 ├── build join filters:
-│   └── filter id:0, build key:a (#0), probe targets:[a (#3)@scan1], filter type:bloom,inlist,min_max
+│   └── filter id:0, build key:a (#0), probe targets:[a (#3)@scan1], filter type:
 ├── estimated rows: 0.00
 ├── TableScan(Build)
 │   ├── table: default.default.t2

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/mark.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/mark.test
@@ -101,7 +101,7 @@ EvalScalar
     ├── join type: LEFT SINGLE
     ├── build keys: [c (#8)]
     ├── probe keys: [c (#0)]
-    ├── keys is null equal: [false]
+    ├── keys is null equal: [true]
     ├── filters: []
     ├── estimated rows: 4.00
     ├── EvalScalar(Build)

--- a/tests/sqllogictests/suites/query/subquery.test
+++ b/tests/sqllogictests/suites/query/subquery.test
@@ -91,6 +91,62 @@ FROM nullable_fixed_probe_a AS a;
 NULL 0
 
 statement ok
+CREATE OR REPLACE TABLE nullable_scalar_outer (id INT, k DECIMAL(6, 0) NULL);
+
+statement ok
+INSERT INTO nullable_scalar_outer VALUES (1, NULL), (2, NULL), (3, 1);
+
+statement ok
+CREATE OR REPLACE TABLE nullable_scalar_payload (v INT);
+
+statement ok
+INSERT INTO nullable_scalar_payload VALUES (7);
+
+statement ok
+CREATE OR REPLACE TABLE nullable_scalar_two_keys (id INT, k1 INT NULL, k2 INT NULL);
+
+statement ok
+INSERT INTO nullable_scalar_two_keys VALUES
+    (1, NULL, 1),
+    (2, NULL, 1),
+    (3, NULL, 2),
+    (4, 1, 1);
+
+query IFI rowsort
+SELECT
+    id,
+    k,
+    (SELECT MAX(v) FROM nullable_scalar_payload WHERE outer_row.k IS NULL)
+FROM nullable_scalar_outer AS outer_row;
+----
+1 NULL 7
+2 NULL 7
+3 1 NULL
+
+query IFI rowsort
+SELECT
+    id,
+    k,
+    (SELECT COUNT(*) FROM nullable_scalar_payload WHERE outer_row.k IS NULL)
+FROM nullable_scalar_outer AS outer_row;
+----
+1 NULL 1
+2 NULL 1
+3 1 0
+
+query I rowsort
+SELECT id
+FROM nullable_scalar_two_keys AS outer_row
+WHERE (
+    SELECT COUNT(*)
+    FROM nullable_scalar_payload
+    WHERE outer_row.k1 IS NULL AND outer_row.k2 = 1
+) = 1;
+----
+1
+2
+
+statement ok
 SET enable_experimental_new_join = 0;
 
 query TBB rowsort
@@ -103,6 +159,40 @@ FROM nullable_fixed_probe_a AS a;
 0 1 1
 1 0 0
 NULL 0 0
+
+query IFI rowsort
+SELECT
+    id,
+    k,
+    (SELECT MAX(v) FROM nullable_scalar_payload WHERE outer_row.k IS NULL)
+FROM nullable_scalar_outer AS outer_row;
+----
+1 NULL 7
+2 NULL 7
+3 1 NULL
+
+query IFI rowsort
+SELECT
+    id,
+    k,
+    (SELECT COUNT(*) FROM nullable_scalar_payload WHERE outer_row.k IS NULL)
+FROM nullable_scalar_outer AS outer_row;
+----
+1 NULL 1
+2 NULL 1
+3 1 0
+
+query I rowsort
+SELECT id
+FROM nullable_scalar_two_keys AS outer_row
+WHERE (
+    SELECT COUNT(*)
+    FROM nullable_scalar_payload
+    WHERE outer_row.k1 IS NULL AND outer_row.k2 = 1
+) = 1;
+----
+1
+2
 
 statement ok
 SET enable_experimental_new_join = 1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Preserve nullable correlation-group identity when reconnecting flattened scalar subquery results to outer rows
- Keep NULL-safe join-key metadata when DPhyp rebuilds reordered joins
- Share nullable correlation-key detection across the decorrelation paths
- Add regression coverage for aggregate scalar subqueries with one and multiple nullable outer-only correlation keys

## Motivation

Scalar subquery decorrelation computes a flattened result per correlation group and joins that result back to the outer input. For a nullable correlation key, the planner previously created this internal join with `is_null_equal = false`. As a result, a result computed for the NULL correlation group could not match the corresponding outer rows, so values such as `MAX(v) = 7` were replaced with NULL and `COUNT(*) = 1` was rewritten to zero.

This internal equality represents correlation-group identity rather than a user-written SQL `=` predicate. The change marks nullable keys on this reconnecting join as NULL-safe, matching the behavior already used by the correlated EXISTS and ANY decorrelation paths. User-written equality predicates retain their normal NULL semantics.

DPhyp previously reduced each join condition to a `(left, right)` pair and recreated every reordered condition with `is_null_equal = false`. That made the correctness fix dependent on whether join reordering ran. DPhyp now carries the complete `JoinEquiCondition`, including its NULL-safe marker, through edge reversal and join reconstruction.

This is an independent planner follow-up discovered while investigating #20364. PR #20354 already fixes #20364's executor validity issue; this PR does not change that executor fix.

## Performance considerations

Databend columns are nullable by default, so more decorrelated scalar joins now correctly use NULL-safe correlation keys. Runtime bloom, in-list, and min/max filters are currently disabled for an individual NULL-safe key, and optimizer rules must not infer ordinary-equality predicates from it. This can change plan shape and reduce runtime-filter opportunities for affected queries, as visible in the updated EXPLAIN and TPC-DS Q01 expectations.

The decorrelator currently has declared expression types but no reliable relational property proving that a nullable key is non-NULL after upstream predicates. Narrowing the marker from metadata or statistics would therefore risk restoring the wrong result. This PR prioritizes correctness and explicitly retains the conservative behavior. No performance benchmark was run; deriving and propagating proven non-nullability can be evaluated as a separate optimizer improvement.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation performed:

- `cargo fmt --all -- --check`
- `cargo check -p databend-common-sql --lib`
- `cargo clippy -p databend-common-sql --lib -- -D warnings`
- `cargo build --bin databend-query --bin databend-sqllogictests`
- `TEST_SUBDIR=tpcds cargo test --package databend-query --test it -- sql::planner::optimizer::optimizer_test::test_optimizer --exact --nocapture`
- `databend-sqllogictests --handlers mysql,http --run tests/sqllogictests/suites/query/subquery.test --enable_sandbox --parallel 1` (277 MySQL and 277 HTTP tests passed)
- Regression cases run with both `enable_experimental_new_join = 0` and `1`, including two nullable correlation keys and duplicate `(NULL, 1)` outer rows
- `git diff --check`

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change)
- [ ] Breaking Change (fix or feature that could cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent investigated the scalar decorrelation and DPhyp join-reordering paths, drafted the planner fixes and regression tests, updated affected optimizer and EXPLAIN expectations, and ran the listed validation commands
- Responsible human: @youngsofun
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20408)
<!-- Reviewable:end -->
