### PR TITLE
ci(query): cover cross-type nullable correlated joins

### DIFF
--- a/tests/sqllogictests/suites/query/subquery.test
+++ b/tests/sqllogictests/suites/query/subquery.test
@@ -91,6 +91,37 @@ FROM nullable_fixed_probe_a AS a;
 NULL 0
 
 statement ok
+CREATE OR REPLACE TABLE nullable_cross_type_probe_a (integer_key BIGINT NULL);
+
+statement ok
+CREATE OR REPLACE TABLE nullable_cross_type_probe_b (decimal_key DECIMAL(20, 0) NULL);
+
+statement ok
+INSERT INTO nullable_cross_type_probe_a VALUES
+    (NULL), (NULL), (NULL), (2097735747), (2109914711);
+
+statement ok
+INSERT INTO nullable_cross_type_probe_b VALUES (0);
+
+query I
+SELECT COUNT(*)
+FROM nullable_cross_type_probe_a AS a
+WHERE EXISTS (
+    SELECT 1 FROM nullable_cross_type_probe_b AS b WHERE b.decimal_key = a.integer_key
+);
+----
+0
+
+query I
+SELECT COUNT(*)
+FROM nullable_cross_type_probe_a AS a
+WHERE NOT EXISTS (
+    SELECT 1 FROM nullable_cross_type_probe_b AS b WHERE b.decimal_key = a.integer_key
+);
+----
+5
+
+statement ok
 SET enable_experimental_new_join = 0;
 
 query TBB rowsort
@@ -103,6 +134,24 @@ FROM nullable_fixed_probe_a AS a;
 0 1 1
 1 0 0
 NULL 0 0
+
+query I
+SELECT COUNT(*)
+FROM nullable_cross_type_probe_a AS a
+WHERE EXISTS (
+    SELECT 1 FROM nullable_cross_type_probe_b AS b WHERE b.decimal_key = a.integer_key
+);
+----
+0
+
+query I
+SELECT COUNT(*)
+FROM nullable_cross_type_probe_a AS a
+WHERE NOT EXISTS (
+    SELECT 1 FROM nullable_cross_type_probe_b AS b WHERE b.decimal_key = a.integer_key
+);
+----
+5
 
 statement ok
 SET enable_experimental_new_join = 1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Closes #20364
- Add an exact regression for correlated `BIGINT = DECIMAL(20, 0)` join-key coercion
- Verify that three NULL probe rows do not falsely match the build-side decimal zero
- Cover both `EXISTS` and `NOT EXISTS` under the experimental and legacy hash joins

## Motivation

PR #20354 fixed correlated hash joins that dropped nullable probe-key validity and consequently treated NULL fixed-width keys as their physical default values. Its regression tests cover same-type DECIMAL, BOOLEAN, and TIMESTAMP keys, but #20364 specifically reported a cross-type numeric comparison where casting a nullable BIGINT probe key to DECIMAL exposed the same defect.

This test-only follow-up preserves the issue's exact cardinality-sensitive input: three NULL rows plus two non-matching BIGINT values on the probe side and a single DECIMAL zero on the build side. `EXISTS` must return zero rows, while `NOT EXISTS` must retain all five probe rows. The assertions pass with #20354 and protect both hash join implementations from regressing this coercion path.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation performed:

- `cargo build --bin databend-query --bin databend-meta --bin databend-sqllogictests`
- `databend-sqllogictests --run 'tests/sqllogictests/suites/query/subquery.test'` (273 MySQL and 273 HTTP tests passed)
- `git diff --check`

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): Test-only regression coverage for #20354 and #20364

## AI assistance

- AI usage: An AI coding agent reproduced the cross-type case, drafted the focused logic-test coverage, and ran the listed validation commands
- Responsible human: @youngsofun
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20409)
<!-- Reviewable:end -->
