### PR TITLE
chore(ci): bump linux build timeout from 60 to 90 minutes

### DIFF
--- a/.github/workflows/reuse.linux.yml
+++ b/.github/workflows/reuse.linux.yml
@@ -83,7 +83,7 @@ jobs:
           # fetch all tags, metasrv and meta client need tag as its version.
           fetch-depth: 0
       - uses: ./.github/actions/build_linux
-        timeout-minutes: 60
+        timeout-minutes: 90
         env:
           DATABEND_ENTERPRISE_LICENSE_PUBLIC_KEY: ${{ secrets.DATABEND_ENTERPRISE_LICENSE_PUBLIC_KEY }}
           DATABEND_TELEMETRY_ENDPOINT: ${{ secrets.DATABEND_TELEMETRY_ENDPOINT}}


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

The full-workspace Linux build in `reuse.linux.yml` has been hitting the 60-minute step timeout as the codebase grows. This raises the `build_linux` step timeout to 90 minutes for the main PR/CI full build (`python-udf,storage-hdfs`, category `full`).

Scope is intentionally limited to the one build step that is timing out. Other `build_linux` usages are left unchanged:
- `cloud.yml` already uses 120 minutes
- `release.yml` has no explicit step timeout
- `meta.yml` builds only a small subset (`meta,metactl,metaverifier`)

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - CI workflow configuration change; no product code affected.

## Type of change

- [x] Other (please describe): CI configuration change (build step timeout)

## AI assistance

- AI usage: Used an AI coding assistant to locate the timeout settings across workflow files, scope the change to the correct build step, edit the YAML, and draft this PR.
- Responsible human: @TCeason 
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20451)
<!-- Reviewable:end -->
