### PR TITLE
fix(query): avoid outer join error panic

### DIFF
--- a/src/query/expression/src/function.rs
+++ b/src/query/expression/src/function.rs
@@ -619,13 +619,21 @@ impl EvalContext<'_> {
         };
 
         let first_error_row = match selection {
-            None => valids.iter().enumerate().find(|(_, v)| !v).unwrap().0,
+            None => {
+                let Some((row, _)) = valids.iter().enumerate().find(|(_, valid)| !valid) else {
+                    return Ok(());
+                };
+                row
+            }
             Some(selection) if valids.len() == 1 => {
-                if valids.get(0) || selection.is_empty() {
+                if valids.get(0) {
                     return Ok(());
                 }
 
-                selection.first().map(|x| *x as usize).unwrap()
+                let Some(row) = selection.first() else {
+                    return Ok(());
+                };
+                *row as usize
             }
             Some(selection) => {
                 let Some(first_invalid) = selection.iter().find(|idx| !valids.get(**idx as usize))
@@ -677,5 +685,41 @@ pub fn error_to_null<I1: AccessType, O: ArgType>(
                 )),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_column::bitmap::MutableBitmap;
+
+    use super::EvalContext;
+
+    #[test]
+    fn render_error_ignores_error_channel_without_invalid_rows() {
+        let errors = Some((MutableBitmap::from_len_set(2), "error".to_string()));
+
+        assert!(EvalContext::render_error(None, &errors, &[], &[], "fn", "expr", None).is_ok());
+    }
+
+    #[test]
+    fn render_error_ignores_empty_selection() {
+        let errors = Some((MutableBitmap::from_len_zeroed(1), "error".to_string()));
+
+        assert!(
+            EvalContext::render_error(None, &errors, &[], &[], "fn", "expr", Some(&[])).is_ok()
+        );
+    }
+
+    #[test]
+    fn render_error_returns_sql_error_for_invalid_row() {
+        let errors = Some((MutableBitmap::from_len_zeroed(1), "error".to_string()));
+
+        let err = EvalContext::render_error(None, &errors, &[], &[], "fn", "expr", None)
+            .expect_err("an invalid row must be reported as a SQL error");
+        assert_eq!(err.code(), 1006);
+        assert!(
+            err.message()
+                .contains("error while evaluating function `fn()`")
+        );
     }
 }

--- a/src/query/sql/tests/it/optimizer/planning_context.rs
+++ b/src/query/sql/tests/it/optimizer/planning_context.rs
@@ -63,6 +63,15 @@ FROM planning_left_rows AS l
 LEFT JOIN planning_right_rows AS r ON l.id = r.id
 WHERE r.id > 0",
         },
+        SqlTestCase {
+            name: "erroring_outer_join_predicate_does_not_panic",
+            description: "An expression error encountered while checking an outer-join predicate must not panic the optimizer.",
+            setup_sqls: &[BOOLEAN_ROWS_TABLE],
+            sql: "SELECT b.c0boolean
+FROM planning_boolean_rows AS a
+LEFT JOIN planning_boolean_rows AS b ON a.c0boolean = b.c0boolean
+WHERE LPAD(CASE WHEN b.c0boolean THEN '' ELSE '0.6' END, 1426755006, '') IS NULL",
+        },
     ];
 
     for case in &cases {
@@ -75,3 +84,4 @@ WHERE r.id > 0",
 const LEFT_ROWS_TABLE: &str = "CREATE TABLE planning_left_rows(id UInt64)";
 const RIGHT_ROWS_TABLE: &str =
     "CREATE TABLE planning_right_rows(id UInt64, ts Nullable(Timestamp))";
+const BOOLEAN_ROWS_TABLE: &str = "CREATE TABLE planning_boolean_rows(c0boolean BOOLEAN)";

--- a/src/query/sql/tests/it/optimizer/planning_context.txt
+++ b/src/query/sql/tests/it/optimizer/planning_context.txt
@@ -110,3 +110,48 @@ EvalScalar
         └── limit: NONE
 
 
+=== erroring_outer_join_predicate_does_not_panic ===
+description: An expression error encountered while checking an outer-join predicate must not panic the optimizer.
+sql: SELECT b.c0boolean
+FROM planning_boolean_rows AS a
+LEFT JOIN planning_boolean_rows AS b ON a.c0boolean = b.c0boolean
+WHERE LPAD(CASE WHEN b.c0boolean THEN '' ELSE '0.6' END, 1426755006, '') IS NULL
+raw_plan:
+EvalScalar
+├── scalars: [planning_boolean_rows.c0boolean (#1) AS (#1)]
+└── Filter
+    ├── filters: [not(is_not_null(lpad(if(planning_boolean_rows.c0boolean (#1), '', '0.6'), 1426755006, '')))]
+    └── Join(Left)
+        ├── build keys: [planning_boolean_rows.c0boolean (#1)]
+        ├── probe keys: [planning_boolean_rows.c0boolean (#0)]
+        ├── other filters: []
+        ├── Scan
+        │   ├── table: default.planning_boolean_rows (#1)
+        │   ├── filters: []
+        │   ├── order by: []
+        │   └── limit: NONE
+        └── Scan
+            ├── table: default.planning_boolean_rows (#0)
+            ├── filters: []
+            ├── order by: []
+            └── limit: NONE
+
+optimized_plan:
+Filter
+├── filters: [not(is_not_null(lpad(if(planning_boolean_rows.c0boolean (#1), '', '0.6'), 1426755006, '')))]
+└── Join(Left)
+    ├── build keys: [planning_boolean_rows.c0boolean (#1)]
+    ├── probe keys: [planning_boolean_rows.c0boolean (#0)]
+    ├── other filters: []
+    ├── Scan
+    │   ├── table: default.planning_boolean_rows (#1)
+    │   ├── filters: []
+    │   ├── order by: []
+    │   └── limit: NONE
+    └── Scan
+        ├── table: default.planning_boolean_rows (#0)
+        ├── filters: []
+        ├── order by: []
+        └── limit: NONE
+
+


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fixes #20421.

An expression error in an outer-join filter could panic during optimizer null-filterability analysis because `EvalContext::render_error` unconditionally unwrapped the first invalid row. This caused the server session to be dropped instead of returning a SQL error.

## Changes

- Make `EvalContext::render_error` handle error channels with no invalid rows and empty selections without panicking.
- Preserve `BadArguments` error reporting when a real invalid row exists.
- Add an expression-level regression test for the error-reporting edge cases.
- Add an optimizer replay regression case for the reported `LEFT JOIN` and `LPAD(CASE ...)` query shape.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p databend-common-expression --lib function::tests`
- `cargo test -p databend-common-sql --test it optimizer::planning_context --no-default-features`

## Type of change

- [x] Bug Fix (non-breaking change)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (change that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent assisted with root-cause analysis, implementation, regression tests, validation, and PR preparation; the responsible human reviewed the final diff.
- Responsible human: @sundy-li
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20452)
<!-- Reviewable:end -->
