### PR TITLE
refactor(storage): refine recluster levels and log level IO

### DIFF
--- a/src/query/catalog/src/plan/partition.rs
+++ b/src/query/catalog/src/plan/partition.rs
@@ -462,8 +462,10 @@ pub struct ReclusterTask {
     /// Base level; the serializer requests `level + 1` (perfect blocks may become -1).
     pub level: i32,
     /// Effective input levels under the current cluster key, not historical stored levels.
+    #[serde(default)]
     pub input_level_stats: Vec<ClusterLevelLogStats>,
     // All input blocks in this task are already ordered by the current cluster key.
+    #[serde(default)]
     pub all_ordered: bool,
 }
 

--- a/src/query/catalog/src/plan/partition.rs
+++ b/src/query/catalog/src/plan/partition.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::collections::hash_map::DefaultHasher;
@@ -430,6 +431,27 @@ impl StealablePartitions {
     }
 }
 
+/// Per-level block sizes for insert/recluster diagnostic logs, not table statistics.
+/// `None` means no cluster statistics; -1 denotes a perfect block.
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ClusterLevelLogStats {
+    pub level: Option<i32>,
+    pub block_count: u64,
+    pub block_size: u64,
+    pub file_size: u64,
+}
+
+impl ClusterLevelLogStats {
+    pub fn accumulate(levels: &mut BTreeMap<Option<i32>, Self>, block: &BlockMeta) {
+        let level = block.cluster_stats.as_ref().map(|stats| stats.level);
+        let stats = levels.entry(level).or_default();
+        stats.level = level;
+        stats.block_count += 1;
+        stats.block_size += block.block_size;
+        stats.file_size += block.file_size;
+    }
+}
+
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct ReclusterTask {
     pub parts: Partitions,
@@ -437,9 +459,11 @@ pub struct ReclusterTask {
     pub total_rows: usize,
     pub total_bytes: usize,
     pub total_compressed: usize,
+    /// Base level; the serializer requests `level + 1` (perfect blocks may become -1).
     pub level: i32,
+    /// Effective input levels under the current cluster key, not historical stored levels.
+    pub input_level_stats: Vec<ClusterLevelLogStats>,
     // All input blocks in this task are already ordered by the current cluster key.
-    #[serde(default)]
     pub all_ordered: bool,
 }
 

--- a/src/query/catalog/src/plan/partition.rs
+++ b/src/query/catalog/src/plan/partition.rs
@@ -431,12 +431,13 @@ impl StealablePartitions {
     }
 }
 
-/// Per-level block sizes for insert/recluster diagnostic logs, not table statistics.
+/// Per-level block counts, rows and sizes for insert/recluster diagnostic logs, not table statistics.
 /// `None` means no cluster statistics; -1 denotes a perfect block.
 #[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ClusterLevelLogStats {
     pub level: Option<i32>,
     pub block_count: u64,
+    pub row_count: u64,
     pub block_size: u64,
     pub file_size: u64,
 }
@@ -447,6 +448,7 @@ impl ClusterLevelLogStats {
         let stats = levels.entry(level).or_default();
         stats.level = level;
         stats.block_count += 1;
+        stats.row_count += block.row_count;
         stats.block_size += block.block_size;
         stats.file_size += block.file_size;
     }

--- a/src/query/service/src/interpreters/interpreter_table_recluster.rs
+++ b/src/query/service/src/interpreters/interpreter_table_recluster.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+databend_common_tracing::register_module_tag!("[FUSE-RECLUSTER]");
+
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
@@ -45,8 +47,8 @@ use databend_common_storages_fuse::operations::ReclusterMode;
 use databend_common_storages_fuse::operations::is_auto_vacuum_enabled;
 use databend_enterprise_vacuum_handler::get_vacuum_handler;
 use databend_storages_common_table_meta::meta::TableSnapshot;
-use log::debug;
 use log::error;
+use log::info;
 use log::warn;
 use rand::Rng;
 
@@ -77,6 +79,23 @@ use crate::sessions::TableContextTableManagement;
 use crate::sessions::TableContextTelemetry;
 
 const MAX_SEGMENT_CLAIM_RETRIES: usize = 3;
