### PR TITLE
refactor(storage): prepare range index domains once

### DIFF
--- a/src/query/storages/common/index/Cargo.toml
+++ b/src/query/storages/common/index/Cargo.toml
@@ -72,5 +72,9 @@ rand = { workspace = true }
 name = "build_from_block"
 harness = false
 
+[[bench]]
+name = "range_index_apply"
+harness = false
+
 [lints]
 workspace = true

--- a/src/query/storages/common/index/benches/range_index_apply.rs
+++ b/src/query/storages/common/index/benches/range_index_apply.rs
@@ -1,0 +1,236 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn main() {
+    divan::main();
+}
+
+/// Benchmark the per-block cost of `RangeIndex::apply`.
+///
+/// The workload mirrors a production pruning scenario: a table clustered by
+/// `site_code`, blocks carrying statistics for 27 columns, and a pushed-down
+/// filter `site_code = '2815' AND contains([N x int64], account)` evaluated
+/// against 930 blocks of which only 3 survive range pruning.
+///
+/// 927 of 930 blocks short-circuit on the first conjunct, so the IN list is
+/// never evaluated on that path; benches are parameterized over the IN size
+/// (200 = production shape, 2000 = 10x) to make that visible.
+#[divan::bench_group(max_time = 2)]
+mod range_index_apply {
+    use std::sync::Arc;
+
+    use databend_common_expression::ColumnRef;
+    use databend_common_expression::Constant;
+    use databend_common_expression::Expr;
+    use databend_common_expression::FromData;
+    use databend_common_expression::FunctionContext;
+    use databend_common_expression::Scalar;
+    use databend_common_expression::TableDataType;
+    use databend_common_expression::TableField;
+    use databend_common_expression::TableSchema;
+    use databend_common_expression::type_check::check_function;
+    use databend_common_expression::types::DataType;
+    use databend_common_expression::types::Int64Type;
+    use databend_common_expression::types::NumberDataType;
+    use databend_common_functions::BUILTIN_FUNCTIONS;
+    use databend_storages_common_index::RangeIndex;
+    use databend_storages_common_table_meta::meta::ColumnStatistics;
+    use databend_storages_common_table_meta::meta::StatisticsOfColumns;
+
+    const BLOCKS: usize = 930;
+    const MATCHING_BLOCKS: usize = 3;
+    /// Column count of the production MV; every block carries statistics for
+    /// all of them even though the predicate only references two.
+    const STAT_COLUMNS: usize = 27;
+    const IN_SIZES: [usize; 2] = [200, 2000];
+
+    fn schema() -> Arc<TableSchema> {
+        let mut fields = vec![
+            TableField::new("site_code", TableDataType::String),
+            TableField::new("account", TableDataType::Number(NumberDataType::Int64)),
+        ];
+        for i in 0..STAT_COLUMNS - 2 {
+            fields.push(TableField::new(
+                &format!("m{i}"),
+                TableDataType::Number(NumberDataType::Int64),
+            ));
+        }
+        Arc::new(TableSchema::new(fields))
+    }
+
+    /// `site_code = '2815' and contains([..in_len ids..], account)`, combined
+    /// with `and_filters` exactly like the storage pushdown does.
+    fn predicate(in_len: usize) -> Expr<String> {
+        let site_code = Expr::ColumnRef(ColumnRef {
+            span: None,
+            id: "site_code".to_string(),
+            data_type: DataType::String,
+            display_name: "site_code".to_string(),
+        });
+        let account = Expr::ColumnRef(ColumnRef {
+            span: None,
+            id: "account".to_string(),
+            data_type: DataType::Number(NumberDataType::Int64),
+            display_name: "account".to_string(),
+        });
+        let target = Expr::Constant(Constant {
+            span: None,
+            scalar: Scalar::String("2815".to_string()),
+            data_type: DataType::String,
+        });
+        let ids: Vec<i64> = (0..in_len as i64)
+            .map(|i| 100_000_000 + i * 4_000_000)
+            .collect();
+        let in_list = Expr::Constant(Constant {
+            span: None,
+            scalar: Scalar::Array(Int64Type::from_data(ids)),
+            data_type: DataType::Array(Box::new(DataType::Number(NumberDataType::Int64))),
+        });
+
+        let eq = check_function(None, "eq", &[], &[site_code, target], &BUILTIN_FUNCTIONS).unwrap();
+        let contains = check_function(
+            None,
+            "contains",
+            &[],
+            &[in_list, account],
+            &BUILTIN_FUNCTIONS,
+        )
+        .unwrap();
+        check_function(
+            None,
+            "and_filters",
+            &[],
+            &[eq, contains],
+            &BUILTIN_FUNCTIONS,
+        )
+        .unwrap()
+    }
+
+    /// Statistics for all 27 columns per block, like a production BlockMeta.
+    fn block_stats(schema: &TableSchema) -> Vec<StatisticsOfColumns> {
+        let site_code_id = schema.leaf_columns_of(&"site_code".to_string())[0];
+        (0..BLOCKS)
+            .map(|i| {
+                // Clustered layout: only the first MATCHING_BLOCKS blocks cover '2815'.
+                let (min, max) = if i < MATCHING_BLOCKS {
+                    ("2800".to_string(), "2900".to_string())
+                } else {
+                    (format!("{:04}", 3000 + i), format!("{:04}", 3001 + i))
+                };
+                let mut stats = StatisticsOfColumns::default();
+                stats.insert(
+                    site_code_id,
+                    ColumnStatistics::new(Scalar::String(min), Scalar::String(max), 0, 0, None),
+                );
+                for field in schema.fields().iter().skip(1) {
+                    stats.insert(
+                        field.column_id(),
+                        ColumnStatistics::new(
+                            Scalar::Number(100_000_000i64.into()),
+                            Scalar::Number(999_999_999i64.into()),
+                            0,
+                            0,
+                            None,
+                        ),
+                    );
+                }
+                stats
+            })
+            .collect()
+    }
+
+    fn build_index(in_len: usize) -> (RangeIndex, Vec<StatisticsOfColumns>) {
+        let schema = schema();
+        let expr = predicate(in_len);
+        let index = RangeIndex::try_create(
+            FunctionContext::default(),
+            &expr,
+            schema.clone(),
+            Default::default(),
+        )
+        .unwrap();
+        let blocks = block_stats(&schema);
+        let kept = blocks
+            .iter()
+            .filter(|stats| index.apply(stats, None, |_| false).unwrap())
+            .count();
+        assert_eq!(kept, MATCHING_BLOCKS);
+        (index, blocks)
+    }
+
+    /// A full sweep over 930 blocks: the wall time the pruner spends on
+    /// `should_keep` for one segment of this shape (production IN size).
+    #[divan::bench]
+    fn sweep_930_blocks(bencher: divan::Bencher) {
+        let (index, blocks) = build_index(200);
+        bencher.bench(|| {
+            let mut kept = 0usize;
+            for stats in &blocks {
+                if index
+                    .apply(divan::black_box(stats), None, |_| false)
+                    .unwrap()
+                {
+                    kept += 1;
+                }
+            }
+            assert_eq!(kept, MATCHING_BLOCKS);
+            kept
+        });
+    }
+
+    /// Per-block cost when the first conjunct short-circuits (927 of 930
+    /// blocks). The IN list must not affect this path.
+    #[divan::bench(args = IN_SIZES)]
+    fn single_block_short_circuit(bencher: divan::Bencher, in_len: usize) {
+        let (index, blocks) = build_index(in_len);
+        let stats = blocks.last().unwrap();
+        assert!(!index.apply(stats, None, |_| false).unwrap());
+        bencher.bench(|| {
+            index
+                .apply(divan::black_box(stats), None, |_| false)
+                .unwrap()
+        });
+    }
+
+    /// Per-block cost when the block survives and the full predicate,
+    /// including the IN list, is evaluated.
+    #[divan::bench(args = IN_SIZES)]
+    fn single_block_kept(bencher: divan::Bencher, in_len: usize) {
+        let (index, blocks) = build_index(in_len);
+        let stats = blocks.first().unwrap();
+        assert!(index.apply(stats, None, |_| false).unwrap());
+        bencher.bench(|| {
+            index
+                .apply(divan::black_box(stats), None, |_| false)
+                .unwrap()
+        });
+    }
+
+    /// Cost of building the index itself; work moved from `apply` to
+    /// `try_create` must stay visible here.
+    #[divan::bench(args = IN_SIZES)]
+    fn try_create(bencher: divan::Bencher, in_len: usize) {
+        let schema = schema();
+        let expr = predicate(in_len);
+        bencher.bench(|| {
+            RangeIndex::try_create(
+                FunctionContext::default(),
+                divan::black_box(&expr),
+                schema.clone(),
+                Default::default(),
+            )
+            .unwrap()
+        });
+    }
+}

