### PR TITLE
fix(query): report UDF endpoint HTTP 502 responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4173,6 +4173,7 @@ dependencies = [
  "geozero",
  "goldenfile",
  "hex",
+ "http 1.3.1",
  "hyper-util",
  "itertools 0.13.0",
  "jiff",
@@ -4199,6 +4200,7 @@ dependencies = [
  "strength_reduce",
  "terminal_size",
  "tonic 0.14.5",
+ "tower 0.5.2",
  "typetag",
  "unicode-segmentation",
 ]

--- a/src/common/exception/src/exception_code.rs
+++ b/src/common/exception/src/exception_code.rs
@@ -411,7 +411,7 @@ build_exceptions! {
     IllegalCloudControlMessageFormat(1703),
 }
 
-// UDF and Extension Errors [1810, 2601-2607]
+// UDF and Extension Errors [1810, 2601-2608]
 build_exceptions! {
     /// UDF runtime error
     UDFRuntimeError(1810),
@@ -429,6 +429,8 @@ build_exceptions! {
     UnsupportedDataType(2606),
     /// UDF data error
     UDFDataError(2607),
+    /// UDF endpoint response error
+    UDFEndpointResponseError(2608),
 }
 
 // Task Errors [2611-2614]

--- a/src/query/expression/Cargo.toml
+++ b/src/query/expression/Cargo.toml
@@ -41,6 +41,7 @@ futures = { workspace = true }
 geo = { workspace = true }
 geozero = { workspace = true }
 hex = { workspace = true }
+http = { workspace = true }
 hyper-util = { workspace = true }
 itertools = { workspace = true }
 jiff = { workspace = true }
@@ -64,6 +65,7 @@ smallvec = { workspace = true }
 strength_reduce = { workspace = true }
 terminal_size = { workspace = true }
 tonic = { workspace = true }
+tower = { workspace = true }
 typetag = { workspace = true }
 unicode-segmentation = { workspace = true }
 

--- a/src/query/expression/src/utils/udf_client.rs
+++ b/src/query/expression/src/utils/udf_client.rs
@@ -43,10 +43,14 @@ use databend_common_metrics::external_server::record_running_requests_external_s
 use futures::StreamExt;
 use futures::TryStreamExt;
 use futures::stream;
+use http::Response as HttpResponse;
+use http::StatusCode;
 use hyper_util::client::legacy::connect::HttpConnector;
 use itertools::Itertools;
 use tonic::Request;
+use tonic::Response as TonicResponse;
 use tonic::Status;
+use tonic::body::Body;
 use tonic::metadata::KeyAndValueRef;
 use tonic::metadata::MetadataKey;
 use tonic::metadata::MetadataMap;
@@ -54,6 +58,7 @@ use tonic::metadata::MetadataValue;
 use tonic::transport::ClientTlsConfig;
 use tonic::transport::Endpoint;
 use tonic::transport::channel::Channel;
+use tower::util::MapResponse;
 
 use crate::BlockEntry;
 use crate::DataBlock;
@@ -81,6 +86,18 @@ const TRANSPORT_ERROR_SNIPPETS: &[&str] = &[
     "no route to host",
 ];
 
+#[derive(Clone, Copy, Debug)]
+struct HttpResponseStatus(StatusCode);
+
+type UdfChannel = MapResponse<Channel, fn(HttpResponse<Body>) -> HttpResponse<Body>>;
+
+/// Preserves the HTTP status before tonic converts the response to gRPC types.
+fn capture_http_status(mut response: HttpResponse<Body>) -> HttpResponse<Body> {
+    let status = HttpResponseStatus(response.status());
+    response.extensions_mut().insert(status);
+    response
+}
+
 #[derive(Debug)]
 enum FlightDecodeIssue {
     TransportInterrupted,
@@ -92,7 +109,7 @@ enum FlightDecodeIssue {
 
 #[derive(Debug, Clone)]
 pub struct UDFFlightClient {
-    inner: FlightServiceClient<Channel>,
+    inner: FlightServiceClient<UdfChannel>,
     batch_rows: usize,
     headers: MetadataMap,
 }
@@ -154,6 +171,7 @@ impl UDFFlightClient {
                     err
                 ))
             })?;
+        let channel: UdfChannel = MapResponse::new(channel, capture_http_status);
         let inner =
             FlightServiceClient::new(channel).max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE);
 
