### PR TITLE
fix(storage): protect live data during post-flashback vacuum

### DIFF
--- a/src/meta/api/src/api_impl/ref_api.rs
+++ b/src/meta/api/src/api_impl/ref_api.rs
@@ -61,7 +61,10 @@ async fn build_lvt_condition(
     };
 
     if let Some(current_lvt) = current_lvt {
-        if current_lvt.time > lvt_check.time {
+        if lvt_check
+            .time
+            .is_none_or(|snapshot_time| current_lvt.time > snapshot_time)
+        {
             return Err(KVAppError::AppError(AppError::TableSnapshotExpired(
                 TableSnapshotExpired::new(
                     table_id,
@@ -331,7 +334,7 @@ mod tests {
             expire_at,
             lvt_check: TableLvtCheck {
                 tenant: testing::tenant(TENANT),
-                time: lvt_time,
+                time: Some(lvt_time),
             },
         }
     }

--- a/src/meta/api/src/api_impl/table_api.rs
+++ b/src/meta/api/src/api_impl/table_api.rs
@@ -1410,29 +1410,33 @@ where
             tbl_seqs.insert(req.table_id, *tb_meta_seq);
             txn.condition.push(txn_cond_seq(&tbid, Eq, *tb_meta_seq));
 
-            // Add LVT check if provided
+            // Add LVT check if provided. A successful flashback also writes the
+            // current value back so the LVT KV sequence acts as its generation
+            // fence against vacuum selections that are already in progress.
             if let Some(check) = req.lvt_check.as_ref() {
                 let lvt_ident = LeastVisibleTimeIdent::new(&check.tenant, req.table_id);
                 let res = self.get_pb(&lvt_ident).await?;
                 let (seq, current_lvt) = match res {
-                    Some(v) => (v.seq, Some(v.data)),
-                    None => (0, None),
+                    Some(v) => (v.seq, v.data),
+                    None => (0, LeastVisibleTime::default()),
                 };
-                if let Some(current_lvt) = current_lvt {
-                    if current_lvt.time > check.time {
-                        return Err(KVAppError::AppError(AppError::TableSnapshotExpired(
-                            TableSnapshotExpired::new(
-                                req.table_id,
-                                format!(
-                                    "snapshot timestamp {:?} is older than the table's least visible time {:?}",
-                                    check.time, current_lvt.time
-                                ),
+                let expired = match check.time {
+                    Some(snapshot_time) => current_lvt.time > snapshot_time,
+                    None => current_lvt.time > LeastVisibleTime::default().time,
+                };
+                if expired {
+                    return Err(KVAppError::AppError(AppError::TableSnapshotExpired(
+                        TableSnapshotExpired::new(
+                            req.table_id,
+                            format!(
+                                "snapshot timestamp {:?} is older than the table's least visible time {:?}",
+                                check.time, current_lvt.time
                             ),
-                        )));
-                    }
+                        ),
+                    )));
                 }
-                // no other one has updated LVT since we read it
                 txn.condition.push(txn_cond_seq(&lvt_ident, Eq, seq));
+                txn.if_then.push(txn_put_pb(&lvt_ident, &current_lvt));
             }
 
             txn.if_then.push(txn_put_pb(&tbid, &new_table_meta));
@@ -1612,6 +1616,33 @@ where
         }
 
         if mismatched_tbs.is_empty() {
+            // The table version may still match while an LVT condition caused the
+            // transaction to fail. Re-read it so flashback reports an expiration
+            // instead of an unrelated generic transaction error.
+            for (req, _) in &update_table_metas {
+                let Some(check) = req.lvt_check.as_ref() else {
+                    continue;
+                };
+                let lvt_ident = LeastVisibleTimeIdent::new(&check.tenant, req.table_id);
+                if let Some(current_lvt) = self.get_pb(&lvt_ident).await?.map(|v| v.data) {
+                    let expired = match check.time {
+                        Some(snapshot_time) => current_lvt.time > snapshot_time,
+                        None => current_lvt.time > LeastVisibleTime::default().time,
+                    };
+                    if expired {
+                        return Err(KVAppError::AppError(AppError::TableSnapshotExpired(
+                            TableSnapshotExpired::new(
+                                req.table_id,
+                                format!(
+                                    "snapshot timestamp {:?} is older than the table's least visible time {:?}",
+                                    check.time, current_lvt.time
+                                ),
+                            ),
+                        )));
+                    }
+                }
+            }
+
             if !insert_if_not_exists_table_ids.is_empty() {
                 // If insert_if_not_exists is true and transaction failed, it's likely due to duplicated files
                 Err(KVAppError::AppError(AppError::from(
@@ -2193,6 +2224,38 @@ where
         return Ok(transition.unwrap().result.into_value().unwrap_or_default());
     }
 
+    /// Advances LVT only if its KV sequence still matches the value observed
+    /// before vacuum selected a GC root.
+    #[logcall::logcall]
+    #[fastrace::trace]
+    async fn set_table_lvt_with_seq(
+        &self,
+        name_ident: &LeastVisibleTimeIdent,
+        value: &LeastVisibleTime,
+        expected_seq: u64,
+    ) -> Result<Option<LeastVisibleTime>, KVAppError> {
+        debug!(req :? =(&name_ident, &value, expected_seq); "TableApi: {}", func_name!());
+
+        let current = self.get_pb(name_ident).await?;
+        let current_seq = current.seq();
+        if current_seq != expected_seq {
+            return Ok(None);
+        }
+
+        let current_lvt = current.map(|v| v.data).unwrap_or_default();
+        let result = if current_lvt.time < value.time {
+            value.clone()
+        } else {
+            current_lvt
+        };
+
+        let txn = TxnRequest::new(vec![txn_cond_eq_seq(name_ident, expected_seq)], vec![
+            txn_put_pb(name_ident, &result),
+        ]);
+        let (succ, _) = send_txn(self, txn).await?;
+        Ok(succ.then_some(result))
+    }
+
     #[logcall::logcall]
     #[fastrace::trace]
     async fn get_table_lvt(
@@ -2202,6 +2265,16 @@ where
         debug!(req :? =(&name_ident); "TableApi: {}", func_name!());
         let res = self.get_pb(name_ident).await?;
         Ok(res.map(|v| v.data))
+    }
+
+    #[logcall::logcall]
+    #[fastrace::trace]
+    async fn get_table_lvt_with_seq(
+        &self,
+        name_ident: &LeastVisibleTimeIdent,
+    ) -> Result<Option<SeqV<LeastVisibleTime>>, KVAppError> {
+        debug!(req :? =(&name_ident); "TableApi: {}", func_name!());
+        Ok(self.get_pb(name_ident).await?)
     }
 }
 

--- a/src/meta/app/src/schema/table/mod.rs
+++ b/src/meta/app/src/schema/table/mod.rs
@@ -813,7 +813,10 @@ pub struct UpdateTableMetaReq {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TableLvtCheck {
     pub tenant: Tenant,
-    pub time: DateTime<Utc>,
+    /// `Some` requires the current LVT not to exceed the snapshot timestamp.
+    /// `None` is used by legacy snapshots without timestamps and requires LVT
+    /// to remain unset.
+    pub time: Option<DateTime<Utc>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/meta/schema-api-test-suite/src/schema_api_test_suite.rs
+++ b/src/meta/schema-api-test-suite/src/schema_api_test_suite.rs
@@ -3729,7 +3729,7 @@ impl SchemaApiTestSuite {
                     base_snapshot_location: None,
                     lvt_check: Some(TableLvtCheck {
                         tenant: tenant.clone(),
-                        time: small_ts,
+                        time: Some(small_ts),
                     }),
                 };
                 let result = mt
@@ -3742,9 +3742,57 @@ impl SchemaApiTestSuite {
                 let table = util.get_table().await.unwrap();
                 assert_eq!(table.meta.comment, "lvt no set");
 
+                // A legacy snapshot has no timestamp. It is valid only while LVT is still unset.
+                let mut legacy_table_meta = table.meta.clone();
+                legacy_table_meta.comment = "legacy lvt no set".to_string();
+                let req = UpdateTableMetaReq {
+                    table_id,
+                    seq: MatchSeq::Exact(table.ident.seq),
+                    new_table_meta: legacy_table_meta,
+                    base_snapshot_location: None,
+                    lvt_check: Some(TableLvtCheck {
+                        tenant: tenant.clone(),
+                        time: None,
+                    }),
+                };
+                mt.update_multi_table_meta(&tenant, UpdateMultiTableMetaReq {
+                    update_table_metas: vec![(req, table.as_ref().clone())],
+                    ..Default::default()
+                })
+                .await?
+                .unwrap();
+
+                let table = util.get_table().await.unwrap();
+                assert_eq!(table.meta.comment, "legacy lvt no set");
+
                 let lvt_ident = LeastVisibleTimeIdent::new(&tenant, table_id);
                 mt.set_table_lvt(&lvt_ident, &LeastVisibleTime::new(lvt_time))
                     .await?;
+
+                // Once LVT exists, a legacy snapshot without a timestamp cannot prove visibility.
+                let table = util.get_table().await.unwrap();
+                let mut legacy_table_meta = table.meta.clone();
+                legacy_table_meta.comment = "legacy lvt guard should fail".to_string();
+                let req = UpdateTableMetaReq {
+                    table_id,
+                    seq: MatchSeq::Exact(table.ident.seq),
+                    new_table_meta: legacy_table_meta,
+                    base_snapshot_location: None,
+                    lvt_check: Some(TableLvtCheck {
+                        tenant: tenant.clone(),
+                        time: None,
+                    }),
+                };
+                let result = mt
+                    .update_multi_table_meta(&tenant, UpdateMultiTableMetaReq {
+                        update_table_metas: vec![(req, table.as_ref().clone())],
+                        ..Default::default()
+                    })
+                    .await;
+                assert!(matches!(
+                    result,
+                    Err(KVAppError::AppError(AppError::TableSnapshotExpired(_)))
+                ));
 
                 // LVT is smaller.
                 let mut new_table_meta = table.meta.clone();
@@ -3756,7 +3804,7 @@ impl SchemaApiTestSuite {
                     base_snapshot_location: None,
                     lvt_check: Some(TableLvtCheck {
                         tenant: tenant.clone(),
-                        time: small_ts,
+                        time: Some(small_ts),
                     }),
                 };
                 let result = mt
@@ -3778,7 +3826,7 @@ impl SchemaApiTestSuite {
                     base_snapshot_location: None,
                     lvt_check: Some(TableLvtCheck {
                         tenant: tenant.clone(),
-                        time: big_time,
+                        time: Some(big_time),
                     }),
                 };
                 mt.update_multi_table_meta(&tenant, UpdateMultiTableMetaReq {

--- a/src/query/catalog/src/catalog/interface.rs
+++ b/src/query/catalog/src/catalog/interface.rs
@@ -717,10 +717,28 @@ pub trait Catalog: DynClone + Send + Sync + Debug {
         unimplemented!()
     }
 
+    /// Advances LVT only if its KV sequence still matches the value observed
+    /// before vacuum selected a GC root.
+    async fn set_table_lvt_with_seq(
+        &self,
+        _name_ident: &LeastVisibleTimeIdent,
+        _value: &LeastVisibleTime,
+        _expected_seq: u64,
+    ) -> Result<Option<LeastVisibleTime>> {
+        unimplemented!()
+    }
+
     async fn get_table_lvt(
         &self,
         _name_ident: &LeastVisibleTimeIdent,
     ) -> Result<Option<LeastVisibleTime>> {
+        unimplemented!()
+    }
+
+    async fn get_table_lvt_with_seq(
+        &self,
+        _name_ident: &LeastVisibleTimeIdent,
+    ) -> Result<Option<SeqV<LeastVisibleTime>>> {
         unimplemented!()
     }
 

--- a/src/query/ee/src/storages/fuse/operations/vacuum_table_v2.rs
+++ b/src/query/ee/src/storages/fuse/operations/vacuum_table_v2.rs
@@ -16,7 +16,6 @@
 databend_common_tracing::register_module_tag!("[FUSE-VACUUM2]");
 
 use std::collections::BTreeMap;
-use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -26,18 +25,15 @@ use databend_common_catalog::table::Table;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
 use databend_common_meta_app::schema::TableIndex;
-use databend_common_meta_app::schema::UpsertTableOptionReq;
 use databend_common_storages_fuse::FuseTable;
 use databend_common_storages_fuse::io::SegmentsIO;
 use databend_common_storages_fuse::io::TableMetaLocationGenerator;
 use databend_common_storages_fuse::operations::is_gc_candidate_segment_block;
-use databend_meta_client::types::MatchSeq;
 use databend_storages_common_cache::CacheAccessor;
 use databend_storages_common_cache::CacheManager;
 use databend_storages_common_io::Files;
 use databend_storages_common_table_meta::meta::CompactSegmentInfo;
 use databend_storages_common_table_meta::meta::Location;
-use databend_storages_common_table_meta::table::OPT_KEY_VACUUM2_FLASHBACK_BARRIER;
 use futures_util::TryStreamExt;
 use log::info;
 use log::warn;
@@ -100,8 +96,7 @@ struct GcRootSnapshotCtx {
     gc_root_meta_ts: DateTime<Utc>,
     protected_segments: HashSet<Location>,
     snapshots_to_gc: Vec<String>,
-    clear_flashback_barrier: bool,
-    table_seq: u64,
+    flashback_barrier_to_clear: Option<DateTime<Utc>>,
 }
 
 #[async_backtrace::framed]
@@ -127,8 +122,7 @@ pub async fn do_vacuum2(
         gc_root_meta_ts,
         protected_segments,
         snapshots_to_gc,
-        clear_flashback_barrier,
-        table_seq,
+        flashback_barrier_to_clear,
     }) = vacuum_base_snapshot_phase(fuse_table, &ctx, respect_flash_back).await?
     else {
         info!("Table {} has no snapshot, stopping vacuum", table_info.desc);
@@ -301,20 +295,12 @@ pub async fn do_vacuum2(
         removed_files,
     ));
 
-    if clear_flashback_barrier {
-        let mut options = HashMap::new();
-        options.insert(OPT_KEY_VACUUM2_FLASHBACK_BARRIER.to_owned(), None);
-        let req = UpsertTableOptionReq {
-            table_id: fuse_table.get_id(),
-            seq: MatchSeq::Exact(table_seq),
-            options,
-        };
-        if let Err(err) = catalog
-            .upsert_table_option(&ctx.get_tenant(), table_info.database_name()?, req)
+    if let Some(barrier) = flashback_barrier_to_clear {
+        if let Err(err) = fuse_table
+            .clear_vacuum2_flashback_barrier(ctx.as_ref(), barrier)
             .await
         {
-            // A concurrent update, especially another flashback, must retain its newer barrier.
-            // Keeping the option merely makes a later vacuum use the conservative path again.
+            // Cleanup is best effort. Keeping the barrier only makes later vacuum conservative.
             warn!(
                 "Failed to clear flashback barrier for table {} after vacuum: {}",
                 table_info.desc, err
@@ -561,8 +547,7 @@ async fn vacuum_base_snapshot_phase(
         gc_root_meta_ts: selection.gc_root_meta_ts,
         protected_segments,
         snapshots_to_gc: selection.snapshots_to_gc,
-        clear_flashback_barrier: selection.clear_flashback_barrier,
-        table_seq: selection.table_seq,
+        flashback_barrier_to_clear: selection.flashback_barrier_to_clear,
     }))
 }
 

--- a/src/query/ee/src/storages/fuse/operations/vacuum_table_v2.rs
+++ b/src/query/ee/src/storages/fuse/operations/vacuum_table_v2.rs
@@ -16,6 +16,7 @@
 databend_common_tracing::register_module_tag!("[FUSE-VACUUM2]");
 
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -25,17 +26,21 @@ use databend_common_catalog::table::Table;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::Result;
 use databend_common_meta_app::schema::TableIndex;
+use databend_common_meta_app::schema::UpsertTableOptionReq;
 use databend_common_storages_fuse::FuseTable;
 use databend_common_storages_fuse::io::SegmentsIO;
 use databend_common_storages_fuse::io::TableMetaLocationGenerator;
 use databend_common_storages_fuse::operations::is_gc_candidate_segment_block;
+use databend_meta_client::types::MatchSeq;
 use databend_storages_common_cache::CacheAccessor;
 use databend_storages_common_cache::CacheManager;
 use databend_storages_common_io::Files;
 use databend_storages_common_table_meta::meta::CompactSegmentInfo;
 use databend_storages_common_table_meta::meta::Location;
+use databend_storages_common_table_meta::table::OPT_KEY_VACUUM2_FLASHBACK_BARRIER;
 use futures_util::TryStreamExt;
 use log::info;
+use log::warn;
 use opendal::Operator;
 
 const VACUUM2_BLOCK_DELETE_CHUNK_SIZE: usize = 1000;
@@ -95,6 +100,8 @@ struct GcRootSnapshotCtx {
     gc_root_meta_ts: DateTime<Utc>,
     protected_segments: HashSet<Location>,
     snapshots_to_gc: Vec<String>,
+    clear_flashback_barrier: bool,
+    table_seq: u64,
 }
 
 #[async_backtrace::framed]
@@ -120,6 +127,8 @@ pub async fn do_vacuum2(
         gc_root_meta_ts,
         protected_segments,
         snapshots_to_gc,
+        clear_flashback_barrier,
+        table_seq,
     }) = vacuum_base_snapshot_phase(fuse_table, &ctx, respect_flash_back).await?
     else {
         info!("Table {} has no snapshot, stopping vacuum", table_info.desc);
@@ -291,6 +300,27 @@ pub async fn do_vacuum2(
         start.elapsed(),
         removed_files,
     ));
+
+    if clear_flashback_barrier {
+        let mut options = HashMap::new();
+        options.insert(OPT_KEY_VACUUM2_FLASHBACK_BARRIER.to_owned(), None);
+        let req = UpsertTableOptionReq {
+            table_id: fuse_table.get_id(),
+            seq: MatchSeq::Exact(table_seq),
+            options,
+        };
+        if let Err(err) = catalog
+            .upsert_table_option(&ctx.get_tenant(), table_info.database_name()?, req)
+            .await
+        {
+            // A concurrent update, especially another flashback, must retain its newer barrier.
+            // Keeping the option merely makes a later vacuum use the conservative path again.
+            warn!(
+                "Failed to clear flashback barrier for table {} after vacuum: {}",
+                table_info.desc, err
+            );
+        }
+    }
 
     Ok(())
 }
@@ -531,6 +561,8 @@ async fn vacuum_base_snapshot_phase(
         gc_root_meta_ts: selection.gc_root_meta_ts,
         protected_segments,
         snapshots_to_gc: selection.snapshots_to_gc,
+        clear_flashback_barrier: selection.clear_flashback_barrier,
+        table_seq: selection.table_seq,
     }))
 }
 

--- a/src/query/ee/src/table_ref/handler.rs
+++ b/src/query/ee/src/table_ref/handler.rs
@@ -113,7 +113,7 @@ impl TableRefHandler for RealTableRefHandler {
                 expire_at: plan.retain.map(|v| Utc::now() + v),
                 lvt_check: TableLvtCheck {
                     tenant: ctx.get_tenant(),
-                    time: snapshot_timestamp,
+                    time: Some(snapshot_timestamp),
                 },
             })
             .await

--- a/src/query/ee/tests/it/storages/fuse/operations/vacuum2.rs
+++ b/src/query/ee/tests/it/storages/fuse/operations/vacuum2.rs
@@ -439,7 +439,6 @@ async fn test_vacuum2_respect_flash_back_selects_lvt_snapshot() -> anyhow::Resul
     // Start with S4 -> S3 -> S2 -> S1, then flash back to S2. Object
     // listing still sees S4 and S3, but the current chain is S2 -> S1.
     let lvt_snapshot = &snapshots[0].0;
-    let abandoned_gc_root = &snapshots[1].0;
     let flashback_snapshot = &snapshots[2].0;
     fixture
         .execute_command(&format!(
@@ -456,8 +455,7 @@ async fn test_vacuum2_respect_flash_back_selects_lvt_snapshot() -> anyhow::Resul
     let current_snapshot = fuse_table.read_table_snapshot().await?.unwrap();
     assert_eq!(current_snapshot.snapshot_id, flashback_snapshot.snapshot_id);
 
-    // Fix LVT at S4. The persisted LVT is monotonic, so set_lvt() keeps this
-    // value even though the current snapshot is S2.
+    // Fix LVT at S4. Publishing LVT must not lower it even though the current snapshot is S2.
     catalog
         .set_table_lvt(
             &LeastVisibleTimeIdent::new(table_ctx.get_tenant(), fuse_table.get_id()),
@@ -465,25 +463,19 @@ async fn test_vacuum2_respect_flash_back_selects_lvt_snapshot() -> anyhow::Resul
         )
         .await?;
 
-    // Without flashback protection, object listing uses S4 as the anchor and
-    // selects its predecessor S3, which belongs to the abandoned branch.
-    let selection = fuse_table
-        .prepare_snapshot_gc_selection(&table_ctx, false)
-        .await?
-        .expect("S3 should be selected as the GC root");
-    assert_eq!(selection.gc_root.snapshot_id, abandoned_gc_root.snapshot_id);
-
-    // With flashback protection, vacuum walks the current committed chain from
-    // S2. It selects S2 and does not use a snapshot from the abandoned branch.
-    let selection = fuse_table
-        .prepare_snapshot_gc_selection(&table_ctx, true)
-        .await?
-        .expect("S2 should be selected as the GC root");
-    assert_eq!(
-        selection.gc_root.snapshot_id,
-        flashback_snapshot.snapshot_id
-    );
-    assert_eq!(selection.gc_root.timestamp, flashback_snapshot.timestamp);
+    // The barrier forces live-chain selection even when the caller opts out of flashback
+    // retention. Without it, directory listing would select S4's abandoned predecessor S3.
+    for respect_flash_back in [false, true] {
+        let selection = fuse_table
+            .prepare_snapshot_gc_selection(&table_ctx, respect_flash_back)
+            .await?
+            .expect("S2 should be selected as the GC root");
+        assert_eq!(
+            selection.gc_root.snapshot_id,
+            flashback_snapshot.snapshot_id
+        );
+        assert_eq!(selection.gc_root.timestamp, flashback_snapshot.timestamp);
+    }
 
     Ok(())
 }
@@ -863,7 +855,7 @@ async fn test_flashback_rejects_snapshot_before_lvt() -> anyhow::Result<()> {
 }
 
 /// Once the selected live GC root is beyond the three-day transaction window, a successful
-/// vacuum should remove the barrier with a table-sequence CAS.
+/// vacuum should remove the barrier generation it observed.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_vacuum2_clears_expired_flashback_barrier() -> anyhow::Result<()> {
     let fixture = TestFixture::setup_with_custom(EESetup::new()).await?;
@@ -919,6 +911,365 @@ async fn test_vacuum2_clears_expired_flashback_barrier() -> anyhow::Result<()> {
         "an expired barrier should be cleared after vacuum succeeds"
     );
 
+    Ok(())
+}
+
+/// Successful cleanup should compare the barrier generation, not the table version from selection.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_vacuum2_barrier_cleanup_allows_writes_but_not_flashback() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup_with_custom(EESetup::new()).await?;
+    fixture.create_default_database().await?;
+    let database = fixture.default_db_name();
+    let name = "t_barrier_generation";
+    fixture
+        .execute_command(&format!("create table {database}.{name} (c int)"))
+        .await?;
+    fixture
+        .execute_command(&format!("insert into {database}.{name} values (1)"))
+        .await?;
+    let ctx = fixture.new_query_ctx().await?;
+    let catalog = ctx.get_default_catalog()?;
+    let table = catalog
+        .get_table(&ctx.get_tenant(), &database, name)
+        .await?;
+    let target = FuseTable::try_from_table(table.as_ref())?
+        .read_table_snapshot()
+        .await?
+        .unwrap();
+    // A future barrier makes strict monotonicity independent of wall-clock progress.
+    let barrier = chrono::Utc::now() + chrono::Duration::days(1);
+    let barrier = chrono::DateTime::from_timestamp_millis(barrier.timestamp_millis()).unwrap();
+    catalog
+        .upsert_table_option(
+            &ctx.get_tenant(),
+            &database,
+            UpsertTableOptionReq::new(
+                &table.get_table_info().ident,
+                OPT_KEY_VACUUM2_FLASHBACK_BARRIER,
+                barrier.to_rfc3339(),
+            ),
+        )
+        .await?;
+    let before_write = catalog
+        .get_table(&ctx.get_tenant(), &database, name)
+        .await?;
+    let stale_fuse = FuseTable::try_from_table(before_write.as_ref())?;
+    fixture
+        .execute_command(&format!("insert into {database}.{name} values (2)"))
+        .await?;
+    stale_fuse
+        .clear_vacuum2_flashback_barrier(ctx.as_ref(), barrier)
+        .await?;
+    let table = catalog
+        .get_table(&ctx.get_tenant(), &database, name)
+        .await?;
+    assert!(
+        !table
+            .get_table_info()
+            .meta
+            .options
+            .contains_key(OPT_KEY_VACUUM2_FLASHBACK_BARRIER)
+    );
+    assert_eq!(
+        FuseTable::try_from_table(table.as_ref())?
+            .read_table_snapshot()
+            .await?
+            .unwrap()
+            .summary
+            .row_count,
+        2
+    );
+
+    // LVT is another generation lower bound when no barrier remains in table options.
+    let lvt = target.timestamp.unwrap();
+    catalog
+        .set_table_lvt(
+            &LeastVisibleTimeIdent::new(ctx.get_tenant(), table.get_id()),
+            &LeastVisibleTime::new(lvt),
+        )
+        .await?;
+    fixture
+        .execute_command(&format!(
+            "alter table {database}.{name} flashback to (snapshot => '{}')",
+            target.snapshot_id.simple()
+        ))
+        .await?;
+    let table = catalog
+        .get_table(&ctx.get_tenant(), &database, name)
+        .await?;
+    let first_barrier = chrono::DateTime::parse_from_rfc3339(
+        &table.get_table_info().meta.options[OPT_KEY_VACUUM2_FLASHBACK_BARRIER],
+    )?
+    .with_timezone(&chrono::Utc);
+    assert!(first_barrier > lvt);
+
+    // Install a future generation, then perform another flashback without waiting for the clock.
+    catalog
+        .upsert_table_option(
+            &ctx.get_tenant(),
+            &database,
+            UpsertTableOptionReq::new(
+                &table.get_table_info().ident,
+                OPT_KEY_VACUUM2_FLASHBACK_BARRIER,
+                barrier.to_rfc3339(),
+            ),
+        )
+        .await?;
+    fixture
+        .execute_command(&format!("insert into {database}.{name} values (3)"))
+        .await?;
+    fixture
+        .execute_command(&format!(
+            "alter table {database}.{name} flashback to (snapshot => '{}')",
+            target.snapshot_id.simple()
+        ))
+        .await?;
+    let table = catalog
+        .get_table(&ctx.get_tenant(), &database, name)
+        .await?;
+    let new_barrier = chrono::DateTime::parse_from_rfc3339(
+        &table.get_table_info().meta.options[OPT_KEY_VACUUM2_FLASHBACK_BARRIER],
+    )?
+    .with_timezone(&chrono::Utc);
+    assert!(new_barrier > barrier);
+    stale_fuse
+        .clear_vacuum2_flashback_barrier(ctx.as_ref(), barrier)
+        .await?;
+    let table = catalog
+        .get_table(&ctx.get_tenant(), &database, name)
+        .await?;
+    assert_eq!(
+        chrono::DateTime::parse_from_rfc3339(
+            &table.get_table_info().meta.options[OPT_KEY_VACUUM2_FLASHBACK_BARRIER]
+        )?,
+        new_barrier
+    );
+    Ok(())
+}
+
+/// Old tagged branches survive cleanup, but increasing retention must not select them below LVT.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_vacuum2_retention_increase_after_barrier_cleanup() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup_with_custom(EESetup::new()).await?;
+    RealTableRefHandler::init()?;
+    fixture
+        .default_session()
+        .get_settings()
+        .set_data_retention_time_in_days(0)?;
+    let database = "vacuum_barrier_tags";
+    let name = "t";
+    for statement in [
+        "set enable_experimental_table_ref=1".to_string(),
+        format!("create database {database}"),
+        format!("create table {database}.{name} (c int) data_retention_num_snapshots_to_keep=1"),
+        format!("insert into {database}.{name} values (1)"),
+        format!("alter table {database}.{name} create tag a"),
+        format!("truncate table {database}.{name}"),
+        format!("alter table {database}.{name} create tag b"),
+        format!("insert into {database}.{name} values (2)"),
+        format!("alter table {database}.{name} create tag c"),
+    ] {
+        fixture.execute_command(&statement).await?;
+    }
+    let ctx = fixture.new_query_ctx().await?;
+    let catalog = ctx.get_default_catalog()?;
+    let table = catalog.get_table(&ctx.get_tenant(), database, name).await?;
+    let fuse = FuseTable::try_from_table(table.as_ref())?;
+    let old_head = fuse.read_table_snapshot().await?.unwrap();
+    let a = catalog
+        .list_table_tags(databend_common_meta_app::schema::ListTableTagsReq {
+            table_id: table.get_id(),
+            include_expired: false,
+        })
+        .await?
+        .into_iter()
+        .find(|(name, _)| name == "a")
+        .unwrap()
+        .1
+        .data
+        .snapshot_loc;
+    let (target, _) =
+        databend_common_storages_fuse::io::SnapshotsIO::read_snapshot(a, fuse.get_operator(), true)
+            .await?;
+    fixture
+        .execute_command(&format!(
+            "alter table {database}.{name} flashback to (snapshot => '{}')",
+            target.snapshot_id.simple()
+        ))
+        .await?;
+    fixture
+        .execute_command(&format!("insert into {database}.{name} values (4)"))
+        .await?;
+    let table = catalog.get_table(&ctx.get_tenant(), database, name).await?;
+    let fuse = FuseTable::try_from_table(table.as_ref())?;
+    let live_root = fuse.read_table_snapshot().await?.unwrap();
+    assert!(live_root.timestamp > old_head.timestamp);
+    // Model an expired safety window without sleeping. All old branch files are already written.
+    let expired = live_root.timestamp.unwrap() - chrono::Duration::days(4);
+    catalog
+        .upsert_table_option(
+            &ctx.get_tenant(),
+            database,
+            UpsertTableOptionReq::new(
+                &table.get_table_info().ident,
+                OPT_KEY_VACUUM2_FLASHBACK_BARRIER,
+                expired.to_rfc3339(),
+            ),
+        )
+        .await?;
+    fixture
+        .execute_command(&format!("vacuum table {database}.{name}"))
+        .await?;
+    let table = catalog.get_table(&ctx.get_tenant(), database, name).await?;
+    assert!(
+        !table
+            .get_table_info()
+            .meta
+            .options
+            .contains_key(OPT_KEY_VACUUM2_FLASHBACK_BARRIER)
+    );
+
+    for statement in [
+        format!("insert into {database}.{name} values (5)"),
+        format!("insert into {database}.{name} values (6)"),
+        format!(
+            "alter table {database}.{name} set options(data_retention_num_snapshots_to_keep=5)"
+        ),
+    ] {
+        fixture.execute_command(&statement).await?;
+    }
+    let table = catalog.get_table(&ctx.get_tenant(), database, name).await?;
+    let fuse = FuseTable::try_from_table(table.as_ref())?;
+    let selection_ctx: Arc<dyn TableContext> = fixture.new_query_ctx().await?;
+    // Directory A,B,C,D,E,F would choose C.prev=B. The live chain only has A,D,E,F,
+    // so fallback must stop instead of using B's empty protection set.
+    assert!(
+        fuse.prepare_snapshot_gc_selection(&selection_ctx, false)
+            .await?
+            .is_none()
+    );
+    fixture
+        .execute_command(&format!("vacuum table {database}.{name}"))
+        .await?;
+    let blocks: Vec<DataBlock> = fixture
+        .execute_query(&format!("select c from {database}.{name}"))
+        .await?
+        .try_collect()
+        .await?;
+    assert_eq!(blocks.iter().map(DataBlock::num_rows).sum::<usize>(), 4);
+    Ok(())
+}
+
+/// Snapshot-count retention must count the live chain, not the abandoned truncate branch.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_vacuum2_flashback_live_chain_retention() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup_with_custom(EESetup::new()).await?;
+    fixture
+        .default_session()
+        .get_settings()
+        .set_data_retention_time_in_days(0)?;
+    fixture.create_default_database().await?;
+    let database = fixture.default_db_name();
+    let name = "t_live_chain_retention";
+    fixture
+        .execute_command(&format!(
+            "create table {database}.{name} (c int) data_retention_num_snapshots_to_keep=4"
+        ))
+        .await?;
+    fixture
+        .execute_command(&format!("insert into {database}.{name} values (1)"))
+        .await?;
+    let ctx = fixture.new_query_ctx().await?;
+    let catalog = ctx.get_default_catalog()?;
+    let table = catalog
+        .get_table(&ctx.get_tenant(), &database, name)
+        .await?;
+    let target = FuseTable::try_from_table(table.as_ref())?
+        .read_table_snapshot()
+        .await?
+        .unwrap();
+    for statement in [
+        format!("truncate table {database}.{name}"),
+        format!("insert into {database}.{name} values (2)"),
+        format!(
+            "alter table {database}.{name} flashback to (snapshot => '{}')",
+            target.snapshot_id.simple()
+        ),
+        format!("insert into {database}.{name} values (4)"),
+        format!("insert into {database}.{name} values (5)"),
+    ] {
+        fixture.execute_command(&statement).await?;
+    }
+
+    let table = catalog
+        .get_table(&ctx.get_tenant(), &database, name)
+        .await?;
+    let fuse = FuseTable::try_from_table(table.as_ref())?;
+    let selection_ctx: Arc<dyn TableContext> = fixture.new_query_ctx().await?;
+    assert!(
+        fuse.prepare_snapshot_gc_selection(&selection_ctx, false)
+            .await?
+            .is_none()
+    );
+    fixture
+        .execute_command(&format!("vacuum table {database}.{name}"))
+        .await?;
+    fixture
+        .execute_command(&format!(
+            "alter table {database}.{name} set options(data_retention_num_snapshots_to_keep=2)"
+        ))
+        .await?;
+    fixture
+        .execute_command(&format!("vacuum table {database}.{name}"))
+        .await?;
+    let blocks: Vec<DataBlock> = fixture
+        .execute_query(&format!("select c from {database}.{name}"))
+        .await?
+        .try_collect()
+        .await?;
+    assert_eq!(blocks.iter().map(DataBlock::num_rows).sum::<usize>(), 3);
+    let table = catalog
+        .get_table(&ctx.get_tenant(), &database, name)
+        .await?;
+    // A successful vacuum must not clear a barrier still inside its safety window.
+    assert!(
+        table
+            .get_table_info()
+            .meta
+            .options
+            .contains_key(OPT_KEY_VACUUM2_FLASHBACK_BARRIER)
+    );
+    let fuse = FuseTable::try_from_table(table.as_ref())?;
+    let snapshot_prefix = fuse.meta_location_generator().snapshot_location_prefix();
+    let files = fuse.get_operator().list(snapshot_prefix).await?;
+    assert_eq!(
+        files
+            .iter()
+            .filter(|entry| entry.metadata().is_file())
+            .count(),
+        2
+    );
+
+    catalog
+        .upsert_table_option(
+            &ctx.get_tenant(),
+            &database,
+            UpsertTableOptionReq::new(
+                &table.get_table_info().ident,
+                OPT_KEY_VACUUM2_FLASHBACK_BARRIER,
+                "invalid".to_string(),
+            ),
+        )
+        .await?;
+    let err = fixture
+        .execute_command(&format!("vacuum table {database}.{name}"))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), ErrorCode::TABLE_OPTION_INVALID);
+    assert_eq!(
+        fuse.get_operator().list(snapshot_prefix).await?.len(),
+        files.len()
+    );
     Ok(())
 }
 

--- a/src/query/ee/tests/it/storages/fuse/operations/vacuum2.rs
+++ b/src/query/ee/tests/it/storages/fuse/operations/vacuum2.rs
@@ -23,6 +23,7 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::DataBlock;
 use databend_common_meta_app::schema::LeastVisibleTime;
+use databend_common_meta_app::schema::UpsertTableOptionReq;
 use databend_common_meta_app::schema::least_visible_time_ident::LeastVisibleTimeIdent;
 use databend_common_sql::plans::VacuumTablesPlan;
 use databend_common_storages_fuse::FuseTable;
@@ -41,6 +42,7 @@ use databend_query::test_kits::TestFixture;
 use databend_query::test_kits::execute_command;
 use databend_storages_common_io::dedup_file_locations;
 use databend_storages_common_table_meta::meta::CompactSegmentInfo;
+use databend_storages_common_table_meta::table::OPT_KEY_VACUUM2_FLASHBACK_BARRIER;
 use futures::TryStreamExt;
 
 async fn table_storage_files(
@@ -731,6 +733,191 @@ async fn test_vacuum2_rejects_transaction_whose_blocks_were_collected() -> anyho
     let blocks: Vec<DataBlock> = stream.try_collect().await?;
     let committed_rows: usize = blocks.iter().map(|block| block.num_rows()).sum();
     assert_eq!(committed_rows, 2);
+
+    Ok(())
+}
+
+/// Model the critical interleaving: vacuum observes the LVT sequence, flashback commits and
+/// touches LVT, then the stale vacuum tries to publish the GC root selected before flashback.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_flashback_fences_in_progress_vacuum_with_lvt_sequence() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup_with_custom(EESetup::new()).await?;
+    fixture.create_default_database().await?;
+    let db_name = fixture.default_db_name();
+    let tbl_name = "t_flashback_vacuum_lvt_fence";
+    fixture
+        .execute_command(&format!("create table {db_name}.{tbl_name} (c int)"))
+        .await?;
+    fixture
+        .execute_command(&format!("insert into {db_name}.{tbl_name} values (1)"))
+        .await?;
+
+    let ctx = fixture.new_query_ctx().await?;
+    let catalog = ctx.get_default_catalog()?;
+    let table = catalog
+        .get_table(&ctx.get_tenant(), &db_name, tbl_name)
+        .await?;
+    let fuse = FuseTable::try_from_table(table.as_ref())?;
+    let table_id = fuse.get_id();
+    let target = fuse.read_table_snapshot().await?.unwrap();
+    let lvt_ident = LeastVisibleTimeIdent::new(ctx.get_tenant(), table_id);
+
+    // Vacuum starts before flashback and observes a missing LVT key (sequence 0).
+    let observed_lvt_seq = catalog
+        .get_table_lvt_with_seq(&lvt_ident)
+        .await?
+        .map(|v| v.seq)
+        .unwrap_or(0);
+    assert_eq!(observed_lvt_seq, 0);
+
+    fixture
+        .execute_command(&format!("insert into {db_name}.{tbl_name} values (2)"))
+        .await?;
+    fixture
+        .execute_command(&format!(
+            "alter table {db_name}.{tbl_name} flashback to (snapshot => '{}')",
+            target.snapshot_id.simple()
+        ))
+        .await?;
+
+    // Flashback writes LVT in the same transaction as TableMeta, changing only its KV sequence.
+    let touched_lvt = catalog
+        .get_table_lvt_with_seq(&lvt_ident)
+        .await?
+        .expect("flashback must create or touch LVT");
+    assert!(touched_lvt.seq > observed_lvt_seq);
+    assert_eq!(touched_lvt.data, LeastVisibleTime::default());
+
+    let stale_gc_root_time = target.timestamp.unwrap();
+    let published = catalog
+        .set_table_lvt_with_seq(
+            &lvt_ident,
+            &LeastVisibleTime::new(stale_gc_root_time),
+            observed_lvt_seq,
+        )
+        .await?;
+    assert!(
+        published.is_none(),
+        "vacuum must not publish an LVT using the sequence observed before flashback"
+    );
+
+    Ok(())
+}
+
+/// Flashback and its LVT validation must be one metadata transaction, otherwise a concurrent
+/// vacuum can make the target snapshot unsafe between validation and commit.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_flashback_rejects_snapshot_before_lvt() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup_with_custom(EESetup::new()).await?;
+    fixture.create_default_database().await?;
+    let db_name = fixture.default_db_name();
+    let tbl_name = "t_flashback_lvt";
+    fixture
+        .execute_command(&format!("create table {db_name}.{tbl_name} (c int)"))
+        .await?;
+    fixture
+        .execute_command(&format!("insert into {db_name}.{tbl_name} values (1)"))
+        .await?;
+
+    let ctx = fixture.new_query_ctx().await?;
+    let table = ctx
+        .get_default_catalog()?
+        .get_table(&ctx.get_tenant(), &db_name, tbl_name)
+        .await?;
+    let table_id = table.get_id();
+    let first_snapshot = FuseTable::try_from_table(table.as_ref())?
+        .read_table_snapshot()
+        .await?
+        .unwrap();
+
+    fixture
+        .execute_command(&format!("insert into {db_name}.{tbl_name} values (2)"))
+        .await?;
+    let table = ctx
+        .get_default_catalog()?
+        .get_table(&ctx.get_tenant(), &db_name, tbl_name)
+        .await?;
+    let latest_timestamp = FuseTable::try_from_table(table.as_ref())?
+        .read_table_snapshot()
+        .await?
+        .unwrap()
+        .timestamp
+        .unwrap();
+    ctx.get_default_catalog()?
+        .set_table_lvt(
+            &LeastVisibleTimeIdent::new(ctx.get_tenant(), table_id),
+            &LeastVisibleTime::new(latest_timestamp),
+        )
+        .await?;
+
+    let err = fixture
+        .execute_command(&format!(
+            "alter table {db_name}.{tbl_name} flashback to (snapshot => '{}')",
+            first_snapshot.snapshot_id.simple()
+        ))
+        .await
+        .expect_err("flashback target older than LVT must be rejected");
+    assert_eq!(err.code(), ErrorCode::TABLE_SNAPSHOT_EXPIRED);
+
+    Ok(())
+}
+
+/// Once the selected live GC root is beyond the three-day transaction window, a successful
+/// vacuum should remove the barrier with a table-sequence CAS.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_vacuum2_clears_expired_flashback_barrier() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup_with_custom(EESetup::new()).await?;
+    fixture.create_default_database().await?;
+    let db_name = fixture.default_db_name();
+    let tbl_name = "t_expired_flashback_barrier";
+    fixture
+        .execute_command(&format!(
+            "create table {db_name}.{tbl_name} (c int) data_retention_num_snapshots_to_keep=1"
+        ))
+        .await?;
+    fixture
+        .execute_command(&format!("insert into {db_name}.{tbl_name} values (1)"))
+        .await?;
+
+    let ctx = fixture.new_query_ctx().await?;
+    let catalog = ctx.get_default_catalog()?;
+    let table = catalog
+        .get_table(&ctx.get_tenant(), &db_name, tbl_name)
+        .await?;
+    let expired_barrier = (chrono::Utc::now() - chrono::Duration::days(4)).to_rfc3339();
+    catalog
+        .upsert_table_option(
+            &ctx.get_tenant(),
+            &db_name,
+            UpsertTableOptionReq::new(
+                &table.get_table_info().ident,
+                OPT_KEY_VACUUM2_FLASHBACK_BARRIER,
+                expired_barrier,
+            ),
+        )
+        .await?;
+
+    // Create another live snapshot after the expired barrier so it can be selected as the root.
+    fixture
+        .execute_command(&format!("insert into {db_name}.{tbl_name} values (2)"))
+        .await?;
+    fixture
+        .execute_command(&format!(
+            "call system$fuse_vacuum2('{db_name}', '{tbl_name}')"
+        ))
+        .await?;
+
+    let table = catalog
+        .get_table(&ctx.get_tenant(), &db_name, tbl_name)
+        .await?;
+    assert!(
+        !table
+            .get_table_info()
+            .meta
+            .options
+            .contains_key(OPT_KEY_VACUUM2_FLASHBACK_BARRIER),
+        "an expired barrier should be cleared after vacuum succeeds"
+    );
 
     Ok(())
 }

--- a/src/query/service/src/catalogs/default/database_catalog.rs
+++ b/src/query/service/src/catalogs/default/database_catalog.rs
@@ -990,11 +990,31 @@ impl Catalog for DatabaseCatalog {
         self.mutable_catalog.set_table_lvt(name_ident, value).await
     }
 
+    async fn set_table_lvt_with_seq(
+        &self,
+        name_ident: &LeastVisibleTimeIdent,
+        value: &LeastVisibleTime,
+        expected_seq: u64,
+    ) -> Result<Option<LeastVisibleTime>> {
+        self.mutable_catalog
+            .set_table_lvt_with_seq(name_ident, value, expected_seq)
+            .await
+    }
+
     async fn get_table_lvt(
         &self,
         name_ident: &LeastVisibleTimeIdent,
     ) -> Result<Option<LeastVisibleTime>> {
         self.mutable_catalog.get_table_lvt(name_ident).await
+    }
+
+    async fn get_table_lvt_with_seq(
+        &self,
+        name_ident: &LeastVisibleTimeIdent,
+    ) -> Result<Option<SeqV<LeastVisibleTime>>> {
+        self.mutable_catalog
+            .get_table_lvt_with_seq(name_ident)
+            .await
     }
 
     async fn rename_dictionary(&self, req: RenameDictionaryReq) -> Result<()> {

--- a/src/query/service/src/catalogs/default/mutable_catalog.rs
+++ b/src/query/service/src/catalogs/default/mutable_catalog.rs
@@ -1041,11 +1041,31 @@ impl Catalog for MutableCatalog {
         Ok(self.ctx.meta.set_table_lvt(name_ident, value).await?)
     }
 
+    async fn set_table_lvt_with_seq(
+        &self,
+        name_ident: &LeastVisibleTimeIdent,
+        value: &LeastVisibleTime,
+        expected_seq: u64,
+    ) -> Result<Option<LeastVisibleTime>> {
+        Ok(self
+            .ctx
+            .meta
+            .set_table_lvt_with_seq(name_ident, value, expected_seq)
+            .await?)
+    }
+
     async fn get_table_lvt(
         &self,
         name_ident: &LeastVisibleTimeIdent,
     ) -> Result<Option<LeastVisibleTime>> {
         Ok(self.ctx.meta.get_table_lvt(name_ident).await?)
+    }
+
+    async fn get_table_lvt_with_seq(
+        &self,
+        name_ident: &LeastVisibleTimeIdent,
+    ) -> Result<Option<SeqV<LeastVisibleTime>>> {
+        Ok(self.ctx.meta.get_table_lvt_with_seq(name_ident).await?)
     }
 
     #[async_backtrace::framed]

--- a/src/query/service/src/catalogs/default/session_catalog.rs
+++ b/src/query/service/src/catalogs/default/session_catalog.rs
@@ -880,11 +880,29 @@ impl Catalog for SessionCatalog {
         self.inner.set_table_lvt(name_ident, value).await
     }
 
+    async fn set_table_lvt_with_seq(
+        &self,
+        name_ident: &LeastVisibleTimeIdent,
+        value: &LeastVisibleTime,
+        expected_seq: u64,
+    ) -> Result<Option<LeastVisibleTime>> {
+        self.inner
+            .set_table_lvt_with_seq(name_ident, value, expected_seq)
+            .await
+    }
+
     async fn get_table_lvt(
         &self,
         name_ident: &LeastVisibleTimeIdent,
     ) -> Result<Option<LeastVisibleTime>> {
         self.inner.get_table_lvt(name_ident).await
+    }
+
+    async fn get_table_lvt_with_seq(
+        &self,
+        name_ident: &LeastVisibleTimeIdent,
+    ) -> Result<Option<SeqV<LeastVisibleTime>>> {
+        self.inner.get_table_lvt_with_seq(name_ident).await
     }
 
     async fn rename_dictionary(&self, req: RenameDictionaryReq) -> Result<()> {

--- a/src/query/storages/common/table_meta/src/meta/mod.rs
+++ b/src/query/storages/common/table_meta/src/meta/mod.rs
@@ -45,7 +45,7 @@ pub use utils::TEMP_TABLE_STORAGE_PREFIX;
 pub use utils::TableMetaTimestamps;
 pub use utils::VACUUM2_OBJECT_KEY_PREFIX;
 pub use utils::is_uuid_v7;
-pub(crate) use utils::monotonically_increased_timestamp;
+pub use utils::monotonically_increased_timestamp;
 pub use utils::parse_storage_prefix;
 pub use utils::trim_object_prefix;
 pub(crate) use utils::trim_timestamp_to_milli_second;

--- a/src/query/storages/common/table_meta/src/meta/utils.rs
+++ b/src/query/storages/common/table_meta/src/meta/utils.rs
@@ -54,7 +54,9 @@ pub(crate) fn trim_timestamp_to_milli_second(ts: DateTime<Utc>) -> DateTime<Utc>
     .unwrap()
 }
 
-pub(crate) fn monotonically_increased_timestamp(
+/// Returns a millisecond timestamp strictly newer than `previous_timestamp`, even if the clock
+/// has not advanced. Callers must serialize updates to the previous timestamp.
+pub fn monotonically_increased_timestamp(
     timestamp: DateTime<Utc>,
     previous_timestamp: &Option<DateTime<Utc>>,
 ) -> DateTime<Utc> {
@@ -198,6 +200,22 @@ mod tests {
     use crate::meta::VACUUM2_OBJECT_KEY_PREFIX;
     use crate::meta::trim_object_prefix;
     use crate::meta::try_extract_uuid_str_from_path;
+
+    #[test]
+    fn test_monotonic_timestamp_survives_clock_rollback() {
+        let now = chrono::DateTime::from_timestamp_millis(1_000).unwrap();
+        let first = super::monotonically_increased_timestamp(now, &None);
+        let second = super::monotonically_increased_timestamp(now, &Some(first));
+        let third =
+            super::monotonically_increased_timestamp(now - Duration::days(1), &Some(second));
+        assert_eq!(second, first + Duration::milliseconds(1));
+        assert_eq!(third, second + Duration::milliseconds(1));
+        let serialized = third.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        assert_eq!(
+            chrono::DateTime::parse_from_rfc3339(&serialized).unwrap(),
+            third
+        );
+    }
 
     #[test]
     fn test_trim_vacuum2_object_prefix() {

--- a/src/query/storages/common/table_meta/src/table/table_keys.rs
+++ b/src/query/storages/common/table_meta/src/table/table_keys.rs
@@ -29,6 +29,9 @@ pub const OPT_KEY_STORAGE_PREFIX: &str = "storage_prefix";
 pub const OPT_KEY_TEMP_PREFIX: &str = "temp_prefix";
 pub const OPT_KEY_RECURSIVE_CTE: &str = "recursive_cte";
 pub const OPT_KEY_SNAPSHOT_LOCATION: &str = "snapshot_location";
+/// Timestamp barrier that forces Vacuum2 to select its GC root from the live snapshot chain
+/// after a table has been flashed back.
+pub const OPT_KEY_VACUUM2_FLASHBACK_BARRIER: &str = "vacuum2_flashback_barrier";
 pub const OPT_KEY_MATERIALIZED_VIEW_SOURCE_SNAPSHOT_LOCATION: &str =
     "materialized_view_source_snapshot_location";
 pub const OPT_KEY_MATERIALIZED_VIEW_SOURCE_TABLE_ID: &str = "materialized_view_source_table_id";
@@ -135,6 +138,7 @@ pub static RESERVED_TABLE_OPTION_KEYS: LazyLock<HashSet<&'static str>> = LazyLoc
     r.insert(OPT_KEY_MATERIALIZED_VIEW_SOURCE_TABLE_ID);
     r.insert(OPT_KEY_MATERIALIZED_VIEW_SOURCE_TABLE_SEQ);
     r.insert(OPT_KEY_MATERIALIZED_VIEW_AGGREGATE_COMPACTION_DELTA_BLOCKS);
+    r.insert(OPT_KEY_VACUUM2_FLASHBACK_BARRIER);
     r
 });
 
@@ -153,6 +157,7 @@ pub static INTERNAL_TABLE_OPTION_KEYS: LazyLock<HashSet<&'static str>> = LazyLoc
     r.insert(OPT_KEY_MATERIALIZED_VIEW_SOURCE_TABLE_ID);
     r.insert(OPT_KEY_MATERIALIZED_VIEW_SOURCE_TABLE_SEQ);
     r.insert(OPT_KEY_MATERIALIZED_VIEW_AGGREGATE_COMPACTION_DELTA_BLOCKS);
+    r.insert(OPT_KEY_VACUUM2_FLASHBACK_BARRIER);
     r
 });
 

--- a/src/query/storages/fuse/src/operations/revert.rs
+++ b/src/query/storages/fuse/src/operations/revert.rs
@@ -15,7 +15,6 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use chrono::DateTime;
 use chrono::SecondsFormat;
 use chrono::Utc;
 use databend_common_catalog::table::NavigationDescriptor;
@@ -27,8 +26,10 @@ use databend_common_expression::ColumnId;
 use databend_common_meta_app::schema::TableLvtCheck;
 use databend_common_meta_app::schema::TableMeta;
 use databend_common_meta_app::schema::UpdateTableMetaReq;
+use databend_common_meta_app::schema::least_visible_time_ident::LeastVisibleTimeIdent;
 use databend_common_sql::binder::validate_constraints_by_schema;
 use databend_meta_client::types::MatchSeq;
+use databend_storages_common_table_meta::meta::monotonically_increased_timestamp;
 use databend_storages_common_table_meta::table::OPT_KEY_VACUUM2_FLASHBACK_BARRIER;
 
 use crate::FuseTable;
@@ -65,28 +66,21 @@ impl FuseTable {
             .read_table_snapshot()
             .await?
             .ok_or_else(|| ErrorCode::Internal("table being flashed back has no snapshot"))?;
-        let existing_barrier = self
-            .table_info
-            .meta
-            .options
-            .get(OPT_KEY_VACUUM2_FLASHBACK_BARRIER)
-            .map(|value| {
-                DateTime::parse_from_rfc3339(value)
-                    .map(|v| v.with_timezone(&Utc))
-                    .map_err(|e| {
-                        ErrorCode::TableOptionInvalid(format!(
-                            "invalid {} value '{}': {}",
-                            OPT_KEY_VACUUM2_FLASHBACK_BARRIER, value, e
-                        ))
-                    })
-            })
-            .transpose()?;
-        let barrier = existing_barrier
+        let table_id = self.table_info.ident.table_id;
+        let tenant = ctx.get_tenant();
+        let catalog = ctx.get_catalog(self.table_info.catalog()).await?;
+        let lvt = catalog
+            .get_table_lvt(&LeastVisibleTimeIdent::new(&tenant, table_id))
+            .await?;
+        // LVT also fences generations after a previous barrier has been cleared: successful
+        // cleanup has already advanced LVT beyond that barrier's transaction safety window.
+        let previous_timestamp = self
+            .vacuum2_flashback_barrier()?
             .into_iter()
             .chain(current_snapshot.timestamp)
-            .chain([Utc::now()])
-            .max()
-            .unwrap();
+            .chain(lvt.map(|value| value.time))
+            .max();
+        let barrier = monotonically_increased_timestamp(Utc::now(), &previous_timestamp);
 
         let mut table_meta_to_be_committed = table_reverting_to.table_info.meta.clone();
         table_meta_to_be_committed.options.insert(
@@ -97,9 +91,6 @@ impl FuseTable {
         // 3. prepare the request
         //  using the CURRENT version as the base table version
         let base_version = self.table_info.ident.seq;
-        let table_id = self.table_info.ident.table_id;
-        let tenant = ctx.get_tenant();
-        let catalog = ctx.get_catalog(self.table_info.catalog()).await?;
         let req = UpdateTableMetaReq {
             table_id,
             seq: MatchSeq::Exact(base_version),

--- a/src/query/storages/fuse/src/operations/revert.rs
+++ b/src/query/storages/fuse/src/operations/revert.rs
@@ -15,16 +15,21 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use chrono::DateTime;
+use chrono::SecondsFormat;
+use chrono::Utc;
 use databend_common_catalog::table::NavigationDescriptor;
 use databend_common_catalog::table::NavigationPoint;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::ColumnId;
+use databend_common_meta_app::schema::TableLvtCheck;
 use databend_common_meta_app::schema::TableMeta;
 use databend_common_meta_app::schema::UpdateTableMetaReq;
 use databend_common_sql::binder::validate_constraints_by_schema;
 use databend_meta_client::types::MatchSeq;
+use databend_storages_common_table_meta::table::OPT_KEY_VACUUM2_FLASHBACK_BARRIER;
 
 use crate::FuseTable;
 use crate::io::SnapshotsIO;
@@ -48,8 +53,46 @@ impl FuseTable {
             return Ok(());
         }
 
-        // 2. prepare table meta which being reverted to
-        let table_meta_to_be_committed = table_reverting_to.table_info.meta.clone();
+        // 2. prepare table meta which being reverted to. Record a monotonic barrier covering
+        // the abandoned committed branch. Vacuum2 must not infer a GC root from listed
+        // snapshots while that barrier is active.
+        let target_snapshot = table_reverting_to
+            .read_table_snapshot()
+            .await?
+            .ok_or_else(|| ErrorCode::Internal("flashback target has no snapshot"))?;
+        let target_timestamp = target_snapshot.timestamp;
+        let current_snapshot = self
+            .read_table_snapshot()
+            .await?
+            .ok_or_else(|| ErrorCode::Internal("table being flashed back has no snapshot"))?;
+        let existing_barrier = self
+            .table_info
+            .meta
+            .options
+            .get(OPT_KEY_VACUUM2_FLASHBACK_BARRIER)
+            .map(|value| {
+                DateTime::parse_from_rfc3339(value)
+                    .map(|v| v.with_timezone(&Utc))
+                    .map_err(|e| {
+                        ErrorCode::TableOptionInvalid(format!(
+                            "invalid {} value '{}': {}",
+                            OPT_KEY_VACUUM2_FLASHBACK_BARRIER, value, e
+                        ))
+                    })
+            })
+            .transpose()?;
+        let barrier = existing_barrier
+            .into_iter()
+            .chain(current_snapshot.timestamp)
+            .chain([Utc::now()])
+            .max()
+            .unwrap();
+
+        let mut table_meta_to_be_committed = table_reverting_to.table_info.meta.clone();
+        table_meta_to_be_committed.options.insert(
+            OPT_KEY_VACUUM2_FLASHBACK_BARRIER.to_owned(),
+            barrier.to_rfc3339_opts(SecondsFormat::Millis, true),
+        );
 
         // 3. prepare the request
         //  using the CURRENT version as the base table version
@@ -62,7 +105,10 @@ impl FuseTable {
             seq: MatchSeq::Exact(base_version),
             new_table_meta: table_meta_to_be_committed.clone(),
             base_snapshot_location: self.snapshot_loc(),
-            lvt_check: None,
+            lvt_check: Some(TableLvtCheck {
+                tenant: tenant.clone(),
+                time: target_timestamp,
+            }),
         };
 
         // 4. let's roll

--- a/src/query/storages/fuse/src/operations/vacuum.rs
+++ b/src/query/storages/fuse/src/operations/vacuum.rs
@@ -15,6 +15,7 @@
 // Logs from this module will show up as "[VACUUM] ...".
 databend_common_tracing::register_module_tag!("[VACUUM]");
 
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -32,8 +33,10 @@ use databend_common_meta_app::schema::DropTableTagReq;
 use databend_common_meta_app::schema::LeastVisibleTime;
 use databend_common_meta_app::schema::ListTableTagsReq;
 use databend_common_meta_app::schema::TableInfo;
+use databend_common_meta_app::schema::UpsertTableOptionReq;
 use databend_common_meta_app::schema::least_visible_time_ident::LeastVisibleTimeIdent;
 use databend_enterprise_vacuum_handler::VacuumHandlerWrapper;
+use databend_meta_client::types::MatchSeq;
 use databend_meta_client::types::SeqV;
 use databend_storages_common_cache::Table;
 use databend_storages_common_cache::TableSnapshot;
@@ -112,10 +115,8 @@ pub struct SnapshotGcSelection {
     pub snapshots_to_gc: Vec<String>,
     pub gc_root_meta_ts: DateTime<Utc>,
     pub gc_root_path: String,
-    /// Remove the barrier only after this selection has been fully vacuumed.
-    pub clear_flashback_barrier: bool,
-    /// Table sequence observed together with the barrier, used for CAS removal.
-    pub table_seq: u64,
+    /// The exact barrier generation to remove only after this selection has been fully vacuumed.
+    pub flashback_barrier_to_clear: Option<DateTime<Utc>>,
 }
 
 /// Object storage supported by Databend is expected to return entries sorted in ascending lexicographical
@@ -475,6 +476,101 @@ impl FuseTable {
         Ok(Some(segments))
     }
 
+    pub(crate) fn vacuum2_flashback_barrier(&self) -> Result<Option<DateTime<Utc>>> {
+        self.table_info
+            .meta
+            .options
+            .get(OPT_KEY_VACUUM2_FLASHBACK_BARRIER)
+            .map(|value| {
+                DateTime::parse_from_rfc3339(value)
+                    .map(|timestamp| timestamp.with_timezone(&Utc))
+                    .map_err(|err| {
+                        ErrorCode::TableOptionInvalid(format!(
+                            "invalid {OPT_KEY_VACUUM2_FLASHBACK_BARRIER} value '{value}': {err}"
+                        ))
+                    })
+            })
+            .transpose()
+    }
+
+    /// Remove only the barrier generation whose live root was successfully vacuumed.
+    /// Ordinary writes during vacuum are allowed; a later flashback must keep its new barrier.
+    pub async fn clear_vacuum2_flashback_barrier(
+        &self,
+        ctx: &dyn TableContext,
+        expected_barrier: DateTime<Utc>,
+    ) -> Result<()> {
+        let catalog = ctx.get_catalog(self.table_info.catalog()).await?;
+        for _ in 0..3 {
+            let refreshed = self.refresh(ctx).await?;
+            let fuse = FuseTable::try_from_table(refreshed.as_ref())?;
+            if fuse.vacuum2_flashback_barrier()? != Some(expected_barrier) {
+                return Ok(());
+            }
+
+            let req = UpsertTableOptionReq {
+                table_id: self.get_id(),
+                seq: MatchSeq::Exact(fuse.table_info.ident.seq),
+                options: HashMap::from([(OPT_KEY_VACUUM2_FLASHBACK_BARRIER.to_owned(), None)]),
+            };
+            match catalog
+                .upsert_table_option(&ctx.get_tenant(), fuse.table_info.database_name()?, req)
+                .await
+            {
+                Err(err) if err.code() == ErrorCode::TABLE_VERSION_MISMATCHED => continue,
+                result => return result.map(|_| ()),
+            }
+        }
+        // Keeping the barrier is safe; a busy table can retry cleanup in its next vacuum.
+        info!(
+            "Concurrent updates prevented flashback barrier cleanup for table {}",
+            self.get_id()
+        );
+        Ok(())
+    }
+
+    async fn live_chain_gc_root(
+        &self,
+        ctx: &Arc<dyn TableContext>,
+        retention_policy: &RetentionPolicy,
+        lvt: DateTime<Utc>,
+    ) -> Result<Option<String>> {
+        let latest_location = self.snapshot_loc().unwrap();
+        match retention_policy {
+            RetentionPolicy::ByTimePeriod(_) => {
+                match self
+                    .find_location(ctx, latest_location, |snapshot| {
+                        is_snapshot_at_or_before_lvt(snapshot.timestamp, lvt)
+                    })
+                    .await
+                {
+                    Ok(location) => Ok(Some(location)),
+                    Err(err) if err.code() == ErrorCode::TABLE_HISTORICAL_DATA_NOT_FOUND => {
+                        Ok(None)
+                    }
+                    Err(err) => Err(err),
+                }
+            }
+            RetentionPolicy::ByNumOfSnapshotsToKeep(keep) => {
+                let snapshots = SnapshotsIO::create(ctx.clone(), self.get_operator())
+                    .read_chained_snapshot_lites(
+                        self.get_operator(),
+                        self.meta_location_generator().clone(),
+                        latest_location,
+                        Some(keep + 1),
+                    )
+                    .await?;
+                if snapshots.len() <= *keep {
+                    return Ok(None);
+                }
+                let root = &snapshots[keep - 1];
+                self.meta_location_generator()
+                    .gen_snapshot_location(&root.snapshot_id, root.format_version)
+                    .map(Some)
+            }
+        }
+    }
+
     pub async fn prepare_snapshot_gc_selection(
         &self,
         ctx: &Arc<dyn TableContext>,
@@ -483,7 +579,7 @@ impl FuseTable {
         // Observe the fence before refreshing the table head. A flashback that
         // commits before or during refresh changes this sequence, while refresh
         // ensures selection never starts from a stale pre-flashback head.
-        let catalog = ctx.get_default_catalog()?;
+        let catalog = ctx.get_catalog(self.table_info.catalog()).await?;
         let lvt_ident = LeastVisibleTimeIdent::new(ctx.get_tenant(), self.get_id());
         let observed_lvt = catalog.get_table_lvt_with_seq(&lvt_ident).await?;
         let refreshed = self.refresh(ctx.as_ref()).await?;
@@ -516,29 +612,14 @@ impl FuseTable {
         let start = std::time::Instant::now();
         let retention_policy = self.get_data_retention_policy(ctx.as_ref())?;
         let snapshot_location_prefix = self.meta_location_generator().snapshot_location_prefix();
-        let catalog = ctx.get_default_catalog()?;
+        let catalog = ctx.get_catalog(self.table_info.catalog()).await?;
         let observed_lvt_seq = observed_lvt.as_ref().map(|v| v.seq).unwrap_or(0);
         let observed_lvt_value = observed_lvt.map(|v| v.data).unwrap_or_default();
 
         let mut is_vacuum_all = false;
         let mut lvt_to_publish = None;
         let mut live_chain_gc_root = None;
-        let flashback_barrier = self
-            .table_info
-            .meta
-            .options
-            .get(OPT_KEY_VACUUM2_FLASHBACK_BARRIER)
-            .map(|value| {
-                DateTime::parse_from_rfc3339(value)
-                    .map(|v| v.with_timezone(&Utc))
-                    .map_err(|e| {
-                        ErrorCode::TableOptionInvalid(format!(
-                            "invalid {} value '{}': {}",
-                            OPT_KEY_VACUUM2_FLASHBACK_BARRIER, value, e
-                        ))
-                    })
-            })
-            .transpose()?;
+        let flashback_barrier = self.vacuum2_flashback_barrier()?;
         let must_follow_live_chain = respect_flash_back || flashback_barrier.is_some();
 
         let snapshots_before_lvt = match retention_policy {
@@ -570,14 +651,9 @@ impl FuseTable {
                 lvt_to_publish = Some(LeastVisibleTime::new(lvt));
 
                 if let Some(lvt) = flashback_gc_root_lvt(must_follow_live_chain, lvt) {
-                    let latest_location = self.snapshot_loc().unwrap();
-                    let gc_root = self
-                        .find_location(ctx, latest_location, |snapshot| {
-                            is_snapshot_at_or_before_lvt(snapshot.timestamp, lvt)
-                        })
-                        .await
-                        .ok();
-                    let Some(gc_root) = gc_root else {
+                    let Some(gc_root) =
+                        self.live_chain_gc_root(ctx, &retention_policy, lvt).await?
+                    else {
                         info!("no gc_root found on live snapshot chain, stop vacuuming");
                         return Ok(None);
                     };
@@ -585,7 +661,7 @@ impl FuseTable {
                 }
 
                 ctx.set_status_info(&format!(
-                    "Set LVT for table {}, elapsed: {:?}, LVT: {:?}",
+                    "Prepared LVT for table {}, elapsed: {:?}, LVT: {:?}",
                     self.table_info.desc,
                     start.elapsed(),
                     lvt
@@ -617,22 +693,12 @@ impl FuseTable {
                 // List the snapshot order by timestamp asc, till the current snapshot(inclusively).
                 let need_one_more = true;
                 if must_follow_live_chain {
-                    let snapshots_io = SnapshotsIO::create(ctx.clone(), self.get_operator());
-                    let chained = snapshots_io
-                        .read_chained_snapshot_lites(
-                            self.get_operator(),
-                            self.meta_location_generator().clone(),
-                            self.snapshot_loc().unwrap(),
-                            Some(num_snapshots_to_keep + 1),
-                        )
-                        .await?;
-                    if chained.len() <= num_snapshots_to_keep {
+                    let Some(root_path) = self
+                        .live_chain_gc_root(ctx, &retention_policy, observed_lvt_value.time)
+                        .await?
+                    else {
                         return Ok(None);
-                    }
-                    let root = &chained[num_snapshots_to_keep - 1];
-                    let root_path = self
-                        .meta_location_generator()
-                        .gen_snapshot_location(&root.snapshot_id, root.format_version)?;
+                    };
                     live_chain_gc_root = Some(root_path.clone());
                     self.list_files_until_prefix(
                         snapshot_location_prefix,
@@ -683,19 +749,40 @@ impl FuseTable {
             slice_summary(&snapshots_before_lvt)
         ));
 
-        let Some(selection) = self
-            .select_gc_root(&snapshots_before_lvt, is_vacuum_all, live_chain_gc_root)
-            .await?
-        else {
+        let directory_selection = !is_vacuum_all && live_chain_gc_root.is_none();
+        let mut selection = self
+            .select_gc_root(
+                &snapshots_before_lvt,
+                is_vacuum_all,
+                live_chain_gc_root,
+                directory_selection.then_some(observed_lvt_value.time),
+            )
+            .await?;
+        if selection.is_none() && directory_selection {
+            // Old tagged snapshots may survive barrier cleanup. Increasing retention must not
+            // let directory counting select their abandoned branch below the published LVT.
+            let lvt = lvt_to_publish
+                .as_ref()
+                .map_or(observed_lvt_value.time, |value| value.time);
+            let Some(root_path) = self.live_chain_gc_root(ctx, &retention_policy, lvt).await?
+            else {
+                return Ok(None);
+            };
+            let candidates = self
+                .list_files_until_prefix(snapshot_location_prefix, &root_path, true, None)
+                .await?;
+            selection = self
+                .select_gc_root(&candidates, false, Some(root_path), None)
+                .await?;
+        }
+        let Some(mut selection) = selection else {
             return Ok(None);
         };
-
-        let mut selection = selection;
-        selection.clear_flashback_barrier = flashback_barrier.is_some_and(|barrier| {
+        selection.flashback_barrier_to_clear = flashback_barrier.filter(|barrier| {
             selection
                 .gc_root
                 .timestamp
-                .is_some_and(|timestamp| timestamp > barrier + ASSUMPTION_MAX_TXN_DURATION)
+                .is_some_and(|timestamp| timestamp > *barrier + ASSUMPTION_MAX_TXN_DURATION)
         });
 
         let lvt_to_publish = lvt_to_publish.unwrap_or_else(|| {
@@ -733,10 +820,11 @@ impl FuseTable {
         snapshots_before_lvt: &[Entry],
         is_vacuum_all: bool,
         live_chain_gc_root: Option<String>,
+        directory_lvt: Option<DateTime<Utc>>,
     ) -> Result<Option<SnapshotGcSelection>> {
         let op = self.get_operator();
         let gc_root_path = if is_vacuum_all {
-            // safe to unwrap, or we should have stopped vacuuming in set_lvt()
+            // The current snapshot is always on the live chain.
             self.snapshot_loc().unwrap()
         } else if let Some(gc_root) = live_chain_gc_root {
             gc_root
@@ -767,6 +855,22 @@ impl FuseTable {
 
         let dal = self.get_operator_ref();
         let gc_root = SnapshotsIO::read_snapshot(gc_root_path.clone(), op.clone(), false).await;
+        if let Ok((root, _)) = &gc_root {
+            if !is_uuid_v7(&root.snapshot_id) || root.timestamp.is_none() {
+                info!(
+                    "gc_root {} has no Vacuum2 timestamp, stopping vacuum",
+                    gc_root_path
+                );
+                return Ok(None);
+            }
+            if directory_lvt.is_some_and(|lvt| root.timestamp.unwrap() < lvt) {
+                info!(
+                    "Directory gc_root {} is older than LVT {:?}, use the live chain",
+                    gc_root_path, directory_lvt
+                );
+                return Ok(None);
+            }
+        }
         let gc_root_meta_ts = match dal.stat(&gc_root_path).await {
             Ok(v) => v.last_modified().ok_or_else(|| {
                 ErrorCode::StorageOther(format!(
@@ -827,8 +931,7 @@ impl FuseTable {
                     snapshots_to_gc,
                     gc_root_meta_ts,
                     gc_root_path,
-                    clear_flashback_barrier: false,
-                    table_seq: self.table_info.ident.seq,
+                    flashback_barrier_to_clear: None,
                 }))
             }
             Err(e) => {

--- a/src/query/storages/fuse/src/operations/vacuum.rs
+++ b/src/query/storages/fuse/src/operations/vacuum.rs
@@ -34,12 +34,14 @@ use databend_common_meta_app::schema::ListTableTagsReq;
 use databend_common_meta_app::schema::TableInfo;
 use databend_common_meta_app::schema::least_visible_time_ident::LeastVisibleTimeIdent;
 use databend_enterprise_vacuum_handler::VacuumHandlerWrapper;
+use databend_meta_client::types::SeqV;
 use databend_storages_common_cache::Table;
 use databend_storages_common_cache::TableSnapshot;
 use databend_storages_common_table_meta::meta::Location;
 use databend_storages_common_table_meta::meta::VACUUM2_OBJECT_KEY_PREFIX;
 use databend_storages_common_table_meta::meta::is_uuid_v7;
 use databend_storages_common_table_meta::meta::uuid_from_date_time;
+use databend_storages_common_table_meta::table::OPT_KEY_VACUUM2_FLASHBACK_BARRIER;
 use futures_util::TryStreamExt;
 use log::info;
 use log::warn;
@@ -110,6 +112,10 @@ pub struct SnapshotGcSelection {
     pub snapshots_to_gc: Vec<String>,
     pub gc_root_meta_ts: DateTime<Utc>,
     pub gc_root_path: String,
+    /// Remove the barrier only after this selection has been fully vacuumed.
+    pub clear_flashback_barrier: bool,
+    /// Table sequence observed together with the barrier, used for CAS removal.
+    pub table_seq: u64,
 }
 
 /// Object storage supported by Databend is expected to return entries sorted in ascending lexicographical
@@ -474,6 +480,31 @@ impl FuseTable {
         ctx: &Arc<dyn TableContext>,
         respect_flash_back: bool,
     ) -> Result<Option<SnapshotGcSelection>> {
+        // Observe the fence before refreshing the table head. A flashback that
+        // commits before or during refresh changes this sequence, while refresh
+        // ensures selection never starts from a stale pre-flashback head.
+        let catalog = ctx.get_default_catalog()?;
+        let lvt_ident = LeastVisibleTimeIdent::new(ctx.get_tenant(), self.get_id());
+        let observed_lvt = catalog.get_table_lvt_with_seq(&lvt_ident).await?;
+        let refreshed = self.refresh(ctx.as_ref()).await?;
+        let refreshed_fuse = FuseTable::try_from_table(refreshed.as_ref())?;
+        refreshed_fuse
+            .prepare_snapshot_gc_selection_with_lvt(
+                ctx,
+                respect_flash_back,
+                lvt_ident,
+                observed_lvt,
+            )
+            .await
+    }
+
+    async fn prepare_snapshot_gc_selection_with_lvt(
+        &self,
+        ctx: &Arc<dyn TableContext>,
+        respect_flash_back: bool,
+        lvt_ident: LeastVisibleTimeIdent,
+        observed_lvt: Option<SeqV<LeastVisibleTime>>,
+    ) -> Result<Option<SnapshotGcSelection>> {
         let Some(latest_snapshot) = self.read_table_snapshot().await? else {
             info!(
                 "Table {} has no snapshot, stopping vacuum",
@@ -485,10 +516,30 @@ impl FuseTable {
         let start = std::time::Instant::now();
         let retention_policy = self.get_data_retention_policy(ctx.as_ref())?;
         let snapshot_location_prefix = self.meta_location_generator().snapshot_location_prefix();
+        let catalog = ctx.get_default_catalog()?;
+        let observed_lvt_seq = observed_lvt.as_ref().map(|v| v.seq).unwrap_or(0);
+        let observed_lvt_value = observed_lvt.map(|v| v.data).unwrap_or_default();
 
         let mut is_vacuum_all = false;
-        let mut need_update_lvt = false;
-        let mut respect_flash_back_with_lvt = None;
+        let mut lvt_to_publish = None;
+        let mut live_chain_gc_root = None;
+        let flashback_barrier = self
+            .table_info
+            .meta
+            .options
+            .get(OPT_KEY_VACUUM2_FLASHBACK_BARRIER)
+            .map(|value| {
+                DateTime::parse_from_rfc3339(value)
+                    .map(|v| v.with_timezone(&Utc))
+                    .map_err(|e| {
+                        ErrorCode::TableOptionInvalid(format!(
+                            "invalid {} value '{}': {}",
+                            OPT_KEY_VACUUM2_FLASHBACK_BARRIER, value, e
+                        ))
+                    })
+            })
+            .transpose()?;
+        let must_follow_live_chain = respect_flash_back || flashback_barrier.is_some();
 
         let snapshots_before_lvt = match retention_policy {
             RetentionPolicy::ByTimePeriod(delta_duration) => {
@@ -503,14 +554,35 @@ impl FuseTable {
                 // A zero retention period indicates that we should vacuum all the historical snapshots
                 is_vacuum_all = retention_period.is_zero();
 
-                let Some(lvt) = self
-                    .set_lvt(latest_snapshot, ctx.as_ref(), retention_period)
-                    .await?
-                else {
+                let Some(latest_ts) = latest_snapshot.timestamp else {
+                    info!("Latest snapshot has no timestamp, stopping vacuum");
                     return Ok(None);
                 };
+                if !is_uuid_v7(&latest_snapshot.snapshot_id) {
+                    info!(
+                        "Latest snapshot is not v7, stopping vacuum: {:?}",
+                        latest_snapshot.snapshot_id
+                    );
+                    return Ok(None);
+                }
+                let lvt_candidate = retention_cutoff(Utc::now(), latest_ts, retention_period);
+                let lvt = std::cmp::max(observed_lvt_value.time, lvt_candidate);
+                lvt_to_publish = Some(LeastVisibleTime::new(lvt));
 
-                respect_flash_back_with_lvt = flashback_gc_root_lvt(respect_flash_back, lvt);
+                if let Some(lvt) = flashback_gc_root_lvt(must_follow_live_chain, lvt) {
+                    let latest_location = self.snapshot_loc().unwrap();
+                    let gc_root = self
+                        .find_location(ctx, latest_location, |snapshot| {
+                            is_snapshot_at_or_before_lvt(snapshot.timestamp, lvt)
+                        })
+                        .await
+                        .ok();
+                    let Some(gc_root) = gc_root else {
+                        info!("no gc_root found on live snapshot chain, stop vacuuming");
+                        return Ok(None);
+                    };
+                    live_chain_gc_root = Some(gc_root);
+                }
 
                 ctx.set_status_info(&format!(
                     "Set LVT for table {}, elapsed: {:?}, LVT: {:?}",
@@ -527,6 +599,11 @@ impl FuseTable {
                         None,
                     )
                     .await?
+                } else if let Some(gc_root) = live_chain_gc_root.as_ref() {
+                    // Use the exact live root path so it is included even if another UUID-v7
+                    // snapshot has the same millisecond timestamp.
+                    self.list_files_until_prefix(snapshot_location_prefix, gc_root, true, None)
+                        .await?
                 } else {
                     self.list_files_until_timestamp(snapshot_location_prefix, lvt, true, None)
                         .await?
@@ -539,36 +616,61 @@ impl FuseTable {
                 );
                 // List the snapshot order by timestamp asc, till the current snapshot(inclusively).
                 let need_one_more = true;
-                let mut snapshots = self
-                    .list_files_until_prefix(
+                if must_follow_live_chain {
+                    let snapshots_io = SnapshotsIO::create(ctx.clone(), self.get_operator());
+                    let chained = snapshots_io
+                        .read_chained_snapshot_lites(
+                            self.get_operator(),
+                            self.meta_location_generator().clone(),
+                            self.snapshot_loc().unwrap(),
+                            Some(num_snapshots_to_keep + 1),
+                        )
+                        .await?;
+                    if chained.len() <= num_snapshots_to_keep {
+                        return Ok(None);
+                    }
+                    let root = &chained[num_snapshots_to_keep - 1];
+                    let root_path = self
+                        .meta_location_generator()
+                        .gen_snapshot_location(&root.snapshot_id, root.format_version)?;
+                    live_chain_gc_root = Some(root_path.clone());
+                    self.list_files_until_prefix(
                         snapshot_location_prefix,
-                        // Safe to unwrap here: we have checked that `fuse_table` has a snapshot
-                        self.snapshot_loc().unwrap().as_str(),
+                        &root_path,
                         need_one_more,
                         None,
                     )
-                    .await?;
-                let len = snapshots.len();
-                if len <= num_snapshots_to_keep {
-                    // Only the current snapshot is there, done
-                    return Ok(None);
-                }
-                if num_snapshots_to_keep == 1 {
-                    // Expecting only one snapshot left, which means that we can use the current snapshot
-                    // as gc root, this flag will be propagated to the select_gc_root func later.
-                    is_vacuum_all = true;
-                }
-                need_update_lvt = true;
+                    .await?
+                } else {
+                    let mut snapshots = self
+                        .list_files_until_prefix(
+                            snapshot_location_prefix,
+                            // Safe to unwrap here: we have checked that `fuse_table` has a snapshot
+                            self.snapshot_loc().unwrap().as_str(),
+                            need_one_more,
+                            None,
+                        )
+                        .await?;
+                    let len = snapshots.len();
+                    if len <= num_snapshots_to_keep {
+                        // Only the current snapshot is there, done
+                        return Ok(None);
+                    }
+                    if num_snapshots_to_keep == 1 {
+                        // Expecting only one snapshot left, which means that we can use the current snapshot
+                        // as gc root, this flag will be propagated to the select_gc_root func later.
+                        is_vacuum_all = true;
+                    }
 
-                // When selecting the GC root later, the last snapshot in `snapshots` (after truncation)
-                // is the candidate, but its commit status is uncertain, so its previous snapshot is used
-                // as the GC root instead (except in the is_vacuum_all case).
-
-                // Therefore, during snapshot truncation, we keep 2 extra snapshots;
-                // see `select_gc_root` for details.
-                let num_candidates = len - num_snapshots_to_keep + 2;
-                snapshots.truncate(num_candidates);
-                snapshots
+                    // When selecting the GC root later, the last snapshot in `snapshots` (after truncation)
+                    // is the candidate, but its commit status is uncertain, so its previous snapshot is used
+                    // as the GC root instead (except in the is_vacuum_all case).
+                    // Therefore, during snapshot truncation, we keep 2 extra snapshots;
+                    // see `select_gc_root` for details.
+                    let num_candidates = len - num_snapshots_to_keep + 2;
+                    snapshots.truncate(num_candidates);
+                    snapshots
+                }
             }
         };
 
@@ -582,24 +684,38 @@ impl FuseTable {
         ));
 
         let Some(selection) = self
-            .select_gc_root(
-                ctx,
-                &snapshots_before_lvt,
-                is_vacuum_all,
-                respect_flash_back_with_lvt,
-            )
+            .select_gc_root(&snapshots_before_lvt, is_vacuum_all, live_chain_gc_root)
             .await?
         else {
             return Ok(None);
         };
 
-        if need_update_lvt {
-            let cat = ctx.get_default_catalog()?;
-            cat.set_table_lvt(
-                &LeastVisibleTimeIdent::new(ctx.get_tenant(), self.get_id()),
-                &LeastVisibleTime::new(selection.gc_root.timestamp.unwrap()),
+        let mut selection = selection;
+        selection.clear_flashback_barrier = flashback_barrier.is_some_and(|barrier| {
+            selection
+                .gc_root
+                .timestamp
+                .is_some_and(|timestamp| timestamp > barrier + ASSUMPTION_MAX_TXN_DURATION)
+        });
+
+        let lvt_to_publish = lvt_to_publish.unwrap_or_else(|| {
+            LeastVisibleTime::new(
+                selection
+                    .gc_root
+                    .timestamp
+                    .expect("v7 GC root has timestamp"),
             )
-            .await?;
+        });
+        if catalog
+            .set_table_lvt_with_seq(&lvt_ident, &lvt_to_publish, observed_lvt_seq)
+            .await?
+            .is_none()
+        {
+            info!(
+                "LVT changed while selecting gc_root for table {}, stop vacuuming",
+                self.table_info.desc
+            );
+            return Ok(None);
         }
 
         ctx.set_status_info(&format!(
@@ -614,27 +730,15 @@ impl FuseTable {
 
     async fn select_gc_root(
         &self,
-        ctx: &Arc<dyn TableContext>,
         snapshots_before_lvt: &[Entry],
         is_vacuum_all: bool,
-        respect_flash_back: Option<DateTime<Utc>>,
+        live_chain_gc_root: Option<String>,
     ) -> Result<Option<SnapshotGcSelection>> {
         let op = self.get_operator();
         let gc_root_path = if is_vacuum_all {
             // safe to unwrap, or we should have stopped vacuuming in set_lvt()
             self.snapshot_loc().unwrap()
-        } else if let Some(lvt) = respect_flash_back {
-            let latest_location = self.snapshot_loc().unwrap();
-            let gc_root = self
-                .find_location(ctx, latest_location, |snapshot| {
-                    is_snapshot_at_or_before_lvt(snapshot.timestamp, lvt)
-                })
-                .await
-                .ok();
-            let Some(gc_root) = gc_root else {
-                info!("no gc_root found, stop vacuuming");
-                return Ok(None);
-            };
+        } else if let Some(gc_root) = live_chain_gc_root {
             gc_root
         } else {
             if snapshots_before_lvt.is_empty() {
@@ -723,6 +827,8 @@ impl FuseTable {
                     snapshots_to_gc,
                     gc_root_meta_ts,
                     gc_root_path,
+                    clear_flashback_barrier: false,
+                    table_seq: self.table_info.ident.seq,
                 }))
             }
             Err(e) => {
@@ -730,37 +836,6 @@ impl FuseTable {
                 Ok(None)
             }
         }
-    }
-
-    /// Try set lvt as min(latest_snapshot.timestamp, now - retention_time).
-    ///
-    /// Return `None` means we stop vacuuming, but don't want to report error to user.
-    pub async fn set_lvt(
-        &self,
-        latest_snapshot: Arc<TableSnapshot>,
-        ctx: &dyn TableContext,
-        retention_period: TimeDelta,
-    ) -> Result<Option<DateTime<Utc>>> {
-        if !is_uuid_v7(&latest_snapshot.snapshot_id) {
-            info!(
-                "Latest snapshot is not v7, stopping vacuum: {:?}",
-                latest_snapshot.snapshot_id
-            );
-            return Ok(None);
-        }
-        let catalog = ctx.get_default_catalog()?;
-        // safe to unwrap, as we have checked the version is v4
-        let latest_ts = latest_snapshot.timestamp.unwrap();
-        let lvt_point_candidate = retention_cutoff(Utc::now(), latest_ts, retention_period);
-
-        let lvt_point = catalog
-            .set_table_lvt(
-                &LeastVisibleTimeIdent::new(ctx.get_tenant(), self.get_id()),
-                &LeastVisibleTime::new(lvt_point_candidate),
-            )
-            .await?
-            .time;
-        Ok(Some(lvt_point))
     }
 }
 

--- a/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0020_vacuum2_flashback_live_chain.test
+++ b/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0020_vacuum2_flashback_live_chain.test
@@ -1,0 +1,67 @@
+statement ok
+DROP DATABASE IF EXISTS vacuum2_flashback_live_chain
+
+statement ok
+CREATE DATABASE vacuum2_flashback_live_chain
+
+# Zero time retention makes blocks use their snapshot time as the object-key cutoff. Keeping four
+# snapshots is deliberately larger than the post-flashback live chain, but smaller than the number
+# of files across both branches.
+statement ok
+SET data_retention_time_in_days = 0
+
+statement ok
+CREATE TABLE vacuum2_flashback_live_chain.t(c INT) DATA_RETENTION_NUM_SNAPSHOTS_TO_KEEP = 4
+
+# A owns the block that must remain live after flashback.
+statement ok
+INSERT INTO vacuum2_flashback_live_chain.t VALUES (1)
+
+statement ok
+SET VARIABLE first_snapshot_id = (
+    SELECT snapshot_id
+    FROM fuse_snapshot('vacuum2_flashback_live_chain', 't')
+    WHERE row_count = 1
+    LIMIT 1
+)
+
+# B drops A's block, and C makes B provably committed to the old list+prev optimization.
+statement ok
+TRUNCATE TABLE vacuum2_flashback_live_chain.t
+
+statement ok
+INSERT INTO vacuum2_flashback_live_chain.t VALUES (2)
+
+statement ok
+ALTER TABLE vacuum2_flashback_live_chain.t FLASHBACK TO (SNAPSHOT => $first_snapshot_id)
+
+# The live chain is A-D-E (three snapshots), while the snapshot directory is A-B-C-D-E.
+statement ok
+INSERT INTO vacuum2_flashback_live_chain.t VALUES (4)
+
+statement ok
+INSERT INTO vacuum2_flashback_live_chain.t VALUES (5)
+
+# Before the fix, keeping four directory entries selects C as the anchor and B as the GC root.
+# Since B is the truncate snapshot and does not protect A's block, Vacuum2 deletes live data.
+# With the flashback barrier, snapshot counting follows A-D-E and stops without vacuuming.
+statement ok
+SELECT * FROM fuse_vacuum2('vacuum2_flashback_live_chain', 't', false) ignore_result
+
+query I
+SELECT c FROM vacuum2_flashback_live_chain.t ORDER BY c
+----
+1
+4
+5
+
+query I
+SELECT count(*) FROM fuse_snapshot('vacuum2_flashback_live_chain', 't')
+----
+3
+
+statement ok
+UNSET data_retention_time_in_days
+
+statement ok
+DROP DATABASE vacuum2_flashback_live_chain

--- a/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0020_vacuum2_flashback_live_chain.test
+++ b/tests/sqllogictests/suites/ee/03_ee_vacuum/03_0020_vacuum2_flashback_live_chain.test
@@ -60,6 +60,25 @@ SELECT count(*) FROM fuse_snapshot('vacuum2_flashback_live_chain', 't')
 ----
 3
 
+# Once the live chain exceeds retention, vacuum must actually collect history safely.
+statement ok
+ALTER TABLE vacuum2_flashback_live_chain.t SET OPTIONS(DATA_RETENTION_NUM_SNAPSHOTS_TO_KEEP = 2)
+
+statement ok
+VACUUM TABLE vacuum2_flashback_live_chain.t
+
+query I
+SELECT c FROM vacuum2_flashback_live_chain.t ORDER BY c
+----
+1
+4
+5
+
+query I
+SELECT count(*) FROM fuse_snapshot('vacuum2_flashback_live_chain', 't')
+----
+2
+
 statement ok
 UNSET data_retention_time_in_days
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Prevent Vacuum2 from selecting a GC root from an abandoned snapshot branch after `FLASHBACK`.
- Make the flashback target's least-visible-time validation part of the same metadata transaction as the table update.
- Preserve the fast directory-based GC root selection path for tables that have not been flashed back.

After `FLASHBACK`, the snapshot directory can contain both the active lineage and an abandoned committed branch:

```text
before flashback: C -> B -> A
after flashback:  E -> D -> A
listed objects:   A, B, C, D, E
```

For snapshot-count retention, directory-based selection could choose `B` from the abandoned branch as the GC root. If `B` is a truncate snapshot, its protection set does not contain segments still referenced by the live `E -> D -> A` chain. With zero time retention, Vacuum2 could consequently delete a segment referenced by the current snapshot.

This PR:

- records an internal, monotonic `vacuum2_flashback_barrier` table option during flashback;
- derives time- and snapshot-count GC roots from the current snapshot lineage while the barrier is active;
- validates the flashback target against table LVT atomically in `UpdateTableMetaReq`;
- clears an expired barrier only after a successful vacuum, using an exact table-sequence match so concurrent updates retain the conservative path;
- keeps existing directory-based selection unchanged when no barrier exists.

The internal barrier may make post-flashback vacuum more conservative until a live-chain GC root advances beyond the transaction safety window. It requires no user migration or backfill.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent assisted with root-cause analysis, implementation review, regression test drafting, validation, and the PR description.
- Responsible human: @zhyass
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20436)
<!-- Reviewable:end -->
