### PR TITLE
feat(query): support cost-based MV scan routing

### DIFF
--- a/src/query/sql/src/planner/binder/ddl/materialized_view.rs
+++ b/src/query/sql/src/planner/binder/ddl/materialized_view.rs
@@ -487,10 +487,7 @@ impl Binder {
         let checker = MaterializedViewChecker::check_query(query);
         if !checker.is_supported() {
             return Err(ErrorCode::SemanticError(format!(
-                "Materialized View only support simple query, like: \
-                    `SELECT ... FROM ... WHERE ... GROUP BY ...`, \
-                     and these aggregate funcs: {}, \
-                     non-deterministic functions are not support like: NOW()",
+                "Materialized View only supports simple SELECT queries over one table, with optional WHERE/GROUP BY clauses, and these aggregate funcs: {}, non-deterministic functions are not supported like: NOW()",
                 SUPPORTED_AGGREGATING_INDEX_FUNCTIONS.join(",")
             )));
         }

--- a/src/query/sql/src/planner/binder/ddl/materialized_view.rs
+++ b/src/query/sql/src/planner/binder/ddl/materialized_view.rs
@@ -77,7 +77,6 @@ use crate::binder::Binder;
 use crate::binder::bind_table_reference::MaterializedViewReadMode;
 use crate::optimizer::ir::SExpr;
 use crate::parse_materialized_view_query;
-use crate::planner::SUPPORTED_AGGREGATING_INDEX_FUNCTIONS;
 use crate::planner::semantic::MaterializedViewChecker;
 use crate::planner::semantic::MaterializedViewRewriter;
 use crate::planner::semantic::ViewRewriter;
@@ -487,8 +486,7 @@ impl Binder {
         let checker = MaterializedViewChecker::check_query(query);
         if !checker.is_supported() {
             return Err(ErrorCode::SemanticError(format!(
-                "Materialized View only supports simple SELECT queries over one table, with optional WHERE/GROUP BY clauses, and these aggregate funcs: {}, non-deterministic functions are not supported like: NOW()",
-                SUPPORTED_AGGREGATING_INDEX_FUNCTIONS.join(",")
+                "Materialized View only supports simple SELECT queries over one table, with optional WHERE/GROUP BY clauses, registered aggregate functions, and deterministic expressions",
             )));
         }
 

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/materialized_view.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/materialized_view.rs
@@ -60,9 +60,9 @@ struct PrefixRouteScore {
 }
 
 #[derive(Default)]
-struct PredicateColumns {
-    equality: HashSet<String>,
-    range: HashSet<String>,
+struct PredicateColumns<'a> {
+    equality: HashSet<&'a str>,
+    range: HashSet<&'a str>,
 }
 
 struct RewriteCandidate {
@@ -318,6 +318,19 @@ fn estimate_compute_cost(s_expr: &SExpr) -> f64 {
 /// Estimate the read cost of a rewritten plan. Cluster-key pruning is applied
 /// at the scan itself; relational operators only adjust the amount of data
 /// flowing through their child scans.
+///
+/// The rewrite cost is modeled as:
+///
+/// ```text
+/// C_rewrite = C_scan + C_compute
+/// C_compute = sum(output_rows of non-scan operators)
+///             + 5 * sum(input_rows of aggregate operators)
+/// C_scan = sum(table_rows * cluster_pruning_factor * filter_selectivity)
+/// filter_selectivity = clamp(output_rows / input_rows, 0, 1)
+/// ```
+///
+/// Unknown cardinalities use `UNKNOWN_CARDINALITY_COST` rather than being
+/// treated as free.
 fn estimate_scan_cost(s_expr: &SExpr, scan_pruning_factor: f64) -> f64 {
     match s_expr.plan() {
         RelOperator::Scan(scan) => scan_cost(scan, scan_pruning_factor),
@@ -364,7 +377,7 @@ fn scan_pruning_factor_for_plan(metadata: &Metadata, plan: &SExpr) -> f64 {
         return 1.0;
     };
     let table = metadata.table(scan.table_index).table();
-    let score = cluster_prefix_score(&cluster_key_columns(table.as_ref()), &predicate_columns);
+    let score = cluster_prefix_score(table.as_ref(), &predicate_columns);
     cluster_pruning_factor(score)
 }
 
@@ -375,13 +388,13 @@ fn find_scan(s_expr: &SExpr) -> Option<&Scan> {
     s_expr.children().find_map(find_scan)
 }
 
-fn predicate_columns_from_plan(s_expr: &SExpr) -> PredicateColumns {
+fn predicate_columns_from_plan<'a>(s_expr: &'a SExpr) -> PredicateColumns<'a> {
     let mut columns = PredicateColumns::default();
     collect_predicate_columns_for_scan(s_expr, &mut columns);
     columns
 }
 
-fn collect_predicate_columns_for_scan(s_expr: &SExpr, columns: &mut PredicateColumns) {
+fn collect_predicate_columns_for_scan<'a>(s_expr: &'a SExpr, columns: &mut PredicateColumns<'a>) {
     match s_expr.plan() {
         RelOperator::Scan(scan) => {
             if let Some(predicates) = &scan.push_down_predicates {
@@ -418,7 +431,10 @@ fn contains_aggregate(s_expr: &SExpr) -> bool {
     matches!(s_expr.plan(), RelOperator::Aggregate(_)) || s_expr.children().any(contains_aggregate)
 }
 
-fn collect_predicate_columns_from_scalar(expr: &ScalarExpr, columns: &mut PredicateColumns) {
+fn collect_predicate_columns_from_scalar<'a>(
+    expr: &'a ScalarExpr,
+    columns: &mut PredicateColumns<'a>,
+) {
     let ScalarExpr::FunctionCall(function) = expr else {
         return;
     };
@@ -435,11 +451,11 @@ fn collect_predicate_columns_from_scalar(expr: &ScalarExpr, columns: &mut Predic
         let column = match (&function.arguments[0], &function.arguments[1]) {
             (ScalarExpr::BoundColumnRef(column), ScalarExpr::ConstantExpr(_))
             | (ScalarExpr::BoundColumnRef(column), ScalarExpr::TypedConstantExpr(_, _)) => {
-                Some(column.column.column_name.clone())
+                Some(column.column.column_name.as_str())
             }
             (ScalarExpr::ConstantExpr(_), ScalarExpr::BoundColumnRef(column))
             | (ScalarExpr::TypedConstantExpr(_, _), ScalarExpr::BoundColumnRef(column)) => {
-                Some(column.column.column_name.clone())
+                Some(column.column.column_name.as_str())
             }
             _ => None,
         };
@@ -461,13 +477,19 @@ fn collect_predicate_columns_from_scalar(expr: &ScalarExpr, columns: &mut Predic
     }
 }
 
-fn cluster_prefix_score<S: AsRef<str>>(
-    cluster_key_columns: &[S],
-    predicate_columns: &PredicateColumns,
+fn cluster_prefix_score(
+    table: &dyn Table,
+    predicate_columns: &PredicateColumns<'_>,
 ) -> PrefixRouteScore {
+    let Some(cluster_keys) = table.resolve_cluster_keys() else {
+        return PrefixRouteScore::default();
+    };
+
     let mut score = PrefixRouteScore::default();
-    for column in cluster_key_columns {
-        let column = column.as_ref();
+    for cluster_key in &cluster_keys {
+        let Some(column) = simple_cluster_key_column(cluster_key) else {
+            return PrefixRouteScore::default();
+        };
         if predicate_columns.equality.contains(column) {
             score.matched_prefix += 1;
             score.equality_prefix += 1;
@@ -481,19 +503,11 @@ fn cluster_prefix_score<S: AsRef<str>>(
     score
 }
 
-fn cluster_key_columns(table: &dyn Table) -> Vec<String> {
-    table
-        .resolve_cluster_keys()
-        .unwrap_or_default()
-        .iter()
-        .map(|expr| match expr {
-            ast::Expr::ColumnRef { column, .. } if column.table.is_none() => {
-                Some(column.column.name().to_string())
-            }
-            _ => None,
-        })
-        .collect::<Option<Vec<_>>>()
-        .unwrap_or_default()
+fn simple_cluster_key_column(expr: &ast::Expr) -> Option<&str> {
+    match expr {
+        ast::Expr::ColumnRef { column, .. } if column.table.is_none() => Some(column.column.name()),
+        _ => None,
+    }
 }
 
 fn input_cardinality(s_expr: &SExpr) -> Option<f64> {

--- a/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/materialized_view.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/rule/agg_rules/materialized_view.rs
@@ -17,6 +17,8 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use databend_common_ast::ast;
+use databend_common_catalog::table::Table;
 use databend_common_exception::Result;
 use log::info;
 
@@ -51,6 +53,18 @@ const UNKNOWN_CARDINALITY_COST: f64 = 1e12;
 const COMPUTE_PER_ROW: f64 = 1.0;
 const AGGREGATE_PER_ROW: f64 = 5.0;
 
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+struct PrefixRouteScore {
+    matched_prefix: usize,
+    equality_prefix: usize,
+}
+
+#[derive(Default)]
+struct PredicateColumns {
+    equality: HashSet<String>,
+    range: HashSet<String>,
+}
+
 struct RewriteCandidate {
     replacement: SExpr,
     mv_table_id: u64,
@@ -78,6 +92,20 @@ impl RewriteCandidate {
             },
         }
     }
+}
+
+/// Cluster-key pruning is part of scan cost, not an independent candidate
+/// ordering rule. The factor is deliberately conservative because optimizer
+/// statistics do not contain per-block pruning results.
+const CLUSTER_PREFIX_PRUNING_FACTOR: f64 = 0.5;
+
+fn cluster_pruning_factor(score: PrefixRouteScore) -> f64 {
+    let equality_factor = CLUSTER_PREFIX_PRUNING_FACTOR.powi(score.equality_prefix as i32);
+    let range_prefix = score.matched_prefix.saturating_sub(score.equality_prefix);
+    let range_factor = CLUSTER_PREFIX_PRUNING_FACTOR
+        .powi(range_prefix as i32)
+        .sqrt();
+    (equality_factor * range_factor).max(0.01)
 }
 
 /// Choose the cheapest semantically valid materialized-view rewrite.
@@ -117,7 +145,8 @@ pub(crate) fn try_rewrite(
         else {
             continue;
         };
-        let cost = estimate_rewrite_cost(&replacement);
+        let scan_pruning_factor = scan_pruning_factor_for_plan(metadata, &replacement);
+        let cost = estimate_rewrite_cost(&replacement, scan_pruning_factor);
         let current = RewriteCandidate {
             replacement,
             mv_table_id: candidate.mv_table_id,
@@ -260,10 +289,14 @@ fn try_build_replacement(
     Ok(Some((replacement, requires_aggregate_rollup)))
 }
 
-fn estimate_rewrite_cost(s_expr: &SExpr) -> f64 {
-    let children_cost: f64 = s_expr.children().map(estimate_rewrite_cost).sum();
+fn estimate_rewrite_cost(s_expr: &SExpr, scan_pruning_factor: f64) -> f64 {
+    estimate_compute_cost(s_expr) + estimate_scan_cost(s_expr, scan_pruning_factor)
+}
+
+fn estimate_compute_cost(s_expr: &SExpr) -> f64 {
+    let children_cost: f64 = s_expr.children().map(estimate_compute_cost).sum();
     let node_cost = match s_expr.plan() {
-        RelOperator::Scan(scan) => scan_cost(scan),
+        RelOperator::Scan(_) => 0.0,
         RelOperator::Aggregate(_) => {
             input_cardinality(s_expr).unwrap_or(UNKNOWN_CARDINALITY_COST) * AGGREGATE_PER_ROW
         }
@@ -282,13 +315,185 @@ fn estimate_rewrite_cost(s_expr: &SExpr) -> f64 {
     children_cost + node_cost
 }
 
-fn scan_cost(scan: &Scan) -> f64 {
+/// Estimate the read cost of a rewritten plan. Cluster-key pruning is applied
+/// at the scan itself; relational operators only adjust the amount of data
+/// flowing through their child scans.
+fn estimate_scan_cost(s_expr: &SExpr, scan_pruning_factor: f64) -> f64 {
+    match s_expr.plan() {
+        RelOperator::Scan(scan) => scan_cost(scan, scan_pruning_factor),
+        RelOperator::Filter(_) => {
+            let Some(child) = s_expr.child(0).ok() else {
+                return UNKNOWN_CARDINALITY_COST;
+            };
+            let child_cost = estimate_scan_cost(child, scan_pruning_factor);
+            let Some(child_rows) = output_cardinality(child) else {
+                return child_cost;
+            };
+            let Some(output_rows) = output_cardinality(s_expr) else {
+                return child_cost;
+            };
+            if child_rows > 0.0 && output_rows.is_finite() {
+                child_cost * (output_rows / child_rows).clamp(0.0, 1.0)
+            } else {
+                child_cost
+            }
+        }
+        RelOperator::UnionAll(_) => s_expr
+            .children()
+            .map(|child| estimate_scan_cost(child, scan_pruning_factor))
+            .sum(),
+        _ => s_expr
+            .children()
+            .map(|child| estimate_scan_cost(child, scan_pruning_factor))
+            .sum(),
+    }
+}
+
+fn scan_cost(scan: &Scan, scan_pruning_factor: f64) -> f64 {
     scan.statistics
         .table_stats
         .as_ref()
         .and_then(|stats| stats.num_rows)
-        .map(|rows| rows as f64 * COMPUTE_PER_ROW)
+        .map(|rows| rows as f64 * COMPUTE_PER_ROW * scan_pruning_factor)
         .unwrap_or(UNKNOWN_CARDINALITY_COST)
+}
+
+fn scan_pruning_factor_for_plan(metadata: &Metadata, plan: &SExpr) -> f64 {
+    let predicate_columns = predicate_columns_from_plan(plan);
+    let Some(scan) = find_scan(plan) else {
+        return 1.0;
+    };
+    let table = metadata.table(scan.table_index).table();
+    let score = cluster_prefix_score(&cluster_key_columns(table.as_ref()), &predicate_columns);
+    cluster_pruning_factor(score)
+}
+
+fn find_scan(s_expr: &SExpr) -> Option<&Scan> {
+    if let RelOperator::Scan(scan) = s_expr.plan() {
+        return Some(scan);
+    }
+    s_expr.children().find_map(find_scan)
+}
+
+fn predicate_columns_from_plan(s_expr: &SExpr) -> PredicateColumns {
+    let mut columns = PredicateColumns::default();
+    collect_predicate_columns_for_scan(s_expr, &mut columns);
+    columns
+}
+
+fn collect_predicate_columns_for_scan(s_expr: &SExpr, columns: &mut PredicateColumns) {
+    match s_expr.plan() {
+        RelOperator::Scan(scan) => {
+            if let Some(predicates) = &scan.push_down_predicates {
+                for predicate in predicates {
+                    collect_predicate_columns_from_scalar(predicate, columns);
+                }
+            }
+        }
+        RelOperator::Filter(filter) => {
+            // A filter above an aggregate cannot prune the aggregate's input
+            // scan. Filters below the aggregate, or directly above the scan,
+            // can still contribute to storage pruning.
+            if s_expr
+                .child(0)
+                .is_ok_and(|child| !contains_aggregate(child))
+            {
+                for predicate in &filter.predicates {
+                    collect_predicate_columns_from_scalar(predicate, columns);
+                }
+            }
+            if let Ok(child) = s_expr.child(0) {
+                collect_predicate_columns_for_scan(child, columns);
+            }
+        }
+        _ => {
+            for child in s_expr.children() {
+                collect_predicate_columns_for_scan(child, columns);
+            }
+        }
+    }
+}
+
+fn contains_aggregate(s_expr: &SExpr) -> bool {
+    matches!(s_expr.plan(), RelOperator::Aggregate(_)) || s_expr.children().any(contains_aggregate)
+}
+
+fn collect_predicate_columns_from_scalar(expr: &ScalarExpr, columns: &mut PredicateColumns) {
+    let ScalarExpr::FunctionCall(function) = expr else {
+        return;
+    };
+
+    if matches!(function.func_name.as_str(), "or" | "or_filters") {
+        return;
+    }
+    if function.arguments.len() == 2
+        && matches!(
+            function.func_name.as_str(),
+            "eq" | "gt" | "gte" | "lt" | "lte"
+        )
+    {
+        let column = match (&function.arguments[0], &function.arguments[1]) {
+            (ScalarExpr::BoundColumnRef(column), ScalarExpr::ConstantExpr(_))
+            | (ScalarExpr::BoundColumnRef(column), ScalarExpr::TypedConstantExpr(_, _)) => {
+                Some(column.column.column_name.clone())
+            }
+            (ScalarExpr::ConstantExpr(_), ScalarExpr::BoundColumnRef(column))
+            | (ScalarExpr::TypedConstantExpr(_, _), ScalarExpr::BoundColumnRef(column)) => {
+                Some(column.column.column_name.clone())
+            }
+            _ => None,
+        };
+        if let Some(column) = column {
+            match function.func_name.as_str() {
+                "eq" => {
+                    columns.equality.insert(column);
+                }
+                "gt" | "gte" | "lt" | "lte" => {
+                    columns.range.insert(column);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    for argument in &function.arguments {
+        collect_predicate_columns_from_scalar(argument, columns);
+    }
+}
+
+fn cluster_prefix_score<S: AsRef<str>>(
+    cluster_key_columns: &[S],
+    predicate_columns: &PredicateColumns,
+) -> PrefixRouteScore {
+    let mut score = PrefixRouteScore::default();
+    for column in cluster_key_columns {
+        let column = column.as_ref();
+        if predicate_columns.equality.contains(column) {
+            score.matched_prefix += 1;
+            score.equality_prefix += 1;
+        } else if predicate_columns.range.contains(column) {
+            score.matched_prefix += 1;
+            break;
+        } else {
+            break;
+        }
+    }
+    score
+}
+
+fn cluster_key_columns(table: &dyn Table) -> Vec<String> {
+    table
+        .resolve_cluster_keys()
+        .unwrap_or_default()
+        .iter()
+        .map(|expr| match expr {
+            ast::Expr::ColumnRef { column, .. } if column.table.is_none() => {
+                Some(column.column.name().to_string())
+            }
+            _ => None,
+        })
+        .collect::<Option<Vec<_>>>()
+        .unwrap_or_default()
 }
 
 fn input_cardinality(s_expr: &SExpr) -> Option<f64> {
@@ -545,6 +750,29 @@ mod tests {
     }
 
     #[test]
+    fn cluster_prefix_is_part_of_scan_cost() {
+        let scan = scan_with_rows(Some(100));
+        let unpruned = estimate_rewrite_cost(&scan, 1.0);
+        let equality_pruned = estimate_rewrite_cost(
+            &scan,
+            cluster_pruning_factor(PrefixRouteScore {
+                matched_prefix: 1,
+                equality_prefix: 1,
+            }),
+        );
+        let range_pruned = estimate_rewrite_cost(
+            &scan,
+            cluster_pruning_factor(PrefixRouteScore {
+                matched_prefix: 1,
+                equality_prefix: 0,
+            }),
+        );
+
+        assert!(equality_pruned < range_pruned);
+        assert!(range_pruned < unpruned);
+    }
+
+    #[test]
     fn cheaper_rewrite_wins() {
         let cheaper = rewrite_candidate(10.0, MaterializedViewCandidateReadMode::Hybrid, 2);
         let expensive = rewrite_candidate(20.0, MaterializedViewCandidateReadMode::Fresh, 1);
@@ -570,8 +798,8 @@ mod tests {
 
     #[test]
     fn smaller_scan_is_cheaper_than_larger_scan() {
-        let small = estimate_rewrite_cost(&scan_with_rows(Some(10)));
-        let large = estimate_rewrite_cost(&scan_with_rows(Some(100)));
+        let small = estimate_rewrite_cost(&scan_with_rows(Some(10)), 1.0);
+        let large = estimate_rewrite_cost(&scan_with_rows(Some(100)), 1.0);
         assert!(small < large);
     }
 
@@ -588,13 +816,13 @@ mod tests {
             ),
             Arc::new(scan.clone()),
         );
-        assert!(estimate_rewrite_cost(&scan) < estimate_rewrite_cost(&with_aggregate));
+        assert!(estimate_rewrite_cost(&scan, 1.0) < estimate_rewrite_cost(&with_aggregate, 1.0));
     }
 
     #[test]
     fn unknown_scan_stats_are_more_expensive_than_known_small_scan() {
-        let unknown = estimate_rewrite_cost(&scan_with_rows(None));
-        let known = estimate_rewrite_cost(&scan_with_rows(Some(1)));
+        let unknown = estimate_rewrite_cost(&scan_with_rows(None), 1.0);
+        let known = estimate_rewrite_cost(&scan_with_rows(Some(1)), 1.0);
         assert!(known < unknown);
     }
 }

--- a/src/query/sql/src/planner/semantic/materialized_view_rewriter.rs
+++ b/src/query/sql/src/planner/semantic/materialized_view_rewriter.rs
@@ -50,7 +50,6 @@ use databend_common_functions::aggregates::AggregateFunctionFactory;
 use databend_common_meta_app::schema::MATERIALIZED_VIEW_SOURCE_ROW_ID_COLUMN;
 
 use crate::MetadataRef;
-use crate::planner::SUPPORTED_AGGREGATING_INDEX_FUNCTIONS;
 
 /// Parse persisted materialized-view SQL and require a query statement.
 ///
@@ -348,7 +347,7 @@ impl Visitor for AggregateFieldCounter {
 
     fn visit_function_call(&mut self, call: &FunctionCall) -> VisitResult {
         let name = call.name.name.to_ascii_lowercase();
-        if SUPPORTED_AGGREGATING_INDEX_FUNCTIONS.contains(&name.as_str()) {
+        if AggregateFunctionFactory::instance().contains_base(&name) {
             self.count += if name == "avg" { 2 } else { 1 };
             return Ok(VisitControl::SkipChildren);
         }
@@ -485,8 +484,7 @@ impl VisitorMut for AggregateExprRewriter<'_> {
                     && !func.has_explicit_lambda()
                     && func.order_by.is_empty()
                     && func.params.is_empty()
-                    && SUPPORTED_AGGREGATING_INDEX_FUNCTIONS
-                        .contains(&func.name.name.to_ascii_lowercase().as_str()) =>
+                    && AggregateFunctionFactory::instance().contains_base(&func.name.name) =>
             {
                 let original = expr.clone();
                 let Expr::FunctionCall { func, .. } = &original else {
@@ -632,10 +630,9 @@ impl Visitor for MaterializedViewChecker {
         if call.window.is_some() || call.filter.is_some() || !call.order_by.is_empty() {
             self.not_supported = true;
         }
-        if AggregateFunctionFactory::instance().contains(&name) {
+        if AggregateFunctionFactory::instance().contains_base(&name) {
             self.has_aggregate = true;
-            if !SUPPORTED_AGGREGATING_INDEX_FUNCTIONS.contains(&name.as_str())
-                || call.distinct
+            if call.distinct
                 || call.filter.is_some()
                 || call.window.is_some()
                 || !call.order_by.is_empty()
@@ -718,6 +715,7 @@ mod tests {
             "SELECT amount AS value FROM t",
             "SELECT amount AS value FROM t WHERE amount > 0",
             "SELECT category, sum(amount) AS total FROM t WHERE amount > 0 GROUP BY category",
+            "SELECT category, stddev(amount) AS deviation FROM t GROUP BY category",
         ] {
             let checker = check_query(sql)?;
             assert!(checker.is_supported(), "should support: {sql}");
@@ -823,6 +821,20 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn test_rewrite_registered_aggregate_state() -> Result<()> {
+        let (query, rewriter) =
+            rewrite("SELECT category, stddev(amount) AS deviation FROM t GROUP BY category")?;
+
+        assert_eq!(rewriter.logical_names(), ["category", "deviation"]);
+        assert_eq!(rewriter.physical_names(), ["deviation", "category"]);
+        assert!(
+            query
+                .to_string()
+                .contains("stddev_state(amount) AS deviation")
+        );
+        Ok(())
+    }
     #[test]
     fn test_rewrite_rejects_invalid_output_names() {
         let error = rewrite("SELECT amount + 1 FROM t").unwrap_err();

--- a/src/query/sql/src/planner/semantic/materialized_view_rewriter.rs
+++ b/src/query/sql/src/planner/semantic/materialized_view_rewriter.rs
@@ -536,7 +536,6 @@ impl VisitorMut for AggregateExprRewriter<'_> {
 pub struct MaterializedViewChecker {
     has_aggregate: bool,
     has_group_by: bool,
-    has_selection: bool,
     not_supported: bool,
 }
 
@@ -552,7 +551,10 @@ impl MaterializedViewChecker {
     }
 
     pub fn is_supported(&self) -> bool {
-        !self.not_supported && (self.has_aggregate || self.has_group_by || self.has_selection)
+        // A projection MV may materialize every row from its source table. A WHERE
+        // clause, GROUP BY, or aggregate is not required for the definition to be
+        // useful or valid.
+        !self.not_supported
     }
 }
 
@@ -598,7 +600,6 @@ impl Visitor for MaterializedViewChecker {
         {
             self.not_supported = true;
         }
-        self.has_selection |= stmt.selection.is_some();
         self.has_group_by |= stmt.group_by.is_some();
         Ok(VisitControl::Continue)
     }
@@ -714,6 +715,7 @@ mod tests {
     #[test]
     fn test_materialized_view_checker_accepts_simple_queries() -> Result<()> {
         for sql in [
+            "SELECT amount AS value FROM t",
             "SELECT amount AS value FROM t WHERE amount > 0",
             "SELECT category, sum(amount) AS total FROM t WHERE amount > 0 GROUP BY category",
         ] {

--- a/tests/sqllogictests/suites/ee/07_ee_materialized_view/07_0000_materialized_view.test
+++ b/tests/sqllogictests/suites/ee/07_ee_materialized_view/07_0000_materialized_view.test
@@ -48,14 +48,21 @@ from source
 where active
 group by category
 
+# Registered aggregates outside the legacy MV whitelist are persisted as states too.
+statement ok
+create materialized view mv_stddev (category_name, deviation) as
+select category, stddev_pop(amount)
+from source
+group by category
+
 query I
 select count(*)
 from system.tables
 where database = 'test_materialized_view'
   and table_type = 'MATERIALIZED VIEW'
-  and name in ('mv_detail', 'mv_projection', 'mv_aggregate')
+  and name in ('mv_detail', 'mv_projection', 'mv_aggregate', 'mv_stddev')
 ----
-3
+4
 
 # CREATE leaves MV storage empty. The first explicit refresh consumes the full endpoint.
 statement ok
@@ -72,6 +79,9 @@ refresh materialized view mv_projection
 
 statement ok
 refresh materialized view mv_aggregate
+
+statement ok
+refresh materialized view mv_stddev
 
 query II
 select item_id, doubled_amount from mv_detail order by item_id
@@ -93,6 +103,14 @@ order by category_name
 ----
 a 10 1 10.0
 b 30 1 30.0
+
+query TF
+select category_name, deviation
+from mv_stddev
+order by category_name
+----
+a 5.0
+b 0.0
 
 # An append-only source endpoint may advance without producing aggregate states when all changed
 # rows are rejected by the MV predicate. Refresh must still checkpoint the endpoint as a valid no-op.
@@ -528,12 +546,15 @@ drop materialized view if exists mv_detail
 statement ok
 drop materialized view mv_aggregate
 
+statement ok
+drop materialized view mv_stddev
+
 query I
 select count(*)
 from system.tables
 where database = 'test_materialized_view'
   and table_type = 'MATERIALIZED VIEW'
-  and name in ('mv_detail', 'mv_projection', 'mv_aggregate')
+  and name in ('mv_detail', 'mv_projection', 'mv_aggregate', 'mv_stddev')
 ----
 0
 

--- a/tests/sqllogictests/suites/ee/07_ee_materialized_view/07_0000_materialized_view.test
+++ b/tests/sqllogictests/suites/ee/07_ee_materialized_view/07_0000_materialized_view.test
@@ -35,6 +35,11 @@ statement ok
 create materialized view mv_detail (item_id, doubled_amount) as
 select id, amount * 2 from source where active
 
+# Projection MVs may materialize the complete source without a WHERE clause.
+statement ok
+create materialized view mv_projection (item_id, amount) as
+select id, amount from source
+
 # Aggregating MVs persist states internally and expose finalized values.
 statement ok
 create materialized view mv_aggregate (category_name, total_amount, row_count, average_amount) as
@@ -48,9 +53,9 @@ select count(*)
 from system.tables
 where database = 'test_materialized_view'
   and table_type = 'MATERIALIZED VIEW'
-  and name in ('mv_detail', 'mv_aggregate')
+  and name in ('mv_detail', 'mv_projection', 'mv_aggregate')
 ----
-2
+3
 
 # CREATE leaves MV storage empty. The first explicit refresh consumes the full endpoint.
 statement ok
@@ -63,6 +68,9 @@ statement ok
 refresh materialized view mv_detail
 
 statement ok
+refresh materialized view mv_projection
+
+statement ok
 refresh materialized view mv_aggregate
 
 query II
@@ -70,6 +78,13 @@ select item_id, doubled_amount from mv_detail order by item_id
 ----
 1 20
 3 60
+
+query II
+select item_id, amount from mv_projection order by item_id
+----
+1 10
+2 20
+3 30
 
 query TIIR
 select category_name, total_amount, row_count, average_amount
@@ -505,6 +520,9 @@ statement ok
 drop materialized view mv_detail
 
 statement ok
+drop materialized view mv_projection
+
+statement ok
 drop materialized view if exists mv_detail
 
 statement ok
@@ -515,7 +533,7 @@ select count(*)
 from system.tables
 where database = 'test_materialized_view'
   and table_type = 'MATERIALIZED VIEW'
-  and name in ('mv_detail', 'mv_aggregate')
+  and name in ('mv_detail', 'mv_projection', 'mv_aggregate')
 ----
 0
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Allow projection materialized views over a complete source query without `WHERE`, `GROUP BY`, or aggregate clauses.
- Allow materialized views to use registered base aggregate functions with generic aggregate-state support.
- Choose materialized-view rewrites using unified compute and scan cost, including cluster-key pruning estimates.
- Add regression coverage for projection MVs and registered aggregates outside the legacy whitelist.

## Implementation

- Relax `MaterializedViewChecker` to accept valid simple projection queries and registered aggregate functions.
- Use `AggregateFunctionFactory` for aggregate detection and generic state rewriting, including states such as `stddev_pop_state`.
- Preserve validation for unsupported aggregate forms: `DISTINCT`, aggregate `FILTER`, aggregate `ORDER BY`, and windowed aggregates.
- Estimate rewrite cost as compute cost plus scan cost.
- Apply predicate selectivity and a conservative cluster-key prefix pruning factor at the scan cost.
- Compare candidates by total cost, retaining Fresh/Hybrid and table-ID tie-breaking for equal costs.
- Do not treat filters above aggregates as predicates that can prune the underlying scan.
- Keep cross-granularity rollup limited to aggregates with proven state rollup mappings; unsupported rollup candidates are rejected instead of producing incorrect results.

## Tests

- [x] Unit Test
- [x] Logic Test
- [x] Benchmark Test
- [ ] No Test - _Explain why_

Local validation:

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p databend-common-sql`
- `cargo test -p databend-common-sql --lib materialized_view --no-default-features` — 20 passed
- Enterprise SQLLogicTest `07_0000_materialized_view.test`:
  - MySQL — 133 passed
  - HTTP — 133 passed
  - Covers `stddev_pop` CREATE, REFRESH, query, and cleanup

CI validation:

- Linux build — passed
- Linux check — passed
- Linux unit tests — passed
- macOS check — passed
- Enterprise SQLLogicTest — passed
- PROXY routing benchmarks — statistics and prefix passed
- Private-task tests — passed
- Full required CI matrix — passed

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent assisted with implementation, review, test execution, and PR preparation; the responsible human reviewed the final diff.
- Responsible human: @sundy-li
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20422)

<!-- Reviewable:end -->