--- a/src/query/storages/common/index/src/eliminate_cast.rs
+++ b/src/query/storages/common/index/src/eliminate_cast.rs
@@ -133,7 +133,7 @@ impl RewriteVisitor<'_> {
         column: &ColumnRef<String>,
         expr: &Expr<String>,
     ) -> RewriteResult {
-        let Some(constant) = self.constant_from_expr(expr) else {
+        let Some(constant) = constant_from_expr(self.func_ctx, expr) else {
             return Ok(None);
         };
         let Some(scalar) = cast_integer_string_constant(
@@ -170,24 +170,6 @@ impl RewriteVisitor<'_> {
             .0
             .into_owned(),
         ))
-    }
-
-    fn constant_from_expr(&self, expr: &Expr<String>) -> Option<Constant> {
-        match expr {
-            Expr::Constant(constant) => Some(constant.clone()),
-            Expr::Cast(cast) if !cast.is_try => {
-                let Expr::Constant(constant) = cast.expr.as_ref() else {
-                    return None;
-                };
-                let scalar = cast_const(self.func_ctx, cast.dest_type.clone(), constant.clone())?;
-                Some(Constant {
-                    span: None,
-                    scalar,
-                    data_type: cast.dest_type.clone(),
-                })
-            }
-            _ => None,
-        }
     }
 
     fn check_no_throw(&self, cast: &Cast<String>) -> bool {
@@ -231,6 +213,81 @@ pub(super) fn cast_const(
     domain.as_singleton()
 }
 
+fn constant_from_expr(func_ctx: &FunctionContext, expr: &Expr<String>) -> Option<Constant> {
+    match expr {
+        Expr::Constant(constant) => Some(constant.clone()),
+        Expr::Cast(cast) if !cast.is_try => {
+            let Expr::Constant(constant) = cast.expr.as_ref() else {
+                return None;
+            };
+            let scalar = cast_const(func_ctx, cast.dest_type.clone(), constant.clone())?;
+            Some(Constant {
+                span: None,
+                scalar,
+                data_type: cast.dest_type.clone(),
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Statically detect whether `expr` contains any pattern that
+/// [`RewriteVisitor`] could rewrite, so that per-block pruning can skip the
+/// rewrite pass when there is provably nothing to rewrite.
+///
+/// This mirrors the domain-independent prefix of the rewrite rules:
+/// - `eq(cast(..), constant)` (either order) with a non-try cast counts as a
+///   candidate; the remaining conditions (`check_no_throw`) depend on
+///   per-block domains, so any such pair is conservatively kept.
+/// - `eq(integer_column, string_constant)` (either order) is a candidate only
+///   when the constant parses as the column's integer type; those conditions
+///   are all domain-independent and are replayed here exactly.
+///
+/// `true` means "the visitor must run per block". False positives merely lose
+/// the optimization, while a false negative would change pruning results, so
+/// every domain-dependent condition is treated as potentially satisfied.
+pub(super) fn has_rewrite_candidates(func_ctx: &FunctionContext, expr: &Expr<String>) -> bool {
+    let mut stack = vec![expr];
+    while let Some(expr) = stack.pop() {
+        match expr {
+            Expr::FunctionCall(call) => {
+                if call.id.name() == "eq" && is_rewrite_candidate_eq(func_ctx, call) {
+                    return true;
+                }
+                stack.extend(call.args.iter());
+            }
+            Expr::Cast(cast) => stack.push(&cast.expr),
+            // The rewrite visitor only walks lambda arguments, not the lambda body.
+            Expr::LambdaFunctionCall(lambda) => stack.extend(lambda.args.iter()),
+            Expr::Constant(_) | Expr::ColumnRef(_) => {}
+        }
+    }
+    false
+}
+
+fn is_rewrite_candidate_eq(func_ctx: &FunctionContext, call: &FunctionCall<String>) -> bool {
+    match call.args.as_slice() {
+        [Expr::Cast(cast), Expr::Constant(_)] | [Expr::Constant(_), Expr::Cast(cast)] => {
+            // Both `check_no_throw` and `try_rewrite` bail out on try-casts
+            // before consulting domains.
+            !cast.is_try
+        }
+        [Expr::ColumnRef(column), expr] | [expr, Expr::ColumnRef(column)] => {
+            match constant_from_expr(func_ctx, expr) {
+                Some(constant) => cast_integer_string_constant(
+                    func_ctx,
+                    &column.data_type,
+                    &constant.data_type,
+                    &constant.scalar,
+                )
+                .is_some(),
+                None => false,
+            }
+        }
+        _ => false,
+    }
+}
+
 fn cast_integer_string_constant(
     func_ctx: &FunctionContext,
     column_type: &DataType,
@@ -270,10 +327,11 @@ fn string_scalar_parses_as_integer_type(scalar: &Scalar, num_ty: &NumberDataType
 pub fn eliminate_cast(
     expr: &Expr<String>,
     input_domains: HashMap<String, Domain>,
+    func_ctx: &FunctionContext,
 ) -> Option<Expr<String>> {
     let mut visitor = RewriteVisitor {
         input_domains,
-        func_ctx: &FunctionContext::default(),
+        func_ctx,
         fn_registry: &BUILTIN_FUNCTIONS,
     };
 

--- a/src/query/storages/common/index/src/range_index.rs
+++ b/src/query/storages/common/index/src/range_index.rs
@@ -70,6 +70,25 @@ pub struct RangeIndex {
     // Default stats for each column if no stats are available (e.g. for new-add columns)
     default_stats: StatisticsOfColumns,
     predicates: Vec<SpatialPredicate>,
+
+    /// Per-column domain sources resolved once from the immutable expression
+    /// and schema, so that each `apply` call avoids re-walking the expression
+    /// tree and re-scanning the schema for every block.
+    column_slots: Vec<ColumnDomainSlot>,
+    /// Whether the expression contains any pattern that the cast-elimination
+    /// rewrite could apply to. When false, `apply` skips the rewrite pass.
+    has_rewrite_candidates: bool,
+}
+
+/// The precomputed domain source for one column referenced by the pruning
+/// expression.
+#[derive(Clone)]
+struct ColumnDomainSlot {
+    name: String,
+    data_type: DataType,
+    /// Leaf column ids resolved from the table schema. `None` when the domain
+    /// is always full: internal/stream columns and virtual columns.
+    leaf_column_ids: Option<Vec<ColumnId>>,
 }
 
 impl RangeIndex {
@@ -83,13 +102,67 @@ impl RangeIndex {
             Some(result) => (result.expr, result.predicates),
             None => (expr.clone(), Vec::new()),
         };
-        Ok(Self {
+        Ok(Self::create_from_parts(
             expr,
             func_ctx,
             schema,
             default_stats,
             predicates,
-        })
+        ))
+    }
+
+    fn create_from_parts(
+        expr: Expr<String>,
+        func_ctx: FunctionContext,
+        schema: TableSchemaRef,
+        default_stats: StatisticsOfColumns,
+        predicates: Vec<SpatialPredicate>,
+    ) -> Self {
+        // Hoist domain-independent rewrites (e.g. `int_col = '123'` =>
+        // `int_col = 123`) out of the per-block path by running the rewrite
+        // pass once with full input domains. A rewrite accepted under full
+        // domains is valid for every block; rewrites that full domains cannot
+        // prove safe (overflow-checked cast elimination) keep their candidate
+        // pattern in the expression and are retried per block through
+        // `has_rewrite_candidates` below, so pruning results are unchanged.
+        let expr = if has_rewrite_candidates(&func_ctx, &expr) {
+            let mut full_domains = HashMap::new();
+            for (name, ty) in expr.column_refs() {
+                full_domains.insert(name, Domain::full(&ty));
+            }
+            match eliminate_cast(&expr, full_domains, &func_ctx) {
+                Some(rewritten) => rewritten,
+                None => expr,
+            }
+        } else {
+            expr
+        };
+
+        let mut column_slots = Vec::new();
+        for (name, data_type) in expr.column_refs() {
+            // Internal/stream columns are not stored; virtual columns have no leaf IDs.
+            let leaf_column_ids = if is_internal_column(&name) || is_stream_column(&name) {
+                None
+            } else {
+                let column_ids = schema.leaf_columns_of(&name);
+                (!column_ids.is_empty()).then_some(column_ids)
+            };
+            column_slots.push(ColumnDomainSlot {
+                name,
+                data_type,
+                leaf_column_ids,
+            });
+        }
+        let has_rewrite_candidates = has_rewrite_candidates(&func_ctx, &expr);
+        Self {
+            expr,
+            func_ctx,
+            schema,
+            default_stats,
+            predicates,
+            column_slots,
+            has_rewrite_candidates,
+        }
     }
 
     pub fn try_apply_const(&self) -> Result<bool> {
@@ -112,62 +185,51 @@ impl RangeIndex {
     where
         F: Fn(&ColumnId) -> bool,
     {
-        let mut input_domains: HashMap<String, Domain> = self
-            .expr
-            .column_refs()
-            .into_iter()
-            .map(|(name, ty)| {
-                // internal column and stream column are not actual stored columns
-                if is_internal_column(&name) || is_stream_column(&name) {
-                    return Ok((name, Domain::full(&ty)));
-                }
-
-                let column_ids = self.schema.leaf_columns_of(&name);
-                // virtual columns are not included in leaf columns
-                // TODO: add range filter for virtual columns
-                if column_ids.is_empty() {
-                    return Ok((name, Domain::full(&ty)));
-                }
-
-                let stats = column_ids
-                    .iter()
-                    .filter_map(|column_id| match stats.get(column_id) {
-                        None => {
-                            if column_is_default(column_id)
-                                && self.default_stats.contains_key(column_id)
-                            {
-                                Some(&self.default_stats[column_id])
-                            } else {
-                                None
+        let mut input_domains: HashMap<String, Domain> =
+            HashMap::with_capacity(self.column_slots.len());
+        for slot in &self.column_slots {
+            let domain = match &slot.leaf_column_ids {
+                None => Domain::full(&slot.data_type),
+                Some(column_ids) => {
+                    let mut column_stats = Vec::with_capacity(column_ids.len());
+                    for column_id in column_ids {
+                        if let Some(stat) = stats.get(column_id) {
+                            column_stats.push(stat);
+                        } else if column_is_default(column_id) {
+                            if let Some(stat) = self.default_stats.get(column_id) {
+                                column_stats.push(stat);
                             }
                         }
-                        other => other,
-                    })
-                    .collect();
-
-                let domain = statistics_to_domain(stats, &ty);
-                Ok((name, domain))
-            })
-            .collect::<Result<_>>()?;
+                    }
+                    statistics_to_domain(column_stats, &slot.data_type)
+                }
+            };
+            input_domains.insert(slot.name.clone(), domain);
+        }
 
         for (name, domain) in self.spatial_predicate_domains(spatial_stats) {
             input_domains.insert(name, domain);
         }
 
-        let mut visitor = RewriteVisitor {
-            input_domains,
-            func_ctx: &self.func_ctx,
-            fn_registry: &BUILTIN_FUNCTIONS,
-        };
+        let (expr, input_domains) = if self.has_rewrite_candidates {
+            let mut visitor = RewriteVisitor {
+                input_domains,
+                func_ctx: &self.func_ctx,
+                fn_registry: &BUILTIN_FUNCTIONS,
+            };
 
-        let expr = match visit_expr(&self.expr, &mut visitor).unwrap() {
-            Some(expr) => Cow::Owned(expr),
-            None => Cow::Borrowed(&self.expr),
+            let expr = match visit_expr(&self.expr, &mut visitor).unwrap() {
+                Some(expr) => Cow::Owned(expr),
+                None => Cow::Borrowed(&self.expr),
+            };
+            (expr, visitor.input_domains)
+        } else {
+            (Cow::Borrowed(&self.expr), input_domains)
         };
 
         let (new_expr, _) = ConstantFolder::fold_with_domain(
             expr,
-            &visitor.input_domains,
+            &input_domains,
             &self.func_ctx,
             &BUILTIN_FUNCTIONS,
         );
@@ -189,13 +251,13 @@ impl RangeIndex {
         partition_columns: &HashMap<String, Scalar>,
     ) -> Result<bool> {
         let expr = self.expr.fill_const_column(partition_columns);
-        RangeIndex {
+        Self::create_from_parts(
             expr,
-            func_ctx: self.func_ctx.clone(),
-            schema: self.schema.clone(),
-            default_stats: self.default_stats.clone(),
-            predicates: self.predicates.clone(),
-        }
+            self.func_ctx.clone(),
+            self.schema.clone(),
+            self.default_stats.clone(),
+            self.predicates.clone(),
+        )
         .apply(stats, None, |_| false)
     }
 

--- a/src/query/storages/common/index/tests/it/eliminate_cast.rs
+++ b/src/query/storages/common/index/tests/it/eliminate_cast.rs
@@ -16,6 +16,7 @@ use std::io::Write;
 
 use databend_common_expression::Domain;
 use databend_common_expression::Expr;
+use databend_common_expression::FunctionContext;
 use databend_common_expression::Scalar;
 use databend_common_expression::type_check;
 use databend_common_expression::types::ArgType;
@@ -64,7 +65,7 @@ fn run_text(file: &mut impl Write, text: &str, ctx: &[(&str, DataType, Domain)])
         .iter()
         .map(|(name, _, domain)| (name.to_string(), domain.clone()))
         .collect();
-    match eliminate_cast(&expr, input_domains) {
+    match eliminate_cast(&expr, input_domains, &FunctionContext::default()) {
         Some(new_expr) => {
             writeln!(file, "rewrited  : {new_expr}").unwrap(); // typos:disable-line
         }

--- a/src/query/storages/common/index/tests/it/range_pruner.rs
+++ b/src/query/storages/common/index/tests/it/range_pruner.rs
@@ -24,6 +24,7 @@ use databend_common_expression::Constant;
 use databend_common_expression::ConstantFolder;
 use databend_common_expression::Domain;
 use databend_common_expression::Expr;
+use databend_common_expression::FromData;
 use databend_common_expression::FunctionContext;
 use databend_common_expression::Scalar;
 use databend_common_expression::TableDataType;
@@ -33,6 +34,7 @@ use databend_common_expression::type_check::check_function;
 use databend_common_expression::types::ArgType;
 use databend_common_expression::types::DataType;
 use databend_common_expression::types::Int32Type;
+use databend_common_expression::types::Int64Type;
 use databend_common_expression::types::NumberDataType;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_storages_common_index::RangeIndex;
@@ -180,7 +182,7 @@ fn test_range_index_keeps_nullable_boolean_cast_under_is_true() {
         .into_iter()
         .collect();
 
-    let rewritten_expr = eliminate_cast(&expr, input_domains).unwrap();
+    let rewritten_expr = eliminate_cast(&expr, input_domains, &FunctionContext::default()).unwrap();
     assert_eq!(rewritten_expr.data_type(), &DataType::Boolean);
     let index = RangeIndex::try_create(func_ctx.clone(), &expr, schema.clone(), Default::default())
         .unwrap();
@@ -190,6 +192,221 @@ fn test_range_index_keeps_nullable_boolean_cast_under_is_true() {
     let inverted_index =
         RangeIndex::try_create(func_ctx, &inverted_expr, schema, Default::default()).unwrap();
     assert!(inverted_index.apply(&stats, None, |_| false).unwrap());
+}
+
+#[test]
+fn test_range_index_plain_predicate_without_rewrite_candidates() {
+    // `site_code = '2815' and contains([1, 5, 9], account)` contains no
+    // cast-elimination candidate, so `apply` runs without the rewrite pass;
+    // pruning decisions must stay identical to the general path.
+    let func_ctx = FunctionContext::default();
+    let schema = Arc::new(TableSchema::new(vec![
+        TableField::new("site_code", TableDataType::String),
+        TableField::new("account", TableDataType::Number(NumberDataType::Int64)),
+    ]));
+
+    let site_code = Expr::ColumnRef(ColumnRef {
+        span: None,
+        id: "site_code".to_string(),
+        data_type: DataType::String,
+        display_name: "site_code".to_string(),
+    });
+    let account = Expr::ColumnRef(ColumnRef {
+        span: None,
+        id: "account".to_string(),
+        data_type: DataType::Number(NumberDataType::Int64),
+        display_name: "account".to_string(),
+    });
+    let target = Expr::Constant(Constant {
+        span: None,
+        scalar: Scalar::String("2815".to_string()),
+        data_type: DataType::String,
+    });
+    let in_list = Expr::Constant(Constant {
+        span: None,
+        scalar: Scalar::Array(Int64Type::from_data(vec![1i64, 5, 9])),
+        data_type: DataType::Array(Box::new(DataType::Number(NumberDataType::Int64))),
+    });
+    let eq = check_function(None, "eq", &[], &[site_code, target], &BUILTIN_FUNCTIONS).unwrap();
+    let contains = check_function(
+        None,
+        "contains",
+        &[],
+        &[in_list, account],
+        &BUILTIN_FUNCTIONS,
+    )
+    .unwrap();
+    let expr = check_function(
+        None,
+        "and_filters",
+        &[],
+        &[eq, contains],
+        &BUILTIN_FUNCTIONS,
+    )
+    .unwrap();
+
+    let index =
+        RangeIndex::try_create(func_ctx, &expr, schema.clone(), Default::default()).unwrap();
+
+    let site_code_id = schema.leaf_columns_of(&"site_code".to_string())[0];
+    let account_id = schema.leaf_columns_of(&"account".to_string())[0];
+    let make_stats = |site_min: &str, site_max: &str, account_min: i64, account_max: i64| {
+        let mut stats = StatisticsOfColumns::default();
+        stats.insert(
+            site_code_id,
+            ColumnStatistics::new(
+                Scalar::String(site_min.to_string()),
+                Scalar::String(site_max.to_string()),
+                0,
+                0,
+                None,
+            ),
+        );
+        stats.insert(
+            account_id,
+            ColumnStatistics::new(
+                Scalar::Number(account_min.into()),
+                Scalar::Number(account_max.into()),
+                0,
+                0,
+                None,
+            ),
+        );
+        stats
+    };
+
+    // Pruned by the first conjunct: '2815' is outside [3000, 3100].
+    let stats = make_stats("3000", "3100", 0, 100);
+    assert!(!index.apply(&stats, None, |_| false).unwrap());
+    // Kept: both conjuncts overlap the block ranges.
+    let stats = make_stats("2800", "2900", 0, 100);
+    assert!(index.apply(&stats, None, |_| false).unwrap());
+    // Pruned by the second conjunct: [1000, 2000] misses every in-list value.
+    let stats = make_stats("2800", "2900", 1000, 2000);
+    assert!(!index.apply(&stats, None, |_| false).unwrap());
+}
+
+#[test]
+fn test_range_index_rewrites_candidates_nested_under_and() {
+    // The rewrite candidates sit below `and`; the candidate detection must
+    // find them so the rewrite pass still runs and prunes the block.
+    fn n(n: i32) -> Scalar {
+        Scalar::Number(n.into())
+    }
+
+    let fields = vec![
+        TableField::new("a", TableDataType::Number(NumberDataType::Int32)),
+        TableField::new("b", TableDataType::Number(NumberDataType::Int32)),
+    ];
+    let schema = Arc::new(TableSchema::new(fields));
+    let stats = create_stats(&[("a", n(-2), n(3)), ("b", n(-2), n(3))], &schema);
+    let columns = [("a", Int32Type::data_type()), ("b", Int32Type::data_type())];
+
+    // `a = '4'` rewrites to `a = 4`, which is outside [-2, 3].
+    for text in ["b = 1 and a = '4'", "b = 1 and to_string(a) = '4'"] {
+        let expr = parse_expr(text, &columns);
+        let index = RangeIndex::try_create(
+            FunctionContext::default(),
+            &expr,
+            schema.clone(),
+            Default::default(),
+        )
+        .unwrap();
+        assert!(
+            !index.apply(&stats, None, |_| false).unwrap(),
+            "{text} should prune the block"
+        );
+    }
+}
+
+#[test]
+fn test_range_index_int_column_string_literal_with_contains() {
+    // Production shape: Int32 `site_code` compared against a String literal
+    // (a cast-elimination rewrite candidate, hoisted at creation) combined
+    // with `contains` over an in-list.
+    fn n(n: i32) -> Scalar {
+        Scalar::Number(n.into())
+    }
+
+    let func_ctx = FunctionContext::default();
+    let schema = Arc::new(TableSchema::new(vec![
+        TableField::new("site_code", TableDataType::Number(NumberDataType::Int32)),
+        TableField::new("account", TableDataType::Number(NumberDataType::Int64)),
+    ]));
+
+    let site_code = Expr::ColumnRef(ColumnRef {
+        span: None,
+        id: "site_code".to_string(),
+        data_type: DataType::Number(NumberDataType::Int32),
+        display_name: "site_code".to_string(),
+    });
+    let account = Expr::ColumnRef(ColumnRef {
+        span: None,
+        id: "account".to_string(),
+        data_type: DataType::Number(NumberDataType::Int64),
+        display_name: "account".to_string(),
+    });
+    let target = Expr::Constant(Constant {
+        span: None,
+        scalar: Scalar::String("2815".to_string()),
+        data_type: DataType::String,
+    });
+    let in_list = Expr::Constant(Constant {
+        span: None,
+        scalar: Scalar::Array(Int64Type::from_data(vec![1i64, 5, 9])),
+        data_type: DataType::Array(Box::new(DataType::Number(NumberDataType::Int64))),
+    });
+    let eq = check_function(None, "eq", &[], &[site_code, target], &BUILTIN_FUNCTIONS).unwrap();
+    let contains = check_function(
+        None,
+        "contains",
+        &[],
+        &[in_list, account],
+        &BUILTIN_FUNCTIONS,
+    )
+    .unwrap();
+    let expr = check_function(
+        None,
+        "and_filters",
+        &[],
+        &[eq, contains],
+        &BUILTIN_FUNCTIONS,
+    )
+    .unwrap();
+
+    let index =
+        RangeIndex::try_create(func_ctx, &expr, schema.clone(), Default::default()).unwrap();
+
+    let site_code_id = schema.leaf_columns_of(&"site_code".to_string())[0];
+    let account_id = schema.leaf_columns_of(&"account".to_string())[0];
+    let make_stats = |site_min: i32, site_max: i32, account_min: i64, account_max: i64| {
+        let mut stats = StatisticsOfColumns::default();
+        stats.insert(
+            site_code_id,
+            ColumnStatistics::new(n(site_min), n(site_max), 0, 0, None),
+        );
+        stats.insert(
+            account_id,
+            ColumnStatistics::new(
+                Scalar::Number(account_min.into()),
+                Scalar::Number(account_max.into()),
+                0,
+                0,
+                None,
+            ),
+        );
+        stats
+    };
+
+    // Pruned by the first conjunct: 2815 is outside [3000, 3100].
+    let stats = make_stats(3000, 3100, 0, 100);
+    assert!(!index.apply(&stats, None, |_| false).unwrap());
+    // Kept: both conjuncts overlap the block ranges.
+    let stats = make_stats(2800, 2900, 0, 100);
+    assert!(index.apply(&stats, None, |_| false).unwrap());
+    // Pruned by the second conjunct: [1000, 2000] misses every in-list value.
+    let stats = make_stats(2800, 2900, 1000, 2000);
+    assert!(!index.apply(&stats, None, |_| false).unwrap());
 }
 
 #[test]

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0009_08_range_index_preparation.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0009_08_range_index_preparation.test
@@ -1,0 +1,36 @@
+# Range-index preparation must preserve implicit casts and compound predicates.
+statement ok
+CREATE OR REPLACE DATABASE range_index_preparation
+
+statement ok
+USE range_index_preparation
+
+statement ok
+CREATE TABLE t(k INT NULL, s STRING) bloom_index_columns=''
+
+statement ok
+INSERT INTO t VALUES (1,'a'),(2,'b'),(3,'c'),(NULL,'n')
+
+query IT
+SELECT * FROM t WHERE k = '2'
+----
+2 b
+
+query IT
+SELECT * FROM t WHERE k::BIGINT = 3 AND s = 'c'
+----
+3 c
+
+query I
+SELECT count(*) FROM t WHERE k = '99'
+----
+0
+
+query IT rowsort
+SELECT * FROM t WHERE (k = '2' OR k IS NULL) AND s IN ('b','n')
+----
+2 b
+NULL n
+
+statement ok
+DROP DATABASE range_index_preparation

--- a/tests/sqllogictests/suites/base/16_tutorial/16_0004_load_data.test
+++ b/tests/sqllogictests/suites/base/16_tutorial/16_0004_load_data.test
@@ -74,11 +74,12 @@ Downtown Loop Rain 3580
 Port Perimeter Overcast 4020
 Airport Connector Clear 3655
 
+# Keep the physical internal-stage path distinct from the parallel Chinese tutorial.
 statement ok
-CREATE OR REPLACE STAGE citydrive_ndjson_stage
+CREATE OR REPLACE STAGE citydrive_ndjson_stage_en
 
 query III
-COPY INTO @citydrive_ndjson_stage
+COPY INTO @citydrive_ndjson_stage_en
     FROM (
     SELECT
     'FRAME-0101' AS doc_id,
@@ -95,7 +96,7 @@ COPY INTO @citydrive_ndjson_stage
 3 245 245
 
 statement ok
-LIST @citydrive_ndjson_stage
+LIST @citydrive_ndjson_stage_en
 
 statement ok
 CREATE OR REPLACE TABLE frame_metadata_catalog (
@@ -108,7 +109,7 @@ COPY INTO frame_metadata_catalog (doc_id, meta_json)
     FROM (
     SELECT $1:doc_id::STRING AS doc_id,
     $1                 AS meta_json
-    FROM @citydrive_ndjson_stage
+    FROM @citydrive_ndjson_stage_en
     )
     PATTERN = '.*[.]ndjson'
     FILE_FORMAT = (TYPE = NDJSON)
@@ -128,7 +129,7 @@ statement ok
 DROP STAGE IF EXISTS citydrive_stage_csv
 
 statement ok
-DROP STAGE IF EXISTS citydrive_ndjson_stage
+DROP STAGE IF EXISTS citydrive_ndjson_stage_en
 
 statement ok
 DROP DATABASE IF EXISTS citydrive_demo

--- a/tests/sqllogictests/suites/base/16_tutorial/16_0004_load_data.test
+++ b/tests/sqllogictests/suites/base/16_tutorial/16_0004_load_data.test
@@ -74,7 +74,7 @@ Downtown Loop Rain 3580
 Port Perimeter Overcast 4020
 Airport Connector Clear 3655
 
-# Keep the physical internal-stage path distinct from the parallel Chinese tutorial.
+# Use a distinct internal-stage name to avoid shared storage paths across parallel tests.
 statement ok
 CREATE OR REPLACE STAGE citydrive_ndjson_stage_en
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Prepare immutable range-index information once rather than rediscovering it for every block:

- Resolve referenced columns to leaf IDs when constructing `RangeIndex`.
- Apply domain-independent cast rewrites once with full domains; retain per-block rewriting for candidates requiring block statistics.
- Skip the rewrite visitor when the expression contains no rewrite candidates.
- Pass the caller's function context into `eliminate_cast`.

Extracted from the page-index work into an independent change based on main. This PR does not introduce page indexes, synthetic column IDs, new storage formats, or writer changes. It affects ordinary range pruning, so pruning correctness and construction overhead are part of the review scope.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation on this branch:

- `cargo test -p databend-storages-common-index --test it --locked`: 25 passed.
- `cargo clippy -p databend-storages-common-index --all-targets --locked -- -D warnings`: passed, including the new benchmark target.
- Built query/meta/sqllogictests binaries from this branch and ran `09_0009_08_range_index_preparation.test` through the HTTP handler: 10 records passed.
- `git diff --check`: passed.

Adds `range_index_apply` benchmarks for construction and repeated pruning. Comparative performance measurements have not been run; no quantified speedup is claimed. Real multi-node validation remains outstanding. Local builds disabled incremental compilation and debug information to limit disk use.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent extracted the range-index changes, adapted the implementation, added regression coverage, and ran local validation.
- Responsible human: @zhang2014
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20438)
<!-- Reviewable:end -->
