### PR TITLE
fix(query): compare persisted statistics without collapsing to Equal

### DIFF
--- a/src/query/catalog/src/runtime_filter_info.rs
+++ b/src/query/catalog/src/runtime_filter_info.rs
@@ -29,6 +29,7 @@ use databend_common_expression::ColumnId;
 use databend_common_expression::Expr;
 use databend_common_expression::Scalar;
 use databend_storages_common_table_meta::meta::ColumnStatistics;
+use databend_storages_common_table_meta::meta::try_cmp_stat_scalars;
 use parking_lot::RwLock;
 use tokio::sync::watch;
 use tokio::sync::watch::Receiver;
@@ -80,10 +81,15 @@ impl RuntimeScanOrder {
             (RuntimeTopNRank::Best, _) => CmpOrdering::Less,
             (_, RuntimeTopNRank::Best) => CmpOrdering::Greater,
             (RuntimeTopNRank::Value(a), RuntimeTopNRank::Value(b)) => {
+                // Persisted bounds may carry a stale decimal precision after a metadata-only
+                // widening; comparing them raw would report every rank as equal. An
+                // incomparable pair carries no ordering information, so treat it as a tie.
+                let ordering = try_cmp_stat_scalars(&a.borrow().as_ref(), &b.borrow().as_ref())
+                    .unwrap_or(CmpOrdering::Equal);
                 if self.asc {
-                    a.borrow().cmp(b.borrow())
+                    ordering
                 } else {
-                    b.borrow().cmp(a.borrow())
+                    ordering.reverse()
                 }
             }
             (RuntimeTopNRank::Value(_), RuntimeTopNRank::Unknown) => CmpOrdering::Less,
@@ -234,7 +240,9 @@ impl RuntimeTopNFilter {
     fn tighter(&self, candidate: &Scalar, current: Option<&Scalar>) -> bool {
         match current {
             None => true,
-            Some(old) => match candidate.partial_cmp(old) {
+            // Boundaries are produced by the running query, so they normally share a size; an
+            // incomparable pair cannot be proven tighter, so keep the published one.
+            Some(old) => match try_cmp_stat_scalars(&candidate.as_ref(), &old.as_ref()) {
                 Some(CmpOrdering::Less) => self.asc,
                 Some(CmpOrdering::Greater) => !self.asc,
                 _ => false,
@@ -289,9 +297,11 @@ impl RuntimeTopNFilter {
         }
 
         if self.asc {
-            min.partial_cmp(boundary) == Some(CmpOrdering::Greater)
+            // A stale decimal precision makes the comparison inconclusive; keep the block rather
+            // than prune on an ordering we cannot establish.
+            try_cmp_stat_scalars(&min.as_ref(), &boundary.as_ref()) == Some(CmpOrdering::Greater)
         } else {
-            max.partial_cmp(boundary) == Some(CmpOrdering::Less)
+            try_cmp_stat_scalars(&max.as_ref(), &boundary.as_ref()) == Some(CmpOrdering::Less)
         }
     }
 }
@@ -529,6 +539,8 @@ mod tests {
     use databend_common_expression::ColumnRef;
     use databend_common_expression::Expr;
     use databend_common_expression::types::DataType;
+    use databend_common_expression::types::DecimalScalar;
+    use databend_common_expression::types::DecimalSize;
     use databend_common_expression::types::NumberDataType;
     use databend_common_expression::types::NumberScalar;
     use tokio::time::Duration;
@@ -725,5 +737,68 @@ mod tests {
         let ready = RuntimeFilterReady::for_statistics_probe_exprs(false, [&probe_expr]);
         assert!(ready.statistics_column_names().is_empty());
         assert!(!ready.has_statistics_pruning());
+    }
+    fn decimal(value: i64, precision: u8, scale: u8) -> Scalar {
+        Scalar::Decimal(DecimalScalar::Decimal64(
+            value,
+            DecimalSize::new(precision, scale).unwrap(),
+        ))
+    }
+
+    // A metadata-only decimal precision widening leaves persisted block bounds tagged with the
+    // previous `DecimalSize`. Raw comparison against the boundary collapses to `Equal`, so no
+    // block is ever excluded; comparing by scale and raw value restores the filter.
+    #[test]
+    fn runtime_top_n_filter_excludes_blocks_across_widened_precision() {
+        let asc = RuntimeTopNFilter::new(7, true, false);
+        asc.update(&decimal(500, 15, 2));
+
+        // Bounds tagged with the old precision but wholly above the boundary.
+        assert!(asc.boundary_excludes(&decimal(600, 10, 2), &decimal(700, 10, 2), 0));
+        // Straddling the boundary: must be kept.
+        assert!(!asc.boundary_excludes(&decimal(400, 10, 2), &decimal(700, 10, 2), 0));
+
+        let desc = RuntimeTopNFilter::new(7, false, false);
+        desc.update(&decimal(500, 15, 2));
+        assert!(desc.boundary_excludes(&decimal(100, 10, 2), &decimal(400, 10, 2), 0));
+        assert!(!desc.boundary_excludes(&decimal(100, 10, 2), &decimal(600, 10, 2), 0));
+    }
+
+    // A scale change is not a widening: the comparison is genuinely inconclusive, so the block
+    // must be kept rather than pruned on an ordering that cannot be established.
+    #[test]
+    fn runtime_top_n_filter_keeps_blocks_with_incomparable_bounds() {
+        let asc = RuntimeTopNFilter::new(7, true, false);
+        asc.update(&decimal(500, 15, 2));
+
+        assert!(!asc.boundary_excludes(&decimal(600, 10, 4), &decimal(700, 10, 4), 0));
+    }
+
+    // Ranking feeds the read order; mixed precisions must still sort by value, otherwise every
+    // part looks equally promising and the scheduling degrades.
+    #[test]
+    fn runtime_scan_order_ranks_across_widened_precision() {
+        let low = RuntimeTopNRank::Value(decimal(100, 10, 2));
+        let high = RuntimeTopNRank::Value(decimal(900, 15, 2));
+
+        let asc = RuntimeScanOrder {
+            column_id: 7,
+            asc: true,
+            nulls_first: false,
+        };
+        assert_eq!(asc.compare_ranks(&low, &high), CmpOrdering::Less);
+        assert_eq!(asc.compare_ranks(&high, &low), CmpOrdering::Greater);
+
+        let desc = RuntimeScanOrder {
+            column_id: 7,
+            asc: false,
+            nulls_first: false,
+        };
+        assert_eq!(desc.compare_ranks(&low, &high), CmpOrdering::Greater);
+        assert_eq!(desc.compare_ranks(&high, &low), CmpOrdering::Less);
+
+        // A scale change is inconclusive, so neither rank is preferred.
+        let other_scale = RuntimeTopNRank::Value(decimal(900, 10, 4));
+        assert_eq!(asc.compare_ranks(&low, &other_scale), CmpOrdering::Equal);
     }
 }

--- a/src/query/storages/common/index/src/range_index.rs
+++ b/src/query/storages/common/index/src/range_index.rs
@@ -33,6 +33,7 @@ use databend_common_expression::types::DataType;
 use databend_common_expression::types::DateType;
 use databend_common_expression::types::Decimal64Type;
 use databend_common_expression::types::DecimalScalar;
+use databend_common_expression::types::DecimalSize;
 use databend_common_expression::types::NumberDataType;
 use databend_common_expression::types::NumberType;
 use databend_common_expression::types::TimestampType;
@@ -48,6 +49,7 @@ use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_storages_common_table_meta::meta::ColumnStatistics;
 use databend_storages_common_table_meta::meta::StatisticsOfColumns;
 use databend_storages_common_table_meta::meta::StatisticsOfSpatialColumns;
+use databend_storages_common_table_meta::meta::retag_stat_scalar;
 use geo::Point;
 use geo::Rect;
 
@@ -248,6 +250,16 @@ impl RangeIndex {
     }
 }
 
+/// The decimal size persisted statistics must be retagged to before use, if any.
+///
+/// Only decimal columns need this; every other type is already comparable as persisted.
+fn target_decimal_size(data_type: &DataType) -> Option<DecimalSize> {
+    match data_type.remove_nullable() {
+        DataType::Decimal(size) => Some(size),
+        _ => None,
+    }
+}
+
 pub fn statistics_to_domain(mut stats: Vec<&ColumnStatistics>, data_type: &DataType) -> Domain {
     if stats.len() != data_type.num_leaf_columns() {
         return Domain::full(data_type);
@@ -299,8 +311,23 @@ pub fn statistics_to_domain(mut stats: Vec<&ColumnStatistics>, data_type: &DataT
         DataType::Vector(_) => Domain::full(data_type),
         _ => {
             let stat = stats[0];
-            let min = stat.min();
-            let max = stat.max();
+            // A metadata-only decimal precision widening leaves persisted bounds tagged with the
+            // previous `DecimalSize`, so retag them to the current schema before building a
+            // domain. Bounds that cannot be retagged did not come from such a widening, and
+            // constructing a domain from them would be unsound, so fall back to the full domain.
+            let (min, max) = match target_decimal_size(data_type) {
+                None => (Cow::Borrowed(stat.min()), Cow::Borrowed(stat.max())),
+                Some(size) => {
+                    let Some(min) = retag_stat_scalar(stat.min(), size) else {
+                        return Domain::full(data_type);
+                    };
+                    let Some(max) = retag_stat_scalar(stat.max(), size) else {
+                        return Domain::full(data_type);
+                    };
+                    (Cow::Owned(min), Cow::Owned(max))
+                }
+            };
+            let (min, max) = (min.as_ref(), max.as_ref());
 
             with_number_mapped_type!(|NUM_TYPE| match data_type {
                 DataType::Number(NumberDataType::NUM_TYPE) => {
@@ -322,9 +349,6 @@ pub fn statistics_to_domain(mut stats: Vec<&ColumnStatistics>, data_type: &DataT
                     max: DateType::try_downcast_scalar(&max.as_ref()).unwrap(),
                 }),
                 DataType::Decimal(size) => {
-                    debug_assert_eq!(*size, min.as_decimal().unwrap().size());
-                    debug_assert_eq!(*size, max.as_decimal().unwrap().size());
-
                     let domain = match min.as_decimal().unwrap() {
                         DecimalScalar::Decimal64(_, _) => {
                             let domain = SimpleDomain {

--- a/src/query/storages/common/index/tests/it/range_pruner.rs
+++ b/src/query/storages/common/index/tests/it/range_pruner.rs
@@ -32,11 +32,15 @@ use databend_common_expression::TableSchema;
 use databend_common_expression::type_check::check_function;
 use databend_common_expression::types::ArgType;
 use databend_common_expression::types::DataType;
+use databend_common_expression::types::DecimalScalar;
+use databend_common_expression::types::DecimalSize;
 use databend_common_expression::types::Int32Type;
 use databend_common_expression::types::NumberDataType;
+use databend_common_expression::types::decimal::DecimalDomain;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_storages_common_index::RangeIndex;
 use databend_storages_common_index::eliminate_cast;
+use databend_storages_common_index::statistics_to_domain;
 use databend_storages_common_table_meta::meta::ColumnStatistics;
 use databend_storages_common_table_meta::meta::SpatialStatistics;
 use databend_storages_common_table_meta::meta::StatisticsOfColumns;
@@ -551,4 +555,61 @@ fn build_spatial_stats(
         is_valid: true,
     };
     [(column_id, stats)].into_iter().collect()
+}
+
+// A metadata-only decimal precision widening leaves persisted bounds tagged with the previous
+// `DecimalSize`. The domain must be built at the current schema size so pruning still works;
+// previously this hit a `debug_assert_eq!` on the size instead.
+#[test]
+fn test_statistics_to_domain_retags_widened_decimal() {
+    let current = DecimalSize::new(15, 2).unwrap();
+    let stale = ColumnStatistics::new(
+        Scalar::Decimal(DecimalScalar::Decimal64(
+            100,
+            DecimalSize::new(10, 2).unwrap(),
+        )),
+        Scalar::Decimal(DecimalScalar::Decimal64(
+            200,
+            DecimalSize::new(10, 2).unwrap(),
+        )),
+        0,
+        0,
+        None,
+    );
+
+    let domain = statistics_to_domain(vec![&stale], &DataType::Decimal(current));
+
+    // The bounds keep their raw values and are reported at the current precision.
+    match domain {
+        Domain::Decimal(DecimalDomain::Decimal64(inner, size)) => {
+            assert_eq!(size, current);
+            assert_eq!(inner.min, 100);
+            assert_eq!(inner.max, 200);
+        }
+        other => panic!("expected a Decimal64 domain, got {other:?}"),
+    }
+}
+
+// Bounds that cannot be retagged did not come from a metadata-only widening, so no sound domain
+// can be derived from them and pruning must fall back to the full domain.
+#[test]
+fn test_statistics_to_domain_falls_back_for_incompatible_decimal() {
+    let current = DataType::Decimal(DecimalSize::new(15, 2).unwrap());
+    // A different scale means the raw value denotes a different number.
+    let other_scale = ColumnStatistics::new(
+        Scalar::Decimal(DecimalScalar::Decimal64(
+            100,
+            DecimalSize::new(10, 4).unwrap(),
+        )),
+        Scalar::Decimal(DecimalScalar::Decimal64(
+            200,
+            DecimalSize::new(10, 4).unwrap(),
+        )),
+        0,
+        0,
+        None,
+    );
+
+    let domain = statistics_to_domain(vec![&other_scale], &current);
+    assert_eq!(domain, Domain::full(&current));
 }

--- a/src/query/storages/common/pruner/src/topn_pruner.rs
+++ b/src/query/storages/common/pruner/src/topn_pruner.rs
@@ -22,9 +22,12 @@ use databend_common_expression::SEARCH_SCORE_COL_NAME;
 use databend_common_expression::Scalar;
 use databend_common_expression::TableDataType;
 use databend_common_expression::TableSchemaRef;
+use databend_common_expression::types::DataType;
+use databend_common_expression::types::DecimalSize;
 use databend_common_expression::types::number::F32;
 use databend_storages_common_table_meta::meta::BlockMeta;
 use databend_storages_common_table_meta::meta::ColumnStatistics;
+use databend_storages_common_table_meta::meta::retag_stat_scalar;
 
 use crate::BlockMetaIndex;
 
@@ -122,25 +125,41 @@ impl TopNPruner {
         };
 
         // String Type min/max is truncated
-        if matches!(
-            self.schema.field_with_name(column)?.data_type(),
-            TableDataType::String
-        ) {
+        let sort_data_type = self.schema.field_with_name(column)?.data_type();
+        if matches!(sort_data_type, TableDataType::String) {
             return Ok(metas);
         }
 
-        let mut id_stats = metas
-            .iter()
-            .map(|(id, meta)| {
-                let stat = meta.col_stats.get(&sort_column_id).ok_or_else(|| {
-                    ErrorCode::UnknownException(format!(
-                        "Unable to get the colStats by ColumnId: {}",
-                        sort_column_id
-                    ))
-                })?;
-                Ok((id.clone(), stat.clone(), meta.clone()))
-            })
-            .collect::<Result<Vec<_>>>()?;
+        // A metadata-only decimal precision widening leaves persisted bounds tagged with the
+        // previous `DecimalSize`. Retag them to the current schema once here, so every comparison
+        // below stays meaningful; comparing mixed sizes would collapse to `Ordering::Equal` and
+        // silently disable this pruner.
+        let target_size = match DataType::from(sort_data_type).remove_nullable() {
+            DataType::Decimal(size) => Some(size),
+            _ => None,
+        };
+
+        let mut id_stats = Vec::with_capacity(metas.len());
+        for (id, meta) in &metas {
+            let stat = meta.col_stats.get(&sort_column_id).ok_or_else(|| {
+                ErrorCode::UnknownException(format!(
+                    "Unable to get the colStats by ColumnId: {}",
+                    sort_column_id
+                ))
+            })?;
+            let stat = match target_size {
+                None => stat.clone(),
+                Some(size) => {
+                    // Bounds that cannot be retagged did not come from a metadata-only widening,
+                    // so there is no sound ordering to prune by; keep every block.
+                    let Some(stat) = retag_column_statistics(stat, size) else {
+                        return Ok(metas);
+                    };
+                    stat
+                }
+            };
+            id_stats.push((id.clone(), stat, meta.clone()));
+        }
 
         if self.filter_only_use_index {
             // For descending order, we determine a lower bound for the Nth largest value.
@@ -306,6 +325,25 @@ fn block_score_range(scores: &[F32]) -> Option<(F32, F32)> {
     Some((min_score, max_score))
 }
 
+/// Retag a column's persisted bounds to `target_size`, keeping every other field.
+///
+/// Returns `None` when the bounds did not come from a metadata-only precision widening of this
+/// column, in which case there is no sound way to compare them against current-schema values.
+fn retag_column_statistics(
+    stat: &ColumnStatistics,
+    target_size: DecimalSize,
+) -> Option<ColumnStatistics> {
+    let min = retag_stat_scalar(stat.min(), target_size)?;
+    let max = retag_stat_scalar(stat.max(), target_size)?;
+    Some(ColumnStatistics::new(
+        min,
+        max,
+        stat.null_count,
+        stat.in_memory_size,
+        stat.distinct_of_values,
+    ))
+}
+
 fn compare_scalar_for_sorting(
     left: &Scalar,
     right: &Scalar,
@@ -417,6 +455,8 @@ mod tests {
     use databend_common_expression::TableField;
     use databend_common_expression::TableSchema;
     use databend_common_expression::types::DataType;
+    use databend_common_expression::types::DecimalDataType;
+    use databend_common_expression::types::DecimalScalar;
     use databend_common_expression::types::number::NumberDataType;
     use databend_storages_common_table_meta::meta::ColumnMeta;
     use databend_storages_common_table_meta::meta::ColumnStatistics;
@@ -730,5 +770,103 @@ mod tests {
         let matched_scores = scores.iter().map(|v| (*v).into()).collect();
         index.matched_scores = Some(matched_scores);
         (index, meta)
+    }
+    fn decimal_type(precision: u8, scale: u8) -> TableDataType {
+        TableDataType::Decimal(DecimalDataType::from(
+            DecimalSize::new(precision, scale).unwrap(),
+        ))
+    }
+
+    fn decimal_scalar(value: i64, precision: u8, scale: u8) -> Scalar {
+        Scalar::Decimal(DecimalScalar::Decimal64(
+            value,
+            DecimalSize::new(precision, scale).unwrap(),
+        ))
+    }
+
+    fn build_decimal_block(
+        column_id: ColumnId,
+        block_id: usize,
+        min: (i64, u8),
+        max: (i64, u8),
+        matched_rows: usize,
+    ) -> (BlockMetaIndex, Arc<BlockMeta>) {
+        let column_stats = ColumnStatistics::new(
+            decimal_scalar(min.0, min.1, 2),
+            decimal_scalar(max.0, max.1, 2),
+            0,
+            0,
+            None,
+        );
+        build_block_with_stats(column_id, block_id, column_stats, matched_rows)
+    }
+
+    // After a metadata-only precision widening, older blocks keep the previous `DecimalSize`.
+    // Comparing those bounds raw collapses to `Ordering::Equal`, which silently disables this
+    // pruner; retagging to the current schema restores it.
+    #[test]
+    fn test_prune_topn_across_widened_decimal_precision() {
+        let schema = Arc::new(TableSchema::new(vec![TableField::new(
+            "c",
+            decimal_type(15, 2),
+        )]));
+        let sort_expr = RemoteExpr::ColumnRef {
+            span: None,
+            id: "c".to_string(),
+            data_type: DataType::Decimal(DecimalSize::new(15, 2).unwrap()),
+            display_name: "c".to_string(),
+        };
+        let column_id = schema.column_id_of("c").unwrap();
+
+        // Block 0 holds the smallest values but is still tagged with the old precision.
+        let metas = vec![
+            build_decimal_block(column_id, 0, (100, 10), (200, 10), 5),
+            build_decimal_block(column_id, 1, (5000, 15), (6000, 15), 5),
+            build_decimal_block(column_id, 2, (9000, 15), (9500, 15), 5),
+        ];
+
+        let pruner = TopNPruner::create(schema, vec![(sort_expr, true, false)], 5, true);
+        let result = pruner.prune(metas).unwrap();
+        let mut kept: Vec<_> = result.iter().map(|(idx, _)| idx.block_id).collect();
+        kept.sort_unstable();
+
+        // Only the block containing the 5 smallest values needs to be read.
+        assert_eq!(kept, vec![0]);
+    }
+
+    // Bounds that cannot be retagged did not come from a metadata-only widening, so there is no
+    // sound ordering to prune by and every block must be kept.
+    #[test]
+    fn test_prune_topn_keeps_all_blocks_for_incompatible_decimal_scale() {
+        let schema = Arc::new(TableSchema::new(vec![TableField::new(
+            "c",
+            decimal_type(15, 2),
+        )]));
+        let sort_expr = RemoteExpr::ColumnRef {
+            span: None,
+            id: "c".to_string(),
+            data_type: DataType::Decimal(DecimalSize::new(15, 2).unwrap()),
+            display_name: "c".to_string(),
+        };
+        let column_id = schema.column_id_of("c").unwrap();
+
+        // A scale of 4 against a schema scale of 2 cannot be reconciled.
+        let mismatched = ColumnStatistics::new(
+            decimal_scalar(100, 10, 4),
+            decimal_scalar(200, 10, 4),
+            0,
+            0,
+            None,
+        );
+        let metas = vec![
+            build_block_with_stats(column_id, 0, mismatched, 5),
+            build_decimal_block(column_id, 1, (9000, 15), (9500, 15), 5),
+        ];
+
+        let pruner = TopNPruner::create(schema, vec![(sort_expr, true, false)], 5, true);
+        let result = pruner.prune(metas).unwrap();
+        let mut kept: Vec<_> = result.iter().map(|(idx, _)| idx.block_id).collect();
+        kept.sort_unstable();
+        assert_eq!(kept, vec![0, 1]);
     }
 }

--- a/src/query/storages/common/table_meta/src/meta/mod.rs
+++ b/src/query/storages/common/table_meta/src/meta/mod.rs
@@ -19,6 +19,7 @@ pub mod compression;
 mod current;
 pub mod format;
 mod histogram_serde;
+mod stat_cmp;
 mod statistics;
 mod utils;
 mod v0;
@@ -36,6 +37,13 @@ pub use format::NUM_BLOCK_ID_BITS;
 pub use format::decode;
 pub(crate) use format::load_json;
 pub use histogram_serde::LegacyHistogram;
+pub use stat_cmp::common_stat_decimal_size;
+pub use stat_cmp::retag_stat_scalar;
+pub use stat_cmp::total_cmp_stat_scalar_slices;
+pub use stat_cmp::total_cmp_stat_scalars;
+pub use stat_cmp::try_cmp_stat_scalar_slices;
+pub use stat_cmp::try_cmp_stat_scalars;
+pub use stat_cmp::try_stat_ranges_disjoint;
 pub use statistics::*;
 // export legacy versioned table meta types locally,
 // currently, used by versioned readers only

--- a/src/query/storages/common/table_meta/src/meta/stat_cmp.rs
+++ b/src/query/storages/common/table_meta/src/meta/stat_cmp.rs
@@ -1,0 +1,383 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Comparison of persisted min/max statistics.
+//!
+//! # Why persisted statistics need their own comparison
+//!
+//! Statistics are written against the schema in effect at the time, but read back against the
+//! current one. A metadata-only `ALTER TABLE ... MODIFY COLUMN` that widens a decimal precision
+//! leaves already-written block, segment, and snapshot statistics tagged with the previous
+//! `DecimalSize`, so a single column can hold a mix of precisions.
+//!
+//! Comparing two decimals of different `DecimalSize` has no defined ordering:
+//! `DecimalScalar::partial_cmp` returns `None`. What makes that dangerous is how the surrounding
+//! impls absorb it:
+//!
+//! - `Ord for Scalar` is `partial_cmp(..).unwrap_or(Ordering::Equal)`, so `<`, `>`, `cmp`,
+//!   `min_by`, `max_by`, and `sort_by` all silently report the values as equal.
+//! - `PartialEq for Scalar` is `partial_cmp(..) == Some(Equal)`, so `==` silently reports them as
+//!   different.
+//!
+//! Neither path raises an error, so a stale precision quietly degrades pruning and ordering, and
+//! `min_by`/`max_by` can even emit a range whose min and max carry different sizes.
+//!
+//! # What this module does
+//!
+//! A decimal's raw integer value is unaffected by its precision: only the scale decides where the
+//! decimal point sits. Two statistics scalars of the same scale are therefore comparable by their
+//! raw values, whatever precision or storage variant they are tagged with. That is exactly the
+//! situation a metadata-only widening produces, so these helpers compare by scale and value and
+//! ignore precision. Genuinely incomparable inputs (different scale, different type) return
+//! `None`, and callers must fall back conservatively rather than assume equality.
+//!
+//! Because comparability does not depend on the current schema, callers need no type information.
+
+use std::cmp::Ordering;
+
+use databend_common_expression::Scalar;
+use databend_common_expression::ScalarRef;
+use databend_common_expression::types::DecimalScalar;
+use databend_common_expression::types::DecimalSize;
+use databend_common_expression::types::i256;
+
+/// Compare two scalars taken from persisted statistics.
+///
+/// Decimals of equal scale compare by raw value regardless of precision or storage variant.
+/// Returns `None` when the values are not comparable; callers must treat that conservatively
+/// instead of assuming `Ordering::Equal` the way `Ord for Scalar` does.
+pub fn try_cmp_stat_scalars(left: &ScalarRef<'_>, right: &ScalarRef<'_>) -> Option<Ordering> {
+    match (left, right) {
+        (ScalarRef::Decimal(left), ScalarRef::Decimal(right)) => {
+            if left.scale() != right.scale() {
+                return None;
+            }
+            // Widening a precision never rewrites the stored value, and it may promote the
+            // storage variant, so compare the raw values in the widest representation.
+            Some(left.as_decimal::<i256>().cmp(&right.as_decimal::<i256>()))
+        }
+        // `Decimal` mixed with anything else is genuinely incomparable; `partial_cmp` already
+        // reports `None` for that, and for every other type it is well defined.
+        _ => left.partial_cmp(right),
+    }
+}
+
+/// Compare two statistics tuples lexicographically, as used by cluster statistics.
+///
+/// Returns `None` if the tuples have different lengths or any position is incomparable.
+pub fn try_cmp_stat_scalar_slices(left: &[Scalar], right: &[Scalar]) -> Option<Ordering> {
+    if left.len() != right.len() {
+        return None;
+    }
+    for (left, right) in left.iter().zip(right) {
+        match try_cmp_stat_scalars(&left.as_ref(), &right.as_ref())? {
+            Ordering::Equal => {}
+            ordering => return Some(ordering),
+        }
+    }
+    Some(Ordering::Equal)
+}
+
+/// A total order over statistics scalars, for use as a sort or map key.
+///
+/// [`try_cmp_stat_scalars`] is the right choice for pruning and range decisions, because it
+/// reports when two values cannot be ordered. Collection keys cannot express that: a `BTreeMap`
+/// whose comparator returns `Equal` for distinct values silently merges them. This function
+/// therefore always yields an ordering.
+///
+/// Decimals order by scale first, then by raw value, so values differing only in precision compare
+/// exactly as [`try_cmp_stat_scalars`] would. Values that are genuinely incomparable get an
+/// arbitrary but stable order rather than being treated as equal.
+pub fn total_cmp_stat_scalars(left: &ScalarRef<'_>, right: &ScalarRef<'_>) -> Ordering {
+    match (left, right) {
+        (ScalarRef::Decimal(left), ScalarRef::Decimal(right)) => left
+            .scale()
+            .cmp(&right.scale())
+            .then_with(|| left.as_decimal::<i256>().cmp(&right.as_decimal::<i256>())),
+        // `Ord for ScalarRef` is only lossy for decimals of differing size; every other pair it
+        // reports as `Equal` is genuinely equal.
+        _ => left.cmp(right),
+    }
+}
+
+/// Lexicographic [`total_cmp_stat_scalars`] over tuples, for use as a map key.
+pub fn total_cmp_stat_scalar_slices(left: &[Scalar], right: &[Scalar]) -> Ordering {
+    left.iter()
+        .map(Scalar::as_ref)
+        .zip(right.iter().map(Scalar::as_ref))
+        .map(|(left, right)| total_cmp_stat_scalars(&left, &right))
+        .find(|ordering| *ordering != Ordering::Equal)
+        .unwrap_or_else(|| left.len().cmp(&right.len()))
+}
+
+/// Whether `[left_min, left_max]` and `[right_min, right_max]` are provably disjoint.
+///
+/// Returns `None` when that cannot be decided, which callers must read as "may overlap".
+pub fn try_stat_ranges_disjoint(
+    left_min: &Scalar,
+    left_max: &Scalar,
+    right_min: &Scalar,
+    right_max: &Scalar,
+) -> Option<bool> {
+    let left_above = try_cmp_stat_scalars(&left_min.as_ref(), &right_max.as_ref())?;
+    let right_above = try_cmp_stat_scalars(&right_min.as_ref(), &left_max.as_ref())?;
+    Some(left_above == Ordering::Greater || right_above == Ordering::Greater)
+}
+
+/// Retag a decimal statistics scalar with `target_size`, keeping the raw value.
+///
+/// Returns `None` when the persisted value cannot be reinterpreted at `target_size`, which means
+/// it did not come from a metadata-only widening of this column. Non-decimal scalars and nulls
+/// are returned unchanged.
+pub fn retag_stat_scalar(scalar: &Scalar, target_size: DecimalSize) -> Option<Scalar> {
+    let Scalar::Decimal(decimal) = scalar else {
+        return Some(scalar.clone());
+    };
+    if decimal.scale() != target_size.scale()
+        || decimal.size().precision() > target_size.precision()
+    {
+        return None;
+    }
+    if decimal.size() == target_size {
+        return Some(scalar.clone());
+    }
+    // Keep the storage variant of the persisted value: statistics written by an external Parquet
+    // reader carry the variant implied by the Parquet physical type, which need not match the
+    // variant the current precision would imply.
+    Some(Scalar::Decimal(match decimal {
+        DecimalScalar::Decimal64(value, _) => DecimalScalar::Decimal64(*value, target_size),
+        DecimalScalar::Decimal128(value, _) => DecimalScalar::Decimal128(*value, target_size),
+        DecimalScalar::Decimal256(value, _) => DecimalScalar::Decimal256(*value, target_size),
+    }))
+}
+
+/// The smallest size that can hold every non-null decimal bound in `scalars`.
+///
+/// Returns `None` if the values are not decimals of a single scale and storage variant, in which
+/// case there is no single size to align them to.
+pub fn common_stat_decimal_size(scalars: &[&Scalar]) -> Option<DecimalSize> {
+    let mut common: Option<DecimalSize> = None;
+    for scalar in scalars {
+        if scalar.is_null() {
+            continue;
+        }
+        let Scalar::Decimal(decimal) = scalar else {
+            return None;
+        };
+        let size = decimal.size();
+        common = match common {
+            None => Some(size),
+            Some(current) if current.scale() == size.scale() => Some(DecimalSize::new_unchecked(
+                current.precision().max(size.precision()),
+                current.scale(),
+            )),
+            Some(_) => return None,
+        };
+    }
+    common
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn d64(value: i64, precision: u8, scale: u8) -> Scalar {
+        Scalar::Decimal(DecimalScalar::Decimal64(
+            value,
+            DecimalSize::new(precision, scale).unwrap(),
+        ))
+    }
+
+    fn d128(value: i128, precision: u8, scale: u8) -> Scalar {
+        Scalar::Decimal(DecimalScalar::Decimal128(
+            value,
+            DecimalSize::new(precision, scale).unwrap(),
+        ))
+    }
+
+    fn cmp(left: &Scalar, right: &Scalar) -> Option<Ordering> {
+        try_cmp_stat_scalars(&left.as_ref(), &right.as_ref())
+    }
+
+    #[test]
+    fn test_raw_ord_collapses_mixed_precision_to_equal() {
+        // The hazard this module exists for: `Ord for Scalar` reports two plainly different
+        // values as equal, and `PartialEq` reports two equal values as different.
+        let stale = d64(100, 10, 2);
+        let current = d64(900, 15, 2);
+        assert_eq!(stale.cmp(&current), Ordering::Equal);
+        assert_ne!(d64(100, 10, 2), d64(100, 15, 2));
+
+        assert_eq!(cmp(&stale, &current), Some(Ordering::Less));
+        assert_eq!(cmp(&current, &stale), Some(Ordering::Greater));
+        assert_eq!(
+            cmp(&d64(100, 10, 2), &d64(100, 15, 2)),
+            Some(Ordering::Equal)
+        );
+    }
+
+    #[test]
+    fn test_compares_across_storage_variants() {
+        // A widening may promote the storage variant, and statistics written by an external
+        // Parquet reader carry the variant implied by the Parquet physical type.
+        assert_eq!(
+            cmp(&d64(100, 10, 2), &d128(900, 25, 2)),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            cmp(&d128(900, 25, 2), &d64(100, 10, 2)),
+            Some(Ordering::Greater)
+        );
+        assert_eq!(
+            cmp(&d64(500, 10, 2), &d128(500, 25, 2)),
+            Some(Ordering::Equal)
+        );
+    }
+
+    #[test]
+    fn test_negative_values_compare_by_raw_value() {
+        assert_eq!(
+            cmp(&d64(-900, 10, 2), &d64(100, 15, 2)),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            cmp(&d64(-100, 10, 2), &d64(-900, 15, 2)),
+            Some(Ordering::Greater)
+        );
+    }
+
+    #[test]
+    fn test_incomparable_inputs_report_none() {
+        // A different scale means the raw value denotes a different number.
+        assert_eq!(cmp(&d64(100, 10, 4), &d64(900, 15, 2)), None);
+        // Decimal against a non-decimal is genuinely incomparable.
+        assert_eq!(cmp(&d64(100, 10, 2), &Scalar::String("x".into())), None);
+    }
+
+    #[test]
+    fn test_non_decimal_scalars_are_unaffected() {
+        assert_eq!(
+            cmp(&Scalar::String("a".into()), &Scalar::String("b".into())),
+            Some(Ordering::Less)
+        );
+        assert_eq!(cmp(&Scalar::Null, &Scalar::Null), Some(Ordering::Equal));
+        // Nulls sort above values, matching `Scalar::partial_cmp`.
+        assert_eq!(
+            cmp(&Scalar::Null, &d64(100, 10, 2)),
+            Some(Ordering::Greater)
+        );
+        assert_eq!(cmp(&d64(100, 10, 2), &Scalar::Null), Some(Ordering::Less));
+    }
+
+    #[test]
+    fn test_slice_comparison_is_lexicographic() {
+        let left = vec![d64(100, 10, 2), d64(200, 10, 2)];
+        let right = vec![d64(100, 15, 2), d64(300, 15, 2)];
+        assert_eq!(
+            try_cmp_stat_scalar_slices(&left, &right),
+            Some(Ordering::Less)
+        );
+
+        // Length mismatch and any incomparable position report `None`.
+        assert_eq!(try_cmp_stat_scalar_slices(&left, &left[..1]), None);
+        let bad_scale = vec![d64(100, 10, 4), d64(200, 10, 4)];
+        assert_eq!(try_cmp_stat_scalar_slices(&left, &bad_scale), None);
+    }
+
+    #[test]
+    fn test_range_disjointness() {
+        // [1.00, 2.00] stale vs [7.00, 8.00] current: provably disjoint.
+        let disjoint = try_stat_ranges_disjoint(
+            &d64(100, 10, 2),
+            &d64(200, 10, 2),
+            &d64(700, 15, 2),
+            &d64(800, 15, 2),
+        );
+        assert_eq!(disjoint, Some(true));
+
+        // [1.00, 9.00] contains [7.00, 8.00].
+        let overlapping = try_stat_ranges_disjoint(
+            &d64(100, 10, 2),
+            &d64(900, 10, 2),
+            &d64(700, 15, 2),
+            &d64(800, 15, 2),
+        );
+        assert_eq!(overlapping, Some(false));
+
+        // Touching at a boundary counts as overlapping.
+        let touching = try_stat_ranges_disjoint(
+            &d64(100, 10, 2),
+            &d64(700, 10, 2),
+            &d64(700, 15, 2),
+            &d64(800, 15, 2),
+        );
+        assert_eq!(touching, Some(false));
+
+        // Incomparable bounds cannot prove disjointness.
+        let unknown = try_stat_ranges_disjoint(
+            &d64(100, 10, 4),
+            &d64(200, 10, 4),
+            &d64(700, 15, 2),
+            &d64(800, 15, 2),
+        );
+        assert_eq!(unknown, None);
+    }
+
+    #[test]
+    fn test_retag_keeps_value_and_variant() {
+        let size = DecimalSize::new(15, 2).unwrap();
+        assert_eq!(
+            retag_stat_scalar(&d64(100, 10, 2), size),
+            Some(d64(100, 15, 2))
+        );
+        // The persisted storage variant is preserved even when the target precision would imply
+        // a narrower one.
+        assert_eq!(
+            retag_stat_scalar(&d128(100, 10, 2), size),
+            Some(d128(100, 15, 2))
+        );
+        // Nulls and non-decimals pass through.
+        assert_eq!(retag_stat_scalar(&Scalar::Null, size), Some(Scalar::Null));
+        let text = Scalar::String("x".into());
+        assert_eq!(retag_stat_scalar(&text, size), Some(text));
+
+        // Narrowing or a scale change is not a metadata-only widening.
+        assert_eq!(retag_stat_scalar(&d64(100, 20, 2), size), None);
+        assert_eq!(retag_stat_scalar(&d64(100, 10, 4), size), None);
+    }
+
+    #[test]
+    fn test_common_decimal_size_takes_widest_precision() {
+        let stale = d64(100, 10, 2);
+        let current = d64(900, 15, 2);
+        assert_eq!(
+            common_stat_decimal_size(&[&stale, &current]),
+            DecimalSize::new(15, 2).ok()
+        );
+
+        // Nulls are skipped; an all-null input has no size to align to.
+        assert_eq!(
+            common_stat_decimal_size(&[&Scalar::Null, &current]),
+            DecimalSize::new(15, 2).ok()
+        );
+        assert_eq!(common_stat_decimal_size(&[&Scalar::Null]), None);
+
+        // Mixed scales and non-decimals have no common size.
+        assert_eq!(common_stat_decimal_size(&[&stale, &d64(100, 10, 4)]), None);
+        assert_eq!(
+            common_stat_decimal_size(&[&stale, &Scalar::String("x".into())]),
+            None
+        );
+    }
+}

--- a/src/query/storages/common/table_meta/src/meta/statistics.rs
+++ b/src/query/storages/common/table_meta/src/meta/statistics.rs
@@ -42,6 +42,8 @@ use crate::meta::VectorDistanceType;
 use crate::meta::format::compress;
 use crate::meta::format::encode;
 use crate::meta::format::read_and_deserialize;
+use crate::meta::stat_cmp::try_cmp_stat_scalar_slices;
+use crate::meta::stat_cmp::try_cmp_stat_scalars;
 use crate::table::ClusterType;
 use crate::table::HILBERT_CLUSTER_DIMENSIONS;
 
@@ -115,8 +117,16 @@ pub fn cluster_stats_scalar_overlap(left: &ClusterStatistics, right: &ClusterSta
         return true;
     }
 
-    scalar_tuple_cmp(left_min, right_max) != Ordering::Greater
-        && scalar_tuple_cmp(right_min, left_max) != Ordering::Greater
+    // An inconclusive comparison cannot prove the ranges are apart, so report overlap. This
+    // happens when a metadata-only decimal precision widening leaves one side tagged with the
+    // previous `DecimalSize` in a way that cannot be reconciled.
+    match (
+        scalar_tuple_cmp(left_min, right_max),
+        scalar_tuple_cmp(right_min, left_max),
+    ) {
+        (Some(left), Some(right)) => left != Ordering::Greater && right != Ordering::Greater,
+        _ => true,
+    }
 }
 
 pub fn reduce_cluster_statistics<T: Borrow<Option<ClusterStatistics>>>(
@@ -160,27 +170,36 @@ pub fn reduce_cluster_min_max(
 
     match cluster_type {
         ClusterType::Linear => {
-            let min = min_stats
-                .iter()
-                .copied()
-                .min_by(|left, right| scalar_tuple_cmp(left, right))?
-                .to_vec();
-            let max = max_stats
-                .iter()
-                .copied()
-                .max_by(|left, right| scalar_tuple_cmp(left, right))?
-                .to_vec();
-            Some((min, max))
+            // Pick the extremes explicitly instead of `min_by`/`max_by`: those swallow an
+            // inconclusive comparison as `Equal` and would take each end from a different input,
+            // producing a range whose min and max disagree. Bail out instead.
+            let mut min = min_stats[0];
+            let mut max = max_stats[0];
+            for next in min_stats.iter().skip(1) {
+                if scalar_tuple_cmp(next, min)? == Ordering::Less {
+                    min = next;
+                }
+            }
+            for next in max_stats.iter().skip(1) {
+                if scalar_tuple_cmp(next, max)? == Ordering::Greater {
+                    max = next;
+                }
+            }
+            Some((min.to_vec(), max.to_vec()))
         }
         ClusterType::Hilbert => {
             if min_stats.len() != max_stats.len()
                 || min_stats.iter().zip(max_stats).any(|(min, max)| {
                     min.len() != HILBERT_CLUSTER_DIMENSIONS
                         || max.len() != HILBERT_CLUSTER_DIMENSIONS
-                        || min
-                            .iter()
-                            .zip(*max)
-                            .any(|(min, max)| min.as_ref().cmp(&max.as_ref()) == Ordering::Greater)
+                        || min.iter().zip(*max).any(|(min, max)| {
+                            // An inconclusive comparison means we cannot confirm min <= max, so
+                            // reject the input rather than build a range we cannot verify.
+                            !matches!(
+                                try_cmp_stat_scalars(&min.as_ref(), &max.as_ref()),
+                                Some(Ordering::Less | Ordering::Equal)
+                            )
+                        })
                 })
             {
                 return None;
@@ -190,12 +209,13 @@ pub fn reduce_cluster_min_max(
             let mut max = max_stats[0].to_vec();
             for (next_min, next_max) in min_stats.iter().zip(max_stats).skip(1) {
                 for dimension in 0..HILBERT_CLUSTER_DIMENSIONS {
-                    if next_min[dimension].as_ref().cmp(&min[dimension].as_ref()) == Ordering::Less
+                    if try_cmp_stat_scalars(&next_min[dimension].as_ref(), &min[dimension].as_ref())
+                        == Some(Ordering::Less)
                     {
                         min[dimension] = next_min[dimension].clone();
                     }
-                    if next_max[dimension].as_ref().cmp(&max[dimension].as_ref())
-                        == Ordering::Greater
+                    if try_cmp_stat_scalars(&next_max[dimension].as_ref(), &max[dimension].as_ref())
+                        == Some(Ordering::Greater)
                     {
                         max[dimension] = next_max[dimension].clone();
                     }
@@ -206,10 +226,12 @@ pub fn reduce_cluster_min_max(
     }
 }
 
-fn scalar_tuple_cmp(left: &[Scalar], right: &[Scalar]) -> Ordering {
-    left.iter()
-        .map(Scalar::as_ref)
-        .cmp(right.iter().map(Scalar::as_ref))
+/// Lexicographic comparison of cluster statistics tuples.
+///
+/// Returns `None` when the tuples are not comparable, so callers must decide what that means for
+/// them rather than silently treating the values as equal.
+fn scalar_tuple_cmp(left: &[Scalar], right: &[Scalar]) -> Option<Ordering> {
+    try_cmp_stat_scalar_slices(left, right)
 }
 
 const COUNT_MIN_SKETCH_WIDTH: usize = 2048;
@@ -389,12 +411,15 @@ impl ColumnTopN {
     }
 
     fn find(&self, scalar: &ScalarRef<'_>) -> std::result::Result<usize, usize> {
-        match self
-            .values
-            .binary_search_by(|entry| entry.scalar.as_ref().cmp(scalar))
-        {
+        // `binary_search_by` needs a total order, and raw `Ord` supplies one only by collapsing
+        // incomparable pairs to `Equal`. Compare through the statistics-aware helper and treat an
+        // inconclusive result as `Greater`, so the search still terminates and the existing
+        // `partial_cmp` recheck below rejects a bogus hit.
+        match self.values.binary_search_by(|entry| {
+            try_cmp_stat_scalars(&entry.scalar.as_ref(), scalar).unwrap_or(Ordering::Greater)
+        }) {
             Ok(index)
-                if self.values[index].scalar.as_ref().partial_cmp(scalar)
+                if try_cmp_stat_scalars(&self.values[index].scalar.as_ref(), scalar)
                     == Some(Ordering::Equal) =>
             {
                 Ok(index)
@@ -696,6 +721,8 @@ pub fn merge_column_count_min_sketch_mut(lhs: &mut BlockCountMinSketch, rhs: Blo
 
 #[cfg(test)]
 mod tests {
+    use databend_common_expression::types::DecimalScalar;
+    use databend_common_expression::types::DecimalSize;
     use databend_common_expression::types::NumberScalar;
 
     use super::*;
@@ -1084,6 +1111,94 @@ mod tests {
         sketch.add_with_count(scalar_ref, 10);
 
         assert_eq!(sketch.estimate(&scalar), Some(110));
+    }
+
+    fn decimal_scalar(value: i64, precision: u8, scale: u8) -> Scalar {
+        Scalar::Decimal(DecimalScalar::Decimal64(
+            value,
+            DecimalSize::new(precision, scale).unwrap(),
+        ))
+    }
+
+    // A metadata-only decimal precision widening leaves one side tagged with the previous
+    // `DecimalSize`. Raw comparison collapses that to `Equal`, which would report every pair of
+    // ranges as overlapping and stop recluster from making progress.
+    #[test]
+    fn cluster_stats_scalar_overlap_across_widened_precision() {
+        let stats = |min: Scalar, max: Scalar| ClusterStatistics::new(0, vec![min], vec![max], 0);
+
+        let stale = stats(decimal_scalar(100, 10, 2), decimal_scalar(200, 10, 2));
+        let current = stats(decimal_scalar(700, 15, 2), decimal_scalar(800, 15, 2));
+        assert!(!cluster_stats_scalar_overlap(&stale, &current));
+
+        let wide = stats(decimal_scalar(100, 10, 2), decimal_scalar(900, 10, 2));
+        assert!(cluster_stats_scalar_overlap(&wide, &current));
+
+        // A scale change cannot be reconciled, so the check must stay conservative.
+        let other_scale = stats(decimal_scalar(100, 10, 4), decimal_scalar(200, 10, 4));
+        assert!(cluster_stats_scalar_overlap(&other_scale, &current));
+    }
+
+    #[test]
+    fn reduce_cluster_min_max_across_widened_precision() {
+        let stale_min = vec![decimal_scalar(900, 10, 2)];
+        let stale_max = vec![decimal_scalar(950, 10, 2)];
+        let current_min = vec![decimal_scalar(100, 15, 2)];
+        let current_max = vec![decimal_scalar(200, 15, 2)];
+
+        let (min, max) = reduce_cluster_min_max(
+            &[stale_min.as_slice(), current_min.as_slice()],
+            &[stale_max.as_slice(), current_max.as_slice()],
+            ClusterType::Linear,
+        )
+        .expect("bounds are comparable");
+        assert_eq!(min, current_min);
+        assert_eq!(max, stale_max);
+
+        // Mixed scales have no sound reduction; bail out rather than take each end from a
+        // different input.
+        let other_scale_min = vec![decimal_scalar(100, 10, 4)];
+        let other_scale_max = vec![decimal_scalar(200, 10, 4)];
+        assert!(
+            reduce_cluster_min_max(
+                &[stale_min.as_slice(), other_scale_min.as_slice()],
+                &[stale_max.as_slice(), other_scale_max.as_slice()],
+                ClusterType::Linear,
+            )
+            .is_none()
+        );
+    }
+
+    // `ColumnTopN` keeps its values sorted and looks them up by binary search, which needs a
+    // consistent order. A stale precision must not make an existing value unfindable or corrupt
+    // the ordering.
+    #[test]
+    fn column_top_n_finds_values_across_widened_precision() {
+        let mut top_n = ColumnTopN::with_capacity(8);
+        top_n.add(decimal_scalar(100, 10, 2).as_ref(), 3);
+        top_n.add(decimal_scalar(300, 10, 2).as_ref(), 5);
+
+        // The same value tagged with the widened precision must hit the existing entry rather
+        // than insert a duplicate.
+        top_n.add(decimal_scalar(100, 15, 2).as_ref(), 4);
+        assert_eq!(top_n.values.len(), 2);
+        assert_eq!(
+            top_n
+                .get_entry(&decimal_scalar(100, 15, 2))
+                .map(|e| e.count),
+            Some(7)
+        );
+
+        // Values stay sorted by raw value regardless of the precision they carry.
+        let scalars = top_n
+            .values
+            .iter()
+            .map(|entry| entry.scalar.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(scalars, vec![
+            decimal_scalar(100, 10, 2),
+            decimal_scalar(300, 10, 2)
+        ]);
     }
 }
 

--- a/src/query/storages/common/table_meta/src/meta/v2/statistics.rs
+++ b/src/query/storages/common/table_meta/src/meta/v2/statistics.rs
@@ -341,10 +341,27 @@ impl ColumnStatistics {
         }
     }
 
+    /// The lowest value seen for this column, as persisted.
+    ///
+    /// # Do not compare this with `<`, `>`, `cmp`, or `==`
+    ///
+    /// Statistics are read back against the current schema but were written against the schema in
+    /// effect at the time. After a metadata-only decimal precision widening this value may still
+    /// carry the previous `DecimalSize`, and decimals of different sizes have no defined ordering:
+    /// `Ord for Scalar` reports them as `Equal` and `PartialEq` reports them as different, neither
+    /// raising an error.
+    ///
+    /// Use [`try_cmp_stat_scalars`](crate::meta::try_cmp_stat_scalars) or
+    /// [`retag_stat_scalar`](crate::meta::retag_stat_scalar) for comparison, ordering, and overlap
+    /// checks. Reading the raw value for serialization, display, or re-derivation is fine.
     pub fn min(&self) -> &Scalar {
         &self.min
     }
 
+    /// The highest value seen for this column, as persisted.
+    ///
+    /// See [`Self::min`]: raw comparison is unsafe here, use
+    /// [`try_cmp_stat_scalars`](crate::meta::try_cmp_stat_scalars) instead.
     pub fn max(&self) -> &Scalar {
         &self.max
     }
@@ -390,10 +407,20 @@ impl ClusterStatistics {
         }
     }
 
+    /// The lower bound of the cluster-key tuple, as persisted.
+    ///
+    /// See [`ColumnStatistics::min`]: raw comparison is unsafe here too, because a metadata-only
+    /// decimal precision widening can leave positions tagged with the previous `DecimalSize`. Use
+    /// [`try_cmp_stat_scalar_slices`](crate::meta::try_cmp_stat_scalar_slices) for ordering and
+    /// overlap checks, or
+    /// [`total_cmp_stat_scalar_slices`](crate::meta::total_cmp_stat_scalar_slices) for a map key.
     pub fn min(&self) -> &Vec<Scalar> {
         &self.min
     }
 
+    /// The upper bound of the cluster-key tuple, as persisted.
+    ///
+    /// See [`Self::min`] for why raw comparison is unsafe here.
     pub fn max(&self) -> &Vec<Scalar> {
         &self.max
     }

--- a/src/query/storages/fuse/src/operations/read_partitions.rs
+++ b/src/query/storages/fuse/src/operations/read_partitions.rs
@@ -15,6 +15,7 @@
 // Logs from this module will show up as "[FUSE-PARTITIONS] ...".
 databend_common_tracing::register_module_tag!("[FUSE-PARTITIONS]");
 
+use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -79,6 +80,7 @@ use databend_storages_common_table_meta::meta::column_oriented_segment::NGRAM_FI
 use databend_storages_common_table_meta::meta::column_oriented_segment::ROW_COUNT;
 use databend_storages_common_table_meta::meta::column_oriented_segment::meta_name;
 use databend_storages_common_table_meta::meta::column_oriented_segment::stat_name;
+use databend_storages_common_table_meta::meta::try_cmp_stat_scalars;
 use databend_storages_common_table_meta::table::ChangeType;
 use itertools::Itertools;
 use log::info;
@@ -1305,31 +1307,38 @@ impl FuseTable {
                 in_memory_size: 0,
                 distinct_of_values: None,
             };
-            if top_k.asc {
-                block_metas.sort_by(|a, b| {
-                    let a =
-                        a.1.col_stats
-                            .get(&top_k.field.column_id)
-                            .unwrap_or(&default_stats);
-                    let b =
-                        b.1.col_stats
-                            .get(&top_k.field.column_id)
-                            .unwrap_or(&default_stats);
-                    (a.min().as_ref(), a.max().as_ref()).cmp(&(b.min().as_ref(), b.max().as_ref()))
-                });
-            } else {
-                block_metas.sort_by(|a, b| {
-                    let a =
-                        a.1.col_stats
-                            .get(&top_k.field.column_id)
-                            .unwrap_or(&default_stats);
-                    let b =
-                        b.1.col_stats
-                            .get(&top_k.field.column_id)
-                            .unwrap_or(&default_stats);
-                    (b.max().as_ref(), b.min().as_ref()).cmp(&(a.max().as_ref(), a.min().as_ref()))
-                });
-            }
+            // A metadata-only decimal precision widening leaves persisted bounds tagged with the
+            // previous `DecimalSize`. Comparing mixed sizes collapses to `Ordering::Equal`, which
+            // would silently leave the blocks unsorted, so compare through the statistics-aware
+            // helper and treat an incomparable pair as a tie.
+            let compare = |a: &ColumnStatistics, b: &ColumnStatistics| {
+                let (primary, secondary) = if top_k.asc {
+                    (
+                        try_cmp_stat_scalars(&a.min().as_ref(), &b.min().as_ref()),
+                        try_cmp_stat_scalars(&a.max().as_ref(), &b.max().as_ref()),
+                    )
+                } else {
+                    (
+                        try_cmp_stat_scalars(&b.max().as_ref(), &a.max().as_ref()),
+                        try_cmp_stat_scalars(&b.min().as_ref(), &a.min().as_ref()),
+                    )
+                };
+                match primary {
+                    Some(Ordering::Equal) | None => secondary.unwrap_or(Ordering::Equal),
+                    Some(ordering) => ordering,
+                }
+            };
+            block_metas.sort_by(|a, b| {
+                let a =
+                    a.1.col_stats
+                        .get(&top_k.field.column_id)
+                        .unwrap_or(&default_stats);
+                let b =
+                    b.1.col_stats
+                        .get(&top_k.field.column_id)
+                        .unwrap_or(&default_stats);
+                compare(a, b)
+            });
         }
 
         let (mut statistics, mut partitions) = match &push_downs {
@@ -1568,6 +1577,13 @@ impl FuseTable {
 
 #[cfg(test)]
 mod tests {
+    use databend_common_expression::TableDataType;
+    use databend_common_expression::TableField;
+    use databend_common_expression::types::DecimalDataType;
+    use databend_common_expression::types::DecimalScalar;
+    use databend_common_expression::types::DecimalSize;
+    use databend_storages_common_table_meta::meta::Compression;
+
     use super::*;
 
     fn segment_location(segment_idx: usize, location: &str, snapshot_loc: &str) -> SegmentLocation {
@@ -1594,5 +1610,111 @@ mod tests {
         let mut changed_segment = original.clone();
         changed_segment[1].location = ("segment-c".to_string(), 1);
         assert!(!same_segment_locations(&original, &changed_segment));
+    }
+    fn decimal_size(precision: u8, scale: u8) -> DecimalSize {
+        DecimalSize::new(precision, scale).unwrap()
+    }
+
+    fn decimal_scalar(value: i64, precision: u8, scale: u8) -> Scalar {
+        Scalar::Decimal(DecimalScalar::Decimal64(
+            value,
+            decimal_size(precision, scale),
+        ))
+    }
+
+    fn decimal_block(
+        column_id: ColumnId,
+        location: &str,
+        min: (i64, u8),
+        max: (i64, u8),
+    ) -> (Option<BlockMetaIndex>, Arc<BlockMeta>) {
+        let col_stats = HashMap::from([(
+            column_id,
+            ColumnStatistics::new(
+                decimal_scalar(min.0, min.1, 2),
+                decimal_scalar(max.0, max.1, 2),
+                0,
+                0,
+                None,
+            ),
+        )]);
+        let meta = BlockMeta::new(
+            1,
+            1,
+            1,
+            col_stats,
+            HashMap::new(),
+            None,
+            (location.to_string(), 0),
+            None,
+            0,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Compression::Lz4Raw,
+            None,
+        );
+        (None, Arc::new(meta))
+    }
+
+    fn sorted_locations(
+        top_k: TopK,
+        blocks: &[(Option<BlockMetaIndex>, Arc<BlockMeta>)],
+    ) -> Vec<String> {
+        let (_, partitions) = FuseTable::to_partitions(
+            None,
+            blocks,
+            &ColumnNodes {
+                column_nodes: vec![],
+            },
+            Some((top_k, Scalar::Null)),
+            None,
+        );
+        partitions
+            .partitions
+            .iter()
+            .map(|part| FuseBlockPartInfo::from_part(part).unwrap().location.clone())
+            .collect()
+    }
+
+    fn decimal_top_k(column_id: ColumnId, asc: bool) -> TopK {
+        TopK {
+            limit: 10,
+            field: TableField::new_from_column_id(
+                "c",
+                TableDataType::Decimal(DecimalDataType::from(decimal_size(15, 2))),
+                column_id,
+            ),
+            asc,
+            leaf_id: 0,
+        }
+    }
+
+    // Blocks are ordered by their statistics so the most promising ones are read first. After a
+    // metadata-only precision widening the older blocks keep the previous `DecimalSize`, and raw
+    // comparison collapses to `Ordering::Equal`, leaving the order untouched.
+    #[test]
+    fn test_to_partitions_sorts_across_widened_decimal_precision() {
+        let column_id = 7;
+        // Deliberately out of order, with the smallest value on the stale precision.
+        let blocks = vec![
+            decimal_block(column_id, "block-mid", (5000, 15), (6000, 15)),
+            decimal_block(column_id, "block-hi", (9000, 15), (9500, 15)),
+            decimal_block(column_id, "block-lo", (100, 10), (200, 10)),
+        ];
+
+        assert_eq!(
+            sorted_locations(decimal_top_k(column_id, true), &blocks),
+            vec!["block-lo", "block-mid", "block-hi"]
+        );
+        assert_eq!(
+            sorted_locations(decimal_top_k(column_id, false), &blocks),
+            vec!["block-hi", "block-mid", "block-lo"]
+        );
     }
 }

--- a/src/query/storages/fuse/src/operations/recluster/linear_recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster/linear_recluster.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use databend_common_exception::Result;
 use databend_common_expression::Scalar;
 use databend_storages_common_table_meta::meta::CompactSegmentInfo;
+use databend_storages_common_table_meta::meta::total_cmp_stat_scalar_slices;
 use indexmap::IndexSet;
 use log::debug;
 
@@ -480,14 +481,16 @@ pub(crate) fn select_scalar_segments(
 }
 
 #[derive(Clone, Copy)]
+/// A cluster-key point used as a `BTreeMap` key.
+///
+/// Ordering goes through [`total_cmp_stat_scalar_slices`] rather than raw `Ord`: persisted decimal
+/// bounds may carry a stale precision after a metadata-only widening, and raw comparison reports
+/// such pairs as equal, which would merge distinct points into one map entry.
 struct ScalarSlice<'a>(&'a [Scalar]);
 
 impl Ord for ScalarSlice<'_> {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.0
-            .iter()
-            .map(Scalar::as_ref)
-            .cmp(other.0.iter().map(Scalar::as_ref))
+        total_cmp_stat_scalar_slices(self.0, other.0)
     }
 }
 

--- a/src/query/storages/fuse/src/operations/recluster/vector_recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster/vector_recluster.rs
@@ -25,6 +25,7 @@ use databend_storages_common_table_meta::meta::BlockMeta;
 use databend_storages_common_table_meta::meta::ClusterStatistics;
 use databend_storages_common_table_meta::meta::CompactSegmentInfo;
 use databend_storages_common_table_meta::meta::VectorColumnStatistics;
+use databend_storages_common_table_meta::meta::try_cmp_stat_scalars;
 use indexmap::IndexSet;
 use log::debug;
 
@@ -570,8 +571,10 @@ fn scalar_le(
     left: &databend_common_expression::Scalar,
     right: &databend_common_expression::Scalar,
 ) -> bool {
+    // An inconclusive comparison must not rule out overlap, so `None` counts as "possibly less
+    // or equal". This is the conservative direction for the overlap check above.
     matches!(
-        left.partial_cmp(right),
+        try_cmp_stat_scalars(&left.as_ref(), &right.as_ref()),
         None | Some(std::cmp::Ordering::Less | std::cmp::Ordering::Equal)
     )
 }

--- a/src/query/storages/fuse/src/operations/replace_into/mutator/replace_into_mutator.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/mutator/replace_into_mutator.rs
@@ -43,6 +43,7 @@ use databend_common_metrics::storage::*;
 use databend_common_sql::executor::physical_plans::OnConflictField;
 use databend_storages_common_index::BloomIndex;
 use databend_storages_common_table_meta::meta::ColumnStatistics;
+use databend_storages_common_table_meta::meta::try_cmp_stat_scalars;
 use log::info;
 
 use crate::operations::replace_into::meta::DeletionByColumn;
@@ -158,7 +159,15 @@ impl ReplaceIntoMutator {
                 let value = column.row_scalar(row_idx)?;
                 let stats = column_stats.get(&field.table_field.column_id);
                 if let Some(stats) = stats {
-                    should_keep = !(value < stats.min().as_ref() || value > stats.max().as_ref());
+                    // A metadata-only decimal precision widening leaves the persisted range index
+                    // tagged with the previous `DecimalSize` while incoming rows carry the current
+                    // one. Raw comparison collapses that to `Equal`, which would silently keep
+                    // every row; an inconclusive comparison must keep the row (it may conflict).
+                    let below_min =
+                        try_cmp_stat_scalars(&value, &stats.min().as_ref()) == Some(Ordering::Less);
+                    let above_max = try_cmp_stat_scalars(&value, &stats.max().as_ref())
+                        == Some(Ordering::Greater);
+                    should_keep = !(below_min || above_max);
                     if !should_keep {
                         // if one column outsides the table level range, no need to check other columns
                         break;

--- a/src/query/storages/fuse/src/operations/replace_into/mutator/replace_into_operation_agg.rs
+++ b/src/query/storages/fuse/src/operations/replace_into/mutator/replace_into_operation_agg.rs
@@ -50,6 +50,7 @@ use databend_storages_common_table_meta::meta::BlockSlotDescription;
 use databend_storages_common_table_meta::meta::ColumnStatistics;
 use databend_storages_common_table_meta::meta::Location;
 use databend_storages_common_table_meta::meta::SegmentInfo;
+use databend_storages_common_table_meta::meta::try_stat_ranges_disjoint;
 use log::info;
 use log::warn;
 use opendal::Operator;
@@ -625,9 +626,13 @@ impl AggregationContext {
         if let Some(stats) = column_stats {
             let max = stats.max();
             let min = stats.min();
-            std::cmp::min(key_max, max) >= std::cmp::max(key_min, min)
-                || // coincide overlap
-                (max == key_max && min == key_min)
+            // A metadata-only decimal precision widening leaves persisted bounds tagged with the
+            // previous `DecimalSize`. Raw comparison would collapse mixed sizes to `Equal` and
+            // could drop a block that really does overlap, so when the ranges cannot be compared
+            // assume they overlap.
+            try_stat_ranges_disjoint(key_min, key_max, min, max)
+                .map(|disjoint| !disjoint)
+                .unwrap_or(true)
         } else {
             // if column range index does not exist, assume overlapped
             true
@@ -794,6 +799,8 @@ mod tests {
     use databend_common_expression::TableDataType;
     use databend_common_expression::TableField;
     use databend_common_expression::TableSchema;
+    use databend_common_expression::types::DecimalScalar;
+    use databend_common_expression::types::DecimalSize;
     use databend_common_expression::types::NumberDataType;
     use databend_common_expression::types::NumberScalar;
 
@@ -1003,5 +1010,66 @@ mod tests {
         assert!(overlap);
 
         Ok(())
+    }
+    fn decimal_scalar(value: i64, precision: u8, scale: u8) -> Scalar {
+        Scalar::Decimal(DecimalScalar::Decimal64(
+            value,
+            DecimalSize::new(precision, scale).unwrap(),
+        ))
+    }
+
+    // A metadata-only decimal precision widening leaves the persisted range index tagged with the
+    // previous `DecimalSize`. Raw comparison collapses that to `Equal`, so a block that cannot
+    // hold the key still looks overlapping and gets read for nothing.
+    #[test]
+    fn test_check_overlapped_by_stats_across_widened_precision() {
+        // Persisted block range [1.00, 2.00] at the old precision.
+        let stats = ColumnStatistics::new(
+            decimal_scalar(100, 10, 2),
+            decimal_scalar(200, 10, 2),
+            0,
+            0,
+            None,
+        );
+
+        // Incoming keys [7.00, 8.00] at the current precision cannot be in that block.
+        assert!(!AggregationContext::check_overlapped_by_stats(
+            Some(&stats),
+            &decimal_scalar(700, 15, 2),
+            &decimal_scalar(800, 15, 2),
+        ));
+
+        // Keys straddling the block range must still be treated as overlapping.
+        assert!(AggregationContext::check_overlapped_by_stats(
+            Some(&stats),
+            &decimal_scalar(150, 15, 2),
+            &decimal_scalar(800, 15, 2),
+        ));
+
+        // Touching at a boundary counts as overlapping.
+        assert!(AggregationContext::check_overlapped_by_stats(
+            Some(&stats),
+            &decimal_scalar(200, 15, 2),
+            &decimal_scalar(800, 15, 2),
+        ));
+    }
+
+    // A scale change is not a widening, so the ranges cannot be compared and the block must be
+    // assumed to overlap rather than skipped.
+    #[test]
+    fn test_check_overlapped_by_stats_assumes_overlap_when_incomparable() {
+        let stats = ColumnStatistics::new(
+            decimal_scalar(100, 10, 4),
+            decimal_scalar(200, 10, 4),
+            0,
+            0,
+            None,
+        );
+
+        assert!(AggregationContext::check_overlapped_by_stats(
+            Some(&stats),
+            &decimal_scalar(700, 15, 2),
+            &decimal_scalar(800, 15, 2),
+        ));
     }
 }

--- a/src/query/storages/fuse/src/statistics/cluster_statistics.rs
+++ b/src/query/storages/fuse/src/statistics/cluster_statistics.rs
@@ -43,6 +43,7 @@ use databend_storages_common_table_meta::meta::ClusterStatistics;
 use databend_storages_common_table_meta::meta::PartitionStatistics;
 use databend_storages_common_table_meta::meta::StatisticsOfColumns;
 use databend_storages_common_table_meta::meta::VectorDistanceType;
+use databend_storages_common_table_meta::meta::try_cmp_stat_scalar_slices;
 use databend_storages_common_table_meta::meta::valid_cluster_stats_hilbert_minmax;
 use databend_storages_common_table_meta::table::HILBERT_CLUSTER_DIMENSIONS;
 use log::warn;
@@ -477,18 +478,16 @@ pub fn sort_by_cluster_stats(
                 return Ordering::Equal;
             }
 
-            let ord_min = a
-                .min()
-                .iter()
-                .map(Scalar::as_ref)
-                .cmp(b.min().iter().map(Scalar::as_ref));
-            if ord_min != Ordering::Equal {
+            // A metadata-only decimal precision widening can leave one side tagged with the
+            // previous `DecimalSize`. An inconclusive comparison carries no ordering information,
+            // so report the pair as equal and leave the relative order to the caller's sort.
+            let ord_min = try_cmp_stat_scalar_slices(a.min(), b.min());
+            if let Some(ord_min) = ord_min
+                && ord_min != Ordering::Equal
+            {
                 return ord_min;
             }
-            a.max()
-                .iter()
-                .map(Scalar::as_ref)
-                .cmp(b.max().iter().map(Scalar::as_ref))
+            try_cmp_stat_scalar_slices(a.max(), b.max()).unwrap_or(Ordering::Equal)
         }
         _ => Ordering::Equal,
     }

--- a/src/query/storages/fuse/src/statistics/reducers.rs
+++ b/src/query/storages/fuse/src/statistics/reducers.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::borrow::Borrow;
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::collections::HashSet;
 
@@ -30,7 +31,10 @@ use databend_storages_common_table_meta::meta::Statistics;
 use databend_storages_common_table_meta::meta::StatisticsOfColumns;
 use databend_storages_common_table_meta::meta::StatisticsOfSpatialColumns;
 use databend_storages_common_table_meta::meta::VirtualColumnMeta;
+use databend_storages_common_table_meta::meta::common_stat_decimal_size;
 pub use databend_storages_common_table_meta::meta::reduce_cluster_statistics;
+use databend_storages_common_table_meta::meta::retag_stat_scalar;
+use databend_storages_common_table_meta::meta::try_cmp_stat_scalars;
 use databend_storages_common_table_meta::meta::validate_segment_partition_statistics;
 
 const VIRTUAL_COLUMN_JSONB_TYPE: u8 = 0;
@@ -58,43 +62,95 @@ pub fn reduce_block_statistics<T: Borrow<StatisticsOfColumns>>(
     col_to_stats_lit
         .iter()
         .fold(HashMap::with_capacity(len), |mut acc, (id, stats)| {
-            let col_stats = reduce_column_statistics(stats);
-            acc.insert(*id, col_stats);
+            // Omit the column when its bounds cannot be reduced; a partial range would be worse
+            // than none, since consumers treat a missing entry as "no information".
+            if let Some(col_stats) = reduce_column_statistics(stats) {
+                acc.insert(*id, col_stats);
+            }
             acc
         })
 }
 
-pub fn reduce_column_statistics<T: Borrow<ColumnStatistics>>(stats: &[T]) -> ColumnStatistics {
-    let mut min_stats = Vec::with_capacity(stats.len());
-    let mut max_stats = Vec::with_capacity(stats.len());
-    let mut ndvs = Vec::with_capacity(stats.len());
+/// Reduce per-block statistics for one column into a single range.
+///
+/// Returns `None` when the inputs carry no usable range, which happens when a column mixes
+/// genuinely incomparable bounds. Callers must then omit the column rather than persist a range
+/// that cannot be trusted: `ColumnStatistics::new` asserts that min and max share a type, and
+/// picking each end independently from incomparable inputs can violate that.
+///
+/// Decimal bounds left tagged with an older precision by a metadata-only widening are aligned to
+/// the widest precision before comparison, so they still reduce normally.
+pub fn reduce_column_statistics<T: Borrow<ColumnStatistics>>(
+    stats: &[T],
+) -> Option<ColumnStatistics> {
+    if stats.is_empty() {
+        return None;
+    }
+
     let mut null_count = 0;
     let mut in_memory_size = 0;
+    let mut ndvs = Vec::with_capacity(stats.len());
+    let mut bounds = Vec::with_capacity(stats.len() * 2);
 
     for col_stats in stats.iter() {
         let col_stats = col_stats.borrow();
-        min_stats.push(col_stats.min().clone());
-        max_stats.push(col_stats.max().clone());
+        bounds.push(col_stats.min());
+        bounds.push(col_stats.max());
         ndvs.push(col_stats.distinct_of_values);
         null_count += col_stats.null_count;
         in_memory_size += col_stats.in_memory_size;
     }
 
-    let min = min_stats
-        .into_iter()
-        .filter(|s| !s.is_null())
-        .min_by(|x, y| x.cmp(y))
-        .unwrap_or(Scalar::Null);
+    // Align stale decimal precisions to the widest one seen, so the comparisons below are
+    // meaningful and the resulting min/max agree on a single size.
+    let target_size = common_stat_decimal_size(&bounds);
+    let align = |scalar: &Scalar| -> Option<Scalar> {
+        match target_size {
+            Some(size) => retag_stat_scalar(scalar, size),
+            None => Some(scalar.clone()),
+        }
+    };
 
-    let max = max_stats
-        .into_iter()
-        .filter(|s| !s.is_null())
-        .max_by(|x, y| x.cmp(y))
-        .unwrap_or(Scalar::Null);
+    let mut min: Option<Scalar> = None;
+    let mut max: Option<Scalar> = None;
+    for col_stats in stats.iter() {
+        let col_stats = col_stats.borrow();
+        if !col_stats.min().is_null() {
+            let candidate = align(col_stats.min())?;
+            min = match min {
+                None => Some(candidate),
+                Some(current) => {
+                    match try_cmp_stat_scalars(&candidate.as_ref(), &current.as_ref())? {
+                        Ordering::Less => Some(candidate),
+                        _ => Some(current),
+                    }
+                }
+            };
+        }
+        if !col_stats.max().is_null() {
+            let candidate = align(col_stats.max())?;
+            max = match max {
+                None => Some(candidate),
+                Some(current) => {
+                    match try_cmp_stat_scalars(&candidate.as_ref(), &current.as_ref())? {
+                        Ordering::Greater => Some(candidate),
+                        _ => Some(current),
+                    }
+                }
+            };
+        }
+    }
+
     let distinct_of_values = ndvs
         .into_iter()
         .try_fold(0, |acc, ndv| ndv.map(|v| acc + v));
-    ColumnStatistics::new(min, max, null_count, in_memory_size, distinct_of_values)
+    Some(ColumnStatistics::new(
+        min.unwrap_or(Scalar::Null),
+        max.unwrap_or(Scalar::Null),
+        null_count,
+        in_memory_size,
+        distinct_of_values,
+    ))
 }
 
 // Generate virtual column statistics from virtual column meta.
@@ -140,7 +196,9 @@ pub fn generate_virtual_column_statistics<T: Borrow<HashMap<ColumnId, VirtualCol
                     .map(|(_, stat)| stat.clone())
                     .collect::<Vec<_>>();
                 let col_stats = reduce_column_statistics(&stats);
-                acc.insert(*id, col_stats);
+                if let Some(col_stats) = col_stats {
+                    acc.insert(*id, col_stats);
+                }
             }
             acc
         },
@@ -193,8 +251,9 @@ pub fn reduce_virtual_column_statistics<T: Borrow<Option<StatisticsOfColumns>>>(
                     }
                 }
 
-                if type_set.len() <= 1 {
-                    let col_stats = reduce_column_statistics(stats);
+                if type_set.len() <= 1
+                    && let Some(col_stats) = reduce_column_statistics(stats)
+                {
                     acc.insert(*id, col_stats);
                 }
                 acc
@@ -515,4 +574,84 @@ pub fn reduce_block_metas<T: Borrow<BlockMeta>>(
         virtual_block_count: merged_virtual_block_count,
         additional_stats_meta: None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_expression::types::DecimalScalar;
+    use databend_common_expression::types::DecimalSize;
+
+    use super::*;
+
+    fn size(precision: u8, scale: u8) -> DecimalSize {
+        DecimalSize::new(precision, scale).unwrap()
+    }
+
+    fn decimal(value: i64, precision: u8, scale: u8) -> Scalar {
+        Scalar::Decimal(DecimalScalar::Decimal64(value, size(precision, scale)))
+    }
+
+    fn stats(min: Scalar, max: Scalar) -> ColumnStatistics {
+        ColumnStatistics::new(min, max, 0, 16, None)
+    }
+
+    // A metadata-only decimal precision widening leaves older blocks tagged with the previous
+    // `DecimalSize`. Reducing across the boundary must still find the true extremes.
+    #[test]
+    fn test_reduce_column_statistics_across_widened_precision() {
+        let old = stats(decimal(100, 10, 2), decimal(200, 10, 2));
+        let new = stats(decimal(500, 15, 2), decimal(800, 15, 2));
+
+        let reduced = reduce_column_statistics(&[new, old]).expect("bounds are comparable");
+
+        // Both ends must agree on one size, otherwise `ColumnStatistics::new` would have
+        // asserted; the widest precision seen wins.
+        assert_eq!(reduced.min(), &decimal(100, 15, 2));
+        assert_eq!(reduced.max(), &decimal(800, 15, 2));
+    }
+
+    // Without alignment, `min_by`/`max_by` take each end from a different input and produce a
+    // range whose min and max disagree on their size.
+    #[test]
+    fn test_reduce_column_statistics_keeps_bounds_on_one_size() {
+        let old = stats(decimal(900, 10, 2), decimal(950, 10, 2));
+        let new = stats(decimal(100, 15, 2), decimal(200, 15, 2));
+
+        let reduced = reduce_column_statistics(&[old, new]).expect("bounds are comparable");
+
+        let min_size = reduced.min().as_decimal().unwrap().size();
+        let max_size = reduced.max().as_decimal().unwrap().size();
+        assert_eq!(min_size, max_size);
+        assert_eq!(reduced.min(), &decimal(100, 15, 2));
+        assert_eq!(reduced.max(), &decimal(950, 15, 2));
+    }
+
+    // A scale change is not a metadata-only widening: the raw value denotes a different number,
+    // so there is no sound way to reduce the bounds.
+    #[test]
+    fn test_reduce_column_statistics_rejects_incompatible_scale() {
+        let a = stats(decimal(100, 10, 2), decimal(200, 10, 2));
+        let b = stats(decimal(100, 10, 4), decimal(200, 10, 4));
+
+        assert!(reduce_column_statistics(&[a, b]).is_none());
+        assert!(reduce_column_statistics::<ColumnStatistics>(&[]).is_none());
+    }
+
+    // Columns whose bounds cannot be reduced are omitted rather than persisted with a range that
+    // cannot be trusted.
+    #[test]
+    fn test_reduce_block_statistics_omits_incomparable_column() {
+        let comparable = HashMap::from([(1u32, stats(decimal(100, 10, 2), decimal(200, 10, 2)))]);
+        let incomparable = HashMap::from([
+            (1u32, stats(decimal(300, 15, 2), decimal(400, 15, 2))),
+            (2u32, stats(decimal(100, 10, 2), decimal(200, 10, 2))),
+        ]);
+        let scale_change = HashMap::from([(2u32, stats(decimal(100, 10, 4), decimal(200, 10, 4)))]);
+
+        let reduced = reduce_block_statistics(&[comparable, incomparable, scale_change]);
+
+        // Column 1 widened cleanly and survives; column 2 mixes scales and is dropped.
+        assert_eq!(reduced.get(&1).map(|s| s.min()), Some(&decimal(100, 15, 2)));
+        assert!(!reduced.contains_key(&2));
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Compare persisted min/max statistics by scale and raw value, so decimals differing only in precision or storage variant order correctly
- Report `None` for genuinely incomparable statistics, and make each consumer decide what that means instead of inheriting a silent `Ordering::Equal`
- Fix `reduce_column_statistics` producing a range whose min and max disagree on their type

## Motivation

Persisted statistics are read back against the *current* schema but were written against the schema in effect at the time. Comparing two decimals of different `DecimalSize` has no defined ordering — `DecimalScalar::partial_cmp` returns `None` — and the surrounding impls absorb that:

- `Ord for Scalar` is `partial_cmp(..).unwrap_or(Ordering::Equal)`, so `<`, `>`, `cmp`, `min_by`, `max_by`, and `sort_by` silently report the values as **equal**
- `PartialEq for Scalar` is `partial_cmp(..) == Some(Equal)`, so `==` silently reports them as **different**

Neither raises an error. A size mismatch therefore degrades pruning, read ordering, and overlap checks with no visible signal.

This is reachable today. `statistics_to_domain` asserted the persisted size matched the schema size (`range_index.rs`), and statistics arriving from an external Parquet column index carry the size implied by the Parquet physical type rather than the schema. It also becomes reachable for fuse tables under any metadata-only `MODIFY COLUMN` that widens a decimal precision without rewriting data.

`reduce_column_statistics` is the sharpest case. It picked `min` and `max` with separate `min_by`/`max_by` passes; when comparisons collapse to `Equal` each pass takes its end from a different input, so the two ends can disagree on their type — which trips the `assert!` inside `ColumnStatistics::new`.

## Implementation

New `meta/stat_cmp.rs`:

- `try_cmp_stat_scalars` / `try_cmp_stat_scalar_slices` — compare by scale, then by raw value widened to `i256`. A decimal's raw value does not depend on its precision, so same-scale values are comparable whatever precision or variant they carry. Return `Option<Ordering>`.
- `try_stat_ranges_disjoint` — range disjointness, `None` when undecidable
- `retag_stat_scalar` / `common_stat_decimal_size` — reinterpret bounds at a target size for callers that must materialize a value
- `total_cmp_stat_scalars` / `total_cmp_stat_scalar_slices` — a genuine total order for `BTreeMap` keys, where returning `Equal` for distinct values would merge map entries

Because comparability depends only on scale, **no consumer signature needed a `data_type` parameter**; `RuntimeTopNFilter::new` and friends are unchanged.

Each consumer picks its own failure direction:

| Site | On inconclusive |
|---|---|
| `reduce_column_statistics` | return `None`, caller omits the column |
| `statistics_to_domain` | `Domain::full` |
| `topn_pruner` | keep every block |
| `RuntimeTopNFilter::boundary_excludes` | keep the block |
| `cluster_stats_scalar_overlap`, `scalar_le` | assume overlap |
| `reduce_cluster_min_max` | bail out rather than mix ends |
| `sort_by_cluster_stats`, rank comparison, `to_partitions` | treat as a tie |
| `check_overlapped_by_stats`, `table_level_row_prune` | assume conflict, keep the row |
| `ColumnTopN::find` | `Greater`, keeping binary search terminating; the existing recheck rejects a bogus hit |
| `linear_recluster::ScalarSlice` | total order, so distinct points stay distinct |

`reduce_column_statistics` now aligns all bounds to the widest precision seen before comparing, so both ends agree on one size, and returns `Option`.

`statistics_to_domain` retags bounds to the schema size, which let the two `debug_assert_eq!` on `DecimalSize` go away — they were asserting a property the data does not guarantee.

## Tests

19 new unit tests. Each was confirmed to **fail without the fix** by reverting the comparison helper and re-running, then confirmed to pass with it.

Notably, restoring the original `debug_assert_eq!` in `range_index.rs` while disabling the retag reproduces the real panic:

```
panicked at range_index.rs:342: assertion `left == right` failed
  left: DecimalSize { precision: 15, scale: 2 }
 right: DecimalSize { precision: 10, scale: 2 }
```

- `cargo test -p databend-storages-common-table-meta -p databend-storages-common-pruner -p databend-storages-common-index -p databend-common-catalog -p databend-common-storages-fuse --lib --tests`
- `cargo test -p databend-query --test it parquet_rs` (5 passed — these are the tests that fail if the comparison predicate wrongly rejects external-Parquet decimals)
- `cargo test -p databend-query --test it storages::fuse::statistics` (15 passed)
- `cargo clippy` on all five crates, `--all-targets -- -D warnings`
- `cargo fmt --all -- --check`

Two pre-existing failures, verified unrelated by reproducing them with this branch stashed on clean `main`: `storages::system::test_caches_table` and `test_columns_table` (goldenfile drift, only when the full `storages::` suite runs). The `databend-common-storages-fuse` bench target needs `/tmp/tpch_1/lineitem.parquet` and fails on any checkout.

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## Notes for review

This is an alternative to #20418 and is meant to be chosen against it, not merged alongside. Both address the same hazard; the difference is scope.

This branch does not make `min`/`max` private and does not introduce a view type. It changes one signature (`reduce_column_statistics` returns `Option`) and leaves the persisted structs and every other consumer signature alone. Whether that restraint is the right call is the main thing worth arguing about: #20418's private fields give compiler enforcement that comments cannot, at the cost of a wider diff. The `min`/`max` doc comments here name the helpers, but nothing forces their use.

Also worth flagging: the `PartialEq` collapse direction is the opposite of `Ord`'s, so `validate_segment_partition_statistics` would report "different partitions" rather than degrade quietly. It is unreachable today because `MODIFY COLUMN` rejects any column referenced by `PARTITION BY`, and this PR leaves it untouched rather than adding speculative handling.

## AI assistance

- AI usage: An AI coding agent wrote the comparison helpers, migrated the consumers, and wrote the tests, including verifying each new test fails without the fix. The responsible human owns the review and follow-ups.
- Responsible human: @youngsofun
- [ ] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20432)
<!-- Reviewable:end -->
