### PR TITLE
fix(query): support expressions in bracket accessors

### DIFF
--- a/src/query/sql/src/planner/binder/table_args.rs
+++ b/src/query/sql/src/planner/binder/table_args.rs
@@ -217,6 +217,16 @@ mod tests {
     use super::contains_subquery;
 
     #[test]
+    fn test_contains_like_subquery_in_bracket_key() {
+        for modifier in ["any", "all", "some"] {
+            let sql = format!("map([true], [1])['a' like {modifier} (select 'a')]");
+            let tokens = tokenize_sql(&sql).unwrap();
+            let expr = parse_expr(&tokens, Dialect::PostgreSQL).unwrap();
+            assert!(contains_subquery(&expr), "{sql}");
+        }
+    }
+
+    #[test]
     fn test_contains_subquery_through_expression_children() {
         let wrappers = [
             "substring({value} from 1)",

--- a/src/query/sql/src/planner/binder/table_args.rs
+++ b/src/query/sql/src/planner/binder/table_args.rs
@@ -41,6 +41,7 @@ pub(crate) fn contains_subquery(expr: &Expr) -> bool {
     match expr {
         Expr::Subquery { .. } => true,
         Expr::InSubquery { .. } => true,
+        Expr::LikeSubquery { .. } => true,
         Expr::Exists { .. } => true,
         Expr::Cast { expr, .. } => contains_subquery(expr),
         Expr::TryCast { expr, .. } => contains_subquery(expr),

--- a/src/query/sql/src/planner/binder/table_args.rs
+++ b/src/query/sql/src/planner/binder/table_args.rs
@@ -21,7 +21,11 @@ use databend_common_ast::ast::ColumnID;
 use databend_common_ast::ast::ColumnRef;
 use databend_common_ast::ast::Expr;
 use databend_common_ast::ast::Identifier;
-use databend_common_ast::ast::MapAccessor;
+use databend_common_ast::ast::Query;
+use databend_common_ast::visit::VisitControl;
+use databend_common_ast::visit::VisitResult;
+use databend_common_ast::visit::Visitor;
+use databend_common_ast::visit::Walk;
 use databend_common_catalog::table_args::TableArgs;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -38,46 +42,18 @@ use crate::plans::ConstantExpr;
 
 /// Check if an AST expression contains a subquery
 pub(crate) fn contains_subquery(expr: &Expr) -> bool {
-    match expr {
-        Expr::Subquery { .. } => true,
-        Expr::InSubquery { .. } => true,
-        Expr::LikeSubquery { .. } => true,
-        Expr::Exists { .. } => true,
-        Expr::Cast { expr, .. } => contains_subquery(expr),
-        Expr::TryCast { expr, .. } => contains_subquery(expr),
-        Expr::FunctionCall { func, .. } => func.args.iter().any(contains_subquery),
-        Expr::BinaryOp { left, right, .. } => contains_subquery(left) || contains_subquery(right),
-        Expr::UnaryOp { expr, .. } => contains_subquery(expr),
-        Expr::IsNull { expr, .. } => contains_subquery(expr),
-        Expr::IsDistinctFrom { left, right, .. } => {
-            contains_subquery(left) || contains_subquery(right)
+    struct SubqueryFinder;
+
+    impl Visitor for SubqueryFinder {
+        fn visit_query(&mut self, _query: &Query) -> VisitResult {
+            Ok(VisitControl::Break(()))
         }
-        Expr::InList { expr, list, .. } => {
-            contains_subquery(expr) || list.iter().any(contains_subquery)
-        }
-        Expr::Between {
-            expr, low, high, ..
-        } => contains_subquery(expr) || contains_subquery(low) || contains_subquery(high),
-        Expr::Case {
-            operand,
-            conditions,
-            results,
-            else_result,
-            ..
-        } => {
-            operand.as_ref().is_some_and(|e| contains_subquery(e))
-                || conditions.iter().any(contains_subquery)
-                || results.iter().any(contains_subquery)
-                || else_result.as_ref().is_some_and(|e| contains_subquery(e))
-        }
-        Expr::MapAccess { expr, accessor, .. } => {
-            contains_subquery(expr)
-                || matches!(accessor, MapAccessor::Bracket { key } if contains_subquery(key))
-        }
-        Expr::Array { exprs, .. } => exprs.iter().any(contains_subquery),
-        Expr::Tuple { exprs, .. } => exprs.iter().any(contains_subquery),
-        _ => false,
     }
+
+    matches!(
+        expr.walk(&mut SubqueryFinder).unwrap(),
+        VisitControl::Break(())
+    )
 }
 
 /// Execute a subquery and extract a single scalar value from the result
@@ -230,4 +206,50 @@ pub fn bind_table_args(
         positioned: positioned_args,
         named: named_args,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_ast::parser::Dialect;
+    use databend_common_ast::parser::parse_expr;
+    use databend_common_ast::parser::tokenize_sql;
+
+    use super::contains_subquery;
+
+    #[test]
+    fn test_contains_subquery_through_expression_children() {
+        let wrappers = [
+            "substring({value} from 1)",
+            "substring('1' from {value})",
+            "substring('1' from 1 for {value})",
+            "trim({value})",
+            "trim(both {value} from '1')",
+            "position({value} in '1')",
+            "position('1' in {value})",
+            "{value} -> 'a'",
+            "parse_json('{}') -> {value}",
+            "extract(day from {value})",
+            "date_part(day, {value})",
+            "date_add(day, {value}, '2026-01-01'::date)",
+            "date_add(day, 1, {value})",
+            "date_sub(day, {value}, '2026-01-01'::date)",
+            "date_sub(day, 1, {value})",
+            "date_diff(day, {value}, '2026-01-01'::date)",
+            "date_diff(day, '2026-01-01'::date, {value})",
+            "date_trunc(day, {value})",
+            "{'a': {value}}",
+            "[1][{value}]",
+            "{value}[1]",
+            "coalesce({value}, 1)",
+            "array_transform([1], x -> {value})",
+        ];
+        for wrapper in wrappers {
+            for (value, expected) in [("(select 1)", true), ("1", false)] {
+                let sql = wrapper.replace("{value}", value);
+                let tokens = tokenize_sql(&sql).unwrap();
+                let expr = parse_expr(&tokens, Dialect::PostgreSQL).unwrap();
+                assert_eq!(contains_subquery(&expr), expected, "{sql}");
+            }
+        }
+    }
 }

--- a/src/query/sql/src/planner/binder/table_args.rs
+++ b/src/query/sql/src/planner/binder/table_args.rs
@@ -21,6 +21,7 @@ use databend_common_ast::ast::ColumnID;
 use databend_common_ast::ast::ColumnRef;
 use databend_common_ast::ast::Expr;
 use databend_common_ast::ast::Identifier;
+use databend_common_ast::ast::MapAccessor;
 use databend_common_catalog::table_args::TableArgs;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -68,7 +69,10 @@ pub(crate) fn contains_subquery(expr: &Expr) -> bool {
                 || results.iter().any(contains_subquery)
                 || else_result.as_ref().is_some_and(|e| contains_subquery(e))
         }
-        Expr::MapAccess { expr, .. } => contains_subquery(expr),
+        Expr::MapAccess { expr, accessor, .. } => {
+            contains_subquery(expr)
+                || matches!(accessor, MapAccessor::Bracket { key } if contains_subquery(key))
+        }
         Expr::Array { exprs, .. } => exprs.iter().any(contains_subquery),
         Expr::Tuple { exprs, .. } => exprs.iter().any(contains_subquery),
         _ => false,

--- a/src/query/sql/src/planner/semantic/type_check/variant.rs
+++ b/src/query/sql/src/planner/semantic/type_check/variant.rs
@@ -61,7 +61,7 @@ impl<'a> CoreExprArena<'a> {
         &mut self,
         root_span: Span,
         root_expr: &'a Expr,
-        root_accessor: &MapAccessor,
+        root_accessor: &'a MapAccessor,
     ) -> Result<CoreExprId> {
         let mut current_span = root_span;
         let mut expr = root_expr;
@@ -83,12 +83,18 @@ impl<'a> CoreExprArena<'a> {
                 }
                 MapAccessor::Colon { key } => Literal::String(key.name.clone()),
                 MapAccessor::DotNumber { key } => Literal::UInt64(*key),
-                _ => {
-                    return Err(ErrorCode::SemanticError(format!(
-                        "Unsupported accessor: {:?}",
-                        accessor
-                    ))
-                    .set_span(current_span));
+                MapAccessor::Bracket { key } => {
+                    let expr = self.lower_call_expr(current_span, "get", [expr, key.as_ref()])?;
+                    return Ok(if paths.is_empty() {
+                        expr
+                    } else {
+                        self.alloc(CoreExpr::MapAccess {
+                            span: root_span,
+                            expr_span: current_span,
+                            expr,
+                            paths,
+                        })
+                    });
                 }
             };
             paths.push_front((current_span, path));

--- a/src/query/sql/tests/it/semantic/type_check/variant.rs
+++ b/src/query/sql/tests/it/semantic/type_check/variant.rs
@@ -22,6 +22,30 @@ async fn test_type_check_variant_rewrites() -> Result<()> {
             sql: "[10, 20, 30][1]",
         },
         SqlTestCase {
+            name: "array_expression_index_access_binds",
+            description: "Non-literal array indices should bind through get with normal type checking.",
+            setup_sqls: &[],
+            sql: "array('a', 'b', 'c')[delta % 2]",
+        },
+        SqlTestCase {
+            name: "array_dynamic_index_before_literal_path_binds",
+            description: "Literal access after a dynamic index should preserve the remaining path.",
+            setup_sqls: &[],
+            sql: "[[10, 20], [30, 40]][delta][2]",
+        },
+        SqlTestCase {
+            name: "array_dynamic_index_after_literal_path_binds",
+            description: "A dynamic index should preserve preceding literal access.",
+            setup_sqls: &[],
+            sql: "[[10, 20], [30, 40]][1][delta]",
+        },
+        SqlTestCase {
+            name: "map_expression_key_access_binds",
+            description: "Computed map keys should use the existing get function.",
+            setup_sqls: &[],
+            sql: "{'k1': 1, 'k2': delta}[concat('k', '1')]",
+        },
+        SqlTestCase {
             name: "map_key_access_binds",
             description: "Map key access should preserve the existing get-function rewrite.",
             setup_sqls: &[],

--- a/src/query/sql/tests/it/semantic/type_check/variant.txt
+++ b/src/query/sql/tests/it/semantic/type_check/variant.txt
@@ -5,6 +5,34 @@ status: ok
 scalar: get([10, 20, 30], 1)
 type: UInt8 NULL
 
+=== array_expression_index_access_binds ===
+description: Non-literal array indices should bind through get with normal type checking.
+sql: array('a', 'b', 'c')[delta % 2]
+status: ok
+scalar: get(['a', 'b', 'c'], modulo(delta (#3), 2))
+type: String NULL
+
+=== array_dynamic_index_before_literal_path_binds ===
+description: Literal access after a dynamic index should preserve the remaining path.
+sql: [[10, 20], [30, 40]][delta][2]
+status: ok
+scalar: get(get([[10, 20], [30, 40]], delta (#3)), 2)
+type: UInt8 NULL
+
+=== array_dynamic_index_after_literal_path_binds ===
+description: A dynamic index should preserve preceding literal access.
+sql: [[10, 20], [30, 40]][1][delta]
+status: ok
+scalar: get([10, 20], delta (#3))
+type: UInt8 NULL
+
+=== map_expression_key_access_binds ===
+description: Computed map keys should use the existing get function.
+sql: {'k1': 1, 'k2': delta}[concat('k', '1')]
+status: ok
+scalar: get(map(['k1', 'k2'], array(1, delta (#3))), 'k1')
+type: Int32 NULL
+
 === map_key_access_binds ===
 description: Map key access should preserve the existing get-function rewrite.
 sql: {'k1': 1, 'k2': delta}['k1']

--- a/tests/sqllogictests/suites/query/functions/02_0061_function_array.test
+++ b/tests/sqllogictests/suites/query/functions/02_0061_function_array.test
@@ -14,6 +14,22 @@ select number from numbers((select [1])[1])
 ----
 0
 
+# LIKE ANY/ALL/SOME subqueries in bracket keys also require the table-argument executor.
+query I
+select number from numbers(map([true], [1])['a' like any (select 'a')])
+----
+0
+
+query I
+select number from numbers(map([true], [1])['a' like all (select 'a')])
+----
+0
+
+query I
+select number from numbers(map([true], [1])['a' like some (select 'a')])
+----
+0
+
 # Array subscripts accept expressions and remain one-based, with NULL for missing elements.
 query T
 select array('a', 'b', 'c')[number % 2] from numbers(3) order by number

--- a/tests/sqllogictests/suites/query/functions/02_0061_function_array.test
+++ b/tests/sqllogictests/suites/query/functions/02_0061_function_array.test
@@ -1,3 +1,54 @@
+# Array subscripts accept expressions and remain one-based, with NULL for missing elements.
+query T
+select array('a', 'b', 'c')[number % 2] from numbers(3) order by number
+----
+NULL
+a
+NULL
+
+query TT
+select array('a', 'b', 'c')[number], array('a', 'b', 'c')[4] from numbers(5) order by number
+----
+NULL NULL
+a NULL
+b NULL
+c NULL
+NULL NULL
+
+query T
+select array('a', 'b', 'c')[if(number = 1, NULL, number + 1)] from numbers(3) order by number
+----
+a
+NULL
+c
+
+query II
+select [10, NULL, 30][number + 1], [][number + 1] from numbers(3) order by number
+----
+10 NULL
+NULL NULL
+30 NULL
+
+query III
+select [[10, 20], [30, 40]][number + 1][2], [[10, 20], [30, 40]][1][number + 1], [[10, 20], [30, 40]][number + 1][number + 1] from numbers(2) order by number
+----
+20 10 10
+40 20 40
+
+query I
+select {'k0': 10, 'k1': 20}[concat('k', to_string(number))] from numbers(3) order by number
+----
+10
+20
+NULL
+
+query T
+select parse_json('{"a":[10,20]}')[concat('a', '')][number] from numbers(3) order by number
+----
+10
+20
+NULL
+
 query T
 select range(10, 20)
 ----

--- a/tests/sqllogictests/suites/query/functions/02_0061_function_array.test
+++ b/tests/sqllogictests/suites/query/functions/02_0061_function_array.test
@@ -1,3 +1,19 @@
+# Table-argument subquery detection must inspect bracket keys, including nested expressions.
+query I
+select number from numbers([1][(select 1)])
+----
+0
+
+query I
+select number from numbers([[1]][1][(select 0) + 1])
+----
+0
+
+query I
+select number from numbers((select [1])[1])
+----
+0
+
 # Array subscripts accept expressions and remain one-based, with NULL for missing elements.
 query T
 select array('a', 'b', 'c')[number % 2] from numbers(3) order by number

--- a/tests/sqllogictests/suites/query/functions/02_0061_function_array.test
+++ b/tests/sqllogictests/suites/query/functions/02_0061_function_array.test
@@ -14,16 +14,15 @@ select number from numbers((select [1])[1])
 ----
 0
 
-# LIKE ANY/ALL/SOME subqueries in bracket keys also require the table-argument executor.
+# LIKE ANY/SOME subqueries in bracket keys also require the table-argument executor.
 query I
 select number from numbers(map([true], [1])['a' like any (select 'a')])
 ----
 0
 
-query I
+# LIKE ALL subqueries are parsed but their comparison rewrite is not supported yet.
+statement error Converting LIKE to its contrary is not currently supported
 select number from numbers(map([true], [1])['a' like all (select 'a')])
-----
-0
 
 query I
 select number from numbers(map([true], [1])['a' like some (select 'a')])

--- a/tests/sqllogictests/suites/query/functions/02_0061_function_array.test
+++ b/tests/sqllogictests/suites/query/functions/02_0061_function_array.test
@@ -30,6 +30,42 @@ select number from numbers(map([true], [1])['a' like some (select 'a')])
 ----
 0
 
+# Subqueries wrapped in other expression forms must also reach the table-argument executor.
+query I
+select number from numbers(map(['1'], [1])[substring((select '1') from 1)])
+----
+0
+
+query I
+select number from numbers(map(['1'], [1])[trim((select ' 1 '))])
+----
+0
+
+query I
+select number from numbers([1][position((select 'a') in 'a')])
+----
+0
+
+query I
+select number from numbers(map(['1'], [1])[(parse_json('{"a":"1"}') ->> (select 'a'))])
+----
+0
+
+query I
+select number from numbers([1][extract(day from (select '2026-01-01'::date))])
+----
+0
+
+query I
+select number from numbers([1][date_diff(day, '2026-01-01'::date, (select '2026-01-02'::date))])
+----
+0
+
+query I
+select number from numbers({'a': (select 1)}['a'])
+----
+0
+
 # Array subscripts accept expressions and remain one-based, with NULL for missing elements.
 query T
 select array('a', 'b', 'c')[number % 2] from numbers(3) order by number


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Bracket accessors reject non-literal keys during AST lowering, even though the existing `get` function supports them. For example:

```sql
SELECT array('a', 'b', 'c')[number % 2] FROM numbers(3);
```

This currently fails with `Unsupported accessor: Bracket { key: BinaryOp ... }`. Lower non-literal bracket access to `get(expr, key)` instead, using its existing type checking and evaluation. Keep literal-path handling unchanged, including tuple/virtual-column pushdown, and preserve literal paths following a dynamic accessor.

The example returns `NULL`, `a`, `NULL`: arrays remain one-based, and zero/out-of-bounds indices still return NULL. The same lowering also supports computed map and variant keys. No executor, storage, or configuration changes.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent investigated the accessor-lowering failure, drafted the scoped implementation and regression tests, ran local checks, and prepared this PR.
- Responsible human: @KKould
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20449)
<!-- Reviewable:end -->
