### PR TITLE
feat(query): Inverted Index support Japanese language tokenizer

### DIFF
--- a/.github/actions/setup_build_tool/action.yml
+++ b/.github/actions/setup_build_tool/action.yml
@@ -120,6 +120,23 @@ runs:
         cat /proc/cpuinfo
         free -h
 
+    - name: configure lindera dictionary cache
+      shell: bash
+      run: |
+        echo "LINDERA_BUILD_DICTIONARY_CACHE_DIR=${HOME}/.cache/lindera" >> "$GITHUB_ENV"
+        mkdir -p "${HOME}/.cache/lindera"
+
+    - name: cache lindera dictionary
+      if: env.RUNNER_PROVIDER != 'aws'
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/lindera
+        key: lindera/${{ runner.os }}/${{ runner.arch }}/${{ inputs.target }}/${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          lindera/${{ runner.os }}/${{ runner.arch }}/${{ inputs.target }}/
+          lindera/${{ runner.os }}/${{ runner.arch }}/
+          lindera/${{ runner.os }}/
+
     - uses: everpcpc/actions-cache@v2
       if: env.RUNNER_PROVIDER == 'aws'
       env:
@@ -131,6 +148,7 @@ runs:
           ~/.cargo/registry/cache
           ~/.cargo/registry/index
           ~/.cargo/git/db
+          ~/.cache/lindera
         key: |
           ${{ runner.os }}/${{ inputs.target }}/${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "apache-avro"
@@ -269,7 +269,7 @@ dependencies = [
  "snap",
  "strum 0.27.2",
  "strum_macros 0.27.2",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "uuid",
  "zstd 0.13.3",
 ]
@@ -1146,7 +1146,7 @@ dependencies = [
  "memchr",
  "num",
  "regex",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.11",
 ]
 
 [[package]]
@@ -1163,7 +1163,7 @@ dependencies = [
  "memchr",
  "num",
  "regex",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.11",
 ]
 
 [[package]]
@@ -1180,7 +1180,7 @@ dependencies = [
  "memchr",
  "num-traits",
  "regex",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.11",
 ]
 
 [[package]]
@@ -1197,7 +1197,7 @@ dependencies = [
  "memchr",
  "num-traits",
  "regex",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.11",
 ]
 
 [[package]]
@@ -1223,7 +1223,7 @@ dependencies = [
  "rquickjs",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "wasi-common",
  "wasmtime",
@@ -2032,6 +2032,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,9 +2193,9 @@ dependencies = [
 
 [[package]]
 name = "bitpacking"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1d3e2bfd8d06048a179f7b17afc3188effa10385e7b00dc65af6aae732ea92"
+checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
 dependencies = [
  "crunchy",
 ]
@@ -2453,8 +2459,20 @@ version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
 dependencies = [
- "bytecheck_derive",
+ "bytecheck_derive 0.6.12",
  "ptr_meta 0.1.4",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26333eeac754f0ad8a6bcd0eb0ac012156302e4e16b852b72ee399aea4f12c29"
+dependencies = [
+ "bytecheck_derive 0.8.3",
+ "ptr_meta 0.3.0",
+ "rancor",
  "simdutf8",
 ]
 
@@ -2467,6 +2485,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46d07918caa9eeaaf06b7873925c53a61daac173539b4f7715090745e44e4e69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2662,7 +2691,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2713,9 +2742,9 @@ dependencies = [
 
 [[package]]
 name = "cedarwood"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d910bedd62c24733263d0bed247460853c9d22e8956bd4cd964302095e04e90"
+checksum = "c0524a528a6a0288df1863c3c20fe92c301875b4941e7b6c4b394ab08c5a4c55"
 dependencies = [
  "smallvec",
 ]
@@ -3404,6 +3433,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crawdad"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fbd1ecd2ed790e11c8fbe034f9b3e7687404818d1bdfd8218d26ec645ec7c5"
+
+[[package]]
 name = "crc"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3579,14 +3614,14 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
 dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3631,6 +3666,12 @@ dependencies = [
  "nix 0.30.1",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "daachorse"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d358f1fa877be3097baa74c1fc22288626450392cb37d844f850baa60e6439a0"
 
 [[package]]
 name = "darling"
@@ -4936,7 +4977,7 @@ dependencies = [
  "http 1.3.1",
  "iceberg",
  "log",
- "lru",
+ "lru 0.12.5",
  "opendal 0.54.1",
  "parquet 58.1.0",
  "prometheus-client 0.22.3",
@@ -5086,6 +5127,9 @@ dependencies = [
  "indexmap 2.14.0",
  "itertools 0.13.0",
  "jsonb",
+ "lindera",
+ "lindera-analysis",
+ "lindera-tantivy",
  "log",
  "match-template",
  "opendal 0.54.1",
@@ -7034,6 +7078,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "datasketches"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c4cf71a36b46dcfc00e5014c0c20ccad2b1b6a008304d7d57d2749b2d41b3d"
+
+[[package]]
 name = "deadpool"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7113,7 +7163,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.27.2",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -7184,7 +7234,7 @@ dependencies = [
  "serde_json",
  "sqlparser 0.56.0",
  "strum 0.27.2",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -7218,12 +7268,11 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -7662,6 +7711,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs_io"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba3fe847045ecff794b9c138293a80db914678c453ad63fbf0c6a9eb6e00b22"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "enquote"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8007,7 +8065,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6503af7917fea18ffef8f7e8553fb8dff89e2e6837e94e09dd7fb069c82d62c"
 dependencies = [
  "bytes",
- "rkyv 0.8.10",
+ "rkyv 0.8.18",
  "serde",
  "simdutf8",
 ]
@@ -8103,13 +8161,13 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.8"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
  "libz-sys",
- "miniz_oxide 0.8.9",
+ "miniz_oxide 0.9.1",
  "zlib-rs",
 ]
 
@@ -8198,6 +8256,12 @@ name = "fragile"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+
+[[package]]
+name = "frostem"
+version = "1.20260821.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ed6437a2ed7fc408115e25cdb41e15ba4b17742a4c8d3d1b5276fe9b687209"
 
 [[package]]
 name = "frunk"
@@ -8680,7 +8744,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tinyvec",
 ]
 
@@ -8694,7 +8758,7 @@ dependencies = [
  "log",
  "scroll 0.13.0",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "wkt",
 ]
 
@@ -8823,7 +8887,7 @@ dependencies = [
  "regex",
  "signal-hook",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8836,7 +8900,7 @@ dependencies = [
  "gix-date",
  "gix-utils 0.2.0",
  "itoa",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "winnow 0.7.10",
 ]
 
@@ -8851,7 +8915,7 @@ dependencies = [
  "gix-object",
  "gix-worktree-stream",
  "jiff",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8867,7 +8931,7 @@ dependencies = [
  "gix-trace",
  "kstring",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "unicode-bom",
 ]
 
@@ -8877,7 +8941,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1db9765c69502650da68f0804e3dc2b5f8ccc6a2d104ca6c85bc40700d37540"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8886,7 +8950,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b1f1d8764958699dc764e3f727cef280ff4d1bd92c107bbf8acd85b30c1bd6f"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8912,7 +8976,7 @@ dependencies = [
  "gix-chunk",
  "gix-hash 0.17.0",
  "memmap2",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8931,7 +8995,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "unicode-bom",
  "winnow 0.7.10",
 ]
@@ -8946,7 +9010,7 @@ dependencies = [
  "bstr",
  "gix-path",
  "libc",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8963,7 +9027,7 @@ dependencies = [
  "gix-sec",
  "gix-trace",
  "gix-url",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8975,7 +9039,7 @@ dependencies = [
  "bstr",
  "itoa",
  "jiff",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8999,7 +9063,7 @@ dependencies = [
  "gix-traverse",
  "gix-worktree",
  "imara-diff",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9019,7 +9083,7 @@ dependencies = [
  "gix-trace",
  "gix-utils 0.2.0",
  "gix-worktree",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9035,7 +9099,7 @@ dependencies = [
  "gix-path",
  "gix-ref",
  "gix-sec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9056,7 +9120,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.3",
  "prodash",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "walkdir",
 ]
 
@@ -9090,7 +9154,7 @@ dependencies = [
  "gix-trace",
  "gix-utils 0.2.0",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9104,7 +9168,7 @@ dependencies = [
  "gix-features 0.41.1",
  "gix-path",
  "gix-utils 0.2.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9118,7 +9182,7 @@ dependencies = [
  "gix-features 0.42.1",
  "gix-path",
  "gix-utils 0.3.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9142,7 +9206,7 @@ dependencies = [
  "faster-hex 0.9.0",
  "gix-features 0.41.1",
  "sha1-checked",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9154,7 +9218,7 @@ dependencies = [
  "faster-hex 0.10.0",
  "gix-features 0.42.1",
  "sha1-checked",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9206,7 +9270,7 @@ dependencies = [
  "memmap2",
  "rustix 0.38.44",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9217,7 +9281,7 @@ checksum = "570f8b034659f256366dc90f1a24924902f20acccd6a15be96d44d1269e7a796"
 dependencies = [
  "gix-tempfile",
  "gix-utils 0.3.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9229,7 +9293,7 @@ dependencies = [
  "bstr",
  "gix-actor",
  "gix-date",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9245,7 +9309,7 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9265,7 +9329,7 @@ dependencies = [
  "gix-validate 0.9.4",
  "itoa",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "winnow 0.7.10",
 ]
 
@@ -9287,7 +9351,7 @@ dependencies = [
  "gix-quote",
  "parking_lot 0.12.3",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9305,7 +9369,7 @@ dependencies = [
  "gix-path",
  "memmap2",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "uluru",
 ]
 
@@ -9318,7 +9382,7 @@ dependencies = [
  "bstr",
  "faster-hex 0.9.0",
  "gix-trace",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9330,7 +9394,7 @@ dependencies = [
  "bstr",
  "faster-hex 0.9.0",
  "gix-trace",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9344,7 +9408,7 @@ dependencies = [
  "gix-validate 0.10.0",
  "home",
  "once_cell",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9359,7 +9423,7 @@ dependencies = [
  "gix-config-value",
  "gix-glob",
  "gix-path",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9372,7 +9436,7 @@ dependencies = [
  "gix-config-value",
  "parking_lot 0.12.3",
  "rustix 0.38.44",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9390,7 +9454,7 @@ dependencies = [
  "gix-transport",
  "gix-utils 0.2.0",
  "maybe-async",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "winnow 0.7.10",
 ]
 
@@ -9402,7 +9466,7 @@ checksum = "1b005c550bf84de3b24aa5e540a23e6146a1c01c7d30470e35d75a12f827f969"
 dependencies = [
  "bstr",
  "gix-utils 0.2.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9422,7 +9486,7 @@ dependencies = [
  "gix-utils 0.2.0",
  "gix-validate 0.9.4",
  "memmap2",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "winnow 0.7.10",
 ]
 
@@ -9437,7 +9501,7 @@ dependencies = [
  "gix-revision",
  "gix-validate 0.9.4",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9455,7 +9519,7 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "gix-trace",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9470,7 +9534,7 @@ dependencies = [
  "gix-hashtable",
  "gix-object",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9494,7 +9558,7 @@ dependencies = [
  "bstr",
  "gix-hash 0.17.0",
  "gix-lock",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9517,7 +9581,7 @@ dependencies = [
  "gix-pathspec",
  "gix-worktree",
  "portable-atomic",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9532,7 +9596,7 @@ dependencies = [
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9570,7 +9634,7 @@ dependencies = [
  "gix-quote",
  "gix-sec",
  "gix-url",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9587,7 +9651,7 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9600,7 +9664,7 @@ dependencies = [
  "gix-features 0.41.1",
  "gix-path",
  "percent-encoding",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "url",
 ]
 
@@ -9632,7 +9696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34b5f1253109da6c79ed7cf6e1e38437080bb6d704c76af14c93e2f255234084"
 dependencies = [
  "bstr",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9642,7 +9706,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77b9e00cacde5b51388d28ed746c493b18a6add1f19b5e01d686b3b9ece66d4d"
 dependencies = [
  "bstr",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9681,7 +9745,7 @@ dependencies = [
  "gix-path",
  "gix-worktree",
  "io-close",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9699,14 +9763,14 @@ dependencies = [
  "gix-path",
  "gix-traverse",
  "parking_lot 0.12.3",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "globiter"
@@ -9896,6 +9960,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -9949,7 +10018,7 @@ dependencies = [
  "regex",
  "roxmltree",
  "socket2 0.6.3",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "url",
  "uuid",
@@ -10099,7 +10168,7 @@ dependencies = [
  "once_cell",
  "rand 0.9.2",
  "ring",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tinyvec",
  "tokio",
  "tracing",
@@ -10122,7 +10191,7 @@ dependencies = [
  "rand 0.9.2",
  "resolv-conf",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -11175,19 +11244,20 @@ dependencies = [
 
 [[package]]
 name = "jieba-macros"
-version = "0.8.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348294e44ee7e3c42685da656490f8febc7359632544019621588902216da95c"
+checksum = "34904340bc65749a9e9a02fcc7f3368e675427c18447b9bbe02df52c15c9a36a"
 dependencies = [
  "phf_codegen 0.13.1",
 ]
 
 [[package]]
 name = "jieba-rs"
-version = "0.8.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "766bd7012aa5ba49411ebdf4e93bddd59b182d2918e085d58dec5bb9b54b7105"
+checksum = "bb5bdea4dc241d589e179f39d2a778f31490f3370aa2f626223dbd930ebc5c9d"
 dependencies = [
+ "bytecount",
  "cedarwood",
  "include-flate",
  "jieba-macros",
@@ -11315,7 +11385,7 @@ dependencies = [
  "serde",
  "serde_json",
  "superboring",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "zeroize",
 ]
 
@@ -11331,6 +11401,15 @@ dependencies = [
  "once_cell",
  "sha2",
  "signature",
+]
+
+[[package]]
+name = "kanaria"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f9d9652540055ac4fded998a73aca97d965899077ab1212587437da44196ff"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -11849,6 +11928,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "lindera"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65015f4b12a1b869058a602e3cf7b39239ca1fbedd4b451bc9bb2fd2c9989eee"
+dependencies = [
+ "anyhow",
+ "lindera-dictionary",
+ "lindera-ipadic",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
+ "url",
+]
+
+[[package]]
+name = "lindera-analysis"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c51c3ff53169ea3329b36bfd6f906b542ce6e11fa812d455ac1093aa29e0b6"
+dependencies = [
+ "anyhow",
+ "daachorse",
+ "kanaria",
+ "lindera",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml_ng",
+ "unicode-blocks",
+ "unicode-normalization",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "lindera-dictionary"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "647b3dd3102151b82d6995f5fafdb4fe512f8b65b5f92ccf6bfde2ba33596423"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "crawdad",
+ "csv",
+ "daachorse",
+ "encoding_rs",
+ "encoding_rs_io",
+ "flate2",
+ "glob",
+ "log",
+ "md5",
+ "memchr",
+ "memmap2",
+ "once_cell",
+ "rand 0.10.2",
+ "rayon",
+ "rkyv 0.8.18",
+ "serde",
+ "serde_json",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
+ "tar",
+ "thiserror 2.0.20",
+ "ureq",
+]
+
+[[package]]
+name = "lindera-ipadic"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d01d06a14be0253c6f11cd48e3acebb0698aee3b199715e8ffae0c6f3111eb8"
+dependencies = [
+ "lindera-dictionary",
+]
+
+[[package]]
+name = "lindera-tantivy"
+version = "5.0.1"
+source = "git+https://github.com/b41sh/lindera-tantivy?rev=0f522e51c8d7517e9560f17740c588011b1b9467#0f522e51c8d7517e9560f17740c588011b1b9467"
+dependencies = [
+ "lindera",
+ "lindera-analysis",
+ "tantivy",
+ "tantivy-tokenizer-api",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11901,9 +12069,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 dependencies = [
  "serde_core",
  "value-bag",
@@ -12000,6 +12168,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d317b4b9eb398e6acce275758ec6125535505e7a146fb1a9b8bda2451b0ff4c"
+dependencies = [
+ "hashbrown 0.17.0",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12069,6 +12246,12 @@ checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
 dependencies = [
  "twox-hash 2.1.0",
 ]
+
+[[package]]
+name = "lz4_flex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
 
 [[package]]
 name = "lzma-rs"
@@ -12210,6 +12393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "md5"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
+
+[[package]]
 name = "measure_time"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12220,9 +12409,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memfd"
@@ -12235,9 +12424,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.9.5"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -12319,6 +12508,15 @@ name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -12521,9 +12719,9 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "murmurhash32"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
+checksum = "a8afc6df942f4c022d70c5725e18df1a705773870e5b7f96fde94ca0334ce77a"
 
 [[package]]
 name = "mysql-common-derive"
@@ -12556,7 +12754,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "keyed_priority_queue",
- "lru",
+ "lru 0.12.5",
  "mysql_common",
  "native-tls",
  "pem",
@@ -12816,9 +13014,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -12974,7 +13172,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -13000,9 +13198,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 dependencies = [
  "critical-section",
  "portable-atomic",
@@ -13010,9 +13208,9 @@ dependencies = [
 
 [[package]]
 name = "oneshot"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce411919553d3f9fa53a0880544cda985a112117a0444d5ff1e870a893d6ea"
+checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 
 [[package]]
 name = "opaque-debug"
@@ -13105,11 +13303,11 @@ dependencies = [
  "openraft-rt",
  "openraft-rt-tokio",
  "peel-off",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
  "smallvec",
  "tabled",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
  "validit",
 ]
@@ -13137,7 +13335,7 @@ dependencies = [
  "futures-util",
  "openraft-macros",
  "pin-project-lite",
- "rand 0.10.1",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -13148,7 +13346,7 @@ checksum = "0bdb85613581297e2bf55a6ee713c0066aeb30fb404cccd5ef0d177e1cb0e879"
 dependencies = [
  "futures-util",
  "openraft-rt",
- "rand 0.10.1",
+ "rand 0.10.2",
  "tokio",
 ]
 
@@ -13231,7 +13429,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -13245,7 +13443,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -13293,7 +13491,7 @@ dependencies = [
  "prost 0.13.5",
  "reqwest",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tonic 0.12.3",
  "tracing",
@@ -13313,7 +13511,7 @@ dependencies = [
  "opentelemetry_sdk 0.29.0",
  "prost 0.13.5",
  "reqwest",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tonic 0.12.3",
  "tracing",
@@ -13361,7 +13559,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.8.5",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -13381,7 +13579,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.9.2",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -13487,7 +13685,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/datafuse-extras/tantivy?rev=b600b0e#b600b0e7df22746cc4beee3a8b9288be16908dbc"
+source = "git+https://github.com/b41sh/tantivy?rev=3eb4dd325d6188bd87ee6b25823b286d5bb310a1#3eb4dd325d6188bd87ee6b25823b286d5bb310a1"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -13717,7 +13915,7 @@ checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
 dependencies = [
  "parse-display-derive",
  "regex",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.11",
 ]
 
 [[package]]
@@ -13729,7 +13927,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.11",
  "structmeta",
  "syn 2.0.106",
 ]
@@ -14092,7 +14290,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "sync_wrapper",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
  "tokio",
  "tokio-openssl",
@@ -14193,7 +14391,7 @@ dependencies = [
  "spin 0.10.0",
  "symbolic-demangle",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -14433,7 +14631,7 @@ dependencies = [
  "crs-definitions",
  "geo-types",
  "js-sys",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -14500,7 +14698,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.11",
  "unarray",
 ]
 
@@ -15012,7 +15210,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls 0.23.36",
  "socket2 0.5.9",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -15033,7 +15231,7 @@ dependencies = [
  "rustls 0.23.36",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -15128,9 +15326,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -15255,9 +15453,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -15265,9 +15463,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -15390,25 +15588,25 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.11",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.11",
 ]
 
 [[package]]
@@ -15431,9 +15629,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "relative-path"
@@ -15447,7 +15645,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
- "bytecheck",
+ "bytecheck 0.6.12",
 ]
 
 [[package]]
@@ -15455,6 +15653,9 @@ name = "rend"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a35e8a6bf28cd121053a66aa2e6a2e3eaffad4a60012179f0e864aa5ffeff215"
+dependencies = [
+ "bytecheck 0.8.3",
+]
 
 [[package]]
 name = "replace_with"
@@ -15613,7 +15814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
 dependencies = [
  "bitvec",
- "bytecheck",
+ "bytecheck 0.6.12",
  "bytes",
  "hashbrown 0.12.3",
  "ptr_meta 0.1.4",
@@ -15626,18 +15827,19 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.10"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e147371c75553e1e2fcdb483944a8540b8438c31426279553b9a8182a9b7b65"
+checksum = "d9776093b7ca170454ab1406954f7b7d97a57c51dc6c0642957fb2ef25c2d399"
 dependencies = [
+ "bytecheck 0.8.3",
  "bytes",
- "hashbrown 0.15.3",
+ "hashbrown 0.17.0",
  "indexmap 2.14.0",
  "munge",
  "ptr_meta 0.3.0",
  "rancor",
  "rend 0.5.2",
- "rkyv_derive 0.8.10",
+ "rkyv_derive 0.8.18",
  "tinyvec",
  "uuid",
 ]
@@ -15655,13 +15857,13 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.10"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246b40ac189af6c675d124b802e8ef6d5246c53e17367ce9501f8f66a81abb7a"
+checksum = "1c25ef604ac7dd839d44d64648952ea23c97866f124ff671b0ed2cf3ad9bb06e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -15905,16 +16107,6 @@ dependencies = [
  "cfg-if",
  "ordered-multimap",
  "trim-in-place",
-]
-
-[[package]]
-name = "rust-stemmers"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
-dependencies = [
- "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -16281,9 +16473,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -16329,22 +16521,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -16367,9 +16559,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -16474,6 +16666,19 @@ name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -16601,9 +16806,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simdutf8"
@@ -16639,7 +16844,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -16688,9 +16893,9 @@ dependencies = [
 
 [[package]]
 name = "sketches-ddsketch"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
+checksum = "513c3f5f732bfd6fbb187619c2dfe9d2f25f1a2976f01d575f0fd329d565df56"
 dependencies = [
  "serde",
 ]
@@ -16842,7 +17047,7 @@ dependencies = [
  "simdutf8",
  "sonic-number",
  "sonic-simd",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -16937,7 +17142,7 @@ dependencies = [
  "similar",
  "subst",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -17001,7 +17206,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -17084,7 +17289,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
  "whoami",
 ]
@@ -17121,7 +17326,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
  "whoami",
 ]
@@ -17145,7 +17350,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
  "url",
 ]
@@ -17267,7 +17472,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c567f1a469136e44fd0d9cba05a1d84bf5e6b4ec9cd7b247a35112c70ec8d071"
 dependencies = [
  "structkey-derive",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -17330,6 +17535,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17360,6 +17574,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -17543,6 +17769,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "syn-mid"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17665,36 +17902,36 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tantivy"
-version = "0.26.0"
-source = "git+https://github.com/datafuse-extras/tantivy?rev=b600b0e#b600b0e7df22746cc4beee3a8b9288be16908dbc"
+version = "0.27.0"
+source = "git+https://github.com/b41sh/tantivy?rev=3eb4dd325d6188bd87ee6b25823b286d5bb310a1#3eb4dd325d6188bd87ee6b25823b286d5bb310a1"
 dependencies = [
  "aho-corasick",
  "arc-swap",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bitpacking",
  "bon",
  "byteorder",
  "census",
  "crc32fast",
  "crossbeam-channel",
+ "datasketches",
  "downcast-rs",
  "fastdivide",
  "fnv",
+ "frostem",
  "fs4",
  "htmlescape",
- "hyperloglogplus",
  "itertools 0.14.0",
  "levenshtein_automata",
  "log",
- "lru",
- "lz4_flex 0.11.3",
+ "lru 0.18.3",
+ "lz4_flex 0.14.0",
  "measure_time",
  "memmap2",
  "once_cell",
  "oneshot",
  "rayon",
  "regex",
- "rust-stemmers",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
@@ -17708,25 +17945,26 @@ dependencies = [
  "tantivy-stacker",
  "tantivy-tokenizer-api",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
  "typetag",
+ "unwrap-infallible",
  "uuid",
  "winapi",
 ]
 
 [[package]]
 name = "tantivy-bitpacker"
-version = "0.9.0"
-source = "git+https://github.com/datafuse-extras/tantivy?rev=b600b0e#b600b0e7df22746cc4beee3a8b9288be16908dbc"
+version = "0.10.0"
+source = "git+https://github.com/b41sh/tantivy?rev=3eb4dd325d6188bd87ee6b25823b286d5bb310a1#3eb4dd325d6188bd87ee6b25823b286d5bb310a1"
 dependencies = [
  "bitpacking",
 ]
 
 [[package]]
 name = "tantivy-columnar"
-version = "0.6.0"
-source = "git+https://github.com/datafuse-extras/tantivy?rev=b600b0e#b600b0e7df22746cc4beee3a8b9288be16908dbc"
+version = "0.7.0"
+source = "git+https://github.com/b41sh/tantivy?rev=3eb4dd325d6188bd87ee6b25823b286d5bb310a1#3eb4dd325d6188bd87ee6b25823b286d5bb310a1"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -17740,8 +17978,8 @@ dependencies = [
 
 [[package]]
 name = "tantivy-common"
-version = "0.10.0"
-source = "git+https://github.com/datafuse-extras/tantivy?rev=b600b0e#b600b0e7df22746cc4beee3a8b9288be16908dbc"
+version = "0.11.0"
+source = "git+https://github.com/b41sh/tantivy?rev=3eb4dd325d6188bd87ee6b25823b286d5bb310a1#3eb4dd325d6188bd87ee6b25823b286d5bb310a1"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -17757,14 +17995,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d60769b80ad7953d8a7b2c70cdfe722bbcdcac6bccc8ac934c40c034d866fc18"
 dependencies = [
  "byteorder",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.11",
  "utf8-ranges",
 ]
 
 [[package]]
 name = "tantivy-jieba"
-version = "0.17.0"
-source = "git+https://github.com/datafuse-extras/tantivy-jieba?rev=68ab55c#68ab55c7015479828456ba339528183cb4635478"
+version = "0.20.0"
+source = "git+https://github.com/b41sh/tantivy-jieba?rev=22c3f82888b304cc97441843da9b4e71cd4d204e#22c3f82888b304cc97441843da9b4e71cd4d204e"
 dependencies = [
  "jieba-rs",
  "lazy_static",
@@ -17773,8 +18011,8 @@ dependencies = [
 
 [[package]]
 name = "tantivy-query-grammar"
-version = "0.25.0"
-source = "git+https://github.com/datafuse-extras/tantivy?rev=b600b0e#b600b0e7df22746cc4beee3a8b9288be16908dbc"
+version = "0.26.0"
+source = "git+https://github.com/b41sh/tantivy?rev=3eb4dd325d6188bd87ee6b25823b286d5bb310a1#3eb4dd325d6188bd87ee6b25823b286d5bb310a1"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -17785,8 +18023,8 @@ dependencies = [
 
 [[package]]
 name = "tantivy-sstable"
-version = "0.6.0"
-source = "git+https://github.com/datafuse-extras/tantivy?rev=b600b0e#b600b0e7df22746cc4beee3a8b9288be16908dbc"
+version = "0.7.0"
+source = "git+https://github.com/b41sh/tantivy?rev=3eb4dd325d6188bd87ee6b25823b286d5bb310a1#3eb4dd325d6188bd87ee6b25823b286d5bb310a1"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -17798,8 +18036,8 @@ dependencies = [
 
 [[package]]
 name = "tantivy-stacker"
-version = "0.6.0"
-source = "git+https://github.com/datafuse-extras/tantivy?rev=b600b0e#b600b0e7df22746cc4beee3a8b9288be16908dbc"
+version = "0.7.0"
+source = "git+https://github.com/b41sh/tantivy?rev=3eb4dd325d6188bd87ee6b25823b286d5bb310a1#3eb4dd325d6188bd87ee6b25823b286d5bb310a1"
 dependencies = [
  "murmurhash32",
  "tantivy-common",
@@ -17807,8 +18045,8 @@ dependencies = [
 
 [[package]]
 name = "tantivy-tokenizer-api"
-version = "0.6.0"
-source = "git+https://github.com/datafuse-extras/tantivy?rev=b600b0e#b600b0e7df22746cc4beee3a8b9288be16908dbc"
+version = "0.7.0"
+source = "git+https://github.com/b41sh/tantivy?rev=3eb4dd325d6188bd87ee6b25823b286d5bb310a1#3eb4dd325d6188bd87ee6b25823b286d5bb310a1"
 dependencies = [
  "serde",
 ]
@@ -17818,6 +18056,17 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
 
 [[package]]
 name = "target-lexicon"
@@ -17953,11 +18202,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -17973,13 +18222,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -18037,32 +18286,31 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -18787,6 +19035,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
+name = "unicode-blocks"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328edfd6d0bb91a22e592bed3a3b54c7b1f5c92a517f5a7aca24a2caef10c363"
+
+[[package]]
 name = "unicode-bom"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18800,9 +19054,9 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
@@ -18815,9 +19069,9 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -18878,6 +19132,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
+name = "unwrap-infallible"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e497bb1f828cc9fb236722c2eaa100dcf201563f38f4da6252357a59037adf31"
+
+[[package]]
+name = "ureq"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
+dependencies = [
+ "base64 0.23.1",
+ "log",
+ "percent-encoding",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots 1.0.0",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
+dependencies = [
+ "base64 0.23.1",
+ "http 1.3.1",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18907,6 +19195,12 @@ name = "utf8-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -19063,7 +19357,7 @@ dependencies = [
  "pin-project",
  "rand 0.9.2",
  "socket2 0.5.9",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tower 0.5.2",
@@ -19094,7 +19388,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "scopeguard",
  "sonic-rs",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "volo",
@@ -20747,9 +21041,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12008,7 +12008,7 @@ dependencies = [
 [[package]]
 name = "lindera-tantivy"
 version = "5.0.1"
-source = "git+https://github.com/b41sh/lindera-tantivy?rev=0f522e51c8d7517e9560f17740c588011b1b9467#0f522e51c8d7517e9560f17740c588011b1b9467"
+source = "git+https://github.com/datafuse-extras/lindera-tantivy?rev=a40ccd7#a40ccd7a87791de6a851224333303d3afb9f96bd"
 dependencies = [
  "lindera",
  "lindera-analysis",
@@ -13685,7 +13685,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/b41sh/tantivy?rev=3eb4dd325d6188bd87ee6b25823b286d5bb310a1#3eb4dd325d6188bd87ee6b25823b286d5bb310a1"
+source = "git+https://github.com/datafuse-extras/tantivy?rev=760ddb7#760ddb7ad6c9e5ff4fbfdbebbd7c6cdc2eab3ca8"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -17903,7 +17903,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.27.0"
-source = "git+https://github.com/b41sh/tantivy?rev=3eb4dd325d6188bd87ee6b25823b286d5bb310a1#3eb4dd325d6188bd87ee6b25823b286d5bb310a1"
+source = "git+https://github.com/datafuse-extras/tantivy?rev=760ddb7#760ddb7ad6c9e5ff4fbfdbebbd7c6cdc2eab3ca8"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -17956,7 +17956,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.10.0"
-source = "git+https://github.com/b41sh/tantivy?rev=3eb4dd325d6188bd87ee6b25823b286d5bb310a1#3eb4dd325d6188bd87ee6b25823b286d5bb310a1"
+source = "git+https://github.com/datafuse-extras/tantivy?rev=760ddb7#760ddb7ad6c9e5ff4fbfdbebbd7c6cdc2eab3ca8"
 dependencies = [
  "bitpacking",
 ]
@@ -17964,7 +17964,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.7.0"
-source = "git+https://github.com/b41sh/tantivy?rev=3eb4dd325d6188bd87ee6b25823b286d5bb310a1#3eb4dd325d6188bd87ee6b25823b286d5bb310a1"
+source = "git+https://github.com/datafuse-extras/tantivy?rev=760ddb7#760ddb7ad6c9e5ff4fbfdbebbd7c6cdc2eab3ca8"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -17979,7 +17979,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.11.0"
-source = "git+https://github.com/b41sh/tantivy?rev=3eb4dd325d6188bd87ee6b25823b286d5bb310a1#3eb4dd325d6188bd87ee6b25823b286d5bb310a1"
+source = "git+https://github.com/datafuse-extras/tantivy?rev=760ddb7#760ddb7ad6c9e5ff4fbfdbebbd7c6cdc2eab3ca8"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -18002,7 +18002,7 @@ dependencies = [
 [[package]]
 name = "tantivy-jieba"
 version = "0.20.0"
-source = "git+https://github.com/b41sh/tantivy-jieba?rev=22c3f82888b304cc97441843da9b4e71cd4d204e#22c3f82888b304cc97441843da9b4e71cd4d204e"
+source = "git+https://github.com/datafuse-extras/tantivy-jieba?rev=3cda3c6#3cda3c626ad6e673c088ef8355d1a5f2bf4a06b5"
 dependencies = [
  "jieba-rs",
  "lazy_static",
@@ -18012,7 +18012,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.26.0"
-source = "git+https://github.com/b41sh/tantivy?rev=3eb4dd325d6188bd87ee6b25823b286d5bb310a1#3eb4dd325d6188bd87ee6b25823b286d5bb310a1"
+source = "git+https://github.com/datafuse-extras/tantivy?rev=760ddb7#760ddb7ad6c9e5ff4fbfdbebbd7c6cdc2eab3ca8"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -18024,7 +18024,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.7.0"
-source = "git+https://github.com/b41sh/tantivy?rev=3eb4dd325d6188bd87ee6b25823b286d5bb310a1#3eb4dd325d6188bd87ee6b25823b286d5bb310a1"
+source = "git+https://github.com/datafuse-extras/tantivy?rev=760ddb7#760ddb7ad6c9e5ff4fbfdbebbd7c6cdc2eab3ca8"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -18037,7 +18037,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.7.0"
-source = "git+https://github.com/b41sh/tantivy?rev=3eb4dd325d6188bd87ee6b25823b286d5bb310a1#3eb4dd325d6188bd87ee6b25823b286d5bb310a1"
+source = "git+https://github.com/datafuse-extras/tantivy?rev=760ddb7#760ddb7ad6c9e5ff4fbfdbebbd7c6cdc2eab3ca8"
 dependencies = [
  "murmurhash32",
  "tantivy-common",
@@ -18046,7 +18046,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.7.0"
-source = "git+https://github.com/b41sh/tantivy?rev=3eb4dd325d6188bd87ee6b25823b286d5bb310a1#3eb4dd325d6188bd87ee6b25823b286d5bb310a1"
+source = "git+https://github.com/datafuse-extras/tantivy?rev=760ddb7#760ddb7ad6c9e5ff4fbfdbebbd7c6cdc2eab3ca8"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -345,6 +345,9 @@ lexical-core = "1"
 libc = { version = "0.2.158" }
 libm = "0.2.6"
 limits-rs = "0.2.0"
+lindera = { version = "5.0.1", features = ["embed-ipadic"] }
+lindera-analysis = "5.0.1"
+lindera-tantivy = { version = "5.0.1", features = ["embed-ipadic"] }
 logforth = { git = "https://github.com/datafuse-extras/logforth", branch = "main", features = [
     'json',
     'rolling-file',
@@ -475,11 +478,12 @@ sub-cache = "0.2.1"
 syn = { version = "2.0", features = ["full"] }
 sys-info = "0.9"
 sysinfo = "0.34.2"
-tantivy = "0.26.0"
-tantivy-common = "0.10.0"
+tantivy = "0.27.0"
+tantivy-common = "0.11.0"
 tantivy-fst = "0.5"
-tantivy-jieba = "0.17.0"
-tantivy-query-grammar = "0.25.0"
+#tantivy-jieba = "0.17.0"
+tantivy-jieba = "0.20.0"
+tantivy-query-grammar = "0.26.0"
 temp-env = "0.3.0"
 tempfile = "3.4.0"
 terminal_size = "0.4.2"
@@ -650,6 +654,8 @@ lance-encoding = { git = "https://github.com/datafuse-extras/lance", rev = "85f9
 lance-file = { git = "https://github.com/datafuse-extras/lance", rev = "85f9401d3246d52a287bca21457dbae0466858ee" }
 lance-io = { git = "https://github.com/datafuse-extras/lance", rev = "85f9401d3246d52a287bca21457dbae0466858ee" }
 lance-table = { git = "https://github.com/datafuse-extras/lance", rev = "85f9401d3246d52a287bca21457dbae0466858ee" }
+#lindera-tantivy = { git = "https://github.com/b41sh/lindera-tantivy", rev = "88dc0df4248f721a34c9de42581233fa973b8493", features = ["embed-ipadic"] }
+lindera-tantivy = { git = "https://github.com/b41sh/lindera-tantivy", rev = "0f522e51c8d7517e9560f17740c588011b1b9467" }
 map-api = { git = "https://github.com/databendlabs/map-api", tag = "v0.5.0" }
 # Keep ORC on a patch while the upstream crate has not caught up with Arrow 58 yet.
 orc-rust = { git = "https://github.com/datafuse-extras/orc-rust", rev = "fc17101f1c96e1ea7c7a19e931110471a4bd7e21" }
@@ -658,9 +664,13 @@ recursive = { git = "https://github.com/datafuse-extras/recursive.git", rev = "1
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1" }
 state-machine-api = { git = "https://github.com/databendlabs/state-machine-api.git", tag = "v0.4.0" }
 sub-cache = { git = "https://github.com/databendlabs/sub-cache", tag = "v0.2.1" }
-tantivy = { git = "https://github.com/datafuse-extras/tantivy", rev = "b600b0e" }
-tantivy-common = { git = "https://github.com/datafuse-extras/tantivy", rev = "b600b0e", package = "tantivy-common" }
-tantivy-jieba = { git = "https://github.com/datafuse-extras/tantivy-jieba", rev = "68ab55c" }
-tantivy-query-grammar = { git = "https://github.com/datafuse-extras/tantivy", rev = "b600b0e", package = "tantivy-query-grammar" }
+#tantivy = { git = "https://github.com/datafuse-extras/tantivy", rev = "b600b0e" }
+#tantivy-common = { git = "https://github.com/datafuse-extras/tantivy", rev = "b600b0e", package = "tantivy-common" }
+#tantivy-jieba = { git = "https://github.com/datafuse-extras/tantivy-jieba", rev = "68ab55c" }
+#tantivy-query-grammar = { git = "https://github.com/datafuse-extras/tantivy", rev = "b600b0e", package = "tantivy-query-grammar" }
+tantivy = { git = "https://github.com/b41sh/tantivy", rev = "3eb4dd325d6188bd87ee6b25823b286d5bb310a1" }
+tantivy-common = { git = "https://github.com/b41sh/tantivy", rev = "3eb4dd325d6188bd87ee6b25823b286d5bb310a1", package = "tantivy-common" }
+tantivy-jieba = { git = "https://github.com/b41sh/tantivy-jieba", rev = "22c3f82888b304cc97441843da9b4e71cd4d204e" }
+tantivy-query-grammar = { git = "https://github.com/b41sh/tantivy", rev = "3eb4dd325d6188bd87ee6b25823b286d5bb310a1", package = "tantivy-query-grammar" }
 watcher = { git = "https://github.com/databendlabs/watcher", tag = "v0.5.0" }
 xorfilter-rs = { git = "https://github.com/datafuse-extras/xorfilter", tag = "databend-alpha.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -481,7 +481,6 @@ sysinfo = "0.34.2"
 tantivy = "0.27.0"
 tantivy-common = "0.11.0"
 tantivy-fst = "0.5"
-#tantivy-jieba = "0.17.0"
 tantivy-jieba = "0.20.0"
 tantivy-query-grammar = "0.26.0"
 temp-env = "0.3.0"
@@ -654,8 +653,7 @@ lance-encoding = { git = "https://github.com/datafuse-extras/lance", rev = "85f9
 lance-file = { git = "https://github.com/datafuse-extras/lance", rev = "85f9401d3246d52a287bca21457dbae0466858ee" }
 lance-io = { git = "https://github.com/datafuse-extras/lance", rev = "85f9401d3246d52a287bca21457dbae0466858ee" }
 lance-table = { git = "https://github.com/datafuse-extras/lance", rev = "85f9401d3246d52a287bca21457dbae0466858ee" }
-#lindera-tantivy = { git = "https://github.com/b41sh/lindera-tantivy", rev = "88dc0df4248f721a34c9de42581233fa973b8493", features = ["embed-ipadic"] }
-lindera-tantivy = { git = "https://github.com/b41sh/lindera-tantivy", rev = "8d1d09f69be8959f7c04375241b61cc061c14b0c" }
+lindera-tantivy = { git = "https://github.com/datafuse-extras/lindera-tantivy", rev = "a40ccd7" }
 map-api = { git = "https://github.com/databendlabs/map-api", tag = "v0.5.0" }
 # Keep ORC on a patch while the upstream crate has not caught up with Arrow 58 yet.
 orc-rust = { git = "https://github.com/datafuse-extras/orc-rust", rev = "fc17101f1c96e1ea7c7a19e931110471a4bd7e21" }
@@ -664,13 +662,9 @@ recursive = { git = "https://github.com/datafuse-extras/recursive.git", rev = "1
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1" }
 state-machine-api = { git = "https://github.com/databendlabs/state-machine-api.git", tag = "v0.4.0" }
 sub-cache = { git = "https://github.com/databendlabs/sub-cache", tag = "v0.2.1" }
-#tantivy = { git = "https://github.com/datafuse-extras/tantivy", rev = "b600b0e" }
-#tantivy-common = { git = "https://github.com/datafuse-extras/tantivy", rev = "b600b0e", package = "tantivy-common" }
-#tantivy-jieba = { git = "https://github.com/datafuse-extras/tantivy-jieba", rev = "68ab55c" }
-#tantivy-query-grammar = { git = "https://github.com/datafuse-extras/tantivy", rev = "b600b0e", package = "tantivy-query-grammar" }
-tantivy = { git = "https://github.com/b41sh/tantivy", rev = "760ddb7ad6c9e5ff4fbfdbebbd7c6cdc2eab3ca8" }
-tantivy-common = { git = "https://github.com/b41sh/tantivy", rev = "760ddb7ad6c9e5ff4fbfdbebbd7c6cdc2eab3ca8", package = "tantivy-common" }
-tantivy-jieba = { git = "https://github.com/b41sh/tantivy-jieba", rev = "c3c0e5bb81f05d89f25f816feaecc26872408b87" }
-tantivy-query-grammar = { git = "https://github.com/b41sh/tantivy", rev = "760ddb7ad6c9e5ff4fbfdbebbd7c6cdc2eab3ca8", package = "tantivy-query-grammar" }
+tantivy = { git = "https://github.com/datafuse-extras/tantivy", rev = "760ddb7" }
+tantivy-common = { git = "https://github.com/datafuse-extras/tantivy", rev = "760ddb7", package = "tantivy-common" }
+tantivy-jieba = { git = "https://github.com/datafuse-extras/tantivy-jieba", rev = "3cda3c6" }
+tantivy-query-grammar = { git = "https://github.com/datafuse-extras/tantivy", rev = "760ddb7", package = "tantivy-query-grammar" }
 watcher = { git = "https://github.com/databendlabs/watcher", tag = "v0.5.0" }
 xorfilter-rs = { git = "https://github.com/datafuse-extras/xorfilter", tag = "databend-alpha.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -655,7 +655,7 @@ lance-file = { git = "https://github.com/datafuse-extras/lance", rev = "85f9401d
 lance-io = { git = "https://github.com/datafuse-extras/lance", rev = "85f9401d3246d52a287bca21457dbae0466858ee" }
 lance-table = { git = "https://github.com/datafuse-extras/lance", rev = "85f9401d3246d52a287bca21457dbae0466858ee" }
 #lindera-tantivy = { git = "https://github.com/b41sh/lindera-tantivy", rev = "88dc0df4248f721a34c9de42581233fa973b8493", features = ["embed-ipadic"] }
-lindera-tantivy = { git = "https://github.com/b41sh/lindera-tantivy", rev = "0f522e51c8d7517e9560f17740c588011b1b9467" }
+lindera-tantivy = { git = "https://github.com/b41sh/lindera-tantivy", rev = "8d1d09f69be8959f7c04375241b61cc061c14b0c" }
 map-api = { git = "https://github.com/databendlabs/map-api", tag = "v0.5.0" }
 # Keep ORC on a patch while the upstream crate has not caught up with Arrow 58 yet.
 orc-rust = { git = "https://github.com/datafuse-extras/orc-rust", rev = "fc17101f1c96e1ea7c7a19e931110471a4bd7e21" }
@@ -668,9 +668,9 @@ sub-cache = { git = "https://github.com/databendlabs/sub-cache", tag = "v0.2.1" 
 #tantivy-common = { git = "https://github.com/datafuse-extras/tantivy", rev = "b600b0e", package = "tantivy-common" }
 #tantivy-jieba = { git = "https://github.com/datafuse-extras/tantivy-jieba", rev = "68ab55c" }
 #tantivy-query-grammar = { git = "https://github.com/datafuse-extras/tantivy", rev = "b600b0e", package = "tantivy-query-grammar" }
-tantivy = { git = "https://github.com/b41sh/tantivy", rev = "3eb4dd325d6188bd87ee6b25823b286d5bb310a1" }
-tantivy-common = { git = "https://github.com/b41sh/tantivy", rev = "3eb4dd325d6188bd87ee6b25823b286d5bb310a1", package = "tantivy-common" }
-tantivy-jieba = { git = "https://github.com/b41sh/tantivy-jieba", rev = "22c3f82888b304cc97441843da9b4e71cd4d204e" }
-tantivy-query-grammar = { git = "https://github.com/b41sh/tantivy", rev = "3eb4dd325d6188bd87ee6b25823b286d5bb310a1", package = "tantivy-query-grammar" }
+tantivy = { git = "https://github.com/b41sh/tantivy", rev = "760ddb7ad6c9e5ff4fbfdbebbd7c6cdc2eab3ca8" }
+tantivy-common = { git = "https://github.com/b41sh/tantivy", rev = "760ddb7ad6c9e5ff4fbfdbebbd7c6cdc2eab3ca8", package = "tantivy-common" }
+tantivy-jieba = { git = "https://github.com/b41sh/tantivy-jieba", rev = "c3c0e5bb81f05d89f25f816feaecc26872408b87" }
+tantivy-query-grammar = { git = "https://github.com/b41sh/tantivy", rev = "760ddb7ad6c9e5ff4fbfdbebbd7c6cdc2eab3ca8", package = "tantivy-query-grammar" }
 watcher = { git = "https://github.com/databendlabs/watcher", tag = "v0.5.0" }
 xorfilter-rs = { git = "https://github.com/datafuse-extras/xorfilter", tag = "databend-alpha.4" }

--- a/src/query/sql/src/planner/binder/ddl/index.rs
+++ b/src/query/sql/src/planner/binder/ddl/index.rs
@@ -83,6 +83,7 @@ static INDEX_TOKENIZER_VALUES: LazyLock<HashSet<&'static str>> = LazyLock::new(|
     let mut r = HashSet::new();
     r.insert("english");
     r.insert("chinese");
+    r.insert("japanese");
     r
 });
 
@@ -92,6 +93,8 @@ static INDEX_FILTER_VALUES: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
     r.insert("english_stop");
     r.insert("english_stemmer");
     r.insert("chinese_stop");
+    r.insert("japanese_stop");
+    r.insert("japanese_stemmer");
     r
 });
 

--- a/src/query/storages/fuse/Cargo.toml
+++ b/src/query/storages/fuse/Cargo.toml
@@ -61,6 +61,9 @@ geo-index = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 jsonb = { workspace = true }
+lindera = { workspace = true }
+lindera-analysis = { workspace = true }
+lindera-tantivy = { workspace = true }
 log = { workspace = true }
 match-template = { workspace = true }
 opendal = { workspace = true }

--- a/src/query/storages/fuse/src/io/write/inverted_index_writer.rs
+++ b/src/query/storages/fuse/src/io/write/inverted_index_writer.rs
@@ -41,6 +41,13 @@ use databend_storages_common_table_meta::meta::Location;
 use databend_storages_common_table_meta::table::TableCompression;
 use jsonb::RawJsonb;
 use jsonb::from_raw_jsonb;
+use lindera::dictionary::load_dictionary;
+use lindera::mode::Mode;
+use lindera::segmenter::Segmenter;
+use lindera_analysis::token_filter::BoxTokenFilter;
+use lindera_analysis::token_filter::japanese_base_form::JapaneseBaseFormTokenFilter;
+use lindera_analysis::token_filter::japanese_stop_tags::JapaneseStopTagsTokenFilter;
+use lindera_tantivy::tokenizer::LinderaTokenizer;
 use log::debug;
 use log::info;
 use opendal::Buffer;
@@ -343,114 +350,132 @@ impl InvertedIndexWriter {
     }
 }
 
-// Create tokenizer can handle both Chinese and English
+// Create tokenizers for English, Chinese, and Japanese.
 pub(crate) fn create_tokenizer_manager(
     index_options: &BTreeMap<String, String>,
 ) -> TokenizerManager {
     let tokenizer_manager = TokenizerManager::new();
+    let filters = index_options
+        .get("filters")
+        .map(|filters| filters.split(',').collect::<HashSet<_>>())
+        .unwrap_or_default();
 
-    let filters: HashSet<String> = match index_options.get("filters") {
-        Some(filters_str) => filters_str.split(',').map(|v| v.to_string()).collect(),
-        None => HashSet::new(),
-    };
+    let tokenizer = index_options
+        .get("tokenizer")
+        .map(String::as_str)
+        .unwrap_or("english");
+    match tokenizer {
+        "english" => tokenizer_manager.register("english", create_english_analyzer(&filters)),
+        "chinese" => tokenizer_manager.register("chinese", create_chinese_analyzer(&filters)),
+        "japanese" => tokenizer_manager.register("japanese", create_japanese_analyzer(&filters)),
+        _ => unreachable!("Invalid tokenizer {}", tokenizer),
+    }
 
-    // add lower case filter by default, so that the search can match
-    // all the rows regardless of whether it is uppercase or lowercase
-    let (english_analyzer, chinese_analyzer) = if filters.is_empty() {
-        let english_analyzer = TextAnalyzer::builder(SimpleTokenizer::default())
-            .filter(LowerCaser)
-            .build();
-        let chinese_analyzer = TextAnalyzer::builder(JiebaTokenizer::new())
-            .filter(LowerCaser)
-            .build();
-
-        (english_analyzer, chinese_analyzer)
-    } else {
-        let mut english_analyzer =
-            TextAnalyzer::builder(SimpleTokenizer::default()).filter_dynamic(LowerCaser);
-        let mut chinese_analyzer =
-            TextAnalyzer::builder(JiebaTokenizer::new()).filter_dynamic(LowerCaser);
-
-        // add optional filters
-        // remove English stop words, like "a", "an", "and", etc.
-        if filters.contains("english_stop") {
-            english_analyzer =
-                english_analyzer.filter_dynamic(StopWordFilter::new(Language::English).unwrap());
-            chinese_analyzer =
-                chinese_analyzer.filter_dynamic(StopWordFilter::new(Language::English).unwrap());
-        }
-        // English stemmer maps different forms of the same word to a common word.
-        // for example, "walking" and "walked" will be mapped to "walk".
-        if filters.contains("english_stemmer") {
-            english_analyzer = english_analyzer.filter_dynamic(Stemmer::new(Language::English));
-            chinese_analyzer = chinese_analyzer.filter_dynamic(Stemmer::new(Language::English));
-        }
-        // remove Chinese stop words, which currently only supports Chinese punctuation is supported.
-        if filters.contains("chinese_stop") {
-            // Punctuation tokens to remove copied from lucene
-            // https://github.com/apache/lucene/blob/main/lucene/analysis/smartcn/src/resources/org/apache/lucene/analysis/cn/smart/stopwords.txt
-            chinese_analyzer = chinese_analyzer.filter_dynamic(StopWordFilter::remove(vec![
-                ",".to_string(),
-                ".".to_string(),
-                "`".to_string(),
-                "-".to_string(),
-                "_".to_string(),
-                "=".to_string(),
-                "?".to_string(),
-                "'".to_string(),
-                "|".to_string(),
-                "\"".to_string(),
-                "(".to_string(),
-                ")".to_string(),
-                "{".to_string(),
-                "}".to_string(),
-                "[".to_string(),
-                "]".to_string(),
-                "<".to_string(),
-                ">".to_string(),
-                "*".to_string(),
-                "#".to_string(),
-                "&".to_string(),
-                "^".to_string(),
-                "$".to_string(),
-                "@".to_string(),
-                "!".to_string(),
-                "~".to_string(),
-                ":".to_string(),
-                ";".to_string(),
-                "+".to_string(),
-                "/".to_string(),
-                "\\".to_string(),
-                "《".to_string(),
-                "》".to_string(),
-                "—".to_string(),
-                "－".to_string(),
-                "，".to_string(),
-                "。".to_string(),
-                "、".to_string(),
-                "：".to_string(),
-                "；".to_string(),
-                "！".to_string(),
-                "·".to_string(),
-                "？".to_string(),
-                "“".to_string(),
-                "”".to_string(),
-                "）".to_string(),
-                "（".to_string(),
-                "【".to_string(),
-                "】".to_string(),
-                "［".to_string(),
-                "］".to_string(),
-                "●".to_string(),
-                "　".to_string(),
-            ]));
-        }
-        (english_analyzer.build(), chinese_analyzer.build())
-    };
-
-    tokenizer_manager.register("english", english_analyzer);
-    tokenizer_manager.register("chinese", chinese_analyzer);
     tokenizer_manager
+}
+
+fn create_english_analyzer(filters: &HashSet<&str>) -> TextAnalyzer {
+    let mut analyzer = TextAnalyzer::builder(SimpleTokenizer::default()).filter_dynamic(LowerCaser);
+
+    if filters.contains("english_stop") {
+        analyzer = analyzer.filter_dynamic(StopWordFilter::new(Language::English).unwrap());
+    }
+    if filters.contains("english_stemmer") {
+        analyzer = analyzer.filter_dynamic(Stemmer::new(Language::English));
+    }
+
+    analyzer.build()
+}
+
+fn create_chinese_analyzer(filters: &HashSet<&str>) -> TextAnalyzer {
+    let mut analyzer = TextAnalyzer::builder(JiebaTokenizer::new()).filter_dynamic(LowerCaser);
+
+    if filters.contains("english_stop") {
+        analyzer = analyzer.filter_dynamic(StopWordFilter::new(Language::English).unwrap());
+    }
+    if filters.contains("english_stemmer") {
+        analyzer = analyzer.filter_dynamic(Stemmer::new(Language::English));
+    }
+    if filters.contains("chinese_stop") {
+        // Punctuation tokens copied from Lucene's Smart Chinese Analyzer.
+        // https://github.com/apache/lucene/blob/main/lucene/analysis/smartcn/src/resources/org/apache/lucene/analysis/cn/smart/stopwords.txt
+        analyzer = analyzer.filter_dynamic(StopWordFilter::remove(chinese_stop_words()));
+    }
+
+    analyzer.build()
+}
+
+fn create_japanese_analyzer(filters: &HashSet<&str>) -> TextAnalyzer {
+    let dictionary = load_dictionary("embedded://ipadic")
+        .expect("the embedded IPADIC dictionary must be available");
+    let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
+    let mut tokenizer = LinderaTokenizer::from_segmenter(segmenter);
+
+    // Lindera filters must run before conversion to Tantivy tokens because
+    // part-of-speech and base-form details are not retained by Tantivy.
+    if filters.contains("japanese_stemmer") {
+        tokenizer.append_token_filter(BoxTokenFilter::from(JapaneseBaseFormTokenFilter::new()));
+    }
+    if filters.contains("japanese_stop") {
+        tokenizer.append_token_filter(BoxTokenFilter::from(JapaneseStopTagsTokenFilter::new(
+            japanese_stop_tags(),
+        )));
+    }
+
+    let mut analyzer = TextAnalyzer::builder(tokenizer).filter_dynamic(LowerCaser);
+    if filters.contains("english_stop") {
+        analyzer = analyzer.filter_dynamic(StopWordFilter::new(Language::English).unwrap());
+    }
+    if filters.contains("english_stemmer") {
+        analyzer = analyzer.filter_dynamic(Stemmer::new(Language::English));
+    }
+
+    analyzer.build()
+}
+
+fn chinese_stop_words() -> Vec<String> {
+    [
+        ",", ".", "`", "-", "_", "=", "?", "'", "|", "\"", "(", ")", "{", "}", "[", "]", "<", ">",
+        "*", "#", "&", "^", "$", "@", "!", "~", ":", ";", "+", "/", "\\", "《", "》", "—", "－",
+        "，", "。", "、", "：", "；", "！", "·", "？", "“", "”", "）", "（", "【", "】", "［",
+        "］", "●", "　",
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect()
+}
+
+fn japanese_stop_tags() -> HashSet<String> {
+    [
+        "接続詞",
+        "助詞",
+        "助詞,格助詞",
+        "助詞,格助詞,一般",
+        "助詞,格助詞,引用",
+        "助詞,格助詞,連語",
+        "助詞,係助詞",
+        "助詞,副助詞",
+        "助詞,間投助詞",
+        "助詞,並立助詞",
+        "助詞,終助詞",
+        "助詞,副助詞／並立助詞／終助詞",
+        "助詞,連体化",
+        "助詞,副詞化",
+        "助詞,特殊",
+        "助動詞",
+        "記号",
+        "記号,一般",
+        "記号,読点",
+        "記号,句点",
+        "記号,空白",
+        "記号,括弧閉",
+        "その他,間投",
+        "フィラー",
+        "非言語音",
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect()
 }
 
 pub(crate) fn create_index_schema(
@@ -481,7 +506,7 @@ pub(crate) fn create_index_schema(
     let text_options = TextOptions::default().set_indexing_options(text_field_indexing.clone());
     let json_options = JsonObjectOptions::default()
         .set_indexing_options(text_field_indexing)
-        .set_fast(None);
+        .set_fast("raw");
 
     let mut schema_builder = Schema::builder();
     let mut index_fields = Vec::with_capacity(schema.fields.len());

--- a/src/query/storages/fuse/src/io/write/inverted_index_writer.rs
+++ b/src/query/storages/fuse/src/io/write/inverted_index_writer.rs
@@ -16,6 +16,7 @@ use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Arc;
+use std::sync::LazyLock;
 use std::time::Instant;
 
 use databend_common_exception::ErrorCode;
@@ -41,6 +42,7 @@ use databend_storages_common_table_meta::meta::Location;
 use databend_storages_common_table_meta::table::TableCompression;
 use jsonb::RawJsonb;
 use jsonb::from_raw_jsonb;
+use lindera::dictionary::Dictionary;
 use lindera::dictionary::load_dictionary;
 use lindera::mode::Mode;
 use lindera::segmenter::Segmenter;
@@ -76,6 +78,10 @@ use tantivy_jieba::JiebaTokenizer;
 
 use crate::index::build_tantivy_footer;
 use crate::io::TableMetaLocationGenerator;
+
+static JAPANESE_DICTIONARY: LazyLock<Dictionary> = LazyLock::new(|| {
+    load_dictionary("embedded://ipadic").expect("the embedded IPADIC dictionary must be available")
+});
 
 #[derive(Clone)]
 pub struct InvertedIndexBuilder {
@@ -406,9 +412,7 @@ fn create_chinese_analyzer(filters: &HashSet<&str>) -> TextAnalyzer {
 }
 
 fn create_japanese_analyzer(filters: &HashSet<&str>) -> TextAnalyzer {
-    let dictionary = load_dictionary("embedded://ipadic")
-        .expect("the embedded IPADIC dictionary must be available");
-    let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
+    let segmenter = Segmenter::new(Mode::Normal, JAPANESE_DICTIONARY.clone(), None);
     let mut tokenizer = LinderaTokenizer::from_segmenter(segmenter);
 
     // Lindera filters must run before conversion to Tantivy tokens because

--- a/tests/sqllogictests/suites/query/index/04_inverted_index/04_0000_inverted_index_base.test
+++ b/tests/sqllogictests/suites/query/index/04_inverted_index/04_0000_inverted_index_base.test
@@ -586,9 +586,143 @@ select * from t_native where query('content:book OR content:basket');
 9 You can not judge a book by its cover
 
 statement ok
+CREATE TABLE t_japanese (
+    id int,
+    content string,
+    INVERTED INDEX idx_japanese (content) tokenizer = 'japanese' filters = 'japanese_stop,japanese_stemmer'
+)
+
+statement ok
+INSERT INTO t_japanese VALUES
+(1, '東京国際空港は東京都大田区にあります'),
+(2, '成田国際空港は千葉県成田市にあります'),
+(3, '関西国際空港は大阪府にあります'),
+(4, '私は毎朝りんごを食べました'),
+(5, '彼は昨日パンを食べた'),
+(6, '京都で美しい桜を見ました'),
+(7, '新幹線で東京から京都まで旅行しました'),
+(8, '図書館で日本の歴史について本を読みました'),
+(9, '子供たちは公園で元気に走っています'),
+(10, '会社で新しい検索システムを開発しました'),
+(11, '富士山は日本で最も高い山です'),
+(12, '北海道では冬に美しい雪が降ります'),
+(13, '寿司と天ぷらは人気のある日本料理です'),
+(14, '毎晩家族と一緒にテレビを見ています'),
+(15, '先生が黒板に漢字を書きました'),
+(16, '昨日は雨が降ったので家で音楽を聞きました'),
+(17, 'コンピューターで大量のデータを分析します'),
+(18, 'データベースは情報を効率的に保存します')
+
+query IT
+SELECT id, content FROM t_japanese WHERE query('content:東京') ORDER BY id;
+----
+1 東京国際空港は東京都大田区にあります
+7 新幹線で東京から京都まで旅行しました
+
+query IT
+SELECT id, content FROM t_japanese WHERE query('content:大阪府') ORDER BY id;
+----
+3 関西国際空港は大阪府にあります
+
+# Verify compound-word tokenization and phrase matching.
+query IT
+SELECT id, content FROM t_japanese WHERE query('content:"東京国際空港"') ORDER BY id;
+----
+1 東京国際空港は東京都大田区にあります
+
+query IT
+SELECT id, content FROM t_japanese WHERE query('content:国際 AND content:空港') ORDER BY id;
+----
+1 東京国際空港は東京都大田区にあります
+2 成田国際空港は千葉県成田市にあります
+
+query IT
+SELECT id, content FROM t_japanese WHERE query('content:京都') ORDER BY id;
+----
+6 京都で美しい桜を見ました
+7 新幹線で東京から京都まで旅行しました
+
+query IT
+SELECT id, content FROM t_japanese WHERE query('content:図書館') ORDER BY id;
+----
+8 図書館で日本の歴史について本を読みました
+
+query IT
+SELECT id, content FROM t_japanese WHERE query('content:検索') ORDER BY id;
+----
+10 会社で新しい検索システムを開発しました
+
+query IT
+SELECT id, content FROM t_japanese WHERE query('content:富士山') ORDER BY id;
+----
+11 富士山は日本で最も高い山です
+
+query IT
+SELECT id, content FROM t_japanese WHERE query('content:北海道') ORDER BY id;
+----
+12 北海道では冬に美しい雪が降ります
+
+query IT
+SELECT id, content FROM t_japanese WHERE query('content:日本料理') ORDER BY id;
+----
+13 寿司と天ぷらは人気のある日本料理です
+
+query IT
+SELECT id, content FROM t_japanese WHERE query('content:データ') ORDER BY id;
+----
+17 コンピューターで大量のデータを分析します
+
+query IT
+SELECT id, content FROM t_japanese WHERE query('content:データベース') ORDER BY id;
+----
+18 データベースは情報を効率的に保存します
+
+# JapaneseBaseFormTokenFilter normalizes conjugated verbs to their dictionary form.
+query IT
+SELECT id, content FROM t_japanese WHERE query('content:食べる') ORDER BY id;
+----
+4 私は毎朝りんごを食べました
+5 彼は昨日パンを食べた
+
+query IT
+SELECT id, content FROM t_japanese WHERE query('content:見る') ORDER BY id;
+----
+6 京都で美しい桜を見ました
+14 毎晩家族と一緒にテレビを見ています
+
+query IT
+SELECT id, content FROM t_japanese WHERE query('content:読む') ORDER BY id;
+----
+8 図書館で日本の歴史について本を読みました
+
+query IT
+SELECT id, content FROM t_japanese WHERE query('content:走る') ORDER BY id;
+----
+9 子供たちは公園で元気に走っています
+
+query IT
+SELECT id, content FROM t_japanese WHERE query('content:書く') ORDER BY id;
+----
+15 先生が黒板に漢字を書きました
+
+query IT
+SELECT id, content FROM t_japanese WHERE query('content:聞く') ORDER BY id;
+----
+16 昨日は雨が降ったので家で音楽を聞きました
+
+query IT
+SELECT id, content FROM t_japanese WHERE query('content:降る') ORDER BY id;
+----
+16 昨日は雨が降ったので家で音楽を聞きました
+
+# JapaneseStopTagsTokenFilter removes particles such as は from both documents and queries.
+query I
+SELECT id FROM t_japanese WHERE query('content:は') ORDER BY id;
+----
+
+statement ok
 use default
 
 statement ok
 drop database test_inverted_index
-
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR adds Japanese language support to inverted indexes using [lindera-tantivy](https://github.com/lindera/lindera-tantivy) with the embedded IPADIC dictionary.

### Changes

- Add japanese as a supported inverted-index tokenizer.
- Add two Japanese analyzer filters:
  - `japanese_stop`, uses `JapaneseStopTagsTokenFilter` to removes common Japanese functional parts of speech, including particles, auxiliary verbs, conjunctions, symbols, fillers, and non-verbal.
  - `japanese_stemmer`, uses `JapaneseBaseFormTokenFilter` to normalizes inflected verbs and adjectives to their dictionary forms. For example, `食べました` and `食べた` are normalized to `食べる`.

### Why IPADIC?

IPADIC was selected as the initial Japanese dictionary because it provides:

- Stable and widely used morphological analysis.
- Predictable part-of-speech tags.
- Good compatibility with Lindera's Japanese base-form and stop-tag filters.
- A reasonable trade-off between vocabulary coverage, binary size, and build cost.

for example

```sql
CREATE TABLE documents (
    id int,
    content string,
    INVERTED INDEX idx_japanese (content) tokenizer = 'japanese' filters = 'japanese_stop,japanese_stemmer'
);

INSERT INTO documents VALUES
(1, '東京国際空港は東京都大田区にあります'),
(2, '成田国際空港は千葉県成田市にあります'),
(3, '関西国際空港は大阪府にあります'),
(4, '私は毎朝りんごを食べました'),
(5, '彼は昨日パンを食べた'),
(6, '京都で美しい桜を見ました');

SELECT * FROM documents WHERE query('content:東京');
╭────────────────────────────────────────────────────────╮
│        id       │                content               │
│ Nullable(Int32) │           Nullable(String)           │
├─────────────────┼──────────────────────────────────────┤
│               1 │ 東京国際空港は東京都大田区にあります │
╰────────────────────────────────────────────────────────╯

SELECT * FROM documents WHERE query('content:食べる');
╭──────────────────────────────────────────────╮
│        id       │           content          │
│ Nullable(Int32) │      Nullable(String)      │
├─────────────────┼────────────────────────────┤
│               4 │ 私は毎朝りんごを食べました │
│               5 │ 彼は昨日パンを食べた       │
╰──────────────────────────────────────────────╯

```


fixes: #20367

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

<!--
See AI_POLICY.md. Agent-opened PRs are welcome; a responsible human on the author side must own the change.
The responsible human is NOT the reviewer — it is the submitter-side owner who has read the diff,
can explain each change, and will answer questions during review.
Write "None" for AI usage if no AI was involved.
-->

- AI usage: An AI coding agent assisted with using the `lindera-tantivy` to support Japanese tokenizer
- Responsible human: @b41sh 
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20412)
<!-- Reviewable:end -->