+
+#[derive(Debug, PartialEq, Eq)]
+enum ReclusterRoundOutcome {
+    Committed,
+    NoParts,
+    ClaimRetriesExhausted,
+}
+
+impl ReclusterRoundOutcome {
+    fn stop_reason(&self) -> Option<&'static str> {
+        match self {
+            Self::Committed => None,
+            Self::NoParts => Some("no_recluster_parts"),
+            Self::ClaimRetriesExhausted => Some("claim_retries_exhausted"),
+        }
+    }
+}
 
 pub struct ReclusterTableInterpreter {
     ctx: Arc<QueryContext>,
@@ -113,7 +132,7 @@ impl Interpreter for ReclusterTableInterpreter {
         let ctx = self.ctx.clone();
         let recluster_timeout_secs = ctx.get_settings().get_recluster_timeout_secs()?;
 
-        let mut times = 0;
+        let mut rounds = 0;
         let mut push_downs = None;
         // FINAL carry is scoped to this fixed-scan statement loop.
         // A new FINAL statement starts from the table head again.
@@ -121,29 +140,29 @@ impl Interpreter for ReclusterTableInterpreter {
         let start = SystemTime::now();
         let timeout = Duration::from_secs(recluster_timeout_secs);
         let is_final = self.plan.is_final;
-        let mut committed = false;
-        let result = loop {
+        let mut committed_rounds = 0;
+        let (result, stop_reason) = loop {
             if let Err(err) = ctx.check_aborting() {
                 error!(
-                    "recluster: statement aborted, server is shutting down or the query was killed, round={}",
-                    times + 1
+                    event = "recluster.aborted",
+                    rounds;
+                    "Recluster aborted before next round"
                 );
-                break Err(err.with_context("failed to execute"));
+                break (Err(err.with_context("failed to execute")), "aborted");
             }
 
+            rounds += 1;
             let res = self
                 .execute_recluster(&mut push_downs, &mut linear_final_carry)
                 .await;
 
             match res {
-                Ok(true) => {
-                    debug!(
-                        "recluster: final loop stop reason=no_recluster_parts round={}",
-                        times + 1,
-                    );
-                    break Ok(());
+                Ok(outcome) => {
+                    if let Some(reason) = outcome.stop_reason() {
+                        break (Ok(()), reason);
+                    }
+                    committed_rounds += 1;
                 }
-                Ok(false) => committed = true,
                 Err(e) => {
                     if is_final
                         && matches!(
@@ -158,48 +177,62 @@ impl Interpreter for ReclusterTableInterpreter {
                         // a bounded fixed scan and does not restart from table
                         // head to chase concurrent snapshot drift.
                         warn!(
-                            "recluster: final loop retry reason=retryable_conflict round={} code={} error={:?}",
-                            times + 1,
-                            e.code(),
-                            e,
+                            event = "recluster.retry",
+                            reason = "retryable_conflict",
+                            round = rounds,
+                            code = e.code(),
+                            error :? = e;
+                            "Recluster round failed with retryable conflict"
                         );
                     } else {
                         error!(
-                            "recluster: final loop stop reason=error round={} code={} error={:?}",
-                            times + 1,
-                            e.code(),
-                            e,
+                            event = "recluster.failed",
+                            round = rounds,
+                            code = e.code(),
+                            error :? = e;
+                            "Recluster round failed"
                         );
-                        break Err(e);
+                        break (Err(e), "error");
                     }
                 }
             }
 
             let elapsed_time = SystemTime::now().duration_since(start).unwrap_or_default();
-            times += 1;
-            // Status.
-            {
-                let status = format!(
-                    "[FUSE-RECLUSTER] Run recluster tasks:{} times, cost:{:?}",
-                    times, elapsed_time
-                );
-                ctx.set_status_info(&status);
-            }
+            ctx.set_status_info(&format!(
+                "[FUSE-RECLUSTER] Executed rounds={} committed_rounds={} elapsed={:?}",
+                rounds, committed_rounds, elapsed_time,
+            ));
 
             if !is_final {
-                break Ok(());
+                break (Ok(()), "single_round_completed");
             }
 
             if elapsed_time >= timeout {
                 warn!(
-                    "recluster: final loop stop reason=timeout round={} timeout={:?}",
-                    times, timeout,
+                    event = "recluster.timeout",
+                    rounds,
+                    timeout_secs = recluster_timeout_secs;
+                    "Recluster stopped at time limit"
                 );
-                break Ok(());
+                break (Ok(()), "timeout");
             }
         };
 
-        if committed {
+        info!(
+            event = "recluster.finished",
+            catalog = self.plan.catalog.as_str(),
+            database = self.plan.database.as_str(),
+            table = self.plan.table.as_str(),
+            is_final,
+            rounds,
+            committed_rounds,
+            stop_reason,
+            success = result.is_ok(),
+            elapsed :? = SystemTime::now().duration_since(start).unwrap_or_default();
+            "Recluster finished"
+        );
+
+        if committed_rounds > 0 {
             self.vacuum_table_history().await;
         }
 
@@ -254,7 +287,7 @@ impl ReclusterTableInterpreter {
         &self,
         push_downs: &mut Option<PushDownInfo>,
         linear_final_carry: &mut ReclusterFinalCarry,
-    ) -> Result<bool> {
+    ) -> Result<ReclusterRoundOutcome> {
         self.ctx.clear_table_meta_timestamps_cache();
         let start = SystemTime::now();
         let settings = self.ctx.get_settings();
@@ -311,7 +344,7 @@ impl ReclusterTableInterpreter {
                 )
                 .await?;
             let Some((parts, snapshot, segments)) = candidate else {
-                return Ok(true);
+                return Ok(ReclusterRoundOutcome::NoParts);
             };
             let Some(claim_manager) = &claim_manager else {
                 break (parts, snapshot, None);
@@ -327,10 +360,12 @@ impl ReclusterTableInterpreter {
             metrics_inc_segment_claim_conflicts();
             if claim_retries >= MAX_SEGMENT_CLAIM_RETRIES {
                 warn!(
-                    "recluster: stop after {} segment claim retries",
-                    MAX_SEGMENT_CLAIM_RETRIES
+                    event = "recluster.claim_retries_exhausted",
+                    table_id = tbl.get_id(),
+                    claim_retries;
+                    "Recluster stopped at segment claim retry limit"
                 );
-                return Ok(true);
+                return Ok(ReclusterRoundOutcome::ClaimRetriesExhausted);
             }
             claim_retries += 1;
 
@@ -404,7 +439,7 @@ impl ReclusterTableInterpreter {
         drop(complete_executor);
 
         execution_result?;
-        Ok(false)
+        Ok(ReclusterRoundOutcome::Committed)
     }
 
     async fn build_linear_candidate(

--- a/src/query/service/src/physical_plans/physical_recluster.rs
+++ b/src/query/service/src/physical_plans/physical_recluster.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+databend_common_tracing::register_module_tag!("[FUSE-RECLUSTER]");
+
 use std::any::Any;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
@@ -173,16 +175,13 @@ impl IPhysicalPlan for Recluster {
                     metrics_inc_recluster_block_bytes_to_read(task.total_bytes as u64);
                     metrics_inc_recluster_row_nums_to_read(task.total_rows as u64);
 
-                    for stats in &task.input_level_stats {
-                        log::info!(
-                            table_id = table.get_id(),
-                            level = stats.level,
-                            block_count = stats.block_count,
-                            block_size = stats.block_size,
-                            file_size = stats.file_size;
-                            "fuse recluster input"
-                        );
-                    }
+                    // Keep all effective input levels in one event per task pipeline build.
+                    log::info!(
+                        event = "recluster.input_planned",
+                        table_id = table.get_id(),
+                        input_levels :serde = task.input_level_stats;
+                        "Recluster input planned"
+                    );
                 }
 
                 builder.ctx.set_partitions(plan.parts.clone())?;

--- a/src/query/service/src/physical_plans/physical_recluster.rs
+++ b/src/query/service/src/physical_plans/physical_recluster.rs
@@ -173,14 +173,16 @@ impl IPhysicalPlan for Recluster {
                     metrics_inc_recluster_block_bytes_to_read(task.total_bytes as u64);
                     metrics_inc_recluster_row_nums_to_read(task.total_rows as u64);
 
-                    log::info!(
-                        "recluster: scheduled blocks level={} block_count={} rows={} bytes={} compressed={}",
-                        task.level,
-                        recluster_block_nums,
-                        task.total_rows,
-                        task.total_bytes,
-                        task.total_compressed,
-                    );
+                    for stats in &task.input_level_stats {
+                        log::info!(
+                            table_id = table.get_id(),
+                            level = stats.level,
+                            block_count = stats.block_count,
+                            block_size = stats.block_size,
+                            file_size = stats.file_size;
+                            "fuse recluster input"
+                        );
+                    }
                 }
 
                 builder.ctx.set_partitions(plan.parts.clone())?;

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
@@ -2111,12 +2111,14 @@ async fn test_final_low_maturity_level_uses_block_size_ratio() -> anyhow::Result
                 ClusterLevelLogStats {
                     level: Some(1),
                     block_count: 2,
+                    row_count: 2000,
                     block_size: 200,
                     file_size: 100
                 },
                 ClusterLevelLogStats {
                     level: Some(3),
                     block_count: 1,
+                    row_count: 1000,
                     block_size: 200,
                     file_size: 100
                 },

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use chrono::Utc;
 use databend_common_base::runtime::Runtime;
+use databend_common_catalog::plan::ClusterLevelLogStats;
 use databend_common_catalog::plan::PushDownInfo;
 use databend_common_catalog::plan::ReclusterParts;
 use databend_common_expression::BlockThresholds;
@@ -478,6 +479,55 @@ async fn materialize_segments_by_level_with_mode(
         max_tasks,
         1000,
         mode,
+    )
+    .await?;
+    Ok((block_num, parts))
+}
+
+async fn materialize_segments_by_level_and_size(
+    level_sizes: &[(i32, u64)],
+    thresholds: BlockThresholds,
+) -> anyhow::Result<(u64, ReclusterParts)> {
+    let fixture = TestFixture::setup().await?;
+    let ctx = fixture.new_query_ctx().await?;
+    ctx.get_settings().set_recluster_block_size(1000)?;
+
+    let data_accessor = ctx.get_application_level_data_operator()?.operator();
+    let location_generator = TableMetaLocationGenerator::new("_prefix".to_owned());
+    let cluster_key_id = 0;
+    let mut segment_locations = Vec::with_capacity(level_sizes.len());
+    for &(level, block_size) in level_sizes {
+        let block = make_recluster_block(
+            cluster_key_id,
+            1,
+            100,
+            level,
+            1000,
+            block_size,
+            block_size / 2,
+        );
+        segment_locations.push(
+            write_recluster_segment(
+                &data_accessor,
+                &location_generator,
+                vec![block],
+                thresholds,
+                cluster_key_id,
+            )
+            .await?,
+        );
+    }
+
+    let ctx: Arc<dyn TableContext> = ctx;
+    let (_, block_num, parts) = materialize_segment_locations_with_mode(
+        ctx,
+        data_accessor,
+        segment_locations,
+        thresholds,
+        cluster_key_id,
+        1,
+        1000,
+        ReclusterMode::Aggressive,
     )
     .await?;
     Ok((block_num, parts))
@@ -1539,99 +1589,6 @@ async fn test_vector_segment_selection_does_not_cross_partitions() -> anyhow::Re
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_accumulates_tasks_across_windows() -> anyhow::Result<()> {
-    let fixture = TestFixture::setup().await?;
-    let ctx = fixture.new_query_ctx().await?;
-    ctx.get_settings().set_recluster_block_size(1000)?;
-
-    let data_accessor = ctx.get_application_level_data_operator()?.operator();
-    let location_generator = TableMetaLocationGenerator::new("_prefix".to_owned());
-    let cluster_key_id = 0;
-    let thresholds = BlockThresholds::new(1000, 100, 100, 2);
-
-    // Two overlapping clusters that are far apart in key space. With a window cap
-    // of 2 they fall into two separate, segment-disjoint windows, so reaching
-    // the budget of 2 requires accumulating tasks across both windows.
-    let segment_locations = gen_recluster_segments_by_ranges(
-        &data_accessor,
-        &location_generator,
-        &[vec![(1, 10)], vec![(2, 9)], vec![(100, 110)], vec![(
-            101, 109,
-        )]],
-        1000,
-        100,
-        100,
-        thresholds,
-        cluster_key_id,
-    )
-    .await?;
-
-    let schema = test_cluster_schema();
-    let ctx: Arc<dyn TableContext> = ctx.clone();
-    let segment_locations = create_segment_location_vector(segment_locations, None);
-    let compact_segments = segment_pruning(
-        &ctx,
-        schema.clone(),
-        data_accessor.clone(),
-        segment_locations,
-    )
-    .await?;
-
-    let max_tasks = 2;
-    let select_mutator = new_test_mutator(
-        ctx.clone(),
-        data_accessor.clone(),
-        schema.clone(),
-        thresholds,
-        cluster_key_id,
-        max_tasks,
-        ReclusterMode::Aggressive,
-    );
-    let mutator = new_test_mutator(
-        ctx.clone(),
-        data_accessor.clone(),
-        schema.clone(),
-        thresholds,
-        cluster_key_id,
-        max_tasks,
-        ReclusterMode::Conservative,
-    );
-
-    let segment_windows = select_mutator.select_segments(&compact_segments, 2)?;
-    // The two far-apart clusters produce two disjoint windows.
-    assert_eq!(segment_windows.len(), 2);
-
-    // Disjoint windows can each materialize work, so a full budget may be filled
-    // from multiple windows.
-    let mut parts = ReclusterParts::default();
-    for selected_segs in segment_windows {
-        let task_budget = max_tasks.saturating_sub(parts.tasks.len());
-        if task_budget == 0 {
-            break;
-        }
-        let (_, candidate_parts) =
-            materialize_candidate_window(&mutator, selected_segs, task_budget).await?;
-        parts.tasks.extend(candidate_parts.tasks);
-        parts
-            .removed_segment_indexes
-            .extend(candidate_parts.removed_segment_indexes);
-    }
-
-    // One task per window, accumulated to the full budget of 2.
-    assert_eq!(parts.tasks.len(), 2);
-    // The four overlapping segments are all scheduled for removal, with no
-    // duplicates across windows.
-    let removed = parts
-        .removed_segment_indexes
-        .iter()
-        .copied()
-        .collect::<HashSet<_>>();
-    assert_eq!(removed.len(), 4);
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn test_builds_multiple_peaks_in_one_window() -> anyhow::Result<()> {
     let fixture = TestFixture::setup().await?;
     let ctx = fixture.new_query_ctx().await?;
@@ -2081,25 +2038,6 @@ async fn test_defers_after_empty_group() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_keeps_low_level_small_task() -> anyhow::Result<()> {
-    let thresholds = BlockThresholds::new(1000, 100, 100, 10);
-    let (block_num, parts) = materialize_segments_by_level_with_mode(
-        &[(0, 3)],
-        thresholds,
-        1,
-        ReclusterMode::Conservative,
-    )
-    .await?;
-
-    assert_eq!(block_num, 3);
-    assert_eq!(parts.tasks.len(), 1);
-    assert_eq!(parts.tasks[0].level, 0);
-    assert_eq!(task_part_counts(&parts), vec![3]);
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn test_fills_budget_with_next_task() -> anyhow::Result<()> {
     let thresholds = BlockThresholds::new(1000, 100, 100, 10);
     let (block_num, parts) = materialize_segments_by_level_with_mode(
@@ -2126,10 +2064,9 @@ async fn test_fills_budget_with_next_task() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_final_groups_mature_level_bands() -> anyhow::Result<()> {
+async fn test_final_groups_only_low_maturity_levels() -> anyhow::Result<()> {
     let thresholds = BlockThresholds::new(1000, 100, 100, 10);
-    // Levels 1 and 2 share the {1-3} bin; level 0 stays isolated, so only the
-    // two mature blocks overlap and form one rewrite task.
+    // Levels 1 and 2 share the low-maturity group; level 0 stays isolated.
     let (block_num, parts) = materialize_segments_by_level_with_mode(
         &[(0, 1), (1, 1), (2, 1)],
         thresholds,
@@ -2140,96 +2077,104 @@ async fn test_final_groups_mature_level_bands() -> anyhow::Result<()> {
 
     assert_eq!(block_num, 2);
     assert_eq!(parts.tasks.len(), 1);
-    // {1-3} bin: majority tie between level 1 and 2 picks the lower level.
-    assert_eq!(parts.tasks[0].level, 1);
+    // Level 2 owns exactly half of the logical bytes, so the actual output is level 3.
+    assert_eq!(parts.tasks[0].level + 1, 3);
     assert_eq!(task_part_counts(&parts), vec![2]);
 
-    // Two high-level blocks alone do not produce rewrite tasks (both are at or
-    // above MAX_RECLUSTER_LEVEL_FOR_TWO_BLOCKS), but they can still be repacked
-    // when that reduces segment count.
-    let (block_num, parts) = materialize_segments_by_level_with_mode(
-        &[(2, 2)],
-        thresholds,
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_final_low_maturity_level_uses_block_size_ratio() -> anyhow::Result<()> {
+    let thresholds = BlockThresholds::new(1000, 100, 100, 10);
+    for (level_sizes, expected_output_level) in [
+        ([(1, 100), (1, 100), (3, 100)], 3),
+        ([(1, 100), (3, 100), (3, 100)], 4),
+        ([(1, 100), (2, 100), (3, 100)], 3),
+        // Below half versus exactly half; block count is unchanged.
+        ([(1, 100), (1, 100), (3, 199)], 3),
+        ([(1, 100), (1, 100), (3, 200)], 4),
+    ] {
+        let (block_num, parts) =
+            materialize_segments_by_level_and_size(&level_sizes, thresholds).await?;
+        assert_eq!(block_num, 3);
+        assert_eq!(parts.tasks.len(), 1);
+        assert_eq!(
+            parts.tasks[0].level + 1,
+            expected_output_level,
+            "{level_sizes:?}"
+        );
+
+        // One representative check is enough for the input IO distribution.
+        if level_sizes == [(1, 100), (1, 100), (3, 200)] {
+            assert_eq!(parts.tasks[0].input_level_stats, vec![
+                ClusterLevelLogStats {
+                    level: Some(1),
+                    block_count: 2,
+                    block_size: 200,
+                    file_size: 100
+                },
+                ClusterLevelLogStats {
+                    level: Some(3),
+                    block_count: 1,
+                    block_size: 200,
+                    file_size: 100
+                },
+            ]);
+        }
+    }
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_final_low_maturity_gets_candidate_budget_before_high_levels() -> anyhow::Result<()> {
+    let (_, parts) = materialize_segments_by_level_with_mode(
+        &[(1, 8), (4, 8)],
+        BlockThresholds::new(1000, 100, 100, 10),
         1,
         ReclusterMode::Aggressive,
     )
     .await?;
+    assert_eq!(parts.tasks.len(), 1);
+    assert_eq!(parts.tasks[0].level + 1, 2);
+    Ok(())
+}
 
-    assert_eq!(block_num, 2);
+#[tokio::test(flavor = "multi_thread")]
+async fn test_final_two_mature_blocks_still_stop() -> anyhow::Result<()> {
+    let (_, parts) = materialize_segments_by_level_with_mode(
+        &[(2, 2)],
+        BlockThresholds::new(1000, 100, 100, 10),
+        1,
+        ReclusterMode::Aggressive,
+    )
+    .await?;
     assert!(parts.tasks.is_empty());
     assert_eq!(parts.remained_blocks.len(), 2);
-    assert_eq!(parts.removed_segment_indexes.len(), 2);
-
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_final_wide_bin_merges_mature_levels() -> anyhow::Result<()> {
+async fn test_final_high_level_boundaries() -> anyhow::Result<()> {
     let thresholds = BlockThresholds::new(1000, 100, 100, 10);
-    // Levels 4 and 8 sit at the edges of the {4-8} bin; the fixed wide bin packs
-    // them into a single task even though they are four levels apart.
-    let (block_num, parts) = materialize_segments_by_level_with_mode(
-        &[(4, 1), (8, 1), (8, 1)],
-        thresholds,
-        1,
-        ReclusterMode::Aggressive,
-    )
-    .await?;
-
-    assert_eq!(block_num, 3);
-    assert_eq!(parts.tasks.len(), 1);
-    // Majority level in {4-8} is 8 (two blocks vs one at level 4).
-    assert_eq!(parts.tasks[0].level, 8);
-    assert_eq!(task_part_counts(&parts), vec![3]);
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_final_high_maturity_bin_majority_level() -> anyhow::Result<()> {
-    let thresholds = BlockThresholds::new(1000, 100, 100, 10);
-    // Levels 9 and above all fall in the {9+} bin and merge into one task; the
-    // output level follows the majority, picking the smaller level on a tie.
-    let (block_num, parts) = materialize_segments_by_level_with_mode(
-        &[(9, 1), (10, 2), (12, 1)],
-        thresholds,
-        1,
-        ReclusterMode::Aggressive,
-    )
-    .await?;
-
-    assert_eq!(block_num, 4);
-    assert_eq!(parts.tasks.len(), 1);
-    assert_eq!(parts.tasks[0].level, 10);
-    assert_eq!(task_part_counts(&parts), vec![4]);
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_final_bin_boundary_is_a_hard_split() -> anyhow::Result<()> {
-    let thresholds = BlockThresholds::new(1000, 100, 100, 10);
-    // Levels 3 and 4 fall in different bins ({1-3} vs {4-8}). The fixed bins do
-    // not merge across that boundary, so the two level bands form two separate
-    // tasks rather than one merged overlap.
-    let (block_num, parts) = materialize_segments_by_level_with_mode(
-        &[(3, 3), (4, 3)],
-        thresholds,
-        2,
-        ReclusterMode::Aggressive,
-    )
-    .await?;
-
-    assert_eq!(block_num, 6);
-    assert_eq!(parts.tasks.len(), 2);
-    let mut levels = parts
-        .tasks
-        .iter()
-        .map(|task| task.level)
-        .collect::<Vec<_>>();
-    levels.sort_unstable();
-    assert_eq!(levels, vec![3, 4]);
-
+    for levels in [[3, 4], [4, 8]] {
+        let (block_num, parts) = materialize_segments_by_level_with_mode(
+            &[(levels[0], 3), (levels[1], 3)],
+            thresholds,
+            2,
+            ReclusterMode::Aggressive,
+        )
+        .await?;
+        assert_eq!(block_num, 6);
+        assert_eq!(parts.tasks.len(), 2);
+        let mut output_levels = parts
+            .tasks
+            .iter()
+            .map(|task| task.level + 1)
+            .collect::<Vec<_>>();
+        output_levels.sort_unstable();
+        assert_eq!(output_levels, levels.map(|level| level + 1));
+    }
     Ok(())
 }
 

--- a/src/query/storages/fuse/src/operations/common/generators/mutation_generator.rs
+++ b/src/query/storages/fuse/src/operations/common/generators/mutation_generator.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+databend_common_tracing::register_module_tag!("[SINK-COMMIT]");
+
 use std::any::Any;
 use std::sync::Arc;
 
@@ -92,7 +94,19 @@ impl SnapshotGenerator for MutationGenerator {
                         &ctx.removed_segment_indexes,
                     )
                 {
-                    info!("resolvable conflicts detected");
+                    let snapshot_changed =
+                        self.base_snapshot.snapshot_id() != previous.snapshot_id();
+                    if snapshot_changed {
+                        info!(
+                            event = "commit.segments_validated",
+                            table_id = table_info.ident.table_id,
+                            operation = self.mutation_kind.to_string().to_ascii_lowercase().as_str(),
+                            snapshot_changed,
+                            removed_segment_count = removed.len(),
+                            replaced_segment_count = replaced.len();
+                            "Mutation segments validated against latest snapshot"
+                        );
+                    }
                     metrics_inc_commit_mutation_modified_segment_exists_in_latest();
                     let new_segments = ConflictResolveContext::merge_segments(
                         previous.segments().to_vec(),

--- a/src/query/storages/fuse/src/operations/common/meta/mutation_log.rs
+++ b/src/query/storages/fuse/src/operations/common/meta/mutation_log.rs
@@ -47,9 +47,9 @@ pub enum MutationLogEntry {
         segment_location: String,
         format_version: FormatVersion,
         summary: Statistics,
-        level_stats: Vec<ClusterLevelLogStats>,
         hll: BlockHLL,
         top_n: BlockTopN,
+        level_stats: Vec<ClusterLevelLogStats>,
     },
     AppendBlock {
         block_meta: Arc<ExtendedBlockMeta>,

--- a/src/query/storages/fuse/src/operations/common/meta/mutation_log.rs
+++ b/src/query/storages/fuse/src/operations/common/meta/mutation_log.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use databend_common_catalog::plan::ClusterLevelLogStats;
 use databend_common_exception::ErrorCode;
 use databend_common_expression::BlockMetaInfo;
 use databend_common_expression::BlockMetaInfoDowncast;
@@ -46,6 +47,7 @@ pub enum MutationLogEntry {
         segment_location: String,
         format_version: FormatVersion,
         summary: Statistics,
+        level_stats: Vec<ClusterLevelLogStats>,
         hll: BlockHLL,
         top_n: BlockTopN,
     },

--- a/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
@@ -347,6 +347,7 @@ impl TableMutationAggregator {
                         let total = self.output_level_stats.entry(stats.level).or_default();
                         total.level = stats.level;
                         total.block_count += stats.block_count;
+                        total.row_count += stats.row_count;
                         total.block_size += stats.block_size;
                         total.file_size += stats.file_size;
                     }

--- a/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
@@ -331,9 +331,9 @@ impl TableMutationAggregator {
                 segment_location,
                 format_version,
                 summary,
-                level_stats,
                 hll,
                 top_n,
+                level_stats,
             } => {
                 if matches!(self.write_segment_ctx.kind, MutationKind::Insert) {
                     for stats in level_stats {

--- a/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
@@ -20,6 +20,7 @@ use std::time::Instant;
 
 use databend_common_base::runtime::execute_futures_in_parallel;
 use databend_common_catalog::plan::BlockMetaWithHLL;
+use databend_common_catalog::plan::ClusterLevelLogStats;
 use databend_common_catalog::table::Table;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
@@ -84,6 +85,7 @@ pub struct TableMutationAggregator {
 
     base_segments: Vec<Location>,
     merged_blocks: Vec<Arc<ExtendedBlockMeta>>,
+    output_level_stats: BTreeMap<Option<i32>, ClusterLevelLogStats>,
 
     mutations: HashMap<SegmentIndex, BlockMutations>,
     extended_mutations: HashMap<SegmentIndex, ExtendedBlockMutations>,
@@ -126,6 +128,23 @@ impl AsyncAccumulatingTransform for TableMutationAggregator {
             self.write_segment_ctx.kind, self.processed_log_entries
         );
         self.generate_append_segments().await?;
+        let message = match self.write_segment_ctx.kind {
+            MutationKind::Insert => Some("fuse insert output"),
+            MutationKind::Recluster => Some("fuse recluster output"),
+            _ => None,
+        };
+        if let Some(message) = message {
+            for (&level, stats) in &self.output_level_stats {
+                info!(
+                    table_id = self.table_id,
+                    level,
+                    block_count = stats.block_count,
+                    block_size = stats.block_size,
+                    file_size = stats.file_size;
+                    "{message}"
+                );
+            }
+        }
 
         let mut new_segment_locs = Vec::new();
         new_segment_locs.extend(self.appended_segments.clone());
@@ -227,6 +246,7 @@ impl TableMutationAggregator {
             virtual_schema_mode: VirtualSchemaMode::Merge,
             base_segments,
             merged_blocks,
+            output_level_stats: BTreeMap::new(),
             appended_statistics: Statistics::default(),
             removed_segment_indexes,
             removed_statistics,
@@ -274,6 +294,13 @@ impl TableMutationAggregator {
                 block_meta,
                 merge_hll,
             } => {
+                // Count newly written blocks only, not preloaded remained_blocks.
+                if matches!(self.write_segment_ctx.kind, MutationKind::Recluster) {
+                    ClusterLevelLogStats::accumulate(
+                        &mut self.output_level_stats,
+                        &block_meta.block_meta,
+                    );
+                }
                 // MERGE and REPLACE append logical INSERT/UPDATE after-images.
                 if merge_hll
                     || matches!(
@@ -304,9 +331,19 @@ impl TableMutationAggregator {
                 segment_location,
                 format_version,
                 summary,
+                level_stats,
                 hll,
                 top_n,
             } => {
+                if matches!(self.write_segment_ctx.kind, MutationKind::Insert) {
+                    for stats in level_stats {
+                        let total = self.output_level_stats.entry(stats.level).or_default();
+                        total.level = stats.level;
+                        total.block_count += stats.block_count;
+                        total.block_size += stats.block_size;
+                        total.file_size += stats.file_size;
+                    }
+                }
                 merge_statistics_mut(
                     &mut self.appended_statistics,
                     &summary,

--- a/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/transform_mutation_aggregator.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+databend_common_tracing::register_module_tag!("[FUSE-MUTATION]");
+
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
@@ -124,26 +126,31 @@ impl AsyncAccumulatingTransform for TableMutationAggregator {
     #[async_backtrace::framed]
     async fn on_finish(&mut self, _output: bool) -> Result<Option<DataBlock>> {
         info!(
-            "{}: finished aggregating mutation logs, entries: {}",
-            self.write_segment_ctx.kind, self.processed_log_entries
+            event = "mutation.aggregated",
+            operation = self.write_segment_ctx.kind.to_string().to_ascii_lowercase().as_str(),
+            table_id = self.table_id,
+            entry_count = self.processed_log_entries;
+            "Mutation logs aggregated"
         );
         self.generate_append_segments().await?;
-        let message = match self.write_segment_ctx.kind {
-            MutationKind::Insert => Some("fuse insert output"),
-            MutationKind::Recluster => Some("fuse recluster output"),
+        let operation = match self.write_segment_ctx.kind {
+            MutationKind::Insert => Some("insert"),
+            MutationKind::Recluster => Some("recluster"),
             _ => None,
         };
-        if let Some(message) = message {
-            for (&level, stats) in &self.output_level_stats {
-                info!(
-                    table_id = self.table_id,
-                    level,
-                    block_count = stats.block_count,
-                    block_size = stats.block_size,
-                    file_size = stats.file_size;
-                    "{message}"
-                );
-            }
+        if let Some(operation) = operation
+            && !self.output_level_stats.is_empty()
+        {
+            // Newly written blocks collected by this aggregator only; segment reuse is
+            // not rewrite output. These statistics precede CommitSink and do not imply
+            // a successful commit. Keep all levels together, even across multiple tasks.
+            info!(
+                event = "mutation.output_written",
+                operation,
+                table_id = self.table_id,
+                output_levels :serde = self.output_level_stats.values().collect::<Vec<_>>();
+                "Mutation output written"
+            );
         }
 
         let mut new_segment_locs = Vec::new();
@@ -538,7 +545,11 @@ impl TableMutationAggregator {
             }
         }
 
-        info!("removed_segment_indexes:{:?}", self.removed_segment_indexes);
+        info!(
+            table_id = self.table_id,
+            removed_segment_indexes :? = self.removed_segment_indexes;
+            "Mutation segment removals collected"
+        );
 
         if matches!(self.virtual_schema_mode, VirtualSchemaMode::Merge) {
             self.update_virtual_schema_block_number(&merged_statistics);

--- a/src/query/storages/fuse/src/operations/common/processors/transform_serialize_segment.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/transform_serialize_segment.rs
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use databend_common_catalog::plan::ClusterLevelLogStats;
 use databend_common_catalog::table::Table;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -80,6 +82,7 @@ pub struct TransformSerializeSegment<B: SegmentBuilder> {
     data_accessor: Operator,
     meta_locations: TableMetaLocationGenerator,
     segment_builder: B,
+    level_stats: BTreeMap<Option<i32>, ClusterLevelLogStats>,
     virtual_column_accumulator: Option<VirtualColumnAccumulator>,
     hll_accumulator: ColumnHLLAccumulator,
     block_top_n_template: Option<BlockTopN>,
@@ -135,6 +138,7 @@ impl<B: SegmentBuilder> TransformSerializeSegment<B> {
             meta_locations: table.meta_location_generator().clone(),
             state: State::None,
             segment_builder,
+            level_stats: Default::default(),
             virtual_column_accumulator,
             hll_accumulator: ColumnHLLAccumulator::default(),
             block_top_n_template,
@@ -285,6 +289,11 @@ impl<B: SegmentBuilder> Processor for TransformSerializeSegment<B> {
                 self.current_partition = next_partition.map(<[Scalar]>::to_vec);
             }
 
+            ClusterLevelLogStats::accumulate(
+                &mut self.level_stats,
+                &extended_block_meta.block_meta,
+            );
+
             if let Some(draft_virtual_block_meta) = extended_block_meta.draft_virtual_block_meta {
                 let mut block_meta = extended_block_meta.block_meta.clone();
                 if let Some(ref mut virtual_column_accumulator) = self.virtual_column_accumulator {
@@ -392,6 +401,9 @@ impl<B: SegmentBuilder> Processor for TransformSerializeSegment<B> {
                         segment_location: location,
                         format_version,
                         summary: segment.summary().clone(),
+                        level_stats: std::mem::take(&mut self.level_stats)
+                            .into_values()
+                            .collect(),
                         hll,
                         top_n,
                     }],

--- a/src/query/storages/fuse/src/operations/common/processors/transform_serialize_segment.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/transform_serialize_segment.rs
@@ -401,11 +401,11 @@ impl<B: SegmentBuilder> Processor for TransformSerializeSegment<B> {
                         segment_location: location,
                         format_version,
                         summary: segment.summary().clone(),
+                        hll,
+                        top_n,
                         level_stats: std::mem::take(&mut self.level_stats)
                             .into_values()
                             .collect(),
-                        hll,
-                        top_n,
                     }],
                     ..Default::default()
                 };

--- a/src/query/storages/fuse/src/operations/read/fuse_source.rs
+++ b/src/query/storages/fuse/src/operations/read/fuse_source.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+databend_common_tracing::register_module_tag!("[FUSE-SOURCE]");
+
 use std::collections::VecDeque;
 use std::sync::Arc;
 
@@ -57,6 +59,7 @@ pub fn build_fuse_source_pipeline(
     virtual_reader: Arc<Option<VirtualColumnReader>>,
     receiver: Option<Receiver<Result<PartInfoPtr>>>,
 ) -> Result<()> {
+    let original_max_io_requests = max_io_requests;
     (max_threads, max_io_requests) = adjust_threads_and_request(max_threads, max_io_requests, plan);
 
     let waker = pipeline.get_waker();
@@ -116,18 +119,20 @@ pub fn build_fuse_source_pipeline(
         )
     })?;
 
-    info!(
-        "[FUSE-SOURCE] Block data reader adjusted max_io_requests to {}",
-        max_io_requests
-    );
-
+    let original_output_streams = pipeline.output_len();
     pipeline.try_resize(std::cmp::min(max_threads, max_io_requests))?;
+    let output_streams = pipeline.output_len();
 
-    info!(
-        "[FUSE-SOURCE] Block read pipeline resized from {} to {} threads",
-        max_io_requests,
-        pipeline.output_len()
-    );
+    if output_streams != original_output_streams {
+        info!(
+            event = "fuse_source.configured",
+            original_max_io_requests,
+            max_io_requests,
+            original_output_streams,
+            output_streams;
+            "Block read pipeline configuration adjusted"
+        );
+    }
 
     match storage_format {
         FuseStorageFormat::Parquet => {

--- a/src/query/storages/fuse/src/operations/recluster/mod.rs
+++ b/src/query/storages/fuse/src/operations/recluster/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+databend_common_tracing::register_module_tag!("[FUSE-RECLUSTER]");
+
 mod hilbert_recluster;
 mod linear_recluster;
 mod recluster_mutator;

--- a/src/query/storages/fuse/src/operations/recluster/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/recluster/recluster_mutator.rs
@@ -402,7 +402,8 @@ impl ReclusterMutator {
                         average_depth: 0.0,
                     },
                     selected_blocks: Vec::new(),
-                    output_level: 0,
+                    base_level: 0,
+                    input_level_stats: Vec::new(),
                     all_ordered: false,
                 });
             } else {
@@ -590,7 +591,8 @@ impl ReclusterMutator {
                     total_rows,
                     total_bytes,
                     total_compressed,
-                    level: candidate.output_level,
+                    level: candidate.base_level,
+                    input_level_stats: candidate.input_level_stats.clone(),
                     all_ordered: candidate.all_ordered,
                 });
                 selected_block_count += block_metas.len() as u64;

--- a/src/query/storages/fuse/src/operations/recluster/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/recluster/recluster_mutator.rs
@@ -17,7 +17,6 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::time::Instant;
 
 use databend_common_base::runtime::GLOBAL_MEM_STAT;
 use databend_common_base::runtime::Runtime;
@@ -490,7 +489,7 @@ impl ReclusterMutator {
                     && (candidate.score.max_depth as f64) < 4.0 * self.properties.depth_threshold;
                 if defer {
                     debug!(
-                        "recluster: defer candidate group={} selected_bytes={} max_depth={} depth_threshold={} skip_reason=deferred_small_shallow_task",
+                        "recluster: defer candidate group={} block_size={} max_depth={} depth_threshold={} skip_reason=deferred_small_shallow_task",
                         group,
                         candidate.score.selected_total_bytes,
                         candidate.score.max_depth,
@@ -663,6 +662,8 @@ impl ReclusterMutator {
         }))
     }
 
+    // Capture group selection time in tracing without duplicating strategy summaries.
+    #[fastrace::trace]
     fn build_recluster_task_candidates_for_indices(
         &self,
         group: ReclusterGroup,
@@ -671,7 +672,6 @@ impl ReclusterMutator {
         task_budget: usize,
     ) -> Result<Vec<ReclusterTaskCandidate>> {
         debug_assert!(task_budget > 0);
-        let group_start = Instant::now();
         let block_count = indices.len();
         if block_count < 2 {
             return Ok(Vec::new());
@@ -711,23 +711,8 @@ impl ReclusterMutator {
             return Ok(vec![task_candidate(group, score, &indices, blocks)]);
         }
 
-        let candidates = self.strategy.fetch_task_candidates(
-            &self.properties,
-            group,
-            &indices,
-            blocks,
-            task_budget,
-        )?;
-
-        debug!(
-            "recluster: candidate selection group={} block_count={} task_count={} elapsed={:?}",
-            group,
-            block_count,
-            candidates.len(),
-            group_start.elapsed(),
-        );
-
-        Ok(candidates)
+        self.strategy
+            .fetch_task_candidates(&self.properties, group, &indices, blocks, task_budget)
     }
 
     /// Fast-path acceptance for very deep, sufficiently large candidates.

--- a/src/query/storages/fuse/src/operations/recluster/recluster_strategy.rs
+++ b/src/query/storages/fuse/src/operations/recluster/recluster_strategy.rs
@@ -337,6 +337,16 @@ impl ReclusterTaskCandidate {
             .sum()
     }
 
+    /// Requested output level for logs, or "null" for repack-only candidates.
+    /// Perfect output blocks may instead become -1.
+    pub(crate) fn requested_output_level(&self) -> String {
+        if self.is_repack_only() {
+            "null".to_string()
+        } else {
+            (self.base_level + 1).to_string()
+        }
+    }
+
     /// Whether this candidate only repacks unchanged blocks into fewer segments.
     pub(crate) fn is_repack_only(&self) -> bool {
         self.selected_blocks.is_empty()
@@ -347,12 +357,8 @@ impl fmt::Display for ReclusterTaskCandidate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "output_level={} repack_only={} max_depth={} avg_depth={} selected_count={} bytes={}",
-            if self.is_repack_only() {
-                "none".to_string()
-            } else {
-                (self.base_level + 1).to_string()
-            },
+            "requested_output_level={} repack_only={} max_depth={} avg_depth={} block_count={} block_size={}",
+            self.requested_output_level(),
             self.is_repack_only(),
             self.score.max_depth,
             self.score.average_depth,

--- a/src/query/storages/fuse/src/operations/recluster/recluster_strategy.rs
+++ b/src/query/storages/fuse/src/operations/recluster/recluster_strategy.rs
@@ -17,6 +17,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::Arc;
 
+use databend_common_catalog::plan::ClusterLevelLogStats;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::BlockThresholds;
@@ -48,7 +49,7 @@ use crate::statistics::prepare_cluster_key_exprs;
 pub enum ReclusterMode {
     /// Legacy one-window probing with tighter rewrite selection.
     Conservative,
-    /// Broader probing that groups mature blocks by level ranges.
+    /// Broader probing that mixes levels 1 through 3 while keeping other levels separate.
     Aggressive,
 }
 
@@ -217,48 +218,70 @@ pub(crate) trait ReclusterStrategy: Send + Sync {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ReclusterGroup {
     /// A single level forms its own group.
     Level(i32),
-    /// Aggressive mode: a fixed maturity bin identified by its lower bound `lo`.
-    Range(i32),
+    /// Aggressive mode groups the low mature levels 1 through 3.
+    LowMaturity,
+}
+
+impl Ord for ReclusterGroup {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        let key = |group: &Self| match group {
+            Self::Level(level) => (*level, 0),
+            Self::LowMaturity => (1, 1),
+        };
+        key(self).cmp(&key(other))
+    }
+}
+
+impl PartialOrd for ReclusterGroup {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 impl ReclusterGroup {
     /// Assign a block's recluster group for the given mode.
     pub(crate) fn assign(level: i32, mode: ReclusterMode) -> ReclusterGroup {
         match mode {
-            ReclusterMode::Conservative => ReclusterGroup::Level(level),
-            ReclusterMode::Aggressive if level == 0 => ReclusterGroup::Level(level),
-            ReclusterMode::Aggressive => {
-                debug_assert!(level > 0);
-                let lo = match level {
-                    1..=3 => 1,
-                    4..=8 => 4,
-                    _ => 9,
-                };
-                ReclusterGroup::Range(lo)
-            }
+            ReclusterMode::Aggressive if (1..=3).contains(&level) => ReclusterGroup::LowMaturity,
+            _ => ReclusterGroup::Level(level),
         }
     }
 
-    fn output_level(self, task_indices: &[usize], blocks: &[&ReclusterBlock]) -> i32 {
+    /// Return the base level consumed by the execution path, which writes blocks at `level + 1`.
+    fn base_level(self, task_indices: &[usize], blocks: &[&ReclusterBlock]) -> i32 {
         match self {
             ReclusterGroup::Level(level) => level,
-            ReclusterGroup::Range(lo) => {
-                let mut counts: BTreeMap<i32, usize> = BTreeMap::new();
-                for &idx in task_indices {
-                    let level = blocks[idx].stats().level;
-                    *counts.entry(level).or_default() += 1;
+            ReclusterGroup::LowMaturity => {
+                let max_level = task_indices
+                    .iter()
+                    .map(|idx| blocks[*idx].stats().level)
+                    .max()
+                    .expect("recluster task must contain blocks");
+                if max_level == 1 {
+                    return 1;
                 }
-                let mut best = (lo, 0usize);
-                for (level, count) in counts {
-                    if count > best.1 {
-                        best = (level, count);
+
+                let mut total_size = 0;
+                let mut max_level_size = 0;
+                for &idx in task_indices {
+                    let block = blocks[idx];
+                    total_size += block.meta.block_size;
+                    if block.stats().level == max_level {
+                        max_level_size += block.meta.block_size;
                     }
                 }
-                best.0
+
+                // The execution path adds one. Keep the final level at max_level unless the
+                // highest input level owns at least half of the selected logical bytes.
+                if max_level_size * 2 >= total_size {
+                    max_level
+                } else {
+                    max_level - 1
+                }
             }
         }
     }
@@ -268,10 +291,7 @@ impl fmt::Display for ReclusterGroup {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ReclusterGroup::Level(level) => write!(f, "{}", level),
-            ReclusterGroup::Range(1) => write!(f, "1-3"),
-            ReclusterGroup::Range(4) => write!(f, "4-8"),
-            ReclusterGroup::Range(9) => write!(f, "9+"),
-            ReclusterGroup::Range(lo) => unreachable!("unexpected FINAL bin lower bound: {lo}"),
+            ReclusterGroup::LowMaturity => write!(f, "1-3"),
         }
     }
 }
@@ -304,7 +324,8 @@ pub(crate) struct ReclusterTaskCandidate {
     pub(crate) score: CandidateScore,
     // Empty means a rebuild-only repack candidate.
     pub(crate) selected_blocks: Vec<(usize, Vec<usize>)>,
-    pub(crate) output_level: i32,
+    pub(crate) base_level: i32,
+    pub(crate) input_level_stats: Vec<ClusterLevelLogStats>,
     pub(crate) all_ordered: bool,
 }
 
@@ -326,8 +347,13 @@ impl fmt::Display for ReclusterTaskCandidate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "output_level={} max_depth={} avg_depth={} selected_count={} bytes={}",
-            self.output_level,
+            "output_level={} repack_only={} max_depth={} avg_depth={} selected_count={} bytes={}",
+            if self.is_repack_only() {
+                "none".to_string()
+            } else {
+                (self.base_level + 1).to_string()
+            },
+            self.is_repack_only(),
             self.score.max_depth,
             self.score.average_depth,
             self.selected_block_count(),
@@ -390,14 +416,29 @@ pub(crate) fn task_candidate(
         }
     }
 
-    let output_level = group.output_level(task_indices, blocks);
+    let base_level = group.base_level(task_indices, blocks);
+    let mut stats_by_level = BTreeMap::<i32, ClusterLevelLogStats>::new();
+    for &idx in task_indices {
+        let block = blocks[idx];
+        let level = block.stats().level;
+        let stats = stats_by_level
+            .entry(level)
+            .or_insert_with(|| ClusterLevelLogStats {
+                level: Some(level),
+                ..Default::default()
+            });
+        stats.block_count += 1;
+        stats.block_size = stats.block_size.saturating_add(block.meta.block_size);
+        stats.file_size = stats.file_size.saturating_add(block.meta.file_size);
+    }
     let all_ordered = task_indices
         .iter()
         .all(|idx| matches!(&blocks[*idx].stats, ReclusterBlockStats::Original));
     ReclusterTaskCandidate {
         score,
         selected_blocks,
-        output_level,
+        base_level,
+        input_level_stats: stats_by_level.into_values().collect(),
         all_ordered,
     }
 }

--- a/src/query/storages/fuse/src/operations/recluster/recluster_strategy.rs
+++ b/src/query/storages/fuse/src/operations/recluster/recluster_strategy.rs
@@ -434,6 +434,7 @@ pub(crate) fn task_candidate(
                 ..Default::default()
             });
         stats.block_count += 1;
+        stats.row_count = stats.row_count.saturating_add(block.meta.row_count);
         stats.block_size = stats.block_size.saturating_add(block.meta.block_size);
         stats.file_size = stats.file_size.saturating_add(block.meta.file_size);
     }

--- a/src/query/storages/fuse/src/operations/recluster/recluster_table.rs
+++ b/src/query/storages/fuse/src/operations/recluster/recluster_table.rs
@@ -178,7 +178,7 @@ impl FuseTable {
             .map(|(idx, location)| (location, idx))
             .collect::<HashMap<_, _>>();
         let number_segments = snapshot.segments.len();
-        let mut recluster_blocks_count = 0;
+        let mut repack_count = 0;
         let mut recluster_segment_pruner = None;
         let mut decode_semaphore = None;
 
@@ -295,7 +295,7 @@ impl FuseTable {
                 .await?;
 
                 let status = format!(
-                    "[FUSE-RECLUSTER] Scanned segment range: scan_start={} scan_end={} scan_segments={} probe_segments={} segment_progress={}/{}, elapsed={:?}",
+                    "[FUSE-RECLUSTER] Scanned segment range: scan_start={} scan_end={} scanned_segments={} probe_segments={} segment_progress={}/{} elapsed={:?}",
                     scan_start,
                     scan_end,
                     scan_segments,
@@ -384,18 +384,20 @@ impl FuseTable {
                             pending_windows.push(window);
                         }
                     }
-                    info!(
-                        "recluster: probed candidate windows candidate_windows={} probe_windows={} probe_tasks={} pending_windows={} elapsed={:?}",
-                        windows_num,
-                        probe_windows,
-                        probe_tasks,
-                        pending_windows.len(),
-                        probe_start.elapsed(),
+                    debug!(
+                        event = "recluster.probed",
+                        table_id = self.get_id(),
+                        candidate_windows = windows_num,
+                        probed_windows = probe_windows,
+                        probe_tasks = probe_tasks,
+                        pending_windows = pending_windows.len(),
+                        elapsed :? = probe_start.elapsed();
+                        "Recluster windows probed"
                     );
                 }
             }
 
-            let (block_count, parts) = if pending_windows.is_empty() {
+            let (_, parts) = if pending_windows.is_empty() {
                 (0, ReclusterParts::default())
             } else {
                 // Step 3: choose task candidates. Preserve score-only ranking unless
@@ -428,9 +430,19 @@ impl FuseTable {
                     } else {
                         for &task_idx in &task_indices {
                             let task = &window.tasks[task_idx];
+                            repack_count += usize::from(task.is_repack_only());
                             info!(
-                                "recluster: selected task candidate window_idx={} task_idx={} {}",
-                                window_idx, task_idx, task,
+                                event = "recluster.candidate_selected",
+                                table_id = self.get_id(),
+                                window_idx,
+                                task_idx,
+                                base_level = task.base_level,
+                                repack_only = task.is_repack_only(),
+                                max_depth = task.score.max_depth,
+                                avg_depth = task.score.average_depth,
+                                block_count = task.selected_block_count(),
+                                block_size = task.score.selected_total_bytes;
+                                "Recluster candidate selected"
                             );
                         }
                         // Any selected task consumes its whole window.
@@ -452,8 +464,6 @@ impl FuseTable {
                     MAX_SEGMENT_LOCATIONS_PER_CLAIM,
                 )));
             }
-            recluster_blocks_count += block_count;
-
             if !parts.is_empty() {
                 // Keep unselected windows as best-effort continuation state for this scan range.
                 // Empty windows cache stable probes while other tasks are still being rewritten.
@@ -492,11 +502,19 @@ impl FuseTable {
 
         let recluster_seg_num = parts.removed_segment_indexes.len() as u64;
         let elapsed_time = start.elapsed();
+        info!(
+            event = "recluster.planned",
+            table_id = self.get_id(),
+            strategy = format!("{:?}", mutator.properties.cluster_key_info.cluster_type).as_str(),
+            mode = format!("{:?}", mode).as_str(),
+            tasks = parts.tasks.len(),
+            repack_count,
+            segments = recluster_seg_num,
+            block_count = parts.tasks.iter().map(|task| task.parts.len()).sum::<usize>();
+            "Recluster planned"
+        );
         ctx.set_status_info(&format!(
-            "[FUSE-RECLUSTER] Built recluster tasks: tasks={} segments={} blocks={} elapsed={:?}",
-            parts.tasks.len(),
-            recluster_seg_num,
-            recluster_blocks_count,
+            "[FUSE-RECLUSTER] Task planning completed: elapsed={:?}",
             elapsed_time,
         ));
         metrics_inc_recluster_build_task_milliseconds(elapsed_time.as_millis() as u64);

--- a/src/query/storages/fuse/src/operations/recluster/recluster_table.rs
+++ b/src/query/storages/fuse/src/operations/recluster/recluster_table.rs
@@ -606,7 +606,8 @@ mod tests {
                 .into_iter()
                 .map(|position| (position, vec![0]))
                 .collect(),
-            output_level: 0,
+            base_level: 0,
+            input_level_stats: Vec::new(),
             all_ordered: false,
         }
     }

--- a/src/query/storages/fuse/src/table_functions/clustering_information.rs
+++ b/src/query/storages/fuse/src/table_functions/clustering_information.rs
@@ -443,6 +443,10 @@ impl ClusteringInformationImpl<'_> {
                 constant_block_count,
                 average_overlaps: rounded_average(aggregate.sum_overlap, aggregate.block_count),
                 average_depth: rounded_average(aggregate.sum_depth, aggregate.block_count),
+                max_depth: aggregate
+                    .depth_counts
+                    .last_key_value()
+                    .map_or(0, |(&depth, _)| depth),
                 p95_depth: percentile_depth(&aggregate.depth_counts, aggregate.block_count, 95),
                 p99_depth: percentile_depth(&aggregate.depth_counts, aggregate.block_count, 99),
                 block_depth_histogram: {
@@ -461,13 +465,14 @@ impl ClusteringInformationImpl<'_> {
             }
         };
         info!(
-            "clustering_information: finished table={} cluster_type={} blocks={} constant_blocks={} average_overlaps={} average_depth={} p95_depth={} p99_depth={} calculation_elapsed={:?} total_elapsed={:?}",
+            "clustering_information: finished table={} cluster_type={} blocks={} constant_blocks={} average_overlaps={} average_depth={} max_depth={} p95_depth={} p99_depth={} calculation_elapsed={:?} total_elapsed={:?}",
             self.table.table_info.desc,
             cluster_type,
             info.total_block_count,
             info.constant_block_count,
             info.average_overlaps,
             info.average_depth,
+            info.max_depth,
             info.p95_depth,
             info.p99_depth,
             calculation_start.elapsed(),
@@ -674,6 +679,7 @@ struct LinearClusterStatistics {
     constant_block_count: u64,
     average_overlaps: f64,
     average_depth: f64,
+    max_depth: usize,
     p95_depth: usize,
     p99_depth: usize,
     block_depth_histogram: BTreeMap<String, u64>,

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0008_fuse_optimize_table.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0008_fuse_optimize_table.test
@@ -528,7 +528,7 @@ insert into t10 values(2),(5),(-7)
 query TTT
 select * exclude(timestamp) from clustering_information('db_09_0008','t10')
 ----
-(abs(a)) linear {"average_depth":2.75,"average_overlaps":2.0,"block_depth_histogram":{"00002":1,"00003":3},"constant_block_count":1,"p95_depth":3,"p99_depth":3,"total_block_count":4}
+(abs(a)) linear {"average_depth":2.75,"average_overlaps":2.0,"block_depth_histogram":{"00002":1,"00003":3},"constant_block_count":1,"max_depth":3,"p95_depth":3,"p99_depth":3,"total_block_count":4}
 
 statement ok
 alter table t10 recluster
@@ -572,7 +572,7 @@ insert into t11 values(-6),(-8)
 query TTT
 select * exclude(timestamp) from clustering_information('db_09_0008','t11')
 ----
-(abs(a)) linear {"average_depth":2.75,"average_overlaps":2.0,"block_depth_histogram":{"00002":1,"00003":3},"constant_block_count":1,"p95_depth":3,"p99_depth":3,"total_block_count":4}
+(abs(a)) linear {"average_depth":2.75,"average_overlaps":2.0,"block_depth_histogram":{"00002":1,"00003":3},"constant_block_count":1,"max_depth":3,"p95_depth":3,"p99_depth":3,"total_block_count":4}
 
 statement ok
 optimize table t11 compact limit 2
@@ -734,7 +734,7 @@ alter table t14 recluster
 query TTT
 select * exclude(timestamp) from clustering_information('db_09_0008','t14')
 ----
-(a, b) linear {"average_depth":1.0,"average_overlaps":0.0,"block_depth_histogram":{"00001":1},"constant_block_count":0,"p95_depth":1,"p99_depth":1,"total_block_count":1}
+(a, b) linear {"average_depth":1.0,"average_overlaps":0.0,"block_depth_histogram":{"00001":1},"constant_block_count":0,"max_depth":1,"p95_depth":1,"p99_depth":1,"total_block_count":1}
 
 statement ok
 create table t16(a int, b int) file_size = 100;

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0014_func_clustering_information_function.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0014_func_clustering_information_function.test
@@ -32,17 +32,17 @@ select min, max, level, block_depth from clustering_statistics('default','t09_00
 query TT?
 select * exclude(timestamp) from clustering_information('default','t09_0014')
 ----
-(b, a) linear {"average_depth":1.6667,"average_overlaps":0.6667,"block_depth_histogram":{"00001":1,"00002":2},"constant_block_count":1,"p95_depth":2,"p99_depth":2,"total_block_count":3}
+(b, a) linear {"average_depth":1.6667,"average_overlaps":0.6667,"block_depth_histogram":{"00001":1,"00002":2},"constant_block_count":1,"max_depth":2,"p95_depth":2,"p99_depth":2,"total_block_count":3}
 
-query TT
-select info:p95_depth, info:p99_depth from clustering_information('default','t09_0014')
+query TTT
+select info:max_depth, info:p95_depth, info:p99_depth from clustering_information('default','t09_0014')
 ----
-2 2
+2 2 2
 
 query TT?
 select * exclude(timestamp) from clustering_information('default','t09_0014', '(a)')
 ----
-(a) linear {"average_depth":1.6667,"average_overlaps":0.6667,"block_depth_histogram":{"00001":1,"00002":2},"constant_block_count":1,"p95_depth":2,"p99_depth":2,"total_block_count":3}
+(a) linear {"average_depth":1.6667,"average_overlaps":0.6667,"block_depth_histogram":{"00001":1,"00002":2},"constant_block_count":1,"max_depth":2,"p95_depth":2,"p99_depth":2,"total_block_count":3}
 
 statement ok
 ALTER TABLE t09_0014 DROP CLUSTER KEY
@@ -56,7 +56,7 @@ select * from clustering_statistics('default','t09_0014')
 query TT?
 select * exclude(timestamp) from clustering_information('default','t09_0014', '(b, a)')
 ----
-(b, a) linear {"average_depth":1.6667,"average_overlaps":0.6667,"block_depth_histogram":{"00001":1,"00002":2},"constant_block_count":1,"p95_depth":2,"p99_depth":2,"total_block_count":3}
+(b, a) linear {"average_depth":1.6667,"average_overlaps":0.6667,"block_depth_histogram":{"00001":1,"00002":2},"constant_block_count":1,"max_depth":2,"p95_depth":2,"p99_depth":2,"total_block_count":3}
 
 statement ok
 drop table t09_0014
@@ -73,22 +73,22 @@ insert into t09_0014_1 values ('xyy'), ('xyz')
 query TT?
 select * exclude(timestamp) from clustering_information('default','t09_0014_1', '(c)')
 ----
-(c) linear {"average_depth":1.0,"average_overlaps":0.0,"block_depth_histogram":{"00001":2},"constant_block_count":0,"p95_depth":1,"p99_depth":1,"total_block_count":2}
+(c) linear {"average_depth":1.0,"average_overlaps":0.0,"block_depth_histogram":{"00001":2},"constant_block_count":0,"max_depth":1,"p95_depth":1,"p99_depth":1,"total_block_count":2}
 
 query TT?
 select * exclude(timestamp) from clustering_information('default','t09_0014_1', '(substr(c,1))')
 ----
-(SUBSTRING(c FROM 1)) linear {"average_depth":1.0,"average_overlaps":0.0,"block_depth_histogram":{"00001":2},"constant_block_count":0,"p95_depth":1,"p99_depth":1,"total_block_count":2}
+(SUBSTRING(c FROM 1)) linear {"average_depth":1.0,"average_overlaps":0.0,"block_depth_histogram":{"00001":2},"constant_block_count":0,"max_depth":1,"p95_depth":1,"p99_depth":1,"total_block_count":2}
 
 query TT?
 select * exclude(timestamp) from clustering_information('default','t09_0014_1', '(substr(c,1,2))')
 ----
-(SUBSTRING(c FROM 1 FOR 2)) linear {"average_depth":1.0,"average_overlaps":0.0,"block_depth_histogram":{"00001":2},"constant_block_count":2,"p95_depth":1,"p99_depth":1,"total_block_count":2}
+(SUBSTRING(c FROM 1 FOR 2)) linear {"average_depth":1.0,"average_overlaps":0.0,"block_depth_histogram":{"00001":2},"constant_block_count":2,"max_depth":1,"p95_depth":1,"p99_depth":1,"total_block_count":2}
 
 query TT?
 select * exclude(timestamp) from clustering_information('default','t09_0014_1', '(substr(c,2,2))')
 ----
-(SUBSTRING(c FROM 2 FOR 2)) linear {"average_depth":2.0,"average_overlaps":1.0,"block_depth_histogram":{"00002":2},"constant_block_count":0,"p95_depth":2,"p99_depth":2,"total_block_count":2}
+(SUBSTRING(c FROM 2 FOR 2)) linear {"average_depth":2.0,"average_overlaps":1.0,"block_depth_histogram":{"00002":2},"constant_block_count":0,"max_depth":2,"p95_depth":2,"p99_depth":2,"total_block_count":2}
 
 statement ok
 drop table t09_0014_1 all
@@ -106,12 +106,12 @@ insert into t09_0014_2 values('bcdff'),('cdefg')
 query TT?
 select * exclude(timestamp) from clustering_information('default','t09_0014_2')
 ----
-(SUBSTRING(c FROM 1 FOR 4)) linear {"average_depth":1.0,"average_overlaps":0.0,"block_depth_histogram":{"00001":2},"constant_block_count":0,"p95_depth":1,"p99_depth":1,"total_block_count":2}
+(SUBSTRING(c FROM 1 FOR 4)) linear {"average_depth":1.0,"average_overlaps":0.0,"block_depth_histogram":{"00001":2},"constant_block_count":0,"max_depth":1,"p95_depth":1,"p99_depth":1,"total_block_count":2}
 
 query TT?
 select * exclude(timestamp) from clustering_information('default','t09_0014_2', 'substr(c,2,4)')
 ----
-(SUBSTRING(c FROM 2 FOR 4)) linear {"average_depth":2.0,"average_overlaps":1.0,"block_depth_histogram":{"00002":2},"constant_block_count":0,"p95_depth":2,"p99_depth":2,"total_block_count":2}
+(SUBSTRING(c FROM 2 FOR 4)) linear {"average_depth":2.0,"average_overlaps":1.0,"block_depth_histogram":{"00002":2},"constant_block_count":0,"max_depth":2,"p95_depth":2,"p99_depth":2,"total_block_count":2}
 
 statement ok
 drop table t09_0014_2 all

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0015_remote_alter_cluster_key.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0015_remote_alter_cluster_key.test
@@ -22,7 +22,7 @@ INSERT INTO t09_0015_0 VALUES(1,3),(2,1)
 query TT?
 select * exclude(timestamp) from clustering_information('db1','t09_0015_0')
 ----
-(b, a) linear {"average_depth":2.0,"average_overlaps":1.0,"block_depth_histogram":{"00002":2},"constant_block_count":0,"p95_depth":2,"p99_depth":2,"total_block_count":2}
+(b, a) linear {"average_depth":2.0,"average_overlaps":1.0,"block_depth_histogram":{"00002":2},"constant_block_count":0,"max_depth":2,"p95_depth":2,"p99_depth":2,"total_block_count":2}
 
 statement ok
 ALTER TABLE t09_0015_0 CLUSTER BY(a,b)
@@ -33,7 +33,7 @@ INSERT INTO t09_0015_0 VALUES(4,4)
 query TT?
 select * exclude(timestamp) from clustering_information('db1','t09_0015_0')
 ----
-(a, b) linear {"average_depth":1.6667,"average_overlaps":0.6667,"block_depth_histogram":{"00001":1,"00002":2},"constant_block_count":1,"p95_depth":2,"p99_depth":2,"total_block_count":3}
+(a, b) linear {"average_depth":1.6667,"average_overlaps":0.6667,"block_depth_histogram":{"00001":1,"00002":2},"constant_block_count":1,"max_depth":2,"p95_depth":2,"p99_depth":2,"total_block_count":3}
 
 query II
 SELECT * FROM t09_0015_0 ORDER BY b,a

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0016_remote_alter_recluster.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0016_remote_alter_recluster.test
@@ -22,7 +22,7 @@ insert into t1 values(4,4)
 query TTT
 select * exclude(timestamp) from clustering_information('db_09_0016','t1')
 ----
-(a + 1) linear {"average_depth":2.0,"average_overlaps":1.3333,"block_depth_histogram":{"00002":3},"constant_block_count":1,"p95_depth":2,"p99_depth":2,"total_block_count":3}
+(a + 1) linear {"average_depth":2.0,"average_overlaps":1.3333,"block_depth_histogram":{"00002":3},"constant_block_count":1,"max_depth":2,"p95_depth":2,"p99_depth":2,"total_block_count":3}
 
 statement ok
 ALTER TABLE t1 RECLUSTER FINAL WHERE a != 4
@@ -30,7 +30,7 @@ ALTER TABLE t1 RECLUSTER FINAL WHERE a != 4
 query TTT
 select * exclude(timestamp) from clustering_information('db_09_0016','t1')
 ----
-(a + 1) linear {"average_depth":2.0,"average_overlaps":1.0,"block_depth_histogram":{"00002":2},"constant_block_count":1,"p95_depth":2,"p99_depth":2,"total_block_count":2}
+(a + 1) linear {"average_depth":2.0,"average_overlaps":1.0,"block_depth_histogram":{"00002":2},"constant_block_count":1,"max_depth":2,"p95_depth":2,"p99_depth":2,"total_block_count":2}
 
 query II
 select * from t1 order by a
@@ -67,7 +67,7 @@ insert into t3 values(1,'a'),(2,null)
 query TTT
 select * exclude(timestamp) from clustering_information('db_09_0016','t3')
 ----
-(b) linear {"average_depth":2.0,"average_overlaps":1.0,"block_depth_histogram":{"00002":2},"constant_block_count":0,"p95_depth":2,"p99_depth":2,"total_block_count":2}
+(b) linear {"average_depth":2.0,"average_overlaps":1.0,"block_depth_histogram":{"00002":2},"constant_block_count":0,"max_depth":2,"p95_depth":2,"p99_depth":2,"total_block_count":2}
 
 statement ok
 insert into t3 values(3,'a'),(4,'c')
@@ -93,7 +93,7 @@ insert into t3 values(3,'123456782'),(4,'123456783')
 query TTT
 select * exclude(timestamp) from clustering_information('db_09_0016','t3')
 ----
-(b) linear {"average_depth":2.0,"average_overlaps":1.0,"block_depth_histogram":{"00002":2},"constant_block_count":2,"p95_depth":2,"p99_depth":2,"total_block_count":2}
+(b) linear {"average_depth":2.0,"average_overlaps":1.0,"block_depth_histogram":{"00002":2},"constant_block_count":2,"max_depth":2,"p95_depth":2,"p99_depth":2,"total_block_count":2}
 
 # Fix pr#13332
 statement ok

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0023_replace_into.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0023_replace_into.test
@@ -436,7 +436,7 @@ select a, b FROM test order by a
 query TTT
 select * exclude(timestamp) FROM clustering_information('db_09_0023','test')
 ----
-(a + 1, b) linear {"average_depth":1.0,"average_overlaps":0.0,"block_depth_histogram":{"00001":3},"constant_block_count":2,"p95_depth":1,"p99_depth":1,"total_block_count":3}
+(a + 1, b) linear {"average_depth":1.0,"average_overlaps":0.0,"block_depth_histogram":{"00001":3},"constant_block_count":2,"max_depth":1,"p95_depth":1,"p99_depth":1,"total_block_count":3}
 
 statement ok
 DROP TABLE test

--- a/tests/sqllogictests/suites/mode/standalone/explain/clustering.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/clustering.test
@@ -16,7 +16,7 @@ ALTER TABLE test_linear RECLUSTER FINAL;
 query TTT
 select * exclude(timestamp) from clustering_information('default','test_linear')
 ----
-(a, b) linear {"average_depth":1.0,"average_overlaps":0.0,"block_depth_histogram":{"00001":2},"constant_block_count":0,"p95_depth":1,"p99_depth":1,"total_block_count":2}
+(a, b) linear {"average_depth":1.0,"average_overlaps":0.0,"block_depth_histogram":{"00001":2},"constant_block_count":0,"max_depth":1,"p95_depth":1,"p99_depth":1,"total_block_count":2}
 
 query T
 EXPLAIN SELECT * FROM test_linear WHERE a = 1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Restrict aggressive recluster mixing to levels 1–3; keep level 0 and each level >= 4 separate, with explicit group ordering before the task budget is consumed.
- Determine promotion from the highest input level's share of uncompressed block bytes: at least 50% advances to max + 1; otherwise keep max. For equal-sized blocks, `1,1,3 -> 3`, `1,3,3 -> 4`, and `1,2,3 -> 3`. Preserve the executor's base-level-plus-one convention.
- Add structured `fuse insert output`, `fuse recluster input`, and `fuse recluster output` logs with `table_id`, `level`, `block_count`, `block_size`, and `file_size`. Share `ClusterLevelLogStats`; preserve per-block insert levels before segment reduction, and exclude unchanged remained blocks from recluster output.
- Add `max_depth` in clustering_information.

These logs describe selected input and pre-commit write observations, not committed snapshot deltas or complete failed-operation IO accounting. Input levels use the current cluster key's effective statistics; output levels reflect written blocks, including perfect level -1 and NULL for missing cluster statistics. No per-round correlation or new history table is introduced.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding assistant helped draft and revise the recluster level calculation, diagnostic logs, regression tests, and PR summary. The responsible human reviewed the diff and directed the simplifications.
- Responsible human: @zhyass
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20443)
<!-- Reviewable:end -->