@@ -426,7 +444,9 @@ impl UDFFlightClient {
             .build(stream::iter(batches))
             .map(|data| data.unwrap());
         let request = self.make_request(flight_data_stream);
-        let flight_data_stream = self.inner.do_exchange(request).await?.into_inner();
+        let response = self.inner.do_exchange(request).await?;
+        ensure_no_http_bad_gateway(func_name, &response)?;
+        let flight_data_stream = response.into_inner();
         let record_batch_stream = FlightRecordBatchStream::new_from_flight_data(
             flight_data_stream.map_err(|err| err.into()),
         )
@@ -443,6 +463,19 @@ impl UDFFlightClient {
         concat_batches(&schema, batches.iter())
             .map_err(|err| ErrorCode::UDFDataError(err.to_string()))
     }
+}
+
+fn ensure_no_http_bad_gateway<T>(func_name: &str, response: &TonicResponse<T>) -> Result<()> {
+    if response
+        .extensions()
+        .get::<HttpResponseStatus>()
+        .is_some_and(|status| status.0 == StatusCode::BAD_GATEWAY)
+    {
+        return Err(ErrorCode::UDFEndpointResponseError(format!(
+            "The endpoint for the user-defined function \"{func_name}\" returned HTTP 502 (Bad Gateway) instead of a gRPC response. Check the proxy or gateway configuration and the UDF server's health and logs."
+        )));
+    }
+    Ok(())
 }
 
 fn handle_flight_decode_error(func_name: &str, err: FlightError) -> ErrorCode {
@@ -549,7 +582,12 @@ pub fn error_kind(message: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
+    use std::convert::Infallible;
+
+    use arrow_flight::FlightData;
+    use futures::executor::block_on;
     use tonic::Code;
+    use tower::service_fn;
 
     use super::*;
 
@@ -611,5 +649,41 @@ mod tests {
             message.contains("could not parse"),
             "malformed data hint missing: {message}"
         );
+    }
+
+    /// Verifies that the captured status survives tonic's response conversion
+    /// and is available before the streaming body is decoded.
+    #[test]
+    fn http_bad_gateway_is_detected_before_body_decode() {
+        block_on(async {
+            let service = service_fn(|_request: http::Request<Body>| async {
+                Ok::<_, Infallible>(
+                    HttpResponse::builder()
+                        .status(StatusCode::BAD_GATEWAY)
+                        .body(Body::empty())
+                        .expect("build HTTP response"),
+                )
+            });
+            let service = MapResponse::new(service, capture_http_status);
+            let mut client = FlightServiceClient::new(service);
+            let response = client
+                .do_exchange(stream::empty::<FlightData>())
+                .await
+                .expect("receive streaming response");
+
+            let err = ensure_no_http_bad_gateway("test_udf", &response)
+                .expect_err("HTTP 502 should be rejected");
+            assert_eq!(err.code(), ErrorCode::U_D_F_ENDPOINT_RESPONSE_ERROR);
+            let message = err.message();
+            assert!(
+                message.contains("returned HTTP 502 (Bad Gateway) instead of a gRPC response"),
+                "HTTP 502 hint missing: {message}"
+            );
+            assert!(
+                !message.contains("could not be reached")
+                    && !message.contains("reported by the proxy or gateway"),
+                "HTTP 502 response was attributed to a specific component: {message}"
+            );
+        });
     }
 }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

A UDF endpoint may return a plain HTTP 502 response instead of gRPC. Previously, tonic passed the response body to Arrow Flight decoding, resulting in a misleading protocol or data error that hid the original HTTP status.

This PR:

- Preserves the structured HTTP status before tonic converts the response into gRPC types
- Detects HTTP 502 before Arrow Flight decodes the streaming response body
- Returns the dedicated `UDFEndpointResponseError` (2608) with actionable, attribution-neutral diagnostics
- Avoids parsing tonic's internal error messages

The handling is intentionally limited to HTTP 502 responses.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

<!--
See AI_POLICY.md. Agent-opened PRs are welcome; a responsible human on the author side must own the change.
The responsible human is NOT the reviewer — it is the submitter-side owner who has read the diff,
can explain each change, and will answer questions during review.
Write "None" for AI usage if no AI was involved.
-->

- AI usage: AI generate the code I review the diff.
- Responsible human: @Tceason
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20423)
<!-- Reviewable:end -->
