### PR TITLE
feat: rewrite decimal stats on metadata-only alter

### DIFF
--- a/src/query/service/src/interpreters/common/mod.rs
+++ b/src/query/service/src/interpreters/common/mod.rs
@@ -47,6 +47,7 @@ pub use query_log::InterpreterQueryLog;
 pub use stream::dml_build_update_stream_req;
 pub use stream::query_build_update_stream_req;
 pub use table::check_referenced_computed_columns;
+pub use table::stored_computed_column_references;
 pub use util::check_deduplicate_label;
 pub use worker::get_worker_client_config;
 

--- a/src/query/service/src/interpreters/common/table.rs
+++ b/src/query/service/src/interpreters/common/table.rs
@@ -56,3 +56,24 @@ pub fn check_referenced_computed_columns(
     }
     Ok(())
 }
+
+pub fn stored_computed_column_references(
+    ctx: Arc<dyn TableContext>,
+    schema: DataSchemaRef,
+    column: &str,
+) -> Result<bool> {
+    for field in schema.fields() {
+        let Some(ComputedExpr::Stored(sql)) = field.computed_expr() else {
+            continue;
+        };
+        let expr = parse_computed_expr(ctx.clone(), schema.clone(), sql)?;
+        if expr
+            .column_refs()
+            .keys()
+            .any(|binding| binding.column_name == column)
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}

--- a/src/query/service/src/interpreters/interpreter_table_modify_column.rs
+++ b/src/query/service/src/interpreters/interpreter_table_modify_column.rs
@@ -16,6 +16,8 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use arrow_schema::Schema as ArrowSchema;
+use chrono::Utc;
 use databend_common_catalog::catalog::Catalog;
 use databend_common_catalog::table::Table;
 use databend_common_catalog::table::TableExt;
@@ -23,12 +25,14 @@ use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::ComputedExpr;
 use databend_common_expression::DataSchema;
+use databend_common_expression::Expr;
 use databend_common_expression::Scalar;
 use databend_common_expression::TableDataType;
 use databend_common_expression::TableField;
 use databend_common_expression::TableSchema;
 use databend_common_expression::TableSchemaRef;
 use databend_common_expression::types::DataType;
+use databend_common_expression::types::DecimalSize;
 use databend_common_license::license::Feature::ComputedColumn;
 use databend_common_license::license::Feature::DataMask;
 use databend_common_license::license_manager::LicenseManagerSwitch;
@@ -45,30 +49,43 @@ use databend_common_sql::DefaultExprBinder;
 use databend_common_sql::Planner;
 use databend_common_sql::analyze_cluster_keys;
 use databend_common_sql::binder::validate_constraints_by_schema;
+use databend_common_sql::parse_cluster_keys;
 use databend_common_sql::plans::ModifyColumnAction;
 use databend_common_sql::plans::ModifyTableColumnPlan;
 use databend_common_sql::plans::Plan;
 use databend_common_sql::resolve_type_name_by_str;
 use databend_common_storages_basic::view_table::VIEW_ENGINE;
 use databend_common_storages_fuse::FuseTable;
+use databend_common_storages_fuse::io::CachedMetaWriter;
+use databend_common_storages_fuse::io::MetaWriter;
+use databend_common_storages_fuse::io::SegmentsIO;
+use databend_common_storages_fuse::io::read_segment_stats;
 use databend_common_storages_stream::stream_table::STREAM_ENGINE;
 use databend_common_users::UserApiProvider;
 use databend_enterprise_data_mask_feature::get_datamask_handler;
 use databend_meta_client::types::MatchSeq;
 use databend_storages_common_index::BloomIndex;
 use databend_storages_common_index::RangeIndex;
+use databend_storages_common_table_meta::meta::SegmentInfo;
+use databend_storages_common_table_meta::meta::SegmentStatistics;
 use databend_storages_common_table_meta::meta::SnapshotId;
 use databend_storages_common_table_meta::meta::TableMetaTimestamps;
+use databend_storages_common_table_meta::meta::TableSnapshot;
+use databend_storages_common_table_meta::meta::Versioned;
 use databend_storages_common_table_meta::readers::snapshot_reader::TableSnapshotAccessor;
 use databend_storages_common_table_meta::table::OPT_KEY_ANALYZE_FREQUENCY_COLUMNS;
 use databend_storages_common_table_meta::table::OPT_KEY_APPROX_DISTINCT_COLUMNS;
 use databend_storages_common_table_meta::table::OPT_KEY_BLOOM_INDEX_COLUMNS;
 use databend_storages_common_table_meta::table::OPT_KEY_PARTITION_BY;
+use databend_storages_common_table_meta::table::OPT_KEY_SNAPSHOT_LOCATION;
+use parquet::arrow::ArrowSchemaConverter;
 
 use crate::interpreters::Interpreter;
 use crate::interpreters::common::check_referenced_computed_columns;
 use crate::interpreters::common::cluster_key_referenced_columns;
+use crate::interpreters::common::stored_computed_column_references;
 use crate::interpreters::interpreter_table_add_column::commit_table_meta;
+use crate::interpreters::interpreter_table_add_column::update_table_meta;
 use crate::meta_service_error;
 use crate::physical_plans::DistributedInsertSelect;
 use crate::physical_plans::PhysicalPlan;
@@ -85,6 +102,19 @@ use crate::sessions::TableContextTableManagement;
 pub struct ModifyTableColumnInterpreter {
     ctx: Arc<QueryContext>,
     plan: ModifyTableColumnPlan,
+}
+
+#[derive(Clone, Copy)]
+struct DecimalStatsRewrite {
+    column_id: u32,
+    size: DecimalSize,
+}
+
+#[derive(Clone, Copy)]
+struct DecimalClusterStatsRewrite {
+    cluster_key_id: u32,
+    dimension: usize,
+    size: DecimalSize,
 }
 
 impl ModifyTableColumnInterpreter {
@@ -419,20 +449,42 @@ impl ModifyTableColumnInterpreter {
         }
 
         let mut modified_default_scalars = HashMap::new();
+        let mut decimal_stats_rewrites = Vec::new();
         let mut default_expr_binder = DefaultExprBinder::try_new(self.ctx.clone())?;
         let new_schema_without_computed_fields = new_schema.remove_computed_fields();
+        let new_data_schema = Arc::new(DataSchema::from(new_schema.as_ref()));
         let format_as_parquet = fuse_table.storage_format_as_parquet();
         if schema != new_schema {
             for (field, _) in field_and_comments {
                 let old_field = schema.field_with_name(&field.name)?;
                 let is_alter_column_string_to_binary =
                     is_string_to_binary(&old_field.data_type, &field.data_type);
+                let is_decimal_precision_widening = format_as_parquet
+                    && !fuse_table.is_column_oriented()
+                    && is_decimal_precision_widening(&old_field.data_type, &field.data_type)?;
+                let has_stored_computed_dependency = is_decimal_precision_widening
+                    && stored_computed_column_references(
+                        self.ctx.clone(),
+                        new_data_schema.clone(),
+                        &field.name,
+                    )?;
+                let is_metadata_only_decimal_widening =
+                    is_decimal_precision_widening && !has_stored_computed_dependency;
+                if is_metadata_only_decimal_widening {
+                    decimal_stats_rewrites.push(DecimalStatsRewrite {
+                        column_id: old_field.column_id,
+                        size: decimal_size(&field.data_type).ok_or_else(|| {
+                            ErrorCode::Internal("Decimal widening has no target DecimalSize")
+                        })?,
+                    });
+                }
                 // If two conditions are met, we don't need rebuild the table,
                 // as rebuild table can be a time-consuming job.
                 // 1. alter column from string to binary in parquet or data type not changed.
                 // 2. default expr and computed expr not changed. Otherwise, we need fill value for
                 //    new added column.
                 if ((format_as_parquet && is_alter_column_string_to_binary)
+                    || is_metadata_only_decimal_widening
                     || old_field.data_type == field.data_type)
                     && old_field.default_expr == field.default_expr
                     && old_field.computed_expr == field.computed_expr
@@ -446,10 +498,45 @@ impl ModifyTableColumnInterpreter {
             }
         }
 
+        let table_is_empty = base_snapshot
+            .as_ref()
+            .is_none_or(|snapshot| snapshot.summary.row_count == 0);
+        let has_persisted_segments = base_snapshot
+            .as_ref()
+            .is_some_and(|snapshot| !snapshot.segments.is_empty());
+        // If this defensive state ever occurs, Decimal statistics in the remaining segment
+        // objects still need retagging. Keep this segment-based gate scoped to Decimal so the
+        // existing empty-table behavior of unrelated metadata-only alters does not change.
+        let needs_decimal_stats_rewrite = !decimal_stats_rewrites.is_empty()
+            && has_persisted_segments
+            && !fuse_table.is_column_oriented();
+        let decimal_cluster_rewrites =
+            if modified_default_scalars.is_empty() && needs_decimal_stats_rewrite {
+                decimal_cluster_stats_rewrites(self.ctx.clone(), fuse_table, new_schema.clone())?
+            } else {
+                Some(Vec::new())
+            };
+
         // if don't need to rebuild table, only update table meta.
-        if modified_default_scalars.is_empty()
-            || base_snapshot.is_none_or(|v| v.summary.row_count == 0)
+        if (modified_default_scalars.is_empty() && decimal_cluster_rewrites.is_some())
+            || (table_is_empty && !needs_decimal_stats_rewrite)
         {
+            if needs_decimal_stats_rewrite {
+                let cluster_rewrites = decimal_cluster_rewrites.as_deref().unwrap_or_default();
+                rewrite_decimal_stats_and_commit(
+                    &self.ctx,
+                    fuse_table,
+                    base_snapshot.unwrap(),
+                    new_schema,
+                    table_info.meta.clone(),
+                    catalog,
+                    &decimal_stats_rewrites,
+                    cluster_rewrites,
+                    table_meta_timestamps,
+                )
+                .await?;
+                return Ok(PipelineBuildResult::create());
+            }
             commit_table_meta(
                 &self.ctx,
                 table.as_ref(),
@@ -878,6 +965,275 @@ fn is_string_to_binary(old_ty: &TableDataType, new_ty: &TableDataType) -> bool {
         }
         _ => false,
     }
+}
+
+fn is_decimal_precision_widening(old_ty: &TableDataType, new_ty: &TableDataType) -> Result<bool> {
+    match (old_ty, new_ty) {
+        (TableDataType::Decimal(old), TableDataType::Decimal(new)) => {
+            if old.scale() != new.scale() || old.precision() >= new.precision() {
+                return Ok(false);
+            }
+            Ok(decimal_parquet_physical_type(old_ty)? == decimal_parquet_physical_type(new_ty)?)
+        }
+        (TableDataType::Nullable(old), TableDataType::Nullable(new)) => {
+            is_decimal_precision_widening(old, new)
+        }
+        _ => Ok(false),
+    }
+}
+
+fn decimal_size(data_type: &TableDataType) -> Option<DecimalSize> {
+    match data_type {
+        TableDataType::Decimal(decimal) => Some(decimal.size()),
+        TableDataType::Nullable(inner) => decimal_size(inner),
+        _ => None,
+    }
+}
+
+fn expression_decimal_size(data_type: &DataType) -> Option<DecimalSize> {
+    match data_type {
+        DataType::Decimal(size) => Some(*size),
+        DataType::Nullable(inner) => expression_decimal_size(inner),
+        _ => None,
+    }
+}
+
+fn decimal_cluster_stats_rewrites(
+    ctx: Arc<QueryContext>,
+    table: &FuseTable,
+    new_schema: TableSchemaRef,
+) -> Result<Option<Vec<DecimalClusterStatsRewrite>>> {
+    let Some((cluster_key_id, _)) = table.cluster_key_meta() else {
+        return Ok(Some(Vec::new()));
+    };
+    let ast_exprs = table
+        .resolve_cluster_keys()
+        .expect("cluster key metadata was checked above");
+    let old_keys = parse_cluster_keys(ctx.clone(), Arc::new(table.clone()), ast_exprs.clone())?;
+    // Hilbert cluster statistics persist MBR dimensions rather than ordinary key-expression
+    // positions. Fall back to the existing table rewrite instead of trying to retag them.
+    if old_keys.is_hilbert() {
+        return Ok(None);
+    }
+    let new_table = table.with_schema(new_schema);
+    let new_keys = parse_cluster_keys(ctx, new_table, ast_exprs)?;
+    if new_keys.is_hilbert() {
+        return Ok(None);
+    }
+    // `into_stats_keys` mirrors the writer layout and removes a vector key, which is not
+    // persisted in ClusterStatistics min/max.
+    let old_exprs = old_keys.into_stats_keys();
+    let new_exprs = new_keys.into_stats_keys();
+    if old_exprs.len() != new_exprs.len() {
+        return Ok(None);
+    }
+
+    let mut rewrites = Vec::new();
+    for (index, (old, new)) in old_exprs.iter().zip(&new_exprs).enumerate() {
+        // A derived expression can depend on type metadata even when its result type is
+        // unchanged (for example, `concat(typeof(d), to_string(d))`). If any referenced
+        // column is rebound with a different type, only a direct reference to that same column
+        // is known to preserve values; all other expressions must use the table-rewrite path.
+        if old.column_refs() != new.column_refs()
+            && !matches!(
+                (old, new),
+                (Expr::ColumnRef(old_ref), Expr::ColumnRef(new_ref))
+                    if old_ref.id == new_ref.id
+            )
+        {
+            return Ok(None);
+        }
+        if old.data_type() == new.data_type() {
+            continue;
+        }
+        let (Some(old_size), Some(new_size)) = (
+            expression_decimal_size(old.data_type()),
+            expression_decimal_size(new.data_type()),
+        ) else {
+            return Ok(None);
+        };
+        if old_size.scale() != new_size.scale()
+            || old_size.data_kind() != new_size.data_kind()
+            || old_size.precision() > new_size.precision()
+        {
+            return Ok(None);
+        }
+        rewrites.push(DecimalClusterStatsRewrite {
+            cluster_key_id,
+            dimension: index,
+            size: new_size,
+        });
+    }
+    Ok(Some(rewrites))
+}
+
+fn widen_cluster_statistics(
+    stats: &mut Option<databend_storages_common_table_meta::meta::ClusterStatistics>,
+    rewrites: &[DecimalClusterStatsRewrite],
+) -> Result<()> {
+    if let Some(stats) = stats {
+        for rewrite in rewrites {
+            // Blocks written before ALTER TABLE ... CLUSTER BY retain statistics for the old
+            // key. Their dimensions must never be interpreted using the current key layout.
+            if stats.cluster_key_id == rewrite.cluster_key_id {
+                stats.widen_decimal_dimension(rewrite.dimension, rewrite.size)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn widen_segment_metadata(
+    segment: &mut SegmentInfo,
+    column_rewrites: &[DecimalStatsRewrite],
+    cluster_rewrites: &[DecimalClusterStatsRewrite],
+) -> Result<()> {
+    for block in &mut segment.blocks {
+        let block = Arc::make_mut(block);
+        for rewrite in column_rewrites {
+            if let Some(stats) = block.col_stats.get_mut(&rewrite.column_id) {
+                stats.widen_decimal_size(rewrite.size)?;
+            }
+        }
+        widen_cluster_statistics(&mut block.cluster_stats, cluster_rewrites)?;
+    }
+    for rewrite in column_rewrites {
+        segment
+            .summary
+            .widen_decimal_column(rewrite.column_id, rewrite.size)?;
+    }
+    widen_cluster_statistics(&mut segment.summary.cluster_stats, cluster_rewrites)?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn rewrite_decimal_stats_and_commit(
+    ctx: &Arc<QueryContext>,
+    fuse_table: &FuseTable,
+    base_snapshot: Arc<TableSnapshot>,
+    new_schema: TableSchemaRef,
+    mut new_table_meta: TableMeta,
+    catalog: Arc<dyn Catalog>,
+    column_rewrites: &[DecimalStatsRewrite],
+    cluster_rewrites: &[DecimalClusterStatsRewrite],
+    table_meta_timestamps: TableMetaTimestamps,
+) -> Result<()> {
+    const SEGMENT_READ_CHUNK_SIZE: usize = 1000;
+
+    let operator = fuse_table.get_operator_ref();
+    let segments_io = SegmentsIO::create(ctx.clone(), operator.clone(), fuse_table.schema());
+    let mut new_segment_locations = Vec::with_capacity(base_snapshot.segments.len());
+
+    for chunk in base_snapshot.segments.chunks(SEGMENT_READ_CHUNK_SIZE) {
+        let segments = segments_io
+            .read_segments::<SegmentInfo>(chunk, false)
+            .await?;
+        for segment in segments {
+            let mut segment = segment?;
+            widen_segment_metadata(&mut segment, column_rewrites, cluster_rewrites)?;
+
+            // Preserve Vacuum2's ordering invariant: segment object UUID timestamps must be
+            // derived from the snapshot's monotonically increased metadata timestamp. Each
+            // call still receives fresh random UUID bits and therefore produces a unique key.
+            let segment_location = fuse_table
+                .meta_location_generator()
+                .gen_segment_info_location(table_meta_timestamps, false);
+            if let Some(old_stats_location) = segment.summary.additional_stats_loc() {
+                let mut stats = read_segment_stats(operator.clone(), old_stats_location)
+                    .await?
+                    .as_ref()
+                    .clone();
+                for rewrite in column_rewrites {
+                    stats.widen_decimal_column(rewrite.column_id, rewrite.size)?;
+                }
+                let stats_location = databend_common_storages_fuse::io::TableMetaLocationGenerator::gen_segment_stats_location_from_segment_location(
+                    &segment_location,
+                );
+                let stats_size = stats.to_bytes()?.len() as u64;
+                stats.write_meta(operator, &stats_location).await?;
+                if let Some(meta) = &mut segment.summary.additional_stats_meta {
+                    meta.size = stats_size;
+                    meta.location = (stats_location, SegmentStatistics::VERSION);
+                }
+            }
+
+            segment.format_version = SegmentInfo::VERSION;
+            segment
+                .write_meta_through_cache(operator, &segment_location)
+                .await?;
+            new_segment_locations.push((segment_location, SegmentInfo::VERSION));
+        }
+    }
+
+    let mut new_snapshot = TableSnapshot::try_from_previous(
+        base_snapshot.clone(),
+        fuse_table.cluster_key_info(),
+        Some(fuse_table.get_table_info().ident.seq),
+        table_meta_timestamps,
+    )?;
+    new_snapshot.schema = new_schema.as_ref().clone();
+    new_snapshot.segments = new_segment_locations;
+    for rewrite in column_rewrites {
+        new_snapshot
+            .summary
+            .widen_decimal_column(rewrite.column_id, rewrite.size)?;
+    }
+    widen_cluster_statistics(&mut new_snapshot.summary.cluster_stats, cluster_rewrites)?;
+
+    if let Some(table_stats) = fuse_table
+        .read_table_snapshot_statistics(Some(&base_snapshot))
+        .await?
+        .filter(|stats| stats.is_fresh_for(&base_snapshot))
+    {
+        let mut table_stats = table_stats.as_ref().clone();
+        for rewrite in column_rewrites {
+            table_stats.widen_decimal_column(rewrite.column_id, rewrite.size)?;
+        }
+        // This sidecar was fresh for the base snapshot and describes unchanged data, so retag
+        // its Decimal Top-N values and keep it fresh for the new metadata-only snapshot. A stale
+        // sidecar is inherited unchanged above and must not participate in this rewrite.
+        table_stats.snapshot_id = base_snapshot.snapshot_id;
+        let location = fuse_table
+            .meta_location_generator()
+            .snapshot_statistics_location_from_uuid(
+                &SnapshotId::now_v7(),
+                table_stats.format_version(),
+            )?;
+        table_stats.write_meta(operator, &location).await?;
+        new_snapshot.table_statistics_location = Some(location);
+    }
+
+    let new_snapshot_location = fuse_table
+        .meta_location_generator()
+        .gen_snapshot_location(&new_snapshot.snapshot_id, TableSnapshot::VERSION)?;
+    new_snapshot
+        .write_meta(operator, &new_snapshot_location)
+        .await?;
+
+    new_table_meta.schema = new_schema;
+    new_table_meta.options.insert(
+        OPT_KEY_SNAPSHOT_LOCATION.to_owned(),
+        new_snapshot_location.clone(),
+    );
+    new_table_meta.updated_on = Utc::now();
+    update_table_meta(fuse_table, &new_table_meta, catalog, ctx.get_tenant()).await?;
+    FuseTable::write_last_snapshot_hint(
+        ctx.as_ref(),
+        operator,
+        fuse_table.meta_location_generator(),
+        &new_snapshot_location,
+        &new_table_meta,
+    )
+    .await;
+    Ok(())
+}
+
+fn decimal_parquet_physical_type(data_type: &TableDataType) -> Result<(parquet::basic::Type, i32)> {
+    let schema = TableSchema::new(vec![TableField::new("decimal", data_type.clone())]);
+    let arrow_schema = ArrowSchema::from(&schema);
+    let parquet_schema = ArrowSchemaConverter::new().convert(&arrow_schema)?;
+    let column = parquet_schema.column(0);
+    Ok((column.physical_type(), column.type_length()))
 }
 
 pub(crate) async fn build_select_insert_plan(

--- a/src/query/storages/common/cache/src/providers/disk_cache_builder.rs
+++ b/src/query/storages/common/cache/src/providers/disk_cache_builder.rs
@@ -42,9 +42,17 @@ pub struct TableDataCacheKey {
 }
 
 impl TableDataCacheKey {
-    pub fn new(block_path: &str, column_id: u32, offset: u64, len: u64) -> Self {
+    pub fn new_no_type(block_path: &str, column_id: u32, offset: u64, len: u64) -> Self {
         Self {
             cache_key: format!("{block_path}-{column_id}-{offset}-{len}"),
+        }
+    }
+
+    pub fn new(block_path: &str, column_id: u32, offset: u64, len: u64, data_type: &str) -> Self {
+        // Deserialized arrays carry logical type metadata, so schema evolution must invalidate
+        // them even when the underlying Parquet column chunk is unchanged.
+        Self {
+            cache_key: format!("{block_path}-{column_id}-{offset}-{len}-{data_type}"),
         }
     }
 }
@@ -58,6 +66,24 @@ impl From<TableDataCacheKey> for String {
 impl AsRef<str> for TableDataCacheKey {
     fn as_ref(&self) -> &str {
         &self.cache_key
+    }
+}
+
+#[cfg(test)]
+mod cache_key_tests {
+    use super::*;
+
+    #[test]
+    fn array_cache_key_includes_data_type() {
+        let raw = TableDataCacheKey::new_no_type("block", 1, 2, 3);
+        let old = TableDataCacheKey::new("block", 1, 2, 3, "Decimal(10, 2)");
+        let new = TableDataCacheKey::new("block", 1, 2, 3, "Decimal(15, 2)");
+        assert_ne!(raw.as_ref(), old.as_ref());
+        assert_ne!(old.as_ref(), new.as_ref());
+        assert_eq!(
+            new.as_ref(),
+            TableDataCacheKey::new("block", 1, 2, 3, "Decimal(15, 2)").as_ref()
+        );
     }
 }
 

--- a/src/query/storages/common/table_meta/src/meta/current/mod.rs
+++ b/src/query/storages/common/table_meta/src/meta/current/mod.rs
@@ -37,6 +37,7 @@ pub use v2::VirtualSegmentColumnPath;
 pub use v2::VirtualSegmentPath;
 pub use v2::VirtualSegmentSchema;
 pub use v2::validate_segment_partition_statistics;
+pub use v2::widen_decimal_scalar;
 pub use v4::CompactSegmentInfo;
 pub use v4::RawBlockMeta;
 pub use v4::SegmentInfo;

--- a/src/query/storages/common/table_meta/src/meta/statistics.rs
+++ b/src/query/storages/common/table_meta/src/meta/statistics.rs
@@ -26,6 +26,7 @@ use databend_common_expression::ColumnId;
 use databend_common_expression::Scalar;
 use databend_common_expression::ScalarRef;
 use databend_common_expression::types::DataType;
+use databend_common_expression::types::DecimalSize;
 use databend_common_frozen_api::FrozenAPI;
 use databend_common_storage::MetaHLL;
 use serde::Deserialize;
@@ -408,6 +409,15 @@ impl ColumnTopN {
         self
     }
 
+    /// Retag Decimal values while preserving their counts and ordering.
+    pub fn widen_decimal_size(&mut self, size: DecimalSize) -> Result<()> {
+        for entry in &mut self.values {
+            crate::meta::widen_decimal_scalar(&mut entry.scalar, size)?;
+        }
+        self.min_index = None;
+        Ok(())
+    }
+
     fn add_ref_with_options(&mut self, scalar: ScalarRef<'_>, count: u64, error: u64) {
         if self.capacity == 0 || count == 0 || matches!(scalar, ScalarRef::Null) {
             return;
@@ -742,6 +752,8 @@ pub fn merge_column_count_min_sketch_mut(lhs: &mut BlockCountMinSketch, rhs: Blo
 mod tests {
     use std::sync::Arc;
 
+    use databend_common_expression::types::DecimalScalar;
+    use databend_common_expression::types::DecimalSize;
     use databend_common_expression::types::NumberScalar;
 
     use super::*;
@@ -997,6 +1009,26 @@ mod tests {
 
         assert_eq!(top_n.get(&int32_scalar(5)), Some(10));
         assert_eq!(top_n.get(&uint_scalar(5)), None);
+    }
+
+    #[test]
+    fn column_top_n_retags_decimal_values() {
+        let old = DecimalSize::new_unchecked(10, 2);
+        let new = DecimalSize::new_unchecked(15, 2);
+        let old_scalar = Scalar::Decimal(DecimalScalar::Decimal64(123, old));
+        let new_scalar = Scalar::Decimal(DecimalScalar::Decimal64(123, new));
+        let mut top_n = ColumnTopN::with_capacity(2);
+        top_n.add_entry_for_test(ColumnTopNEntry {
+            scalar: old_scalar.clone(),
+            count: 10,
+            error: 1,
+        });
+
+        top_n.widen_decimal_size(new).unwrap();
+
+        assert_eq!(top_n.get(&old_scalar), None);
+        assert_eq!(top_n.get(&new_scalar), Some(10));
+        assert_eq!(top_n.values[0].error, 1);
     }
 
     #[test]

--- a/src/query/storages/common/table_meta/src/meta/v2/mod.rs
+++ b/src/query/storages/common/table_meta/src/meta/v2/mod.rs
@@ -44,4 +44,5 @@ pub use statistics::VirtualSegmentColumnPath;
 pub use statistics::VirtualSegmentPath;
 pub use statistics::VirtualSegmentSchema;
 pub use statistics::validate_segment_partition_statistics;
+pub use statistics::widen_decimal_scalar;
 pub use table_snapshot_statistics::TableSnapshotStatistics;

--- a/src/query/storages/common/table_meta/src/meta/v2/segment_statistics.rs
+++ b/src/query/storages/common/table_meta/src/meta/v2/segment_statistics.rs
@@ -16,6 +16,7 @@ use std::io::Read;
 
 use databend_common_exception::Result;
 use databend_common_expression::ColumnId;
+use databend_common_expression::types::DecimalSize;
 use databend_common_frozen_api::FrozenAPI;
 use databend_common_frozen_api::frozen_api;
 use databend_common_io::prelude::BinaryRead;
@@ -87,6 +88,16 @@ impl SegmentStatistics {
                 })
                 .sum::<usize>();
         std::mem::size_of::<Self>() + hll_size + top_n_size
+    }
+
+    /// Retag Top-N values for one Decimal column in every block.
+    pub fn widen_decimal_column(&mut self, column_id: ColumnId, size: DecimalSize) -> Result<()> {
+        for block_top_n in &mut self.block_top_ns {
+            if let Some(top_n) = block_top_n.get_mut(&column_id) {
+                top_n.widen_decimal_size(size)?;
+            }
+        }
+        Ok(())
     }
 
     pub fn to_bytes(&self) -> Result<Vec<u8>> {

--- a/src/query/storages/common/table_meta/src/meta/v2/statistics.rs
+++ b/src/query/storages/common/table_meta/src/meta/v2/statistics.rs
@@ -18,6 +18,7 @@ use std::marker::PhantomData;
 
 use databend_common_base::base::OrderedFloat;
 use databend_common_exception::ErrorCode;
+use databend_common_exception::Result as DatabendResult;
 use databend_common_expression::ColumnId;
 use databend_common_expression::Scalar;
 use databend_common_expression::TableDataType;
@@ -25,6 +26,8 @@ use databend_common_expression::TableField;
 use databend_common_expression::converts::datavalues::from_scalar;
 use databend_common_expression::converts::meta::IndexScalar;
 use databend_common_expression::types::DataType;
+use databend_common_expression::types::DecimalScalar;
+use databend_common_expression::types::DecimalSize;
 use databend_common_expression::types::F32;
 use databend_common_frozen_api::FrozenAPI;
 use databend_common_vector::angular_distance;
@@ -429,6 +432,12 @@ impl ColumnStatistics {
         &self.max
     }
 
+    /// Retag Decimal bounds after a metadata-only precision widening.
+    pub fn widen_decimal_size(&mut self, size: DecimalSize) -> DatabendResult<()> {
+        widen_decimal_scalar(&mut self.min, size)?;
+        widen_decimal_scalar(&mut self.max, size)
+    }
+
     pub fn from_v0(
         v0: &crate::meta::v0::statistics::ColumnStatistics,
         data_type: &TableDataType,
@@ -482,6 +491,27 @@ impl ClusterStatistics {
         self.min.eq(&self.max)
     }
 
+    /// Retag one Decimal cluster-key dimension after a metadata-only precision widening.
+    pub fn widen_decimal_dimension(
+        &mut self,
+        index: usize,
+        size: DecimalSize,
+    ) -> DatabendResult<()> {
+        let min = self.min.get_mut(index).ok_or_else(|| {
+            ErrorCode::Internal(format!("cluster statistics dimension {index} is missing"))
+        })?;
+        let max = self.max.get_mut(index).ok_or_else(|| {
+            ErrorCode::Internal(format!("cluster statistics dimension {index} is missing"))
+        })?;
+        widen_decimal_scalar(min, size)?;
+        widen_decimal_scalar(max, size)?;
+        // `pages` is a legacy per-page index whose entries are tuples containing every
+        // cluster-key dimension, not a vector indexed by cluster-key dimension. Page pruning
+        // has been removed, and the field is retained only for rollback decoding, so keep it
+        // byte-for-byte unchanged.
+        Ok(())
+    }
+
     pub fn from_v0(
         v0: crate::meta::v0::statistics::ClusterStatistics,
         data_type: &TableDataType,
@@ -521,7 +551,55 @@ impl ClusterStatistics {
     }
 }
 
+/// Change only the logical Decimal precision carried by a persisted scalar.
+/// The raw integer, physical Decimal kind, and scale remain unchanged.
+pub fn widen_decimal_scalar(scalar: &mut Scalar, target: DecimalSize) -> DatabendResult<()> {
+    if scalar.is_null() {
+        return Ok(());
+    }
+    let Scalar::Decimal(decimal) = scalar else {
+        return Err(ErrorCode::Internal(format!(
+            "expected Decimal statistics, got {}",
+            scalar.as_ref().infer_data_type()
+        )));
+    };
+    let source = decimal.size();
+    if source.scale() != target.scale()
+        || source.data_kind() != target.data_kind()
+        || source.precision() > target.precision()
+    {
+        return Err(ErrorCode::Internal(format!(
+            "cannot widen Decimal statistics from {source} to {target}"
+        )));
+    }
+    *decimal = match decimal {
+        DecimalScalar::Decimal64(value, _) => DecimalScalar::Decimal64(*value, target),
+        DecimalScalar::Decimal128(value, _) => DecimalScalar::Decimal128(*value, target),
+        DecimalScalar::Decimal256(value, _) => DecimalScalar::Decimal256(*value, target),
+    };
+    Ok(())
+}
+
 impl Statistics {
+    /// Retag the persisted bounds for one Decimal column after a precision widening.
+    pub fn widen_decimal_column(
+        &mut self,
+        column_id: ColumnId,
+        size: DecimalSize,
+    ) -> DatabendResult<()> {
+        if let Some(stats) = self.col_stats.get_mut(&column_id) {
+            stats.widen_decimal_size(size)?;
+        }
+        if let Some(stats) = self
+            .virtual_col_stats
+            .as_mut()
+            .and_then(|stats| stats.get_mut(&column_id))
+        {
+            stats.widen_decimal_size(size)?;
+        }
+        Ok(())
+    }
+
     pub(crate) fn convert_column_stats(
         v0: &HashMap<ColumnId, v0::statistics::ColumnStatistics>,
         fields: &[TableField],
@@ -749,6 +827,8 @@ impl<'de> serde::de::Visitor<'de> for ColStatsVisitor {
 
 #[cfg(test)]
 mod tests {
+    use databend_common_expression::types::i256;
+
     use super::*;
 
     #[derive(serde::Serialize)]
@@ -787,6 +867,83 @@ mod tests {
         let decoded: ClusterStatistics = rmp_serde::from_slice(&bytes).unwrap();
 
         assert_eq!(decoded, ClusterStatistics::new(7, stats.min, stats.max, 2));
+    }
+
+    #[test]
+    fn widens_decimal_statistics_without_changing_values() {
+        let old = DecimalSize::new_unchecked(1, 0);
+        let new = DecimalSize::new_unchecked(18, 0);
+        let mut column = ColumnStatistics::new(
+            Scalar::Decimal(DecimalScalar::Decimal64(-1, old)),
+            Scalar::Decimal(DecimalScalar::Decimal64(7, old)),
+            0,
+            16,
+            Some(2),
+        );
+
+        column.widen_decimal_size(new).unwrap();
+
+        assert_eq!(
+            column.min(),
+            &Scalar::Decimal(DecimalScalar::Decimal64(-1, new))
+        );
+        assert_eq!(
+            column.max(),
+            &Scalar::Decimal(DecimalScalar::Decimal64(7, new))
+        );
+
+        let old = DecimalSize::new_unchecked(19, 2);
+        let new = DecimalSize::new_unchecked(38, 2);
+        let mut cluster = ClusterStatistics::new(
+            3,
+            vec![Scalar::Decimal(DecimalScalar::Decimal128(100, old))],
+            vec![Scalar::Decimal(DecimalScalar::Decimal128(900, old))],
+            0,
+        );
+        cluster.pages = Some(vec![Scalar::Tuple(vec![Scalar::Decimal(
+            DecimalScalar::Decimal128(500, old),
+        )])]);
+        let legacy_pages = cluster.pages.clone();
+
+        cluster.widen_decimal_dimension(0, new).unwrap();
+
+        assert_eq!(cluster.min(), &vec![Scalar::Decimal(
+            DecimalScalar::Decimal128(100, new)
+        )]);
+        assert_eq!(cluster.max(), &vec![Scalar::Decimal(
+            DecimalScalar::Decimal128(900, new)
+        )]);
+        assert_eq!(cluster.pages, legacy_pages);
+
+        let old = DecimalSize::new_unchecked(39, 3);
+        let new = DecimalSize::new_unchecked(76, 3);
+        let mut scalar = Scalar::Decimal(DecimalScalar::Decimal256(i256::from(42), old));
+        widen_decimal_scalar(&mut scalar, new).unwrap();
+        assert_eq!(
+            scalar,
+            Scalar::Decimal(DecimalScalar::Decimal256(i256::from(42), new))
+        );
+    }
+
+    #[test]
+    fn rejects_incompatible_decimal_statistics_retag() {
+        let scalar = || {
+            Scalar::Decimal(DecimalScalar::Decimal64(
+                1,
+                DecimalSize::new_unchecked(10, 2),
+            ))
+        };
+
+        assert!(widen_decimal_scalar(&mut scalar(), DecimalSize::new_unchecked(9, 2)).is_err());
+        assert!(widen_decimal_scalar(&mut scalar(), DecimalSize::new_unchecked(15, 3)).is_err());
+        assert!(widen_decimal_scalar(&mut scalar(), DecimalSize::new_unchecked(19, 2)).is_err());
+        assert!(
+            widen_decimal_scalar(
+                &mut Scalar::Number(1_i64.into()),
+                DecimalSize::new_unchecked(15, 2),
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/src/query/storages/common/table_meta/src/meta/v4/table_snapshot_statistics.rs
+++ b/src/query/storages/common/table_meta/src/meta/v4/table_snapshot_statistics.rs
@@ -14,7 +14,9 @@
 
 use std::collections::HashMap;
 
+use databend_common_exception::Result;
 use databend_common_expression::ColumnId;
+use databend_common_expression::types::DecimalSize;
 use databend_common_frozen_api::FrozenAPI;
 use databend_common_frozen_api::frozen_api;
 use databend_common_statistics::Histogram;
@@ -24,6 +26,7 @@ use crate::meta::ColumnCountMinSketch;
 use crate::meta::ColumnTopN;
 use crate::meta::FormatVersion;
 use crate::meta::SnapshotId;
+use crate::meta::TableSnapshot;
 use crate::meta::Versioned;
 use crate::meta::v1;
 use crate::meta::v2;
@@ -87,6 +90,24 @@ impl TableSnapshotStatistics {
             .iter()
             .map(|hll| (*hll.0, hll.1.count() as u64))
             .collect()
+    }
+
+    /// Whether freshness-sensitive statistics describe all rows visible in `snapshot`.
+    pub fn is_fresh_for(&self, snapshot: &TableSnapshot) -> bool {
+        self.row_count == snapshot.summary.row_count
+            && snapshot
+                .prev_snapshot_id
+                .as_ref()
+                .is_none_or(|(snapshot_id, _)| *snapshot_id == self.snapshot_id)
+    }
+
+    /// Retag Top-N values for one Decimal column. Other statistics either do not store
+    /// DecimalSize or deliberately hash only the raw value.
+    pub fn widen_decimal_column(&mut self, column_id: ColumnId, size: DecimalSize) -> Result<()> {
+        if let Some(top_n) = self.top_n.get_mut(&column_id) {
+            top_n.widen_decimal_size(size)?;
+        }
+        Ok(())
     }
 }
 

--- a/src/query/storages/fuse/src/fuse_table.rs
+++ b/src/query/storages/fuse/src/fuse_table.rs
@@ -1288,13 +1288,7 @@ impl Table for FuseTable {
                 .unwrap_or_default();
             let aligned_table_statistics = table_statistics
                 .as_ref()
-                .filter(|v| v.row_count == snapshot.summary.row_count)
-                .filter(|v| {
-                    snapshot
-                        .prev_snapshot_id
-                        .as_ref()
-                        .is_none_or(|(snapshot_id, _)| *snapshot_id == v.snapshot_id)
-                });
+                .filter(|stats| stats.is_fresh_for(&snapshot));
             let top_n = aligned_table_statistics
                 .map(|v| v.top_n.clone())
                 .unwrap_or_default();

--- a/src/query/storages/fuse/src/io/mod.rs
+++ b/src/query/storages/fuse/src/io/mod.rs
@@ -33,6 +33,7 @@ pub use read::TableSnapshotReader;
 pub use read::VirtualBlockReadResult;
 pub use read::VirtualColumnReader;
 pub use read::build_columns_meta;
+pub use read::read_segment_stats;
 pub use segments::SegmentsIO;
 pub use segments::SerializedSegment;
 pub use snapshots::SnapshotLiteExtended;

--- a/src/query/storages/fuse/src/io/read/block/block_reader_merge_io_async.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_merge_io_async.rs
@@ -70,7 +70,7 @@ impl BlockReadContext {
 
         let column_cache_key_builder = ColumnCacheKeyBuilder::new(location);
 
-        for (_index, (column_id, ..)) in self.project_indices().iter() {
+        for (_index, (column_id, _, data_type)) in self.project_indices().iter() {
             if let Some(ignore_column_ids) = ignore_column_ids {
                 if ignore_column_ids.contains(column_id) {
                     continue;
@@ -81,10 +81,17 @@ impl BlockReadContext {
                 let (offset, len) = column_meta.offset_length();
 
                 let column_cache_key = column_cache_key_builder.cache_key(column_id, column_meta);
+                let column_array_cache_key = column_cache_key_builder.array_cache_key(
+                    column_id,
+                    column_meta,
+                    &data_type.to_string(),
+                );
 
                 // first, check in memory table data cache
                 // column_array_cache
-                if let Some(cache_array) = column_array_cache.get_sized(&column_cache_key, len) {
+                if let Some(cache_array) =
+                    column_array_cache.get_sized(&column_array_cache_key, len)
+                {
                     // Record bytes scanned from memory cache (table data only)
                     Profile::record_usize_profile(
                         ProfileStatisticsName::ScanBytesFromMemory,
@@ -169,6 +176,16 @@ impl<'a> ColumnCacheKeyBuilder<'a> {
     }
     fn cache_key(&self, column_id: &ColumnId, column_meta: &ColumnMeta) -> TableDataCacheKey {
         let (offset, len) = column_meta.offset_length();
-        TableDataCacheKey::new(self.block_path, *column_id, offset, len)
+        TableDataCacheKey::new_no_type(self.block_path, *column_id, offset, len)
+    }
+
+    fn array_cache_key(
+        &self,
+        column_id: &ColumnId,
+        column_meta: &ColumnMeta,
+        data_type: &str,
+    ) -> TableDataCacheKey {
+        let (offset, len) = column_meta.offset_length();
+        TableDataCacheKey::new(self.block_path, *column_id, offset, len, data_type)
     }
 }

--- a/src/query/storages/fuse/src/io/read/block/parquet/mod.rs
+++ b/src/query/storages/fuse/src/io/read/block/parquet/mod.rs
@@ -27,6 +27,7 @@ use databend_common_expression::FilterVisitor;
 use databend_common_expression::TableDataType;
 use databend_common_expression::TableSchema;
 use databend_common_expression::Value;
+use databend_common_expression::types::DataType;
 use databend_common_expression::visitor::ValueVisitor;
 use databend_storages_common_cache::CacheAccessor;
 use databend_storages_common_cache::CacheManager;
@@ -106,7 +107,7 @@ impl BlockReader {
             .enumerate()
             .zip(self.project_column_nodes.iter())
         {
-            let data_type = field.data_type().into();
+            let data_type: DataType = field.data_type().into();
 
             // NOTE, there is something tricky here:
             // - `column_chunks` always contains data of leaf columns
@@ -130,8 +131,13 @@ impl BlockReader {
                         if let Some(cache) = &array_cache {
                             let meta = column_metas.get(&field.column_id).unwrap();
                             let (offset, len) = meta.offset_length();
-                            let key =
-                                TableDataCacheKey::new(block_path, field.column_id, offset, len);
+                            let key = TableDataCacheKey::new(
+                                block_path,
+                                field.column_id,
+                                offset,
+                                len,
+                                &data_type.to_string(),
+                            );
                             let array_memory_size = arrow_array.get_array_memory_size();
                             cache.insert(key.into(), (arrow_array.clone(), array_memory_size));
                         }

--- a/src/query/storages/fuse/src/operations/commit.rs
+++ b/src/query/storages/fuse/src/operations/commit.rs
@@ -590,9 +590,5 @@ pub(crate) fn is_fresh_table_snapshot_top_n(
     snapshot: &TableSnapshot,
     stats: &TableSnapshotStatistics,
 ) -> bool {
-    stats.row_count == snapshot.summary.row_count
-        && snapshot
-            .prev_snapshot_id
-            .as_ref()
-            .is_none_or(|(snapshot_id, _)| *snapshot_id == stats.snapshot_id)
+    stats.is_fresh_for(snapshot)
 }

--- a/tests/sqllogictests/suites/base/05_ddl/05_0066_alter_decimal_precision_metadata_only.test
+++ b/tests/sqllogictests/suites/base/05_ddl/05_0066_alter_decimal_precision_metadata_only.test
@@ -1,0 +1,390 @@
+statement ok
+DROP TABLE IF EXISTS decimal_derived_cluster_key
+
+statement ok
+DROP TABLE IF EXISTS decimal_derived_cluster_key_blocks
+
+statement ok
+DROP TABLE IF EXISTS decimal_type_dependent_cluster_key
+
+statement ok
+DROP TABLE IF EXISTS decimal_type_dependent_cluster_key_blocks
+
+statement ok
+DROP TABLE IF EXISTS decimal_stale_table_stats
+
+statement ok
+DROP TABLE IF EXISTS decimal_stale_scale_stats
+
+statement ok
+DROP TABLE IF EXISTS decimal_stale_scale_stats_blocks
+
+statement ok
+DROP TABLE IF EXISTS decimal_metadata_only
+
+statement ok
+DROP TABLE IF EXISTS decimal_metadata_only_blocks
+
+# Same Parquet representation: preserve blocks, retag persisted column/cluster stats,
+# and allow predicates plus new writes that produce stats with the wider precision.
+statement ok
+CREATE TABLE decimal_metadata_only(d DECIMAL(10, 2)) CLUSTER BY (d) row_per_block=2 block_per_segment=1
+
+statement ok
+INSERT INTO decimal_metadata_only VALUES (1.00), (2.00), (3.00), (4.00)
+
+statement ok
+CREATE TABLE decimal_metadata_only_blocks AS
+SELECT block_location FROM fuse_block('default', 'decimal_metadata_only')
+
+statement ok
+ALTER TABLE decimal_metadata_only MODIFY COLUMN d DECIMAL(15, 2)
+
+query I
+SELECT count(*)
+FROM decimal_metadata_only_blocks old_blocks
+LEFT JOIN fuse_block('default', 'decimal_metadata_only') new_blocks
+  ON old_blocks.block_location = new_blocks.block_location
+WHERE new_blocks.block_location IS NULL
+----
+0
+
+query IT rowsort
+SELECT d, typeof(d) FROM decimal_metadata_only WHERE d > 2.00 ORDER BY d LIMIT 2
+----
+3.00 DECIMAL(15, 2) NULL
+4.00 DECIMAL(15, 2) NULL
+
+statement ok
+INSERT INTO decimal_metadata_only VALUES (5.00), (6.00)
+
+query IT rowsort
+SELECT d, typeof(d) FROM decimal_metadata_only WHERE d >= 4.00
+----
+4.00 DECIMAL(15, 2) NULL
+5.00 DECIMAL(15, 2) NULL
+6.00 DECIMAL(15, 2) NULL
+
+statement ok
+DROP TABLE decimal_metadata_only
+
+statement ok
+DROP TABLE decimal_metadata_only_blocks
+
+statement ok
+DROP TABLE IF EXISTS decimal_vector_cluster_key
+
+statement ok
+DROP TABLE IF EXISTS decimal_vector_cluster_key_blocks
+
+# Vector keys are not persisted in ClusterStatistics min/max. The Decimal key therefore
+# remains dimension zero even though it is expression one in CLUSTER BY.
+statement ok
+CREATE TABLE decimal_vector_cluster_key(
+  embedding VECTOR(3),
+  d DECIMAL(10, 2),
+  VECTOR INDEX idx (embedding) distance='cosine'
+) CLUSTER BY (embedding, d) row_per_block=2 block_per_segment=1
+
+statement ok
+INSERT INTO decimal_vector_cluster_key VALUES
+  ([1.0, 0.0, 0.0], 1.00),
+  ([0.0, 1.0, 0.0], 2.00),
+  ([0.0, 0.0, 1.0], 3.00)
+
+statement ok
+CREATE TABLE decimal_vector_cluster_key_blocks AS
+SELECT block_location FROM fuse_block('default', 'decimal_vector_cluster_key')
+
+statement ok
+ALTER TABLE decimal_vector_cluster_key MODIFY COLUMN d DECIMAL(15, 2)
+
+query I
+SELECT count(*)
+FROM decimal_vector_cluster_key_blocks old_blocks
+LEFT JOIN fuse_block('default', 'decimal_vector_cluster_key') new_blocks
+  ON old_blocks.block_location = new_blocks.block_location
+WHERE new_blocks.block_location IS NULL
+----
+0
+
+query IT rowsort
+SELECT d, typeof(d) FROM decimal_vector_cluster_key WHERE d >= 2.00
+----
+2.00 DECIMAL(15, 2) NULL
+3.00 DECIMAL(15, 2) NULL
+
+statement ok
+INSERT INTO decimal_vector_cluster_key VALUES ([1.0, 1.0, 0.0], 4.00)
+
+query I
+SELECT count(*) FROM decimal_vector_cluster_key WHERE d > 0
+----
+4
+
+statement ok
+DROP TABLE decimal_vector_cluster_key
+
+statement ok
+DROP TABLE decimal_vector_cluster_key_blocks
+
+statement ok
+DROP TABLE IF EXISTS decimal_historical_cluster_key
+
+statement ok
+DROP TABLE IF EXISTS decimal_historical_cluster_key_blocks
+
+# Blocks retain cluster statistics tagged with the key ID active when they were written.
+# Widening the current Decimal key must leave obsolete integer-key statistics untouched.
+statement ok
+CREATE TABLE decimal_historical_cluster_key(i INT, d DECIMAL(10, 2))
+CLUSTER BY (i) row_per_block=2 block_per_segment=1
+
+statement ok
+INSERT INTO decimal_historical_cluster_key VALUES (1, 1.00), (2, 2.00)
+
+statement ok
+ALTER TABLE decimal_historical_cluster_key CLUSTER BY (d)
+
+statement ok
+INSERT INTO decimal_historical_cluster_key VALUES (3, 3.00), (4, 4.00)
+
+statement ok
+CREATE TABLE decimal_historical_cluster_key_blocks AS
+SELECT block_location FROM fuse_block('default', 'decimal_historical_cluster_key')
+
+statement ok
+ALTER TABLE decimal_historical_cluster_key MODIFY COLUMN d DECIMAL(15, 2)
+
+query I
+SELECT count(*)
+FROM decimal_historical_cluster_key_blocks old_blocks
+LEFT JOIN fuse_block('default', 'decimal_historical_cluster_key') new_blocks
+  ON old_blocks.block_location = new_blocks.block_location
+WHERE new_blocks.block_location IS NULL
+----
+0
+
+query II rowsort
+SELECT i, d FROM decimal_historical_cluster_key WHERE d >= 2.00
+----
+2 2.00
+3 3.00
+4 4.00
+
+statement ok
+INSERT INTO decimal_historical_cluster_key VALUES (5, 5.00)
+
+query I
+SELECT count(*) FROM decimal_historical_cluster_key WHERE d > 0
+----
+5
+
+statement ok
+DROP TABLE decimal_historical_cluster_key
+
+statement ok
+DROP TABLE decimal_historical_cluster_key_blocks
+
+statement ok
+DROP TABLE IF EXISTS decimal_hilbert_cluster_key
+
+statement ok
+DROP TABLE IF EXISTS decimal_hilbert_cluster_key_blocks
+
+# Hilbert statistics persist MBR dimensions. Decimal widening deliberately falls back
+# to the existing full-table rewrite instead of trying to retag ordinary key positions.
+statement ok
+CREATE TABLE decimal_hilbert_cluster_key(d DECIMAL(10, 2), x INT)
+CLUSTER BY HILBERT(d, x) row_per_block=2 block_per_segment=1
+
+statement ok
+INSERT INTO decimal_hilbert_cluster_key VALUES (1.00, 1), (2.00, 2), (3.00, 3)
+
+statement ok
+CREATE TABLE decimal_hilbert_cluster_key_blocks AS
+SELECT block_location FROM fuse_block('default', 'decimal_hilbert_cluster_key')
+
+statement ok
+ALTER TABLE decimal_hilbert_cluster_key MODIFY COLUMN d DECIMAL(15, 2)
+
+query I
+SELECT count(*)
+FROM decimal_hilbert_cluster_key_blocks old_blocks
+JOIN fuse_block('default', 'decimal_hilbert_cluster_key') new_blocks
+  ON old_blocks.block_location = new_blocks.block_location
+----
+0
+
+query IT rowsort
+SELECT d, typeof(d) FROM decimal_hilbert_cluster_key WHERE d >= 2.00
+----
+2.00 DECIMAL(15, 2) NULL
+3.00 DECIMAL(15, 2) NULL
+
+statement ok
+DROP TABLE decimal_hilbert_cluster_key
+
+statement ok
+DROP TABLE decimal_hilbert_cluster_key_blocks
+
+# The column itself stays INT64 in Parquet, but the derived cluster key changes
+# from Decimal64(18, 0) to Decimal128(19, 0). Metadata-only retagging cannot
+# safely update those cluster statistics, so MODIFY COLUMN must fall back to the
+# existing full-table rewrite instead of returning an internal error.
+statement ok
+CREATE TABLE decimal_derived_cluster_key(d DECIMAL(17, 0)) CLUSTER BY (d + CAST(1 AS DECIMAL(1, 0)))
+
+statement ok
+INSERT INTO decimal_derived_cluster_key VALUES (1), (2), (99999999999999999)
+
+statement ok
+CREATE TABLE decimal_derived_cluster_key_blocks AS
+SELECT block_location FROM fuse_block('default', 'decimal_derived_cluster_key')
+
+statement ok
+ALTER TABLE decimal_derived_cluster_key MODIFY COLUMN d DECIMAL(18, 0)
+
+query IT rowsort
+SELECT d, typeof(d) FROM decimal_derived_cluster_key
+----
+1 DECIMAL(18, 0) NULL
+2 DECIMAL(18, 0) NULL
+99999999999999999 DECIMAL(18, 0) NULL
+
+query I
+SELECT count(*)
+FROM decimal_derived_cluster_key_blocks old_blocks
+JOIN fuse_block('default', 'decimal_derived_cluster_key') new_blocks
+  ON old_blocks.block_location = new_blocks.block_location
+----
+0
+
+statement ok
+DROP TABLE decimal_derived_cluster_key
+
+statement ok
+DROP TABLE decimal_derived_cluster_key_blocks
+
+# A derived key can keep the same result type while changing values when its input Decimal
+# precision changes. Such keys must fall back to the full-table rewrite.
+statement ok
+CREATE TABLE decimal_type_dependent_cluster_key(d DECIMAL(10, 2))
+CLUSTER BY (concat(typeof(d), to_string(d))) row_per_block=2 block_per_segment=1
+
+statement ok
+INSERT INTO decimal_type_dependent_cluster_key VALUES (1.00), (2.00), (3.00)
+
+statement ok
+CREATE TABLE decimal_type_dependent_cluster_key_blocks AS
+SELECT block_location FROM fuse_block('default', 'decimal_type_dependent_cluster_key')
+
+statement ok
+ALTER TABLE decimal_type_dependent_cluster_key MODIFY COLUMN d DECIMAL(15, 2)
+
+query I
+SELECT count(*)
+FROM decimal_type_dependent_cluster_key_blocks old_blocks
+JOIN fuse_block('default', 'decimal_type_dependent_cluster_key') new_blocks
+  ON old_blocks.block_location = new_blocks.block_location
+----
+0
+
+query IT rowsort
+SELECT d, typeof(d) FROM decimal_type_dependent_cluster_key
+----
+1.00 DECIMAL(15, 2) NULL
+2.00 DECIMAL(15, 2) NULL
+3.00 DECIMAL(15, 2) NULL
+
+statement ok
+DROP TABLE decimal_type_dependent_cluster_key
+
+statement ok
+DROP TABLE decimal_type_dependent_cluster_key_blocks
+
+# UPDATE leaves the ANALYZE sidecar stale. A metadata-only widening must not make its old
+# Top-N/Count-Min data fresh again, and a later append must not merge against that stale base.
+statement ok
+CREATE TABLE decimal_stale_table_stats(id INT, d DECIMAL(10, 2))
+approx_distinct_columns = '' analyze_frequency_columns = 'd' analyze_top_n_size = 2
+analyze_count_min_sketch_error_rate = '0.001'
+
+statement ok
+INSERT INTO decimal_stale_table_stats
+SELECT number::INT, if(number < 90, 1, number - 88)::DECIMAL(10, 2) FROM numbers(100)
+
+statement ok
+ANALYZE TABLE decimal_stale_table_stats
+
+statement ok
+UPDATE decimal_stale_table_stats SET d = 2.00 WHERE id < 80
+
+query T
+EXPLAIN SELECT * FROM decimal_stale_table_stats WHERE d = 1.00
+----
+table: default.default.decimal_stale_table_stats<slt:ignore>estimated rows: 9.09
+
+statement ok
+ALTER TABLE decimal_stale_table_stats MODIFY COLUMN d DECIMAL(15, 2)
+
+query T
+EXPLAIN SELECT * FROM decimal_stale_table_stats WHERE d = 1.00
+----
+table: default.default.decimal_stale_table_stats<slt:ignore>estimated rows: 9.09
+
+statement ok
+INSERT INTO decimal_stale_table_stats SELECT number::INT + 100, 3.00 FROM numbers(100)
+
+query T
+EXPLAIN SELECT * FROM decimal_stale_table_stats WHERE d = 1.00
+----
+table: default.default.decimal_stale_table_stats<slt:ignore>estimated rows: 18.18
+
+statement ok
+DROP TABLE decimal_stale_table_stats
+
+# A scale-changing ALTER uses the full-table rewrite and leaves the old ANALYZE sidecar stale.
+# The following metadata-only precision widening must inherit that unusable sidecar unchanged,
+# rather than trying to retag its old-scale Decimal Top-N values.
+statement ok
+CREATE TABLE decimal_stale_scale_stats(d DECIMAL(10, 2))
+approx_distinct_columns = '' analyze_frequency_columns = 'd' analyze_top_n_size = 2
+
+statement ok
+INSERT INTO decimal_stale_scale_stats VALUES (1.00), (2.00), (2.00)
+
+statement ok
+ANALYZE TABLE decimal_stale_scale_stats
+
+statement ok
+ALTER TABLE decimal_stale_scale_stats MODIFY COLUMN d DECIMAL(10, 3)
+
+statement ok
+CREATE TABLE decimal_stale_scale_stats_blocks AS
+SELECT block_location FROM fuse_block('default', 'decimal_stale_scale_stats')
+
+statement ok
+ALTER TABLE decimal_stale_scale_stats MODIFY COLUMN d DECIMAL(15, 3)
+
+query I
+SELECT count(*)
+FROM decimal_stale_scale_stats_blocks old_blocks
+LEFT JOIN fuse_block('default', 'decimal_stale_scale_stats') new_blocks
+  ON old_blocks.block_location = new_blocks.block_location
+WHERE new_blocks.block_location IS NULL
+----
+0
+
+query IT rowsort
+SELECT d, typeof(d) FROM decimal_stale_scale_stats
+----
+1.000 DECIMAL(15, 3) NULL
+2.000 DECIMAL(15, 3) NULL
+2.000 DECIMAL(15, 3) NULL
+
+statement ok
+DROP TABLE decimal_stale_scale_stats
+
+statement ok
+DROP TABLE decimal_stale_scale_stats_blocks

--- a/tests/sqllogictests/suites/ee/02_computed_column/02_0002_decimal_widen_stored.test
+++ b/tests/sqllogictests/suites/ee/02_computed_column/02_0002_decimal_widen_stored.test
@@ -1,0 +1,62 @@
+## Copyright 2026 Databend Cloud
+##
+## Licensed under the Elastic License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     https://www.elastic.co/licensing/elastic-license
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+statement ok
+DROP DATABASE IF EXISTS computed_decimal_widen
+
+statement ok
+CREATE DATABASE computed_decimal_widen
+
+statement ok
+USE computed_decimal_widen
+
+# Stored values may depend on Decimal type metadata even when the computed result type stays
+# unchanged. Widening the source must rewrite old rows so they match post-ALTER inserts.
+statement ok
+CREATE TABLE stored_typeof(
+    d DECIMAL(10, 2),
+    d_type STRING NOT NULL AS (typeof(d)) STORED
+) ROW_PER_BLOCK=2 BLOCK_PER_SEGMENT=1
+
+statement ok
+INSERT INTO stored_typeof(d) VALUES (1.00), (2.00), (3.00)
+
+statement ok
+CREATE TABLE old_blocks AS
+SELECT block_location FROM fuse_block('computed_decimal_widen', 'stored_typeof')
+
+statement ok
+ALTER TABLE stored_typeof MODIFY COLUMN d DECIMAL(15, 2)
+
+query I
+SELECT count(*)
+FROM old_blocks old
+JOIN fuse_block('computed_decimal_widen', 'stored_typeof') new
+  ON old.block_location = new.block_location
+----
+0
+
+statement ok
+INSERT INTO stored_typeof(d) VALUES (4.00)
+
+query T rowsort
+SELECT d_type FROM stored_typeof
+----
+DECIMAL(15, 2) NULL
+DECIMAL(15, 2) NULL
+DECIMAL(15, 2) NULL
+DECIMAL(15, 2) NULL
+
+statement ok
+DROP DATABASE computed_decimal_widen


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Make `ALTER TABLE ... MODIFY COLUMN` metadata-only when Decimal precision widens without changing the Parquet physical representation.
- Rewrite reachable Decimal statistics metadata before atomically publishing the new snapshot and schema.
- Preserve data blocks and old snapshots; use the existing full-table rewrite when the Parquet layout changes or for column-oriented tables.

## Motivation

Databend currently rewrites every data block for a lossless Decimal precision widening, even when Parquet stores both types identically. Merely changing the schema is unsafe because persisted column, cluster, segment Top-N, and table Top-N statistics retain the old `DecimalSize`; later appends and pruning can compare incompatible scalars or panic.

This change keeps data files unchanged while rebuilding the smaller metadata graph under the existing DDL lock. One catalog sequence-CAS publishes the schema and snapshot. Pre-CAS failures leave only unreachable metadata, and time travel retains the untouched old snapshots.

## Implementation

- Use Arrow's Parquet schema converter to compare both physical type and fixed-byte-array length.
- Clone row-oriented segment metadata to unique locations and retag block, summary, cluster, segment Top-N, and table Top-N Decimal statistics.
- Leave HLL, count-min sketch, and histogram data unchanged because they do not persist `DecimalSize` in a form requiring retagging.
- Include logical type in deserialized array-cache keys to prevent reuse of old-schema arrays.
- Keep the data rewrite for scale changes, narrowing, Decimal-kind/layout changes, and column-oriented tables.

## Risks

This changes snapshot and segment metadata publication. New metadata is written before the catalog CAS and existing objects are never overwritten. Unit coverage includes Decimal64/128/256, precision 1, cluster pages, Top-N, incompatible rewrites, and schema-sensitive cache keys.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

- `cargo fmt --all -- --check`
- CI query and storage suites

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent drafted the metadata rewrite, cache invalidation, focused tests, and PR description; the responsible human reviewed the full diff and design tradeoffs.
- Responsible human: @youngsofun
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20446)
<!-- Reviewable:end -->
