### PR TITLE
fix(storage): avoid overflow in block thresholds

### DIFF
--- a/src/query/expression/src/utils/block_thresholds.rs
+++ b/src/query/expression/src/utils/block_thresholds.rs
@@ -57,7 +57,7 @@ impl BlockThresholds {
         BlockThresholds {
             max_rows_per_block,
             min_rows_per_block: Self::min_block_threshold(max_rows_per_block),
-            max_bytes_per_block: bytes_per_block * MAX_BYTES_PER_BLOCK_FACTOR,
+            max_bytes_per_block: bytes_per_block.saturating_mul(MAX_BYTES_PER_BLOCK_FACTOR),
             min_bytes_per_block: Self::min_block_threshold(bytes_per_block),
             max_compressed_per_block,
             min_compressed_per_block: Self::min_block_threshold(max_compressed_per_block),
@@ -74,14 +74,14 @@ impl BlockThresholds {
 
     #[inline]
     pub fn set_bytes_per_block(mut self, bytes_per_block: usize) -> Self {
-        self.max_bytes_per_block = bytes_per_block * MAX_BYTES_PER_BLOCK_FACTOR;
+        self.max_bytes_per_block = bytes_per_block.saturating_mul(MAX_BYTES_PER_BLOCK_FACTOR);
         self.min_bytes_per_block = Self::min_block_threshold(bytes_per_block);
         self
     }
 
     #[inline]
     pub fn min_block_threshold(value: usize) -> usize {
-        (value * 4).div_ceil(5)
+        value - value / 5
     }
 
     #[inline]
@@ -105,9 +105,18 @@ impl BlockThresholds {
         total_compressed: usize,
     ) -> bool {
         total_blocks >= self.block_per_segment
-            && (total_rows >= self.min_rows_per_block * self.block_per_segment
-                || total_bytes >= self.min_bytes_per_block * self.block_per_segment
-                || total_compressed >= self.min_compressed_per_block * self.block_per_segment)
+            && (total_rows
+                >= self
+                    .min_rows_per_block
+                    .saturating_mul(self.block_per_segment)
+                || total_bytes
+                    >= self
+                        .min_bytes_per_block
+                        .saturating_mul(self.block_per_segment)
+                || total_compressed
+                    >= self
+                        .min_compressed_per_block
+                        .saturating_mul(self.block_per_segment))
     }
 
     #[inline]
@@ -117,7 +126,8 @@ impl BlockThresholds {
 
     #[inline]
     pub fn check_for_compact(&self, row_count: usize, block_size: usize) -> bool {
-        row_count < 2 * self.min_rows_per_block && block_size < 2 * self.min_bytes_per_block
+        row_count < self.min_rows_per_block.saturating_mul(2)
+            && block_size < self.min_bytes_per_block.saturating_mul(2)
     }
 
     #[inline]
@@ -129,19 +139,20 @@ impl BlockThresholds {
 
     #[inline]
     pub fn check_too_large(&self, row_count: usize, block_size: usize) -> bool {
-        row_count > 2 * self.min_rows_per_block || block_size > self.max_bytes_per_block
+        row_count > self.min_rows_per_block.saturating_mul(2)
+            || block_size > self.max_bytes_per_block
     }
 
     #[inline]
     pub fn calc_compact_block_num(&self, total_rows: usize, total_bytes: usize) -> usize {
-        let block_num_by_rows = if total_rows >= 2 * self.min_rows_per_block {
+        let block_num_by_rows = if total_rows >= self.min_rows_per_block.saturating_mul(2) {
             (total_rows / self.max_rows_per_block).max(2)
         } else {
             1
         };
 
         let bytes_per_block = self.max_bytes_per_block / MAX_BYTES_PER_BLOCK_FACTOR;
-        let block_num_by_bytes = if total_bytes >= 2 * self.min_bytes_per_block {
+        let block_num_by_bytes = if total_bytes >= self.min_bytes_per_block.saturating_mul(2) {
             (total_bytes / bytes_per_block).max(2)
         } else {
             1
@@ -175,7 +186,7 @@ impl BlockThresholds {
             .div_ceil(MAX_BYTES_PER_BLOCK_FACTOR);
         // Check if the data is compact enough to skip further calculations.
         if self.check_for_compact(total_rows, total_bytes)
-            && total_compressed < 2 * self.min_compressed_per_block
+            && total_compressed < self.min_compressed_per_block.saturating_mul(2)
         {
             return (total_rows, default_bytes_per_block);
         }
@@ -183,8 +194,8 @@ impl BlockThresholds {
         let block_num_by_rows = std::cmp::max(total_rows / self.min_rows_per_block, 1);
         let block_num_by_compressed = total_compressed.div_ceil(self.max_compressed_per_block);
 
-        let max_bytes_per_block =
-            default_bytes_per_block + default_bytes_per_block.min(DEFAULT_BLOCK_BUFFER_SIZE);
+        let max_bytes_per_block = default_bytes_per_block
+            .saturating_add(default_bytes_per_block.min(DEFAULT_BLOCK_BUFFER_SIZE));
         let min_block_num_by_bytes = total_bytes.div_ceil(max_bytes_per_block);
 
         // When rows require the most blocks, preserve the row-based sizing decision.

--- a/src/query/expression/tests/it/block_thresholds.rs
+++ b/src/query/expression/tests/it/block_thresholds.rs
@@ -83,6 +83,36 @@ fn test_calc_compact_block_num() {
 }
 
 #[test]
+fn test_threshold_arithmetic_at_usize_limit() {
+    for value in [0, 1, 4, 5, 6, 1000, usize::MAX / 2, usize::MAX] {
+        let expected = ((value as u128 * 4).div_ceil(5)) as usize;
+        assert_eq!(BlockThresholds::min_block_threshold(value), expected);
+    }
+
+    let thresholds = BlockThresholds::new(usize::MAX, usize::MAX, usize::MAX, 4);
+    assert_eq!(thresholds.max_bytes_per_block, usize::MAX);
+    assert_eq!(
+        default_thresholds()
+            .set_bytes_per_block(usize::MAX)
+            .max_bytes_per_block,
+        usize::MAX
+    );
+    assert!(!thresholds.check_perfect_segment(4, usize::MAX - 1, 1, 1));
+    assert!(!thresholds.check_perfect_segment(4, 1, usize::MAX - 1, 1));
+    assert!(!thresholds.check_perfect_segment(4, 1, 1, usize::MAX - 1));
+    assert!(thresholds.check_for_compact(usize::MAX - 1, usize::MAX - 1));
+    assert!(!thresholds.check_too_large(usize::MAX - 1, usize::MAX - 1));
+    assert_eq!(
+        thresholds.calc_compact_block_num(usize::MAX - 1, usize::MAX - 1),
+        1
+    );
+    assert_eq!(
+        thresholds.calc_rows_for_recluster(usize::MAX - 1, usize::MAX - 1, usize::MAX - 1),
+        (usize::MAX - 1, usize::MAX.div_ceil(2))
+    );
+}
+
+#[test]
 fn test_calc_rows_for_recluster() {
     let t = default_thresholds();
 

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0056_block_threshold_overflow.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0056_block_threshold_overflow.test
@@ -1,0 +1,26 @@
+# A large byte threshold must not overflow during ordinary FUSE writes/compaction.
+statement ok
+CREATE OR REPLACE DATABASE block_threshold_overflow
+
+statement ok
+USE block_threshold_overflow
+
+statement ok
+CREATE TABLE t(k INT) CLUSTER BY(k) block_size_threshold=18446744073709551615 file_size=18446744073709551615
+
+statement ok
+INSERT INTO t VALUES (1),(3)
+
+statement ok
+INSERT INTO t VALUES (2),(4)
+
+statement ok
+ALTER TABLE t RECLUSTER FINAL
+
+query II
+SELECT count(*), sum(k) FROM t
+----
+4 10
+
+statement ok
+DROP DATABASE block_threshold_overflow


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Avoid integer overflow in block-threshold arithmetic for large configured values:

- Compute the 80% minimum threshold without multiplying first.
- Saturate byte-limit and segment/block threshold multiplication.
- Saturate addition when deriving the recluster byte limit.

This is an independent extraction from the page-index branch. It preserves main's ordinary sizing formulas and existing `row_per_block` validation. It does not raise row limits, change recluster candidate selection, or introduce page indexes.

Adds boundary tests at `usize::MAX` and an SQL regression that writes and reclusters a table with large byte thresholds.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation on this branch:

- `cargo test -p databend-common-expression --test it block_thresholds --locked`: 8 passed.
- `cargo clippy -p databend-common-expression --lib --tests --locked -- -D warnings`: passed.
- Built query/meta/sqllogictests binaries from this branch and ran `09_0056_block_threshold_overflow.test` through the HTTP handler: 9 records passed.
- `git diff --check`: passed.

Local builds disabled incremental compilation and debug information. Performance A/B and real multi-node validation have not been run.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent extracted the arithmetic fixes, separated them from sizing-policy changes, added boundary and SQL tests, and ran local validation.
- Responsible human: @zhang2014
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20439)
<!-- Reviewable:end -->
