### PR TITLE
fix(query): prevent hash exchange hangs after early receiver closure

### DIFF
--- a/src/query/service/src/servers/flight/v1/exchange/broadcast_send_transform.rs
+++ b/src/query/service/src/servers/flight/v1/exchange/broadcast_send_transform.rs
@@ -89,6 +89,7 @@ impl Processor for BroadcastSendTransform {
                     self.channels.handle_send_results(results)?;
                     if self.no_active_downstream() {
                         self.input.finish();
+                        self.channels.close_all();
                         return Ok(Event::Finished);
                     }
                 }
@@ -101,6 +102,7 @@ impl Processor for BroadcastSendTransform {
 
         if self.no_active_downstream() {
             self.input.finish();
+            self.channels.close_all();
             return Ok(Event::Finished);
         }
 
@@ -141,6 +143,7 @@ impl Processor for BroadcastSendTransform {
                         self.channels.handle_send_results(results)?;
                         if self.no_active_downstream() {
                             self.input.finish();
+                            self.channels.close_all();
                             return Ok(Event::Finished);
                         }
                     }

--- a/src/query/service/src/servers/flight/v1/exchange/hash_send_sink.rs
+++ b/src/query/service/src/servers/flight/v1/exchange/hash_send_sink.rs
@@ -90,6 +90,7 @@ impl Processor for HashSendSink {
                     self.channels.handle_send_results(results)?;
                     if self.channels.all_closed() {
                         self.input.finish();
+                        self.channels.close_all();
                         return Ok(Event::Finished);
                     }
                 }
@@ -131,6 +132,7 @@ impl Processor for HashSendSink {
                             self.channels.handle_send_results(results)?;
                             if self.channels.all_closed() {
                                 self.input.finish();
+                                self.channels.close_all();
                                 return Ok(Event::Finished);
                             }
                         }

--- a/src/query/service/src/servers/flight/v1/exchange/hash_send_transform.rs
+++ b/src/query/service/src/servers/flight/v1/exchange/hash_send_transform.rs
@@ -101,6 +101,7 @@ impl Processor for HashSendTransform {
                     self.channels.handle_send_results(results)?;
                     if self.no_active_downstream() {
                         self.input.finish();
+                        self.channels.close_all();
                         return Ok(Event::Finished);
                     }
                 }
@@ -113,6 +114,7 @@ impl Processor for HashSendTransform {
 
         if self.no_active_downstream() {
             self.input.finish();
+            self.channels.close_all();
             return Ok(Event::Finished);
         }
 
@@ -161,6 +163,7 @@ impl Processor for HashSendTransform {
                             self.channels.handle_send_results(results)?;
                             if self.no_active_downstream() {
                                 self.input.finish();
+                                self.channels.close_all();
                                 return Ok(Event::Finished);
                             }
                         }

--- a/src/query/service/src/servers/flight/v1/exchange/outbound_send_channels.rs
+++ b/src/query/service/src/servers/flight/v1/exchange/outbound_send_channels.rs
@@ -70,11 +70,10 @@ impl OutboundSendChannels {
     }
 
     pub(super) fn close(&mut self, idx: usize) {
-        if !self.channels[idx].is_closed() {
-            let mut closed = DummyOutboundChannel::create();
-            std::mem::swap(&mut self.channels[idx], &mut closed);
-            closed.close();
-        }
+        // Closed destinations still own the shared send buffer. Release their
+        // references so other destinations can receive EOF before the graph drops.
+        let closed = std::mem::replace(&mut self.channels[idx], DummyOutboundChannel::create());
+        closed.close();
     }
 
     pub(super) fn close_all(&mut self) {

--- a/tests/sqllogictests/suites/mode/cluster/hash_exchange_early_close.test
+++ b/tests/sqllogictests/suites/mode/cluster/hash_exchange_early_close.test
@@ -1,0 +1,106 @@
+# Keep the probe distributed across many blocks. Only the node receiving key 0
+# produces matches and reaches its local LIMIT; the other nodes must receive EOF.
+# A finished sender must release channels even when a destination closed early.
+statement ok
+set max_threads = 1
+
+statement ok
+set max_block_size = 1024
+
+statement ok
+set enforce_shuffle_join = 1
+
+statement ok
+set disable_join_reorder = 1
+
+statement ok
+set enable_experimental_new_join = 1
+
+# Keep unmatched probe rows flowing after the matching destination finishes.
+statement ok
+set enable_join_runtime_filter = 0
+
+# Flush partitions while the scan is running, before all producers reach EOF.
+statement ok
+set hash_shuffle_rows_threshold = 1
+
+statement ok
+set hash_shuffle_bytes_threshold = 1
+
+# A hang must fail this test instead of waiting for the whole CI job to time out.
+statement ok
+set max_execute_time_in_seconds = 30
+
+statement ok
+drop table if exists t_hash_exchange_early_close_build
+
+statement ok
+drop table if exists t_hash_exchange_early_close_probe
+
+statement ok
+create table t_hash_exchange_early_close_build(k UInt64, v UInt64)
+
+statement ok
+create table t_hash_exchange_early_close_probe(k UInt64, v UInt64) row_per_block = 1024
+
+# Give every destination a nonempty build, but amplify matches only for key 0.
+statement ok
+insert into t_hash_exchange_early_close_build
+select if(number < 1000, 0, number - 999), number from numbers(1100)
+
+statement ok
+insert into t_hash_exchange_early_close_probe
+select if(number % 1024 = 0, 0, 1000 + number % 100), number from numbers(100000)
+
+# The full join is small and terminates without early receiver closure.
+query I
+select count(*)
+from t_hash_exchange_early_close_probe p
+inner join t_hash_exchange_early_close_build b on p.k = b.k
+----
+98000
+
+# Check terminal success as well as the result: the buggy query returns 100
+# before getting stuck waiting for remote EOF and eventually being aborted.
+query I
+select count(*) from (
+    select p.v as pv, b.v as bv
+    from t_hash_exchange_early_close_probe p
+    inner join t_hash_exchange_early_close_build b on p.k = b.k
+    limit 100
+)
+----
+100
+
+statement ok
+drop table t_hash_exchange_early_close_build
+
+statement ok
+drop table t_hash_exchange_early_close_probe
+
+statement ok
+unset max_threads
+
+statement ok
+unset max_block_size
+
+statement ok
+unset enforce_shuffle_join
+
+statement ok
+unset disable_join_reorder
+
+statement ok
+unset enable_experimental_new_join
+
+statement ok
+unset enable_join_runtime_filter
+
+statement ok
+unset hash_shuffle_rows_threshold
+
+statement ok
+unset hash_shuffle_bytes_threshold
+
+statement ok
+unset max_execute_time_in_seconds


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary


A distributed hash exchange can hang after one destination reaches its local `LIMIT` and closes early. The sender treats the destination's closed state as if it had already released the local channel object. However, `RemoteChannel::is_closed()` only reports the destination's state; the channel still owns an `Arc<ExchangeSinkBuffer>` shared across destinations.

The original `OutboundSendChannels::close()` only replaces a channel when `!is_closed()`. Consequently, even `close_all()` can leave an already-closed remote channel in the finished sender. Some early `Event::Finished` paths also omit `close_all()` entirely.

```mermaid
flowchart LR
    G["Graph retains<br/>finished sender"]
    B["Closed channel<br/>retains buffer"]
    S["Buffer drop and<br/>shutdown blocked"]
    R["Receivers<br/>wait for EOF"]

    G -->|owns| B
    B -->|prevents release| S
    S -->|no EOF| R
    R -->|keeps graph alive| G
```

`Event::Finished` changes the processor's scheduling state; it does not destroy the processor. Meanwhile, `ExchangeSinkBufferInner::drop()` is responsible for notifying the outgoing transports to shut down. Those transports drain pending data and close their send streams so receivers can observe EOF. Retaining the shared buffer prevents this normal end-of-stream path, including for destinations that did not close early.

This creates a lifecycle wait cycle: execution completion waits for receivers, receivers wait for EOF, and EOF waits for resources still owned by the execution graphs. A sender can therefore be finished with no pending sends or buffered partitions while other receivers remain idle indefinitely. The unfinished execution can retain join state and other query allocations; the retained exchange buffer does not itself have to contain all of that memory.

This fix breaks the cycle at sender completion by releasing each channel reference regardless of its closed state and cleaning up channels on every early-finish path. Existing pending-send handling is preserved before normal EOF cleanup so outgoing data is drained correctly.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

<!--
See AI_POLICY.md. Agent-opened PRs are welcome; a responsible human on the author side must own the change.
The responsible human is NOT the reviewer — it is the submitter-side owner who has read the diff,
can explain each change, and will answer questions during review.
Write "None" for AI usage if no AI was involved.
-->

- AI usage: An AI coding agent investigated the exchange lifecycle, constructed and repeatedly ran the SQL reproduction, drafted the regression test and channel lifecycle fix, and prepared this PR description.
- Responsible human: @dqhl76
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20450)
<!-- Reviewable:end -->
