### PR TITLE
fix(query): avoid UTF-8 boundary panic in datetime domain folding

### DIFF
--- a/src/query/functions/src/scalars/timestamp/src/datetime.rs
+++ b/src/query/functions/src/scalars/timestamp/src/datetime.rs
@@ -369,8 +369,11 @@ fn register_string_to_timestamp(registry: &mut FunctionRegistry) {
                 let mut d = string_to_timestamp(v, &ctx.tz);
                 // the string max domain maybe truncated into `"2024-09-02 00:0�"`
                 const MAX_LEN: usize = "1000-01-01".len();
-                if d.is_err() && v.len() > MAX_LEN {
-                    d = string_to_timestamp(&v[0..MAX_LEN], &ctx.tz);
+                if d.is_err()
+                    && v.len() > MAX_LEN
+                    && let Some(prefix) = v.get(..MAX_LEN)
+                {
+                    d = string_to_timestamp(prefix, &ctx.tz);
                     if i == 0 {
                         extend_num = -1;
                     } else {
@@ -907,8 +910,11 @@ fn register_string_to_date(registry: &mut FunctionRegistry) {
 
                 let mut extend_num = 0;
                 let mut d = string_to_date(v, &ctx.tz);
-                if d.is_err() && v.len() > 10 {
-                    d = string_to_date(&v[0..10], &ctx.tz);
+                if d.is_err()
+                    && v.len() > 10
+                    && let Some(prefix) = v.get(..10)
+                {
+                    d = string_to_date(prefix, &ctx.tz);
                     if i == 0 {
                         extend_num = -1;
                     } else {

--- a/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
+++ b/tests/sqllogictests/suites/query/functions/02_0012_function_datetimes.test
@@ -177,6 +177,16 @@ select to_datetime('9999-01-01 01:12.123+02:00')
 statement error 1006
 select to_datetime('10000-01-01 00:00:00')
 
+# Multi-byte characters crossing the date prefix boundary must not panic during domain folding.
+statement error 1046
+select to_date('6Cu䚆kL禱uc')
+
+statement error 1046
+select to_date(CASE WHEN true THEN '售>僃I彰' ELSE 'x' END)
+
+statement error 1046
+select to_timestamp('R沀4{쒵慦赶')
+
 query ?
 select to_datetime('0999-12-31 23:59:59')
 ----


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

`TO_DATE` and `TO_TIMESTAMP` may panic during domain folding when an invalid
string contains a multi-byte UTF-8 character crossing the fixed 10-byte date
prefix boundary.

The domain evaluators retry parsing with `&value[..10]` after parsing the full
string fails. Rust string slicing requires the offset to be a valid UTF-8
character boundary, so such inputs can panic and terminate the client session
instead of returning a SQL error.


- fixes: #20427


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

<!--
See AI_POLICY.md. Agent-opened PRs are welcome; a responsible human on the author side must own the change.
The responsible human is NOT the reviewer — it is the submitter-side owner who has read the diff,
can explain each change, and will answer questions during review.
Write "None" for AI usage if no AI was involved.
-->

- AI usage: AI generate the test I modify the code.
- Responsible human: @TCeason
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20430)
<!-- Reviewable:end -->
