### PR TITLE
fix(query): disable join selectivity backoff and align propagation

### DIFF
--- a/src/query/sql/src/planner/optimizer/ir/stats/join.rs
+++ b/src/query/sql/src/planner/optimizer/ir/stats/join.rs
@@ -44,6 +44,9 @@ use crate::plans::JoinType;
 use crate::plans::ScalarExpr;
 
 const DEFAULT_NON_EQUI_SELECTIVITY: f64 = 0.5;
+// Keep strongest-condition estimates until multi-condition backoff handles
+// correlated and repeated join keys without severe underestimation.
+const ENABLE_JOIN_SELECTIVITY_BACKOFF: bool = false;
 
 pub(super) struct JoinStats {
     pub(super) output_rows: f64,
@@ -235,7 +238,14 @@ impl JoinConditionEstimates {
         if estimate.matched_pair_rows < self.strongest_equi_pair_rows {
             self.strongest_equi_pair_rows = estimate.matched_pair_rows;
             self.strongest_condition_ndv = estimate.ndv;
+        } else if estimate.matched_pair_rows == self.strongest_equi_pair_rows {
+            self.strongest_condition_ndv = match (self.strongest_condition_ndv, estimate.ndv) {
+                (Some(left), Some(right)) => Some(left.min(right)),
+                (left, right) => left.or(right),
+            };
         }
+        // Pair selectivity and side coverage need not rank conditions in the
+        // same order. Collect every condition before combining each quantity.
         self.left.add_equi_matches(
             estimate.left_matched_rows,
             estimate.left_histogram_estimated_matched_rows,
@@ -651,10 +661,13 @@ impl JoinStatsEstimator {
             (JoinType::Full | JoinType::FullAsof, Side::Right) => left.unmatched_rows(),
             _ => 0.0,
         };
-        let combines_condition_ndv = matches!(
-            self.join_type,
-            JoinType::Inner | JoinType::InnerAny | JoinType::LeftSemi | JoinType::RightSemi
-        );
+        // Without backoff, propagate side coverage without applying an extra
+        // condition selectivity to either join keys or non-key columns.
+        let combines_condition_ndv = ENABLE_JOIN_SELECTIVITY_BACKOFF
+            && matches!(
+                self.join_type,
+                JoinType::Inner | JoinType::InnerAny | JoinType::LeftSemi | JoinType::RightSemi
+            );
         let (ndv_surviving_input_rows, residual_ndv_selectivity) =
             if !combines_condition_ndv || expression_output == ExpressionStatOutput::Input {
                 (surviving_input_rows, 1.0)
@@ -1125,6 +1138,15 @@ fn combine_condition_estimates(
 ) -> f64 {
     if estimates.is_empty() || input_cardinality <= 0.0 {
         return fallback;
+    }
+
+    if !ENABLE_JOIN_SELECTIVITY_BACKOFF {
+        return estimates
+            .iter()
+            .copied()
+            .reduce(f64::min)
+            .unwrap()
+            .clamp(0.0, input_cardinality);
     }
 
     estimates.sort_by(f64::total_cmp);

--- a/src/query/sql/test-support/data/results/obfuscated/01_multi_join_avg_case_expression_optimized.txt
+++ b/src/query/sql/test-support/data/results/obfuscated/01_multi_join_avg_case_expression_optimized.txt
@@ -14,40 +14,40 @@ Exchange(Merge)
                     └── EvalScalar
                         ├── scalars: [a0c.a0d (#0) AS (#0), a0c.a0k (#7) AS (#7), a0c.a0m (#9) AS (#9), a2x.a5m (#144) AS (#144), if(eq(a5r.a1v (#154), '603020'), 1, 0) AS (#166), a1z.a2t (#70) AS (#171), a2x.a4m (#118) AS (#172), a5r.a5w (#156) AS (#173)]
                         └── Join(Inner)
-                            ├── build keys: [a0c.a0m (#9)]
-                            ├── probe keys: [a0m (#149)]
+                            ├── build keys: [a5r.a5t (#151)]
+                            ├── probe keys: [a0c.a0l (#8)]
                             ├── other filters: []
                             ├── Exchange(Broadcast)
-                            │   └── Join(Inner)
-                            │       ├── build keys: [a5r.a5t (#151)]
-                            │       ├── probe keys: [a0c.a0l (#8)]
-                            │       ├── other filters: []
-                            │       ├── Exchange(Broadcast)
-                            │       │   └── Scan
-                            │       │       ├── table: default.a5r (#3)
-                            │       │       ├── filters: [eq(substring(a5r.a5w (#156), 1, 1), '1')]
-                            │       │       ├── order by: []
-                            │       │       └── limit: NONE
-                            │       └── Join(Inner)
-                            │           ├── build keys: [a1z.a0k (#48), a1z.a0n (#50)]
-                            │           ├── probe keys: [a0c.a0k (#7), a0c.a0n (#10)]
-                            │           ├── other filters: [lte(a1z.a2c (#52), a0c.a0d (#0)), gt(a1z.a2k (#61), a0c.a0d (#0))]
-                            │           ├── Exchange(Broadcast)
-                            │           │   └── Scan
-                            │           │       ├── table: default.a1z (#1)
-                            │           │       ├── filters: [eq(a1z.a2t (#70), '624100')]
-                            │           │       ├── order by: []
-                            │           │       └── limit: NONE
-                            │           └── Scan
-                            │               ├── table: default.a0c (#0)
-                            │               ├── filters: [gte(a0c.a0d (#0), '20240526'), lte(a0c.a0d (#0), '20250525')]
-                            │               ├── order by: []
-                            │               └── limit: NONE
-                            └── EvalScalar
-                                ├── scalars: [CAST(a2x.a0m (#74) AS String NULL) AS (#149)]
-                                └── Scan
-                                    ├── table: default.a2x (#2)
-                                    ├── filters: [eq(substring(a2x.a4m (#118), 20, 1), '1')]
-                                    ├── order by: []
-                                    └── limit: NONE
+                            │   └── Scan
+                            │       ├── table: default.a5r (#3)
+                            │       ├── filters: [eq(substring(a5r.a5w (#156), 1, 1), '1')]
+                            │       ├── order by: []
+                            │       └── limit: NONE
+                            └── Join(Inner)
+                                ├── build keys: [a0m (#149)]
+                                ├── probe keys: [a0c.a0m (#9)]
+                                ├── other filters: []
+                                ├── Exchange(Broadcast)
+                                │   └── EvalScalar
+                                │       ├── scalars: [CAST(a2x.a0m (#74) AS String NULL) AS (#149)]
+                                │       └── Scan
+                                │           ├── table: default.a2x (#2)
+                                │           ├── filters: [eq(substring(a2x.a4m (#118), 20, 1), '1')]
+                                │           ├── order by: []
+                                │           └── limit: NONE
+                                └── Join(Inner)
+                                    ├── build keys: [a1z.a0k (#48), a1z.a0n (#50)]
+                                    ├── probe keys: [a0c.a0k (#7), a0c.a0n (#10)]
+                                    ├── other filters: [lte(a1z.a2c (#52), a0c.a0d (#0)), gt(a1z.a2k (#61), a0c.a0d (#0))]
+                                    ├── Exchange(Broadcast)
+                                    │   └── Scan
+                                    │       ├── table: default.a1z (#1)
+                                    │       ├── filters: [eq(a1z.a2t (#70), '624100')]
+                                    │       ├── order by: []
+                                    │       └── limit: NONE
+                                    └── Scan
+                                        ├── table: default.a0c (#0)
+                                        ├── filters: [gte(a0c.a0d (#0), '20240526'), lte(a0c.a0d (#0), '20250525')]
+                                        ├── order by: []
+                                        └── limit: NONE
 

--- a/src/query/sql/test-support/data/results/obfuscated/01_multi_join_avg_case_expression_physical.txt
+++ b/src/query/sql/test-support/data/results/obfuscated/01_multi_join_avg_case_expression_physical.txt
@@ -4,108 +4,110 @@ Exchange
 └── EvalScalar
     ├── output columns: [sell_mnt = 0 (#170)]
     ├── expressions: [t.sell_mnt (#169) = 0]
-    ├── estimated rows: 14021.84
+    ├── estimated rows: 58807078.72
     └── EvalScalar
         ├── output columns: [sell_mnt (#169)]
         ├── expressions: [sum(CASE WHEN d.a1v = '603020' THEN 1 ELSE 0 END) (#167) / CAST(if(CAST(count(CASE WHEN d.a1v = '603020' THEN 1 ELSE 0 END) (#168) = 0 AS Boolean NULL), 1, count(CASE WHEN d.a1v = '603020' THEN 1 ELSE 0 END) (#168)) AS UInt64 NULL) + 3]
-        ├── estimated rows: 14021.84
+        ├── estimated rows: 58807078.72
         └── AggregateFinal
             ├── output columns: [sum(CASE WHEN d.a1v = '603020' THEN 1 ELSE 0 END) (#167), count(CASE WHEN d.a1v = '603020' THEN 1 ELSE 0 END) (#168), a.a0d (#0), a.a0k (#7), a.a0m (#9), c.a5m (#144)]
             ├── group by: [a0d, a0k, a0m, a5m]
             ├── aggregate functions: [sum(sum_arg_0), count()]
-            ├── estimated rows: 14021.84
+            ├── estimated rows: 58807078.72
             └── Exchange
                 ├── output columns: [sum(CASE WHEN d.a1v = '603020' THEN 1 ELSE 0 END) (#167), count(CASE WHEN d.a1v = '603020' THEN 1 ELSE 0 END) (#168), a.a0d (#0), a.a0k (#7), a.a0m (#9), c.a5m (#144)]
                 ├── exchange type: Hash(0, 1, 2, 3)
                 └── AggregatePartial
                     ├── group by: [a0d, a0k, a0m, a5m]
                     ├── aggregate functions: [sum(sum_arg_0), count()]
-                    ├── estimated rows: 14021.84
+                    ├── estimated rows: 58807078.72
                     └── EvalScalar
-                        ├── output columns: [c.a5m (#144), a.a0d (#0), a.a0k (#7), a.a0m (#9), sum_arg_0 (#166)]
+                        ├── output columns: [a.a0d (#0), a.a0k (#7), a.a0m (#9), c.a5m (#144), sum_arg_0 (#166)]
                         ├── expressions: [if(d.a1v (#154) = '603020', 1, 0)]
-                        ├── estimated rows: 14021.84
+                        ├── estimated rows: 58807078.72
                         └── HashJoin
-                            ├── output columns: [c.a5m (#144), a.a0d (#0), a.a0k (#7), d.a1v (#154), a.a0m (#9)]
+                            ├── output columns: [a.a0d (#0), a.a0k (#7), a.a0m (#9), c.a5m (#144), d.a1v (#154)]
                             ├── join type: INNER
-                            ├── build keys: [a.a0m (#9)]
-                            ├── probe keys: [c.a0m (#149)]
+                            ├── build keys: [d.a5t (#151)]
+                            ├── probe keys: [a.a0l (#8)]
                             ├── keys is null equal: [false]
                             ├── filters: []
-                            ├── estimated rows: 14021.84
+                            ├── build join filters:
+                            │   └── filter id:3, build key:d.a5t (#151), probe targets:[a.a0l (#8)@scan0], filter type:bloom,inlist,min_max
+                            ├── estimated rows: 58807078.72
                             ├── Exchange(Build)
-                            │   ├── output columns: [a.a0d (#0), a.a0k (#7), a.a0m (#9), d.a1v (#154)]
+                            │   ├── output columns: [d.a5t (#151), d.a1v (#154)]
                             │   ├── exchange type: Broadcast
-                            │   └── HashJoin
-                            │       ├── output columns: [a.a0d (#0), a.a0k (#7), a.a0m (#9), d.a1v (#154)]
-                            │       ├── join type: INNER
-                            │       ├── build keys: [d.a5t (#151)]
-                            │       ├── probe keys: [a.a0l (#8)]
-                            │       ├── keys is null equal: [false]
-                            │       ├── filters: []
-                            │       ├── build join filters:
-                            │       │   └── filter id:2, build key:d.a5t (#151), probe targets:[a.a0l (#8)@scan0], filter type:bloom,inlist,min_max
-                            │       ├── estimated rows: 14094.12
-                            │       ├── Exchange(Build)
-                            │       │   ├── output columns: [d.a5t (#151), d.a1v (#154)]
-                            │       │   ├── exchange type: Broadcast
-                            │       │   └── TableScan
-                            │       │       ├── table: default.default.a5r
-                            │       │       ├── scan id: 3
-                            │       │       ├── output columns: [a5t (#151), a1v (#154)]
-                            │       │       ├── read rows: 0
-                            │       │       ├── read size: 0
-                            │       │       ├── partitions total: 0
-                            │       │       ├── partitions scanned: 0
-                            │       │       ├── push downs: [filters: [is_true(substr(a5r.a5w (#156), 1, 1) = '1')], limit: NONE]
-                            │       │       └── estimated rows: 806.60
-                            │       └── HashJoin(Probe)
-                            │           ├── output columns: [a.a0d (#0), a.a0k (#7), a.a0l (#8), a.a0m (#9)]
-                            │           ├── join type: INNER
-                            │           ├── build keys: [b.a0k (#48), b.a0n (#50)]
-                            │           ├── probe keys: [a.a0k (#7), a.a0n (#10)]
-                            │           ├── keys is null equal: [false, false]
-                            │           ├── filters: [b.a2c (#52) <= a.a0d (#0), b.a2k (#61) > a.a0d (#0)]
-                            │           ├── build join filters:
-                            │           │   ├── filter id:0, build key:b.a0k (#48), probe targets:[a.a0k (#7)@scan0], filter type:bloom,inlist,min_max
-                            │           │   └── filter id:1, build key:b.a0n (#50), probe targets:[a.a0n (#10)@scan0], filter type:bloom,inlist,min_max
-                            │           ├── estimated rows: 14072.43
-                            │           ├── Exchange(Build)
-                            │           │   ├── output columns: [b.a0k (#48), b.a0n (#50), b.a2c (#52), b.a2k (#61)]
-                            │           │   ├── exchange type: Broadcast
-                            │           │   └── TableScan
-                            │           │       ├── table: default.default.a1z
-                            │           │       ├── scan id: 1
-                            │           │       ├── output columns: [a0k (#48), a0n (#50), a2c (#52), a2k (#61)]
-                            │           │       ├── read rows: 0
-                            │           │       ├── read size: 0
-                            │           │       ├── partitions total: 0
-                            │           │       ├── partitions scanned: 0
-                            │           │       ├── push downs: [filters: [is_true(a1z.a2t (#70) = '624100')], limit: NONE]
-                            │           │       └── estimated rows: 11373457.90
-                            │           └── TableScan(Probe)
-                            │               ├── table: default.default.a0c
-                            │               ├── scan id: 0
-                            │               ├── output columns: [a0d (#0), a0k (#7), a0l (#8), a0m (#9), a0n (#10)]
-                            │               ├── read rows: 0
-                            │               ├── read size: 0
-                            │               ├── partitions total: 0
-                            │               ├── partitions scanned: 0
-                            │               ├── push downs: [filters: [a0c.a0d (#0) >= '20240526' and a0c.a0d (#0) <= '20250525'], limit: NONE]
-                            │               ├── apply join filters: [#2, #0, #1]
-                            │               └── estimated rows: 62086049.42
-                            └── EvalScalar(Probe)
-                                ├── output columns: [c.a5m (#144), a0m (#149)]
-                                ├── expressions: [CAST(c.a0m (#74) AS String NULL)]
-                                ├── estimated rows: 63773.60
-                                └── TableScan
-                                    ├── table: default.default.a2x
-                                    ├── scan id: 2
-                                    ├── output columns: [a0m (#74), a5m (#144)]
-                                    ├── read rows: 0
-                                    ├── read size: 0
-                                    ├── partitions total: 0
-                                    ├── partitions scanned: 0
-                                    ├── push downs: [filters: [is_true(substr(a2x.a4m (#118), 20, 1) = '1')], limit: NONE]
-                                    └── estimated rows: 63773.60
+                            │   └── TableScan
+                            │       ├── table: default.default.a5r
+                            │       ├── scan id: 3
+                            │       ├── output columns: [a5t (#151), a1v (#154)]
+                            │       ├── read rows: 0
+                            │       ├── read size: 0
+                            │       ├── partitions total: 0
+                            │       ├── partitions scanned: 0
+                            │       ├── push downs: [filters: [is_true(substr(a5r.a5w (#156), 1, 1) = '1')], limit: NONE]
+                            │       └── estimated rows: 806.60
+                            └── HashJoin(Probe)
+                                ├── output columns: [a.a0d (#0), a.a0k (#7), a.a0l (#8), a.a0m (#9), c.a5m (#144)]
+                                ├── join type: INNER
+                                ├── build keys: [c.a0m (#149)]
+                                ├── probe keys: [a.a0m (#9)]
+                                ├── keys is null equal: [false]
+                                ├── filters: []
+                                ├── build join filters:
+                                │   └── filter id:2, build key:c.a0m (#149), probe targets:[a.a0m (#9)@scan0], filter type:bloom,inlist,min_max
+                                ├── estimated rows: 58716607.09
+                                ├── Exchange(Build)
+                                │   ├── output columns: [c.a5m (#144), a0m (#149)]
+                                │   ├── exchange type: Broadcast
+                                │   └── EvalScalar
+                                │       ├── output columns: [c.a5m (#144), a0m (#149)]
+                                │       ├── expressions: [CAST(c.a0m (#74) AS String NULL)]
+                                │       ├── estimated rows: 63773.60
+                                │       └── TableScan
+                                │           ├── table: default.default.a2x
+                                │           ├── scan id: 2
+                                │           ├── output columns: [a0m (#74), a5m (#144)]
+                                │           ├── read rows: 0
+                                │           ├── read size: 0
+                                │           ├── partitions total: 0
+                                │           ├── partitions scanned: 0
+                                │           ├── push downs: [filters: [is_true(substr(a2x.a4m (#118), 20, 1) = '1')], limit: NONE]
+                                │           └── estimated rows: 63773.60
+                                └── HashJoin(Probe)
+                                    ├── output columns: [a.a0d (#0), a.a0k (#7), a.a0l (#8), a.a0m (#9)]
+                                    ├── join type: INNER
+                                    ├── build keys: [b.a0k (#48), b.a0n (#50)]
+                                    ├── probe keys: [a.a0k (#7), a.a0n (#10)]
+                                    ├── keys is null equal: [false, false]
+                                    ├── filters: [b.a2c (#52) <= a.a0d (#0), b.a2k (#61) > a.a0d (#0)]
+                                    ├── build join filters:
+                                    │   ├── filter id:0, build key:b.a0k (#48), probe targets:[a.a0k (#7)@scan0], filter type:bloom,inlist,min_max
+                                    │   └── filter id:1, build key:b.a0n (#50), probe targets:[a.a0n (#10)@scan0], filter type:bloom,inlist,min_max
+                                    ├── estimated rows: 59019257.39
+                                    ├── Exchange(Build)
+                                    │   ├── output columns: [b.a0k (#48), b.a0n (#50), b.a2c (#52), b.a2k (#61)]
+                                    │   ├── exchange type: Broadcast
+                                    │   └── TableScan
+                                    │       ├── table: default.default.a1z
+                                    │       ├── scan id: 1
+                                    │       ├── output columns: [a0k (#48), a0n (#50), a2c (#52), a2k (#61)]
+                                    │       ├── read rows: 0
+                                    │       ├── read size: 0
+                                    │       ├── partitions total: 0
+                                    │       ├── partitions scanned: 0
+                                    │       ├── push downs: [filters: [is_true(a1z.a2t (#70) = '624100')], limit: NONE]
+                                    │       └── estimated rows: 11373457.90
+                                    └── TableScan(Probe)
+                                        ├── table: default.default.a0c
+                                        ├── scan id: 0
+                                        ├── output columns: [a0d (#0), a0k (#7), a0l (#8), a0m (#9), a0n (#10)]
+                                        ├── read rows: 0
+                                        ├── read size: 0
+                                        ├── partitions total: 0
+                                        ├── partitions scanned: 0
+                                        ├── push downs: [filters: [a0c.a0d (#0) >= '20240526' and a0c.a0d (#0) <= '20250525'], limit: NONE]
+                                        ├── apply join filters: [#3, #2, #0, #1]
+                                        └── estimated rows: 62086049.42
 

--- a/src/query/sql/test-support/data/results/obfuscated/01_multi_join_sum_case_expression_optimized.txt
+++ b/src/query/sql/test-support/data/results/obfuscated/01_multi_join_sum_case_expression_optimized.txt
@@ -12,40 +12,40 @@ Exchange(Merge)
                 └── EvalScalar
                     ├── scalars: [a0c.a0d (#0) AS (#0), a0c.a0k (#7) AS (#7), a0c.a0m (#9) AS (#9), a2x.a5m (#144) AS (#144), if(eq(a5r.a1v (#154), '603020'), 1, 0) AS (#166), a1z.a2t (#70) AS (#169), a2x.a4m (#118) AS (#170), a5r.a5w (#156) AS (#171)]
                     └── Join(Inner)
-                        ├── build keys: [a0c.a0m (#9)]
-                        ├── probe keys: [a0m (#149)]
+                        ├── build keys: [a5r.a5t (#151)]
+                        ├── probe keys: [a0c.a0l (#8)]
                         ├── other filters: []
                         ├── Exchange(Broadcast)
-                        │   └── Join(Inner)
-                        │       ├── build keys: [a5r.a5t (#151)]
-                        │       ├── probe keys: [a0c.a0l (#8)]
-                        │       ├── other filters: []
-                        │       ├── Exchange(Broadcast)
-                        │       │   └── Scan
-                        │       │       ├── table: default.a5r (#3)
-                        │       │       ├── filters: [eq(substring(a5r.a5w (#156), 1, 1), '1')]
-                        │       │       ├── order by: []
-                        │       │       └── limit: NONE
-                        │       └── Join(Inner)
-                        │           ├── build keys: [a1z.a0k (#48), a1z.a0n (#50)]
-                        │           ├── probe keys: [a0c.a0k (#7), a0c.a0n (#10)]
-                        │           ├── other filters: [lte(a1z.a2c (#52), a0c.a0d (#0)), gt(a1z.a2k (#61), a0c.a0d (#0))]
-                        │           ├── Exchange(Broadcast)
-                        │           │   └── Scan
-                        │           │       ├── table: default.a1z (#1)
-                        │           │       ├── filters: [eq(a1z.a2t (#70), '624100')]
-                        │           │       ├── order by: []
-                        │           │       └── limit: NONE
-                        │           └── Scan
-                        │               ├── table: default.a0c (#0)
-                        │               ├── filters: [gte(a0c.a0d (#0), '20240526'), lte(a0c.a0d (#0), '20250525')]
-                        │               ├── order by: []
-                        │               └── limit: NONE
-                        └── EvalScalar
-                            ├── scalars: [CAST(a2x.a0m (#74) AS String NULL) AS (#149)]
-                            └── Scan
-                                ├── table: default.a2x (#2)
-                                ├── filters: [eq(substring(a2x.a4m (#118), 20, 1), '1')]
-                                ├── order by: []
-                                └── limit: NONE
+                        │   └── Scan
+                        │       ├── table: default.a5r (#3)
+                        │       ├── filters: [eq(substring(a5r.a5w (#156), 1, 1), '1')]
+                        │       ├── order by: []
+                        │       └── limit: NONE
+                        └── Join(Inner)
+                            ├── build keys: [a0m (#149)]
+                            ├── probe keys: [a0c.a0m (#9)]
+                            ├── other filters: []
+                            ├── Exchange(Broadcast)
+                            │   └── EvalScalar
+                            │       ├── scalars: [CAST(a2x.a0m (#74) AS String NULL) AS (#149)]
+                            │       └── Scan
+                            │           ├── table: default.a2x (#2)
+                            │           ├── filters: [eq(substring(a2x.a4m (#118), 20, 1), '1')]
+                            │           ├── order by: []
+                            │           └── limit: NONE
+                            └── Join(Inner)
+                                ├── build keys: [a1z.a0k (#48), a1z.a0n (#50)]
+                                ├── probe keys: [a0c.a0k (#7), a0c.a0n (#10)]
+                                ├── other filters: [lte(a1z.a2c (#52), a0c.a0d (#0)), gt(a1z.a2k (#61), a0c.a0d (#0))]
+                                ├── Exchange(Broadcast)
+                                │   └── Scan
+                                │       ├── table: default.a1z (#1)
+                                │       ├── filters: [eq(a1z.a2t (#70), '624100')]
+                                │       ├── order by: []
+                                │       └── limit: NONE
+                                └── Scan
+                                    ├── table: default.a0c (#0)
+                                    ├── filters: [gte(a0c.a0d (#0), '20240526'), lte(a0c.a0d (#0), '20250525')]
+                                    ├── order by: []
+                                    └── limit: NONE
 

--- a/src/query/sql/test-support/data/results/obfuscated/01_multi_join_sum_case_expression_physical.txt
+++ b/src/query/sql/test-support/data/results/obfuscated/01_multi_join_sum_case_expression_physical.txt
@@ -4,104 +4,106 @@ Exchange
 └── EvalScalar
     ├── output columns: [sell_mnt = 0 (#168)]
     ├── expressions: [sum(CASE WHEN d.a1v = '603020' THEN 1 ELSE 0 END) (#167) = 0]
-    ├── estimated rows: 14021.84
+    ├── estimated rows: 58807078.72
     └── AggregateFinal
         ├── output columns: [sum(CASE WHEN d.a1v = '603020' THEN 1 ELSE 0 END) (#167), a.a0d (#0), a.a0k (#7), a.a0m (#9), c.a5m (#144)]
         ├── group by: [a0d, a0k, a0m, a5m]
         ├── aggregate functions: [sum(sum_arg_0)]
-        ├── estimated rows: 14021.84
+        ├── estimated rows: 58807078.72
         └── Exchange
             ├── output columns: [sum(CASE WHEN d.a1v = '603020' THEN 1 ELSE 0 END) (#167), a.a0d (#0), a.a0k (#7), a.a0m (#9), c.a5m (#144)]
             ├── exchange type: Hash(0, 1, 2, 3)
             └── AggregatePartial
                 ├── group by: [a0d, a0k, a0m, a5m]
                 ├── aggregate functions: [sum(sum_arg_0)]
-                ├── estimated rows: 14021.84
+                ├── estimated rows: 58807078.72
                 └── EvalScalar
-                    ├── output columns: [c.a5m (#144), a.a0d (#0), a.a0k (#7), a.a0m (#9), sum_arg_0 (#166)]
+                    ├── output columns: [a.a0d (#0), a.a0k (#7), a.a0m (#9), c.a5m (#144), sum_arg_0 (#166)]
                     ├── expressions: [if(d.a1v (#154) = '603020', 1, 0)]
-                    ├── estimated rows: 14021.84
+                    ├── estimated rows: 58807078.72
                     └── HashJoin
-                        ├── output columns: [c.a5m (#144), a.a0d (#0), a.a0k (#7), d.a1v (#154), a.a0m (#9)]
+                        ├── output columns: [a.a0d (#0), a.a0k (#7), a.a0m (#9), c.a5m (#144), d.a1v (#154)]
                         ├── join type: INNER
-                        ├── build keys: [a.a0m (#9)]
-                        ├── probe keys: [c.a0m (#149)]
+                        ├── build keys: [d.a5t (#151)]
+                        ├── probe keys: [a.a0l (#8)]
                         ├── keys is null equal: [false]
                         ├── filters: []
-                        ├── estimated rows: 14021.84
+                        ├── build join filters:
+                        │   └── filter id:3, build key:d.a5t (#151), probe targets:[a.a0l (#8)@scan0], filter type:bloom,inlist,min_max
+                        ├── estimated rows: 58807078.72
                         ├── Exchange(Build)
-                        │   ├── output columns: [a.a0d (#0), a.a0k (#7), a.a0m (#9), d.a1v (#154)]
+                        │   ├── output columns: [d.a5t (#151), d.a1v (#154)]
                         │   ├── exchange type: Broadcast
-                        │   └── HashJoin
-                        │       ├── output columns: [a.a0d (#0), a.a0k (#7), a.a0m (#9), d.a1v (#154)]
-                        │       ├── join type: INNER
-                        │       ├── build keys: [d.a5t (#151)]
-                        │       ├── probe keys: [a.a0l (#8)]
-                        │       ├── keys is null equal: [false]
-                        │       ├── filters: []
-                        │       ├── build join filters:
-                        │       │   └── filter id:2, build key:d.a5t (#151), probe targets:[a.a0l (#8)@scan0], filter type:bloom,inlist,min_max
-                        │       ├── estimated rows: 14094.12
-                        │       ├── Exchange(Build)
-                        │       │   ├── output columns: [d.a5t (#151), d.a1v (#154)]
-                        │       │   ├── exchange type: Broadcast
-                        │       │   └── TableScan
-                        │       │       ├── table: default.default.a5r
-                        │       │       ├── scan id: 3
-                        │       │       ├── output columns: [a5t (#151), a1v (#154)]
-                        │       │       ├── read rows: 0
-                        │       │       ├── read size: 0
-                        │       │       ├── partitions total: 0
-                        │       │       ├── partitions scanned: 0
-                        │       │       ├── push downs: [filters: [is_true(substr(a5r.a5w (#156), 1, 1) = '1')], limit: NONE]
-                        │       │       └── estimated rows: 806.60
-                        │       └── HashJoin(Probe)
-                        │           ├── output columns: [a.a0d (#0), a.a0k (#7), a.a0l (#8), a.a0m (#9)]
-                        │           ├── join type: INNER
-                        │           ├── build keys: [b.a0k (#48), b.a0n (#50)]
-                        │           ├── probe keys: [a.a0k (#7), a.a0n (#10)]
-                        │           ├── keys is null equal: [false, false]
-                        │           ├── filters: [b.a2c (#52) <= a.a0d (#0), b.a2k (#61) > a.a0d (#0)]
-                        │           ├── build join filters:
-                        │           │   ├── filter id:0, build key:b.a0k (#48), probe targets:[a.a0k (#7)@scan0], filter type:bloom,inlist,min_max
-                        │           │   └── filter id:1, build key:b.a0n (#50), probe targets:[a.a0n (#10)@scan0], filter type:bloom,inlist,min_max
-                        │           ├── estimated rows: 14072.43
-                        │           ├── Exchange(Build)
-                        │           │   ├── output columns: [b.a0k (#48), b.a0n (#50), b.a2c (#52), b.a2k (#61)]
-                        │           │   ├── exchange type: Broadcast
-                        │           │   └── TableScan
-                        │           │       ├── table: default.default.a1z
-                        │           │       ├── scan id: 1
-                        │           │       ├── output columns: [a0k (#48), a0n (#50), a2c (#52), a2k (#61)]
-                        │           │       ├── read rows: 0
-                        │           │       ├── read size: 0
-                        │           │       ├── partitions total: 0
-                        │           │       ├── partitions scanned: 0
-                        │           │       ├── push downs: [filters: [is_true(a1z.a2t (#70) = '624100')], limit: NONE]
-                        │           │       └── estimated rows: 11373457.90
-                        │           └── TableScan(Probe)
-                        │               ├── table: default.default.a0c
-                        │               ├── scan id: 0
-                        │               ├── output columns: [a0d (#0), a0k (#7), a0l (#8), a0m (#9), a0n (#10)]
-                        │               ├── read rows: 0
-                        │               ├── read size: 0
-                        │               ├── partitions total: 0
-                        │               ├── partitions scanned: 0
-                        │               ├── push downs: [filters: [a0c.a0d (#0) >= '20240526' and a0c.a0d (#0) <= '20250525'], limit: NONE]
-                        │               ├── apply join filters: [#2, #0, #1]
-                        │               └── estimated rows: 62086049.42
-                        └── EvalScalar(Probe)
-                            ├── output columns: [c.a5m (#144), a0m (#149)]
-                            ├── expressions: [CAST(c.a0m (#74) AS String NULL)]
-                            ├── estimated rows: 63773.60
-                            └── TableScan
-                                ├── table: default.default.a2x
-                                ├── scan id: 2
-                                ├── output columns: [a0m (#74), a5m (#144)]
-                                ├── read rows: 0
-                                ├── read size: 0
-                                ├── partitions total: 0
-                                ├── partitions scanned: 0
-                                ├── push downs: [filters: [is_true(substr(a2x.a4m (#118), 20, 1) = '1')], limit: NONE]
-                                └── estimated rows: 63773.60
+                        │   └── TableScan
+                        │       ├── table: default.default.a5r
+                        │       ├── scan id: 3
+                        │       ├── output columns: [a5t (#151), a1v (#154)]
+                        │       ├── read rows: 0
+                        │       ├── read size: 0
+                        │       ├── partitions total: 0
+                        │       ├── partitions scanned: 0
+                        │       ├── push downs: [filters: [is_true(substr(a5r.a5w (#156), 1, 1) = '1')], limit: NONE]
+                        │       └── estimated rows: 806.60
+                        └── HashJoin(Probe)
+                            ├── output columns: [a.a0d (#0), a.a0k (#7), a.a0l (#8), a.a0m (#9), c.a5m (#144)]
+                            ├── join type: INNER
+                            ├── build keys: [c.a0m (#149)]
+                            ├── probe keys: [a.a0m (#9)]
+                            ├── keys is null equal: [false]
+                            ├── filters: []
+                            ├── build join filters:
+                            │   └── filter id:2, build key:c.a0m (#149), probe targets:[a.a0m (#9)@scan0], filter type:bloom,inlist,min_max
+                            ├── estimated rows: 58716607.09
+                            ├── Exchange(Build)
+                            │   ├── output columns: [c.a5m (#144), a0m (#149)]
+                            │   ├── exchange type: Broadcast
+                            │   └── EvalScalar
+                            │       ├── output columns: [c.a5m (#144), a0m (#149)]
+                            │       ├── expressions: [CAST(c.a0m (#74) AS String NULL)]
+                            │       ├── estimated rows: 63773.60
+                            │       └── TableScan
+                            │           ├── table: default.default.a2x
+                            │           ├── scan id: 2
+                            │           ├── output columns: [a0m (#74), a5m (#144)]
+                            │           ├── read rows: 0
+                            │           ├── read size: 0
+                            │           ├── partitions total: 0
+                            │           ├── partitions scanned: 0
+                            │           ├── push downs: [filters: [is_true(substr(a2x.a4m (#118), 20, 1) = '1')], limit: NONE]
+                            │           └── estimated rows: 63773.60
+                            └── HashJoin(Probe)
+                                ├── output columns: [a.a0d (#0), a.a0k (#7), a.a0l (#8), a.a0m (#9)]
+                                ├── join type: INNER
+                                ├── build keys: [b.a0k (#48), b.a0n (#50)]
+                                ├── probe keys: [a.a0k (#7), a.a0n (#10)]
+                                ├── keys is null equal: [false, false]
+                                ├── filters: [b.a2c (#52) <= a.a0d (#0), b.a2k (#61) > a.a0d (#0)]
+                                ├── build join filters:
+                                │   ├── filter id:0, build key:b.a0k (#48), probe targets:[a.a0k (#7)@scan0], filter type:bloom,inlist,min_max
+                                │   └── filter id:1, build key:b.a0n (#50), probe targets:[a.a0n (#10)@scan0], filter type:bloom,inlist,min_max
+                                ├── estimated rows: 59019257.39
+                                ├── Exchange(Build)
+                                │   ├── output columns: [b.a0k (#48), b.a0n (#50), b.a2c (#52), b.a2k (#61)]
+                                │   ├── exchange type: Broadcast
+                                │   └── TableScan
+                                │       ├── table: default.default.a1z
+                                │       ├── scan id: 1
+                                │       ├── output columns: [a0k (#48), a0n (#50), a2c (#52), a2k (#61)]
+                                │       ├── read rows: 0
+                                │       ├── read size: 0
+                                │       ├── partitions total: 0
+                                │       ├── partitions scanned: 0
+                                │       ├── push downs: [filters: [is_true(a1z.a2t (#70) = '624100')], limit: NONE]
+                                │       └── estimated rows: 11373457.90
+                                └── TableScan(Probe)
+                                    ├── table: default.default.a0c
+                                    ├── scan id: 0
+                                    ├── output columns: [a0d (#0), a0k (#7), a0l (#8), a0m (#9), a0n (#10)]
+                                    ├── read rows: 0
+                                    ├── read size: 0
+                                    ├── partitions total: 0
+                                    ├── partitions scanned: 0
+                                    ├── push downs: [filters: [a0c.a0d (#0) >= '20240526' and a0c.a0d (#0) <= '20250525'], limit: NONE]
+                                    ├── apply join filters: [#3, #2, #0, #1]
+                                    └── estimated rows: 62086049.42
 

--- a/src/query/sql/test-support/data/results/tpcds/materialized_cte_ref_stats_after_dphyp_optimized.txt
+++ b/src/query/sql/test-support/data/results/tpcds/materialized_cte_ref_stats_after_dphyp_optimized.txt
@@ -15,214 +15,211 @@ Exchange(Merge)
     │               └── EvalScalar
     │                   ├── scalars: [store_sales.ss_wholesale_cost (#11) AS (#11), store_sales.ss_list_price (#12) AS (#12), store_sales.ss_coupon_amt (#19) AS (#19), date_dim.d_year (#113) AS (#113), date_dim.d_year (#141) AS (#141), date_dim.d_year (#169) AS (#169), store.s_store_name (#196) AS (#196), store.s_zip (#216) AS (#216), customer_address.ca_street_number (#287) AS (#287), customer_address.ca_street_name (#288) AS (#288), customer_address.ca_city (#291) AS (#291), customer_address.ca_zip (#294) AS (#294), customer_address.ca_street_number (#300) AS (#300), customer_address.ca_street_name (#301) AS (#301), customer_address.ca_city (#304) AS (#304), customer_address.ca_zip (#307) AS (#307), item.i_item_sk (#317) AS (#317), item.i_product_name (#338) AS (#338), sum(cs_ext_list_price) (#104) AS (#1032), sum(cr_refunded_cash + cr_reversed_charge + cr_store_credit) (#106) AS (#1033), store_sales.ss_store_sk (#7) AS (#1034), store.s_store_sk (#191) AS (#1035), store_sales.ss_sold_date_sk (#0) AS (#1036), date_dim.d_date_sk (#107) AS (#1037), store_sales.ss_customer_sk (#3) AS (#1038), customer.c_customer_sk (#220) AS (#1039), store_sales.ss_cdemo_sk (#4) AS (#1040), customer_demographics.cd_demo_sk (#238) AS (#1041), store_sales.ss_hdemo_sk (#5) AS (#1042), household_demographics.hd_demo_sk (#275) AS (#1043), store_sales.ss_addr_sk (#6) AS (#1044), customer_address.ca_address_sk (#285) AS (#1045), store_sales.ss_item_sk (#2) AS (#1046), store_returns.sr_item_sk (#25) AS (#1047), store_sales.ss_ticket_number (#9) AS (#1048), store_returns.sr_ticket_number (#32) AS (#1049), catalog_sales.cs_item_sk (#58) AS (#1050), customer.c_current_cdemo_sk (#222) AS (#1051), customer_demographics.cd_demo_sk (#247) AS (#1052), customer.c_current_hdemo_sk (#223) AS (#1053), household_demographics.hd_demo_sk (#280) AS (#1054), customer.c_current_addr_sk (#224) AS (#1055), customer_address.ca_address_sk (#298) AS (#1056), customer.c_first_sales_date_sk (#226) AS (#1057), date_dim.d_date_sk (#135) AS (#1058), customer.c_first_shipto_date_sk (#225) AS (#1059), date_dim.d_date_sk (#163) AS (#1060), store_sales.ss_promo_sk (#8) AS (#1061), promotion.p_promo_sk (#256) AS (#1062), household_demographics.hd_income_band_sk (#276) AS (#1063), income_band.ib_income_band_sk (#311) AS (#1064), household_demographics.hd_income_band_sk (#281) AS (#1065), income_band.ib_income_band_sk (#314) AS (#1066), customer_demographics.cd_marital_status (#240) AS (#1067), customer_demographics.cd_marital_status (#249) AS (#1068), item.i_color (#334) AS (#1069), item.i_current_price (#322) AS (#1070)]
     │                   └── Join(Inner)
-    │                       ├── build keys: [household_demographics.hd_demo_sk (#280)]
-    │                       ├── probe keys: [customer.c_current_hdemo_sk (#223)]
-    │                       ├── other filters: []
+    │                       ├── build keys: [customer.c_customer_sk (#220)]
+    │                       ├── probe keys: [store_sales.ss_customer_sk (#3)]
+    │                       ├── other filters: [noteq(customer_demographics.cd_marital_status (#240), customer_demographics.cd_marital_status (#249))]
     │                       ├── Exchange(Broadcast)
     │                       │   └── Join(Inner)
-    │                       │       ├── build keys: [income_band.ib_income_band_sk (#314)]
-    │                       │       ├── probe keys: [household_demographics.hd_income_band_sk (#281)]
+    │                       │       ├── build keys: [customer_address.ca_address_sk (#298)]
+    │                       │       ├── probe keys: [customer.c_current_addr_sk (#224)]
     │                       │       ├── other filters: []
-    │                       │       ├── Exchange(Broadcast)
+    │                       │       ├── Exchange(Hash)
+    │                       │       │   ├── Exchange(Hash): keys: [customer_address.ca_address_sk (#298)]
     │                       │       │   └── Scan
-    │                       │       │       ├── table: default.income_band (#17)
+    │                       │       │       ├── table: default.customer_address (#15)
     │                       │       │       ├── filters: []
     │                       │       │       ├── order by: []
     │                       │       │       └── limit: NONE
-    │                       │       └── Scan
-    │                       │           ├── table: default.household_demographics (#13)
-    │                       │           ├── filters: []
-    │                       │           ├── order by: []
-    │                       │           └── limit: NONE
+    │                       │       └── Exchange(Hash)
+    │                       │           ├── Exchange(Hash): keys: [customer.c_current_addr_sk (#224)]
+    │                       │           └── Join(Inner)
+    │                       │               ├── build keys: [customer.c_current_cdemo_sk (#222)]
+    │                       │               ├── probe keys: [customer_demographics.cd_demo_sk (#247)]
+    │                       │               ├── other filters: []
+    │                       │               ├── Exchange(Hash)
+    │                       │               │   ├── Exchange(Hash): keys: [customer.c_current_cdemo_sk (#222)]
+    │                       │               │   └── Join(Inner)
+    │                       │               │       ├── build keys: [household_demographics.hd_demo_sk (#280)]
+    │                       │               │       ├── probe keys: [customer.c_current_hdemo_sk (#223)]
+    │                       │               │       ├── other filters: []
+    │                       │               │       ├── Exchange(Broadcast)
+    │                       │               │       │   └── Join(Inner)
+    │                       │               │       │       ├── build keys: [income_band.ib_income_band_sk (#314)]
+    │                       │               │       │       ├── probe keys: [household_demographics.hd_income_band_sk (#281)]
+    │                       │               │       │       ├── other filters: []
+    │                       │               │       │       ├── Exchange(Broadcast)
+    │                       │               │       │       │   └── Scan
+    │                       │               │       │       │       ├── table: default.income_band (#17)
+    │                       │               │       │       │       ├── filters: []
+    │                       │               │       │       │       ├── order by: []
+    │                       │               │       │       │       └── limit: NONE
+    │                       │               │       │       └── Scan
+    │                       │               │       │           ├── table: default.household_demographics (#13)
+    │                       │               │       │           ├── filters: []
+    │                       │               │       │           ├── order by: []
+    │                       │               │       │           └── limit: NONE
+    │                       │               │       └── Join(Inner)
+    │                       │               │           ├── build keys: [date_dim.d_date_sk (#163)]
+    │                       │               │           ├── probe keys: [customer.c_first_shipto_date_sk (#225)]
+    │                       │               │           ├── other filters: []
+    │                       │               │           ├── Exchange(Broadcast)
+    │                       │               │           │   └── Scan
+    │                       │               │           │       ├── table: default.date_dim (#6)
+    │                       │               │           │       ├── filters: []
+    │                       │               │           │       ├── order by: []
+    │                       │               │           │       └── limit: NONE
+    │                       │               │           └── Join(Inner)
+    │                       │               │               ├── build keys: [date_dim.d_date_sk (#135)]
+    │                       │               │               ├── probe keys: [customer.c_first_sales_date_sk (#226)]
+    │                       │               │               ├── other filters: []
+    │                       │               │               ├── Exchange(Broadcast)
+    │                       │               │               │   └── Scan
+    │                       │               │               │       ├── table: default.date_dim (#5)
+    │                       │               │               │       ├── filters: []
+    │                       │               │               │       ├── order by: []
+    │                       │               │               │       └── limit: NONE
+    │                       │               │               └── Scan
+    │                       │               │                   ├── table: default.customer (#8)
+    │                       │               │                   ├── filters: []
+    │                       │               │                   ├── order by: []
+    │                       │               │                   └── limit: NONE
+    │                       │               └── Exchange(Hash)
+    │                       │                   ├── Exchange(Hash): keys: [customer_demographics.cd_demo_sk (#247)]
+    │                       │                   └── Scan
+    │                       │                       ├── table: default.customer_demographics (#10)
+    │                       │                       ├── filters: []
+    │                       │                       ├── order by: []
+    │                       │                       └── limit: NONE
     │                       └── Join(Inner)
-    │                           ├── build keys: [household_demographics.hd_demo_sk (#275)]
-    │                           ├── probe keys: [store_sales.ss_hdemo_sk (#5)]
+    │                           ├── build keys: [customer_address.ca_address_sk (#285)]
+    │                           ├── probe keys: [store_sales.ss_addr_sk (#6)]
     │                           ├── other filters: []
     │                           ├── Exchange(Broadcast)
-    │                           │   └── Join(Inner)
-    │                           │       ├── build keys: [income_band.ib_income_band_sk (#311)]
-    │                           │       ├── probe keys: [household_demographics.hd_income_band_sk (#276)]
-    │                           │       ├── other filters: []
-    │                           │       ├── Exchange(Broadcast)
-    │                           │       │   └── Scan
-    │                           │       │       ├── table: default.income_band (#16)
-    │                           │       │       ├── filters: []
-    │                           │       │       ├── order by: []
-    │                           │       │       └── limit: NONE
-    │                           │       └── Scan
-    │                           │           ├── table: default.household_demographics (#12)
-    │                           │           ├── filters: []
-    │                           │           ├── order by: []
-    │                           │           └── limit: NONE
+    │                           │   └── Scan
+    │                           │       ├── table: default.customer_address (#14)
+    │                           │       ├── filters: []
+    │                           │       ├── order by: []
+    │                           │       └── limit: NONE
     │                           └── Join(Inner)
-    │                               ├── build keys: [customer.c_current_addr_sk (#224)]
-    │                               ├── probe keys: [customer_address.ca_address_sk (#298)]
+    │                               ├── build keys: [customer_demographics.cd_demo_sk (#238)]
+    │                               ├── probe keys: [store_sales.ss_cdemo_sk (#4)]
     │                               ├── other filters: []
     │                               ├── Exchange(Broadcast)
-    │                               │   └── Join(Inner)
-    │                               │       ├── build keys: [store_sales.ss_addr_sk (#6)]
-    │                               │       ├── probe keys: [customer_address.ca_address_sk (#285)]
-    │                               │       ├── other filters: []
-    │                               │       ├── Exchange(Broadcast)
-    │                               │       │   └── Join(Inner)
-    │                               │       │       ├── build keys: [customer.c_current_cdemo_sk (#222)]
-    │                               │       │       ├── probe keys: [customer_demographics.cd_demo_sk (#247)]
-    │                               │       │       ├── other filters: [noteq(customer_demographics.cd_marital_status (#240), customer_demographics.cd_marital_status (#249))]
-    │                               │       │       ├── Exchange(Broadcast)
-    │                               │       │       │   └── Join(Inner)
-    │                               │       │       │       ├── build keys: [date_dim.d_date_sk (#135)]
-    │                               │       │       │       ├── probe keys: [customer.c_first_sales_date_sk (#226)]
-    │                               │       │       │       ├── other filters: []
-    │                               │       │       │       ├── Exchange(Hash)
-    │                               │       │       │       │   ├── Exchange(Hash): keys: [date_dim.d_date_sk (#135)]
-    │                               │       │       │       │   └── Scan
-    │                               │       │       │       │       ├── table: default.date_dim (#5)
-    │                               │       │       │       │       ├── filters: []
-    │                               │       │       │       │       ├── order by: []
-    │                               │       │       │       │       └── limit: NONE
-    │                               │       │       │       └── Exchange(Hash)
-    │                               │       │       │           ├── Exchange(Hash): keys: [customer.c_first_sales_date_sk (#226)]
-    │                               │       │       │           └── Join(Inner)
-    │                               │       │       │               ├── build keys: [date_dim.d_date_sk (#163)]
-    │                               │       │       │               ├── probe keys: [customer.c_first_shipto_date_sk (#225)]
-    │                               │       │       │               ├── other filters: []
-    │                               │       │       │               ├── Exchange(Hash)
-    │                               │       │       │               │   ├── Exchange(Hash): keys: [date_dim.d_date_sk (#163)]
-    │                               │       │       │               │   └── Scan
-    │                               │       │       │               │       ├── table: default.date_dim (#6)
-    │                               │       │       │               │       ├── filters: []
-    │                               │       │       │               │       ├── order by: []
-    │                               │       │       │               │       └── limit: NONE
-    │                               │       │       │               └── Exchange(Hash)
-    │                               │       │       │                   ├── Exchange(Hash): keys: [customer.c_first_shipto_date_sk (#225)]
-    │                               │       │       │                   └── Join(Inner)
-    │                               │       │       │                       ├── build keys: [store_sales.ss_customer_sk (#3)]
-    │                               │       │       │                       ├── probe keys: [customer.c_customer_sk (#220)]
-    │                               │       │       │                       ├── other filters: []
-    │                               │       │       │                       ├── Exchange(Broadcast)
-    │                               │       │       │                       │   └── Join(Inner)
-    │                               │       │       │                       │       ├── build keys: [store_sales.ss_cdemo_sk (#4)]
-    │                               │       │       │                       │       ├── probe keys: [customer_demographics.cd_demo_sk (#238)]
-    │                               │       │       │                       │       ├── other filters: []
-    │                               │       │       │                       │       ├── Exchange(Broadcast)
-    │                               │       │       │                       │       │   └── Join(Inner)
-    │                               │       │       │                       │       │       ├── build keys: [promotion.p_promo_sk (#256)]
-    │                               │       │       │                       │       │       ├── probe keys: [store_sales.ss_promo_sk (#8)]
-    │                               │       │       │                       │       │       ├── other filters: []
-    │                               │       │       │                       │       │       ├── Exchange(Broadcast)
-    │                               │       │       │                       │       │       │   └── Scan
-    │                               │       │       │                       │       │       │       ├── table: default.promotion (#11)
-    │                               │       │       │                       │       │       │       ├── filters: []
-    │                               │       │       │                       │       │       │       ├── order by: []
-    │                               │       │       │                       │       │       │       └── limit: NONE
-    │                               │       │       │                       │       │       └── Join(Inner)
-    │                               │       │       │                       │       │           ├── build keys: [store.s_store_sk (#191)]
-    │                               │       │       │                       │       │           ├── probe keys: [store_sales.ss_store_sk (#7)]
-    │                               │       │       │                       │       │           ├── other filters: []
-    │                               │       │       │                       │       │           ├── Exchange(Broadcast)
-    │                               │       │       │                       │       │           │   └── Scan
-    │                               │       │       │                       │       │           │       ├── table: default.store (#7)
-    │                               │       │       │                       │       │           │       ├── filters: []
-    │                               │       │       │                       │       │           │       ├── order by: []
-    │                               │       │       │                       │       │           │       └── limit: NONE
-    │                               │       │       │                       │       │           └── Join(Inner)
-    │                               │       │       │                       │       │               ├── build keys: [date_dim.d_date_sk (#107)]
-    │                               │       │       │                       │       │               ├── probe keys: [store_sales.ss_sold_date_sk (#0)]
-    │                               │       │       │                       │       │               ├── other filters: []
-    │                               │       │       │                       │       │               ├── Exchange(Hash)
-    │                               │       │       │                       │       │               │   ├── Exchange(Hash): keys: [date_dim.d_date_sk (#107)]
-    │                               │       │       │                       │       │               │   └── Scan
-    │                               │       │       │                       │       │               │       ├── table: default.date_dim (#4)
-    │                               │       │       │                       │       │               │       ├── filters: []
-    │                               │       │       │                       │       │               │       ├── order by: []
-    │                               │       │       │                       │       │               │       └── limit: NONE
-    │                               │       │       │                       │       │               └── Exchange(Hash)
-    │                               │       │       │                       │       │                   ├── Exchange(Hash): keys: [store_sales.ss_sold_date_sk (#0)]
-    │                               │       │       │                       │       │                   └── Join(Inner)
-    │                               │       │       │                       │       │                       ├── build keys: [item.i_item_sk (#317), store_returns.sr_ticket_number (#32)]
-    │                               │       │       │                       │       │                       ├── probe keys: [store_sales.ss_item_sk (#2), store_sales.ss_ticket_number (#9)]
-    │                               │       │       │                       │       │                       ├── other filters: []
-    │                               │       │       │                       │       │                       ├── Exchange(Broadcast)
-    │                               │       │       │                       │       │                       │   └── Join(Inner)
-    │                               │       │       │                       │       │                       │       ├── build keys: [item.i_item_sk (#317)]
-    │                               │       │       │                       │       │                       │       ├── probe keys: [store_returns.sr_item_sk (#25)]
-    │                               │       │       │                       │       │                       │       ├── other filters: []
-    │                               │       │       │                       │       │                       │       ├── Exchange(Broadcast)
-    │                               │       │       │                       │       │                       │       │   └── Join(Inner)
-    │                               │       │       │                       │       │                       │       │       ├── build keys: [item.i_item_sk (#317)]
-    │                               │       │       │                       │       │                       │       │       ├── probe keys: [catalog_sales.cs_item_sk (#58)]
-    │                               │       │       │                       │       │                       │       │       ├── other filters: []
-    │                               │       │       │                       │       │                       │       │       ├── Exchange(Hash)
-    │                               │       │       │                       │       │                       │       │       │   ├── Exchange(Hash): keys: [item.i_item_sk (#317)]
-    │                               │       │       │                       │       │                       │       │       │   └── Scan
-    │                               │       │       │                       │       │                       │       │       │       ├── table: default.item (#18)
-    │                               │       │       │                       │       │                       │       │       │       ├── filters: [contains(['blanched', 'medium', 'brown', 'chocolate', 'burlywood', 'drab'], item.i_color (#334)), gte(item.i_current_price (#322), 23), lte(item.i_current_price (#322), 33), gte(item.i_current_price (#322), 24), lte(item.i_current_price (#322), 38)]
-    │                               │       │       │                       │       │                       │       │       │       ├── order by: []
-    │                               │       │       │                       │       │                       │       │       │       └── limit: NONE
-    │                               │       │       │                       │       │                       │       │       └── Exchange(Hash)
-    │                               │       │       │                       │       │                       │       │           ├── Exchange(Hash): keys: [catalog_sales.cs_item_sk (#58)]
-    │                               │       │       │                       │       │                       │       │           └── Filter
-    │                               │       │       │                       │       │                       │       │               ├── filters: [gt(sum(cs_ext_list_price) (#104), multiply(2, sum(cr_refunded_cash + cr_reversed_charge + cr_store_credit) (#106)))]
-    │                               │       │       │                       │       │                       │       │               └── Aggregate(Final)
-    │                               │       │       │                       │       │                       │       │                   ├── group items: [catalog_sales.cs_item_sk (#58) AS (#58)]
-    │                               │       │       │                       │       │                       │       │                   ├── aggregate functions: [sum(catalog_sales.cs_ext_list_price (#68)) AS (#104), sum(sum_arg_0 (#105)) AS (#106)]
-    │                               │       │       │                       │       │                       │       │                   └── Aggregate(Partial)
-    │                               │       │       │                       │       │                       │       │                       ├── group items: [catalog_sales.cs_item_sk (#58) AS (#58)]
-    │                               │       │       │                       │       │                       │       │                       ├── aggregate functions: [sum(catalog_sales.cs_ext_list_price (#68)) AS (#104), sum(sum_arg_0 (#105)) AS (#106)]
-    │                               │       │       │                       │       │                       │       │                       └── Exchange(Hash)
-    │                               │       │       │                       │       │                       │       │                           ├── Exchange(Hash): keys: [catalog_sales.cs_item_sk (#58)]
-    │                               │       │       │                       │       │                       │       │                           └── EvalScalar
-    │                               │       │       │                       │       │                       │       │                               ├── scalars: [catalog_sales.cs_item_sk (#58) AS (#58), catalog_sales.cs_ext_list_price (#68) AS (#68), plus(plus(catalog_returns.cr_refunded_cash (#100), catalog_returns.cr_reversed_charge (#101)), catalog_returns.cr_store_credit (#102)) AS (#105), catalog_returns.cr_item_sk (#79) AS (#1029), catalog_sales.cs_order_number (#60) AS (#1030), catalog_returns.cr_order_number (#93) AS (#1031)]
-    │                               │       │       │                       │       │                       │       │                               └── Join(Inner)
-    │                               │       │       │                       │       │                       │       │                                   ├── build keys: [catalog_returns.cr_item_sk (#79), catalog_returns.cr_order_number (#93)]
-    │                               │       │       │                       │       │                       │       │                                   ├── probe keys: [catalog_sales.cs_item_sk (#58), catalog_sales.cs_order_number (#60)]
-    │                               │       │       │                       │       │                       │       │                                   ├── other filters: []
-    │                               │       │       │                       │       │                       │       │                                   ├── Exchange(Broadcast)
-    │                               │       │       │                       │       │                       │       │                                   │   └── Scan
-    │                               │       │       │                       │       │                       │       │                                   │       ├── table: default.catalog_returns (#3)
-    │                               │       │       │                       │       │                       │       │                                   │       ├── filters: []
-    │                               │       │       │                       │       │                       │       │                                   │       ├── order by: []
-    │                               │       │       │                       │       │                       │       │                                   │       └── limit: NONE
-    │                               │       │       │                       │       │                       │       │                                   └── Scan
-    │                               │       │       │                       │       │                       │       │                                       ├── table: default.catalog_sales (#2)
-    │                               │       │       │                       │       │                       │       │                                       ├── filters: []
-    │                               │       │       │                       │       │                       │       │                                       ├── order by: []
-    │                               │       │       │                       │       │                       │       │                                       └── limit: NONE
-    │                               │       │       │                       │       │                       │       └── Scan
-    │                               │       │       │                       │       │                       │           ├── table: default.store_returns (#1)
-    │                               │       │       │                       │       │                       │           ├── filters: []
-    │                               │       │       │                       │       │                       │           ├── order by: []
-    │                               │       │       │                       │       │                       │           └── limit: NONE
-    │                               │       │       │                       │       │                       └── Scan
-    │                               │       │       │                       │       │                           ├── table: default.store_sales (#0)
-    │                               │       │       │                       │       │                           ├── filters: []
-    │                               │       │       │                       │       │                           ├── order by: []
-    │                               │       │       │                       │       │                           └── limit: NONE
-    │                               │       │       │                       │       └── Scan
-    │                               │       │       │                       │           ├── table: default.customer_demographics (#9)
-    │                               │       │       │                       │           ├── filters: []
-    │                               │       │       │                       │           ├── order by: []
-    │                               │       │       │                       │           └── limit: NONE
-    │                               │       │       │                       └── Scan
-    │                               │       │       │                           ├── table: default.customer (#8)
-    │                               │       │       │                           ├── filters: []
-    │                               │       │       │                           ├── order by: []
-    │                               │       │       │                           └── limit: NONE
-    │                               │       │       └── Scan
-    │                               │       │           ├── table: default.customer_demographics (#10)
-    │                               │       │           ├── filters: []
-    │                               │       │           ├── order by: []
-    │                               │       │           └── limit: NONE
-    │                               │       └── Scan
-    │                               │           ├── table: default.customer_address (#14)
-    │                               │           ├── filters: []
-    │                               │           ├── order by: []
-    │                               │           └── limit: NONE
-    │                               └── Scan
-    │                                   ├── table: default.customer_address (#15)
-    │                                   ├── filters: []
-    │                                   ├── order by: []
-    │                                   └── limit: NONE
+    │                               │   └── Scan
+    │                               │       ├── table: default.customer_demographics (#9)
+    │                               │       ├── filters: []
+    │                               │       ├── order by: []
+    │                               │       └── limit: NONE
+    │                               └── Join(Inner)
+    │                                   ├── build keys: [promotion.p_promo_sk (#256)]
+    │                                   ├── probe keys: [store_sales.ss_promo_sk (#8)]
+    │                                   ├── other filters: []
+    │                                   ├── Exchange(Broadcast)
+    │                                   │   └── Scan
+    │                                   │       ├── table: default.promotion (#11)
+    │                                   │       ├── filters: []
+    │                                   │       ├── order by: []
+    │                                   │       └── limit: NONE
+    │                                   └── Join(Inner)
+    │                                       ├── build keys: [store.s_store_sk (#191)]
+    │                                       ├── probe keys: [store_sales.ss_store_sk (#7)]
+    │                                       ├── other filters: []
+    │                                       ├── Exchange(Broadcast)
+    │                                       │   └── Scan
+    │                                       │       ├── table: default.store (#7)
+    │                                       │       ├── filters: []
+    │                                       │       ├── order by: []
+    │                                       │       └── limit: NONE
+    │                                       └── Join(Inner)
+    │                                           ├── build keys: [household_demographics.hd_demo_sk (#275)]
+    │                                           ├── probe keys: [store_sales.ss_hdemo_sk (#5)]
+    │                                           ├── other filters: []
+    │                                           ├── Exchange(Broadcast)
+    │                                           │   └── Join(Inner)
+    │                                           │       ├── build keys: [income_band.ib_income_band_sk (#311)]
+    │                                           │       ├── probe keys: [household_demographics.hd_income_band_sk (#276)]
+    │                                           │       ├── other filters: []
+    │                                           │       ├── Exchange(Broadcast)
+    │                                           │       │   └── Scan
+    │                                           │       │       ├── table: default.income_band (#16)
+    │                                           │       │       ├── filters: []
+    │                                           │       │       ├── order by: []
+    │                                           │       │       └── limit: NONE
+    │                                           │       └── Scan
+    │                                           │           ├── table: default.household_demographics (#12)
+    │                                           │           ├── filters: []
+    │                                           │           ├── order by: []
+    │                                           │           └── limit: NONE
+    │                                           └── Join(Inner)
+    │                                               ├── build keys: [date_dim.d_date_sk (#107)]
+    │                                               ├── probe keys: [store_sales.ss_sold_date_sk (#0)]
+    │                                               ├── other filters: []
+    │                                               ├── Exchange(Broadcast)
+    │                                               │   └── Scan
+    │                                               │       ├── table: default.date_dim (#4)
+    │                                               │       ├── filters: []
+    │                                               │       ├── order by: []
+    │                                               │       └── limit: NONE
+    │                                               └── Join(Inner)
+    │                                                   ├── build keys: [item.i_item_sk (#317), store_returns.sr_ticket_number (#32)]
+    │                                                   ├── probe keys: [store_sales.ss_item_sk (#2), store_sales.ss_ticket_number (#9)]
+    │                                                   ├── other filters: []
+    │                                                   ├── Exchange(Broadcast)
+    │                                                   │   └── Join(Inner)
+    │                                                   │       ├── build keys: [item.i_item_sk (#317)]
+    │                                                   │       ├── probe keys: [store_returns.sr_item_sk (#25)]
+    │                                                   │       ├── other filters: []
+    │                                                   │       ├── Exchange(Broadcast)
+    │                                                   │       │   └── Join(Inner)
+    │                                                   │       │       ├── build keys: [item.i_item_sk (#317)]
+    │                                                   │       │       ├── probe keys: [catalog_sales.cs_item_sk (#58)]
+    │                                                   │       │       ├── other filters: []
+    │                                                   │       │       ├── Exchange(Hash)
+    │                                                   │       │       │   ├── Exchange(Hash): keys: [item.i_item_sk (#317)]
+    │                                                   │       │       │   └── Scan
+    │                                                   │       │       │       ├── table: default.item (#18)
+    │                                                   │       │       │       ├── filters: [contains(['blanched', 'medium', 'brown', 'chocolate', 'burlywood', 'drab'], item.i_color (#334)), gte(item.i_current_price (#322), 23), lte(item.i_current_price (#322), 33), gte(item.i_current_price (#322), 24), lte(item.i_current_price (#322), 38)]
+    │                                                   │       │       │       ├── order by: []
+    │                                                   │       │       │       └── limit: NONE
+    │                                                   │       │       └── Exchange(Hash)
+    │                                                   │       │           ├── Exchange(Hash): keys: [catalog_sales.cs_item_sk (#58)]
+    │                                                   │       │           └── Filter
+    │                                                   │       │               ├── filters: [gt(sum(cs_ext_list_price) (#104), multiply(2, sum(cr_refunded_cash + cr_reversed_charge + cr_store_credit) (#106)))]
+    │                                                   │       │               └── Aggregate(Final)
+    │                                                   │       │                   ├── group items: [catalog_sales.cs_item_sk (#58) AS (#58)]
+    │                                                   │       │                   ├── aggregate functions: [sum(catalog_sales.cs_ext_list_price (#68)) AS (#104), sum(sum_arg_0 (#105)) AS (#106)]
+    │                                                   │       │                   └── Aggregate(Partial)
+    │                                                   │       │                       ├── group items: [catalog_sales.cs_item_sk (#58) AS (#58)]
+    │                                                   │       │                       ├── aggregate functions: [sum(catalog_sales.cs_ext_list_price (#68)) AS (#104), sum(sum_arg_0 (#105)) AS (#106)]
+    │                                                   │       │                       └── Exchange(Hash)
+    │                                                   │       │                           ├── Exchange(Hash): keys: [catalog_sales.cs_item_sk (#58)]
+    │                                                   │       │                           └── EvalScalar
+    │                                                   │       │                               ├── scalars: [catalog_sales.cs_item_sk (#58) AS (#58), catalog_sales.cs_ext_list_price (#68) AS (#68), plus(plus(catalog_returns.cr_refunded_cash (#100), catalog_returns.cr_reversed_charge (#101)), catalog_returns.cr_store_credit (#102)) AS (#105), catalog_returns.cr_item_sk (#79) AS (#1029), catalog_sales.cs_order_number (#60) AS (#1030), catalog_returns.cr_order_number (#93) AS (#1031)]
+    │                                                   │       │                               └── Join(Inner)
+    │                                                   │       │                                   ├── build keys: [catalog_returns.cr_item_sk (#79), catalog_returns.cr_order_number (#93)]
+    │                                                   │       │                                   ├── probe keys: [catalog_sales.cs_item_sk (#58), catalog_sales.cs_order_number (#60)]
+    │                                                   │       │                                   ├── other filters: []
+    │                                                   │       │                                   ├── Exchange(Broadcast)
+    │                                                   │       │                                   │   └── Scan
+    │                                                   │       │                                   │       ├── table: default.catalog_returns (#3)
+    │                                                   │       │                                   │       ├── filters: []
+    │                                                   │       │                                   │       ├── order by: []
+    │                                                   │       │                                   │       └── limit: NONE
+    │                                                   │       │                                   └── Scan
+    │                                                   │       │                                       ├── table: default.catalog_sales (#2)
+    │                                                   │       │                                       ├── filters: []
+    │                                                   │       │                                       ├── order by: []
+    │                                                   │       │                                       └── limit: NONE
+    │                                                   │       └── Scan
+    │                                                   │           ├── table: default.store_returns (#1)
+    │                                                   │           ├── filters: []
+    │                                                   │           ├── order by: []
+    │                                                   │           └── limit: NONE
+    │                                                   └── Scan
+    │                                                       ├── table: default.store_sales (#0)
+    │                                                       ├── filters: []
+    │                                                       ├── order by: []
+    │                                                       └── limit: NONE
     └── EvalScalar
         ├── scalars: [item.i_item_sk (#660) AS (#660), item.i_item_sk (#1003) AS (#1071), store.s_store_name (#539) AS (#1072), store.s_store_name (#882) AS (#1073), store.s_zip (#559) AS (#1074), store.s_zip (#902) AS (#1075)]
         └── Join(Inner)

--- a/src/query/sql/test-support/data/results/tpcds/materialized_cte_ref_stats_after_dphyp_physical.txt
+++ b/src/query/sql/test-support/data/results/tpcds/materialized_cte_ref_stats_after_dphyp_physical.txt
@@ -7,483 +7,477 @@ Exchange
     │       ├── output columns: [item.i_product_name (#338), item.i_item_sk (#317), store.s_store_name (#196), store.s_zip (#216), ad1.ca_street_number (#287), ad1.ca_street_name (#288), ad1.ca_city (#291), ad1.ca_zip (#294), ad2.ca_street_number (#300), ad2.ca_street_name (#301), ad2.ca_city (#304), ad2.ca_zip (#307), d1.d_year (#113), d2.d_year (#141), d3.d_year (#169)]
     │       ├── group by: [i_product_name, i_item_sk, s_store_name, s_zip, ca_street_number, ca_street_name, ca_city, ca_zip, ca_street_number, ca_street_name, ca_city, ca_zip, d_year, d_year, d_year]
     │       ├── aggregate functions: []
-    │       ├── estimated rows: 79800.12
+    │       ├── estimated rows: 40561782.71
     │       └── Exchange
     │           ├── output columns: [item.i_product_name (#338), item.i_item_sk (#317), store.s_store_name (#196), store.s_zip (#216), ad1.ca_street_number (#287), ad1.ca_street_name (#288), ad1.ca_city (#291), ad1.ca_zip (#294), ad2.ca_street_number (#300), ad2.ca_street_name (#301), ad2.ca_city (#304), ad2.ca_zip (#307), d1.d_year (#113), d2.d_year (#141), d3.d_year (#169)]
     │           ├── exchange type: Hash(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14)
     │           └── AggregatePartial
     │               ├── group by: [i_product_name, i_item_sk, s_store_name, s_zip, ca_street_number, ca_street_name, ca_city, ca_zip, ca_street_number, ca_street_name, ca_city, ca_zip, d_year, d_year, d_year]
     │               ├── aggregate functions: []
-    │               ├── estimated rows: 79800.12
+    │               ├── estimated rows: 40561782.71
     │               └── HashJoin
-    │                   ├── output columns: [ad2.ca_street_number (#300), ad2.ca_street_name (#301), ad2.ca_city (#304), ad2.ca_zip (#307), ad1.ca_street_number (#287), ad1.ca_street_name (#288), ad1.ca_city (#291), ad1.ca_zip (#294), item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113), store.s_store_name (#196), store.s_zip (#216), d3.d_year (#169), d2.d_year (#141)]
+    │                   ├── output columns: [item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113), store.s_store_name (#196), store.s_zip (#216), ad1.ca_street_number (#287), ad1.ca_street_name (#288), ad1.ca_city (#291), ad1.ca_zip (#294), d2.d_year (#141), d3.d_year (#169), ad2.ca_street_number (#300), ad2.ca_street_name (#301), ad2.ca_city (#304), ad2.ca_zip (#307)]
     │                   ├── join type: INNER
-    │                   ├── build keys: [hd2.hd_demo_sk (#280)]
-    │                   ├── probe keys: [customer.c_current_hdemo_sk (#223)]
+    │                   ├── build keys: [customer.c_customer_sk (#220)]
+    │                   ├── probe keys: [store_sales.ss_customer_sk (#3)]
     │                   ├── keys is null equal: [false]
-    │                   ├── filters: []
+    │                   ├── filters: [cd1.cd_marital_status (#240) <> cd2.cd_marital_status (#249)]
     │                   ├── build join filters:
-    │                   │   └── filter id:19, build key:hd2.hd_demo_sk (#280), probe targets:[customer.c_current_hdemo_sk (#223)@scan8], filter type:bloom,inlist,min_max
-    │                   ├── estimated rows: 79800.12
+    │                   │   └── filter id:19, build key:customer.c_customer_sk (#220), probe targets:[store_sales.ss_customer_sk (#3)@scan0], filter type:bloom,inlist,min_max
+    │                   ├── estimated rows: 40561782.71
     │                   ├── Exchange(Build)
-    │                   │   ├── output columns: [hd2.hd_demo_sk (#280)]
+    │                   │   ├── output columns: [cd2.cd_marital_status (#249), customer.c_customer_sk (#220), d2.d_year (#141), d3.d_year (#169), ad2.ca_street_number (#300), ad2.ca_street_name (#301), ad2.ca_city (#304), ad2.ca_zip (#307)]
     │                   │   ├── exchange type: Broadcast
     │                   │   └── HashJoin
-    │                   │       ├── output columns: [hd2.hd_demo_sk (#280)]
+    │                   │       ├── output columns: [cd2.cd_marital_status (#249), customer.c_customer_sk (#220), d2.d_year (#141), d3.d_year (#169), ad2.ca_street_number (#300), ad2.ca_street_name (#301), ad2.ca_city (#304), ad2.ca_zip (#307)]
     │                   │       ├── join type: INNER
-    │                   │       ├── build keys: [ib2.ib_income_band_sk (#314)]
-    │                   │       ├── probe keys: [hd2.hd_income_band_sk (#281)]
+    │                   │       ├── build keys: [ad2.ca_address_sk (#298)]
+    │                   │       ├── probe keys: [customer.c_current_addr_sk (#224)]
     │                   │       ├── keys is null equal: [false]
     │                   │       ├── filters: []
-    │                   │       ├── build join filters:
-    │                   │       │   └── filter id:18, build key:ib2.ib_income_band_sk (#314), probe targets:[hd2.hd_income_band_sk (#281)@scan13], filter type:bloom,inlist,min_max
-    │                   │       ├── estimated rows: 7200.00
+    │                   │       ├── build join filters(distributed):
+    │                   │       │   └── filter id:18, build key:ad2.ca_address_sk (#298), probe targets:[customer.c_current_addr_sk (#224)@scan8], filter type:bloom,inlist,min_max
+    │                   │       ├── estimated rows: 2071704.00
     │                   │       ├── Exchange(Build)
-    │                   │       │   ├── output columns: [ib2.ib_income_band_sk (#314)]
-    │                   │       │   ├── exchange type: Broadcast
+    │                   │       │   ├── output columns: [ad2.ca_address_sk (#298), ad2.ca_street_number (#300), ad2.ca_street_name (#301), ad2.ca_city (#304), ad2.ca_zip (#307)]
+    │                   │       │   ├── exchange type: Hash(ad2.ca_address_sk (#298))
     │                   │       │   └── TableScan
-    │                   │       │       ├── table: default.default.income_band
-    │                   │       │       ├── scan id: 17
-    │                   │       │       ├── output columns: [ib_income_band_sk (#314)]
+    │                   │       │       ├── table: default.default.customer_address
+    │                   │       │       ├── scan id: 15
+    │                   │       │       ├── output columns: [ca_address_sk (#298), ca_street_number (#300), ca_street_name (#301), ca_city (#304), ca_zip (#307)]
     │                   │       │       ├── read rows: 0
     │                   │       │       ├── read size: 0
     │                   │       │       ├── partitions total: 0
     │                   │       │       ├── partitions scanned: 0
     │                   │       │       ├── push downs: [filters: [], limit: NONE]
-    │                   │       │       └── estimated rows: 20.00
-    │                   │       └── TableScan(Probe)
-    │                   │           ├── table: default.default.household_demographics
-    │                   │           ├── scan id: 13
-    │                   │           ├── output columns: [hd_demo_sk (#280), hd_income_band_sk (#281)]
-    │                   │           ├── read rows: 0
-    │                   │           ├── read size: 0
-    │                   │           ├── partitions total: 0
-    │                   │           ├── partitions scanned: 0
-    │                   │           ├── push downs: [filters: [], limit: NONE]
-    │                   │           ├── apply join filters: [#18]
-    │                   │           └── estimated rows: 7200.00
+    │                   │       │       └── estimated rows: 1000000.00
+    │                   │       └── Exchange(Probe)
+    │                   │           ├── output columns: [cd2.cd_marital_status (#249), customer.c_customer_sk (#220), customer.c_current_addr_sk (#224), d2.d_year (#141), d3.d_year (#169)]
+    │                   │           ├── exchange type: Hash(customer.c_current_addr_sk (#224))
+    │                   │           └── HashJoin
+    │                   │               ├── output columns: [cd2.cd_marital_status (#249), customer.c_customer_sk (#220), customer.c_current_addr_sk (#224), d2.d_year (#141), d3.d_year (#169)]
+    │                   │               ├── join type: INNER
+    │                   │               ├── build keys: [customer.c_current_cdemo_sk (#222)]
+    │                   │               ├── probe keys: [cd2.cd_demo_sk (#247)]
+    │                   │               ├── keys is null equal: [false]
+    │                   │               ├── filters: []
+    │                   │               ├── build join filters(distributed):
+    │                   │               │   └── filter id:17, build key:customer.c_current_cdemo_sk (#222), probe targets:[cd2.cd_demo_sk (#247)@scan10], filter type:bloom,inlist,min_max
+    │                   │               ├── estimated rows: 1843926.36
+    │                   │               ├── Exchange(Build)
+    │                   │               │   ├── output columns: [customer.c_customer_sk (#220), customer.c_current_cdemo_sk (#222), customer.c_current_addr_sk (#224), d2.d_year (#141), d3.d_year (#169)]
+    │                   │               │   ├── exchange type: Hash(customer.c_current_cdemo_sk (#222))
+    │                   │               │   └── HashJoin
+    │                   │               │       ├── output columns: [customer.c_customer_sk (#220), customer.c_current_cdemo_sk (#222), customer.c_current_addr_sk (#224), d2.d_year (#141), d3.d_year (#169)]
+    │                   │               │       ├── join type: INNER
+    │                   │               │       ├── build keys: [hd2.hd_demo_sk (#280)]
+    │                   │               │       ├── probe keys: [customer.c_current_hdemo_sk (#223)]
+    │                   │               │       ├── keys is null equal: [false]
+    │                   │               │       ├── filters: []
+    │                   │               │       ├── build join filters:
+    │                   │               │       │   └── filter id:16, build key:hd2.hd_demo_sk (#280), probe targets:[customer.c_current_hdemo_sk (#223)@scan8], filter type:bloom,inlist,min_max
+    │                   │               │       ├── estimated rows: 1748252.93
+    │                   │               │       ├── Exchange(Build)
+    │                   │               │       │   ├── output columns: [hd2.hd_demo_sk (#280)]
+    │                   │               │       │   ├── exchange type: Broadcast
+    │                   │               │       │   └── HashJoin
+    │                   │               │       │       ├── output columns: [hd2.hd_demo_sk (#280)]
+    │                   │               │       │       ├── join type: INNER
+    │                   │               │       │       ├── build keys: [ib2.ib_income_band_sk (#314)]
+    │                   │               │       │       ├── probe keys: [hd2.hd_income_band_sk (#281)]
+    │                   │               │       │       ├── keys is null equal: [false]
+    │                   │               │       │       ├── filters: []
+    │                   │               │       │       ├── build join filters:
+    │                   │               │       │       │   └── filter id:15, build key:ib2.ib_income_band_sk (#314), probe targets:[hd2.hd_income_band_sk (#281)@scan13], filter type:bloom,inlist,min_max
+    │                   │               │       │       ├── estimated rows: 7200.00
+    │                   │               │       │       ├── Exchange(Build)
+    │                   │               │       │       │   ├── output columns: [ib2.ib_income_band_sk (#314)]
+    │                   │               │       │       │   ├── exchange type: Broadcast
+    │                   │               │       │       │   └── TableScan
+    │                   │               │       │       │       ├── table: default.default.income_band
+    │                   │               │       │       │       ├── scan id: 17
+    │                   │               │       │       │       ├── output columns: [ib_income_band_sk (#314)]
+    │                   │               │       │       │       ├── read rows: 0
+    │                   │               │       │       │       ├── read size: 0
+    │                   │               │       │       │       ├── partitions total: 0
+    │                   │               │       │       │       ├── partitions scanned: 0
+    │                   │               │       │       │       ├── push downs: [filters: [], limit: NONE]
+    │                   │               │       │       │       └── estimated rows: 20.00
+    │                   │               │       │       └── TableScan(Probe)
+    │                   │               │       │           ├── table: default.default.household_demographics
+    │                   │               │       │           ├── scan id: 13
+    │                   │               │       │           ├── output columns: [hd_demo_sk (#280), hd_income_band_sk (#281)]
+    │                   │               │       │           ├── read rows: 0
+    │                   │               │       │           ├── read size: 0
+    │                   │               │       │           ├── partitions total: 0
+    │                   │               │       │           ├── partitions scanned: 0
+    │                   │               │       │           ├── push downs: [filters: [], limit: NONE]
+    │                   │               │       │           ├── apply join filters: [#15]
+    │                   │               │       │           └── estimated rows: 7200.00
+    │                   │               │       └── HashJoin(Probe)
+    │                   │               │           ├── output columns: [customer.c_customer_sk (#220), customer.c_current_cdemo_sk (#222), customer.c_current_hdemo_sk (#223), customer.c_current_addr_sk (#224), d2.d_year (#141), d3.d_year (#169)]
+    │                   │               │           ├── join type: INNER
+    │                   │               │           ├── build keys: [d3.d_date_sk (#163)]
+    │                   │               │           ├── probe keys: [customer.c_first_shipto_date_sk (#225)]
+    │                   │               │           ├── keys is null equal: [false]
+    │                   │               │           ├── filters: []
+    │                   │               │           ├── build join filters:
+    │                   │               │           │   └── filter id:14, build key:d3.d_date_sk (#163), probe targets:[customer.c_first_shipto_date_sk (#225)@scan8], filter type:bloom,inlist,min_max
+    │                   │               │           ├── estimated rows: 1811339.15
+    │                   │               │           ├── Exchange(Build)
+    │                   │               │           │   ├── output columns: [d3.d_date_sk (#163), d3.d_year (#169)]
+    │                   │               │           │   ├── exchange type: Broadcast
+    │                   │               │           │   └── TableScan
+    │                   │               │           │       ├── table: default.default.date_dim
+    │                   │               │           │       ├── scan id: 6
+    │                   │               │           │       ├── output columns: [d_date_sk (#163), d_year (#169)]
+    │                   │               │           │       ├── read rows: 0
+    │                   │               │           │       ├── read size: 0
+    │                   │               │           │       ├── partitions total: 0
+    │                   │               │           │       ├── partitions scanned: 0
+    │                   │               │           │       ├── push downs: [filters: [], limit: NONE]
+    │                   │               │           │       └── estimated rows: 73049.00
+    │                   │               │           └── HashJoin(Probe)
+    │                   │               │               ├── output columns: [customer.c_customer_sk (#220), customer.c_current_cdemo_sk (#222), customer.c_current_hdemo_sk (#223), customer.c_current_addr_sk (#224), customer.c_first_shipto_date_sk (#225), d2.d_year (#141)]
+    │                   │               │               ├── join type: INNER
+    │                   │               │               ├── build keys: [d2.d_date_sk (#135)]
+    │                   │               │               ├── probe keys: [customer.c_first_sales_date_sk (#226)]
+    │                   │               │               ├── keys is null equal: [false]
+    │                   │               │               ├── filters: []
+    │                   │               │               ├── build join filters:
+    │                   │               │               │   └── filter id:13, build key:d2.d_date_sk (#135), probe targets:[customer.c_first_sales_date_sk (#226)@scan8], filter type:bloom,inlist,min_max
+    │                   │               │               ├── estimated rows: 1877113.20
+    │                   │               │               ├── Exchange(Build)
+    │                   │               │               │   ├── output columns: [d2.d_date_sk (#135), d2.d_year (#141)]
+    │                   │               │               │   ├── exchange type: Broadcast
+    │                   │               │               │   └── TableScan
+    │                   │               │               │       ├── table: default.default.date_dim
+    │                   │               │               │       ├── scan id: 5
+    │                   │               │               │       ├── output columns: [d_date_sk (#135), d_year (#141)]
+    │                   │               │               │       ├── read rows: 0
+    │                   │               │               │       ├── read size: 0
+    │                   │               │               │       ├── partitions total: 0
+    │                   │               │               │       ├── partitions scanned: 0
+    │                   │               │               │       ├── push downs: [filters: [], limit: NONE]
+    │                   │               │               │       └── estimated rows: 73049.00
+    │                   │               │               └── TableScan(Probe)
+    │                   │               │                   ├── table: default.default.customer
+    │                   │               │                   ├── scan id: 8
+    │                   │               │                   ├── output columns: [c_customer_sk (#220), c_current_cdemo_sk (#222), c_current_hdemo_sk (#223), c_current_addr_sk (#224), c_first_shipto_date_sk (#225), c_first_sales_date_sk (#226)]
+    │                   │               │                   ├── read rows: 0
+    │                   │               │                   ├── read size: 0
+    │                   │               │                   ├── partitions total: 0
+    │                   │               │                   ├── partitions scanned: 0
+    │                   │               │                   ├── push downs: [filters: [], limit: NONE]
+    │                   │               │                   ├── apply join filters: [#18, #16, #14, #13]
+    │                   │               │                   └── estimated rows: 2000000.00
+    │                   │               └── Exchange(Probe)
+    │                   │                   ├── output columns: [cd2.cd_demo_sk (#247), cd2.cd_marital_status (#249)]
+    │                   │                   ├── exchange type: Hash(cd2.cd_demo_sk (#247))
+    │                   │                   └── TableScan
+    │                   │                       ├── table: default.default.customer_demographics
+    │                   │                       ├── scan id: 10
+    │                   │                       ├── output columns: [cd_demo_sk (#247), cd_marital_status (#249)]
+    │                   │                       ├── read rows: 0
+    │                   │                       ├── read size: 0
+    │                   │                       ├── partitions total: 0
+    │                   │                       ├── partitions scanned: 0
+    │                   │                       ├── push downs: [filters: [], limit: NONE]
+    │                   │                       ├── apply join filters: [#17]
+    │                   │                       └── estimated rows: 1920800.00
     │                   └── HashJoin(Probe)
-    │                       ├── output columns: [ad2.ca_street_number (#300), ad2.ca_street_name (#301), ad2.ca_city (#304), ad2.ca_zip (#307), ad1.ca_street_number (#287), ad1.ca_street_name (#288), ad1.ca_city (#291), ad1.ca_zip (#294), customer.c_current_hdemo_sk (#223), item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113), store.s_store_name (#196), store.s_zip (#216), d3.d_year (#169), d2.d_year (#141)]
+    │                       ├── output columns: [store_sales.ss_customer_sk (#3), item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113), store.s_store_name (#196), store.s_zip (#216), cd1.cd_marital_status (#240), ad1.ca_street_number (#287), ad1.ca_street_name (#288), ad1.ca_city (#291), ad1.ca_zip (#294)]
     │                       ├── join type: INNER
-    │                       ├── build keys: [hd1.hd_demo_sk (#275)]
-    │                       ├── probe keys: [store_sales.ss_hdemo_sk (#5)]
+    │                       ├── build keys: [ad1.ca_address_sk (#285)]
+    │                       ├── probe keys: [store_sales.ss_addr_sk (#6)]
     │                       ├── keys is null equal: [false]
     │                       ├── filters: []
     │                       ├── build join filters:
-    │                       │   └── filter id:17, build key:hd1.hd_demo_sk (#275), probe targets:[store_sales.ss_hdemo_sk (#5)@scan0], filter type:bloom,inlist,min_max
-    │                       ├── estimated rows: 82679.73
+    │                       │   └── filter id:12, build key:ad1.ca_address_sk (#285), probe targets:[store_sales.ss_addr_sk (#6)@scan0], filter type:bloom,inlist,min_max
+    │                       ├── estimated rows: 36610848.56
     │                       ├── Exchange(Build)
-    │                       │   ├── output columns: [hd1.hd_demo_sk (#275)]
+    │                       │   ├── output columns: [ad1.ca_address_sk (#285), ad1.ca_street_number (#287), ad1.ca_street_name (#288), ad1.ca_city (#291), ad1.ca_zip (#294)]
     │                       │   ├── exchange type: Broadcast
-    │                       │   └── HashJoin
-    │                       │       ├── output columns: [hd1.hd_demo_sk (#275)]
-    │                       │       ├── join type: INNER
-    │                       │       ├── build keys: [ib1.ib_income_band_sk (#311)]
-    │                       │       ├── probe keys: [hd1.hd_income_band_sk (#276)]
-    │                       │       ├── keys is null equal: [false]
-    │                       │       ├── filters: []
-    │                       │       ├── build join filters:
-    │                       │       │   └── filter id:16, build key:ib1.ib_income_band_sk (#311), probe targets:[hd1.hd_income_band_sk (#276)@scan12], filter type:bloom,inlist,min_max
-    │                       │       ├── estimated rows: 7200.00
-    │                       │       ├── Exchange(Build)
-    │                       │       │   ├── output columns: [ib1.ib_income_band_sk (#311)]
-    │                       │       │   ├── exchange type: Broadcast
-    │                       │       │   └── TableScan
-    │                       │       │       ├── table: default.default.income_band
-    │                       │       │       ├── scan id: 16
-    │                       │       │       ├── output columns: [ib_income_band_sk (#311)]
-    │                       │       │       ├── read rows: 0
-    │                       │       │       ├── read size: 0
-    │                       │       │       ├── partitions total: 0
-    │                       │       │       ├── partitions scanned: 0
-    │                       │       │       ├── push downs: [filters: [], limit: NONE]
-    │                       │       │       └── estimated rows: 20.00
-    │                       │       └── TableScan(Probe)
-    │                       │           ├── table: default.default.household_demographics
-    │                       │           ├── scan id: 12
-    │                       │           ├── output columns: [hd_demo_sk (#275), hd_income_band_sk (#276)]
-    │                       │           ├── read rows: 0
-    │                       │           ├── read size: 0
-    │                       │           ├── partitions total: 0
-    │                       │           ├── partitions scanned: 0
-    │                       │           ├── push downs: [filters: [], limit: NONE]
-    │                       │           ├── apply join filters: [#16]
-    │                       │           └── estimated rows: 7200.00
+    │                       │   └── TableScan
+    │                       │       ├── table: default.default.customer_address
+    │                       │       ├── scan id: 14
+    │                       │       ├── output columns: [ca_address_sk (#285), ca_street_number (#287), ca_street_name (#288), ca_city (#291), ca_zip (#294)]
+    │                       │       ├── read rows: 0
+    │                       │       ├── read size: 0
+    │                       │       ├── partitions total: 0
+    │                       │       ├── partitions scanned: 0
+    │                       │       ├── push downs: [filters: [], limit: NONE]
+    │                       │       └── estimated rows: 1000000.00
     │                       └── HashJoin(Probe)
-    │                           ├── output columns: [ad2.ca_street_number (#300), ad2.ca_street_name (#301), ad2.ca_city (#304), ad2.ca_zip (#307), ad1.ca_street_number (#287), ad1.ca_street_name (#288), ad1.ca_city (#291), ad1.ca_zip (#294), customer.c_current_hdemo_sk (#223), store_sales.ss_hdemo_sk (#5), item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113), store.s_store_name (#196), store.s_zip (#216), d3.d_year (#169), d2.d_year (#141)]
+    │                           ├── output columns: [store_sales.ss_customer_sk (#3), store_sales.ss_addr_sk (#6), item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113), store.s_store_name (#196), store.s_zip (#216), cd1.cd_marital_status (#240)]
     │                           ├── join type: INNER
-    │                           ├── build keys: [customer.c_current_addr_sk (#224)]
-    │                           ├── probe keys: [ad2.ca_address_sk (#298)]
+    │                           ├── build keys: [cd1.cd_demo_sk (#238)]
+    │                           ├── probe keys: [store_sales.ss_cdemo_sk (#4)]
     │                           ├── keys is null equal: [false]
     │                           ├── filters: []
     │                           ├── build join filters:
-    │                           │   └── filter id:15, build key:customer.c_current_addr_sk (#224), probe targets:[ad2.ca_address_sk (#298)@scan15], filter type:bloom,inlist,min_max
-    │                           ├── estimated rows: 86574.78
+    │                           │   └── filter id:11, build key:cd1.cd_demo_sk (#238), probe targets:[store_sales.ss_cdemo_sk (#4)@scan0], filter type:bloom,inlist,min_max
+    │                           ├── estimated rows: 34120648.00
     │                           ├── Exchange(Build)
-    │                           │   ├── output columns: [ad1.ca_street_number (#287), ad1.ca_street_name (#288), ad1.ca_city (#291), ad1.ca_zip (#294), customer.c_current_hdemo_sk (#223), customer.c_current_addr_sk (#224), store_sales.ss_hdemo_sk (#5), item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113), store.s_store_name (#196), store.s_zip (#216), d3.d_year (#169), d2.d_year (#141)]
+    │                           │   ├── output columns: [cd1.cd_demo_sk (#238), cd1.cd_marital_status (#240)]
     │                           │   ├── exchange type: Broadcast
-    │                           │   └── HashJoin
-    │                           │       ├── output columns: [ad1.ca_street_number (#287), ad1.ca_street_name (#288), ad1.ca_city (#291), ad1.ca_zip (#294), customer.c_current_hdemo_sk (#223), customer.c_current_addr_sk (#224), store_sales.ss_hdemo_sk (#5), item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113), store.s_store_name (#196), store.s_zip (#216), d3.d_year (#169), d2.d_year (#141)]
-    │                           │       ├── join type: INNER
-    │                           │       ├── build keys: [store_sales.ss_addr_sk (#6)]
-    │                           │       ├── probe keys: [ad1.ca_address_sk (#285)]
-    │                           │       ├── keys is null equal: [false]
-    │                           │       ├── filters: []
-    │                           │       ├── build join filters:
-    │                           │       │   └── filter id:14, build key:store_sales.ss_addr_sk (#6), probe targets:[ad1.ca_address_sk (#285)@scan14], filter type:bloom,inlist,min_max
-    │                           │       ├── estimated rows: 77056.14
-    │                           │       ├── Exchange(Build)
-    │                           │       │   ├── output columns: [customer.c_current_hdemo_sk (#223), customer.c_current_addr_sk (#224), store_sales.ss_hdemo_sk (#5), store_sales.ss_addr_sk (#6), item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113), store.s_store_name (#196), store.s_zip (#216), d3.d_year (#169), d2.d_year (#141)]
-    │                           │       │   ├── exchange type: Broadcast
-    │                           │       │   └── HashJoin
-    │                           │       │       ├── output columns: [customer.c_current_hdemo_sk (#223), customer.c_current_addr_sk (#224), store_sales.ss_hdemo_sk (#5), store_sales.ss_addr_sk (#6), item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113), store.s_store_name (#196), store.s_zip (#216), d3.d_year (#169), d2.d_year (#141)]
-    │                           │       │       ├── join type: INNER
-    │                           │       │       ├── build keys: [customer.c_current_cdemo_sk (#222)]
-    │                           │       │       ├── probe keys: [cd2.cd_demo_sk (#247)]
-    │                           │       │       ├── keys is null equal: [false]
-    │                           │       │       ├── filters: [cd1.cd_marital_status (#240) <> cd2.cd_marital_status (#249)]
-    │                           │       │       ├── build join filters:
-    │                           │       │       │   └── filter id:13, build key:customer.c_current_cdemo_sk (#222), probe targets:[cd2.cd_demo_sk (#247)@scan10], filter type:bloom,inlist,min_max
-    │                           │       │       ├── estimated rows: 71814.93
-    │                           │       │       ├── Exchange(Build)
-    │                           │       │       │   ├── output columns: [customer.c_current_cdemo_sk (#222), customer.c_current_hdemo_sk (#223), customer.c_current_addr_sk (#224), cd1.cd_marital_status (#240), store_sales.ss_hdemo_sk (#5), store_sales.ss_addr_sk (#6), item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113), store.s_store_name (#196), store.s_zip (#216), d3.d_year (#169), d2.d_year (#141)]
-    │                           │       │       │   ├── exchange type: Broadcast
-    │                           │       │       │   └── HashJoin
-    │                           │       │       │       ├── output columns: [customer.c_current_cdemo_sk (#222), customer.c_current_hdemo_sk (#223), customer.c_current_addr_sk (#224), cd1.cd_marital_status (#240), store_sales.ss_hdemo_sk (#5), store_sales.ss_addr_sk (#6), item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113), store.s_store_name (#196), store.s_zip (#216), d3.d_year (#169), d2.d_year (#141)]
-    │                           │       │       │       ├── join type: INNER
-    │                           │       │       │       ├── build keys: [d2.d_date_sk (#135)]
-    │                           │       │       │       ├── probe keys: [customer.c_first_sales_date_sk (#226)]
-    │                           │       │       │       ├── keys is null equal: [false]
-    │                           │       │       │       ├── filters: []
-    │                           │       │       │       ├── build join filters(distributed):
-    │                           │       │       │       │   └── filter id:12, build key:d2.d_date_sk (#135), probe targets:[customer.c_first_sales_date_sk (#226)@scan8], filter type:bloom,inlist,min_max
-    │                           │       │       │       ├── estimated rows: 96292.05
-    │                           │       │       │       ├── Exchange(Build)
-    │                           │       │       │       │   ├── output columns: [d2.d_date_sk (#135), d2.d_year (#141)]
-    │                           │       │       │       │   ├── exchange type: Hash(d2.d_date_sk (#135))
-    │                           │       │       │       │   └── TableScan
-    │                           │       │       │       │       ├── table: default.default.date_dim
-    │                           │       │       │       │       ├── scan id: 5
-    │                           │       │       │       │       ├── output columns: [d_date_sk (#135), d_year (#141)]
-    │                           │       │       │       │       ├── read rows: 0
-    │                           │       │       │       │       ├── read size: 0
-    │                           │       │       │       │       ├── partitions total: 0
-    │                           │       │       │       │       ├── partitions scanned: 0
-    │                           │       │       │       │       ├── push downs: [filters: [], limit: NONE]
-    │                           │       │       │       │       └── estimated rows: 73049.00
-    │                           │       │       │       └── Exchange(Probe)
-    │                           │       │       │           ├── output columns: [customer.c_current_cdemo_sk (#222), customer.c_current_hdemo_sk (#223), customer.c_current_addr_sk (#224), customer.c_first_sales_date_sk (#226), cd1.cd_marital_status (#240), store_sales.ss_hdemo_sk (#5), store_sales.ss_addr_sk (#6), item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113), store.s_store_name (#196), store.s_zip (#216), d3.d_year (#169)]
-    │                           │       │       │           ├── exchange type: Hash(customer.c_first_sales_date_sk (#226))
-    │                           │       │       │           └── HashJoin
-    │                           │       │       │               ├── output columns: [customer.c_current_cdemo_sk (#222), customer.c_current_hdemo_sk (#223), customer.c_current_addr_sk (#224), customer.c_first_sales_date_sk (#226), cd1.cd_marital_status (#240), store_sales.ss_hdemo_sk (#5), store_sales.ss_addr_sk (#6), item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113), store.s_store_name (#196), store.s_zip (#216), d3.d_year (#169)]
-    │                           │       │       │               ├── join type: INNER
-    │                           │       │       │               ├── build keys: [d3.d_date_sk (#163)]
-    │                           │       │       │               ├── probe keys: [customer.c_first_shipto_date_sk (#225)]
-    │                           │       │       │               ├── keys is null equal: [false]
-    │                           │       │       │               ├── filters: []
-    │                           │       │       │               ├── build join filters(distributed):
-    │                           │       │       │               │   └── filter id:11, build key:d3.d_date_sk (#163), probe targets:[customer.c_first_shipto_date_sk (#225)@scan8], filter type:bloom,inlist,min_max
-    │                           │       │       │               ├── estimated rows: 99781.92
-    │                           │       │       │               ├── Exchange(Build)
-    │                           │       │       │               │   ├── output columns: [d3.d_date_sk (#163), d3.d_year (#169)]
-    │                           │       │       │               │   ├── exchange type: Hash(d3.d_date_sk (#163))
-    │                           │       │       │               │   └── TableScan
-    │                           │       │       │               │       ├── table: default.default.date_dim
-    │                           │       │       │               │       ├── scan id: 6
-    │                           │       │       │               │       ├── output columns: [d_date_sk (#163), d_year (#169)]
-    │                           │       │       │               │       ├── read rows: 0
-    │                           │       │       │               │       ├── read size: 0
-    │                           │       │       │               │       ├── partitions total: 0
-    │                           │       │       │               │       ├── partitions scanned: 0
-    │                           │       │       │               │       ├── push downs: [filters: [], limit: NONE]
-    │                           │       │       │               │       └── estimated rows: 73049.00
-    │                           │       │       │               └── Exchange(Probe)
-    │                           │       │       │                   ├── output columns: [customer.c_current_cdemo_sk (#222), customer.c_current_hdemo_sk (#223), customer.c_current_addr_sk (#224), customer.c_first_shipto_date_sk (#225), customer.c_first_sales_date_sk (#226), cd1.cd_marital_status (#240), store_sales.ss_hdemo_sk (#5), store_sales.ss_addr_sk (#6), item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113), store.s_store_name (#196), store.s_zip (#216)]
-    │                           │       │       │                   ├── exchange type: Hash(customer.c_first_shipto_date_sk (#225))
-    │                           │       │       │                   └── HashJoin
-    │                           │       │       │                       ├── output columns: [customer.c_current_cdemo_sk (#222), customer.c_current_hdemo_sk (#223), customer.c_current_addr_sk (#224), customer.c_first_shipto_date_sk (#225), customer.c_first_sales_date_sk (#226), cd1.cd_marital_status (#240), store_sales.ss_hdemo_sk (#5), store_sales.ss_addr_sk (#6), item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113), store.s_store_name (#196), store.s_zip (#216)]
-    │                           │       │       │                       ├── join type: INNER
-    │                           │       │       │                       ├── build keys: [store_sales.ss_customer_sk (#3)]
-    │                           │       │       │                       ├── probe keys: [customer.c_customer_sk (#220)]
-    │                           │       │       │                       ├── keys is null equal: [false]
-    │                           │       │       │                       ├── filters: []
-    │                           │       │       │                       ├── build join filters:
-    │                           │       │       │                       │   └── filter id:10, build key:store_sales.ss_customer_sk (#3), probe targets:[customer.c_customer_sk (#220)@scan8], filter type:bloom,inlist,min_max
-    │                           │       │       │                       ├── estimated rows: 103405.24
-    │                           │       │       │                       ├── Exchange(Build)
-    │                           │       │       │                       │   ├── output columns: [cd1.cd_marital_status (#240), store_sales.ss_customer_sk (#3), store_sales.ss_hdemo_sk (#5), store_sales.ss_addr_sk (#6), item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113), store.s_store_name (#196), store.s_zip (#216)]
-    │                           │       │       │                       │   ├── exchange type: Broadcast
-    │                           │       │       │                       │   └── HashJoin
-    │                           │       │       │                       │       ├── output columns: [cd1.cd_marital_status (#240), store_sales.ss_customer_sk (#3), store_sales.ss_hdemo_sk (#5), store_sales.ss_addr_sk (#6), item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113), store.s_store_name (#196), store.s_zip (#216)]
-    │                           │       │       │                       │       ├── join type: INNER
-    │                           │       │       │                       │       ├── build keys: [store_sales.ss_cdemo_sk (#4)]
-    │                           │       │       │                       │       ├── probe keys: [cd1.cd_demo_sk (#238)]
-    │                           │       │       │                       │       ├── keys is null equal: [false]
-    │                           │       │       │                       │       ├── filters: []
-    │                           │       │       │                       │       ├── build join filters:
-    │                           │       │       │                       │       │   └── filter id:9, build key:store_sales.ss_cdemo_sk (#4), probe targets:[cd1.cd_demo_sk (#238)@scan9], filter type:bloom,inlist,min_max
-    │                           │       │       │                       │       ├── estimated rows: 96679.21
-    │                           │       │       │                       │       ├── Exchange(Build)
-    │                           │       │       │                       │       │   ├── output columns: [store_sales.ss_customer_sk (#3), store_sales.ss_cdemo_sk (#4), store_sales.ss_hdemo_sk (#5), store_sales.ss_addr_sk (#6), item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113), store.s_store_name (#196), store.s_zip (#216)]
-    │                           │       │       │                       │       │   ├── exchange type: Broadcast
-    │                           │       │       │                       │       │   └── HashJoin
-    │                           │       │       │                       │       │       ├── output columns: [store_sales.ss_customer_sk (#3), store_sales.ss_cdemo_sk (#4), store_sales.ss_hdemo_sk (#5), store_sales.ss_addr_sk (#6), item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113), store.s_store_name (#196), store.s_zip (#216)]
-    │                           │       │       │                       │       │       ├── join type: INNER
-    │                           │       │       │                       │       │       ├── build keys: [promotion.p_promo_sk (#256)]
-    │                           │       │       │                       │       │       ├── probe keys: [store_sales.ss_promo_sk (#8)]
-    │                           │       │       │                       │       │       ├── keys is null equal: [false]
-    │                           │       │       │                       │       │       ├── filters: []
-    │                           │       │       │                       │       │       ├── build join filters:
-    │                           │       │       │                       │       │       │   └── filter id:8, build key:promotion.p_promo_sk (#256), probe targets:[store_sales.ss_promo_sk (#8)@scan0], filter type:bloom,inlist,min_max
-    │                           │       │       │                       │       │       ├── estimated rows: 92623.95
-    │                           │       │       │                       │       │       ├── Exchange(Build)
-    │                           │       │       │                       │       │       │   ├── output columns: [promotion.p_promo_sk (#256)]
-    │                           │       │       │                       │       │       │   ├── exchange type: Broadcast
-    │                           │       │       │                       │       │       │   └── TableScan
-    │                           │       │       │                       │       │       │       ├── table: default.default.promotion
-    │                           │       │       │                       │       │       │       ├── scan id: 11
-    │                           │       │       │                       │       │       │       ├── output columns: [p_promo_sk (#256)]
-    │                           │       │       │                       │       │       │       ├── read rows: 0
-    │                           │       │       │                       │       │       │       ├── read size: 0
-    │                           │       │       │                       │       │       │       ├── partitions total: 0
-    │                           │       │       │                       │       │       │       ├── partitions scanned: 0
-    │                           │       │       │                       │       │       │       ├── push downs: [filters: [], limit: NONE]
-    │                           │       │       │                       │       │       │       └── estimated rows: 1000.00
-    │                           │       │       │                       │       │       └── HashJoin(Probe)
-    │                           │       │       │                       │       │           ├── output columns: [store_sales.ss_customer_sk (#3), store_sales.ss_cdemo_sk (#4), store_sales.ss_hdemo_sk (#5), store_sales.ss_addr_sk (#6), store_sales.ss_promo_sk (#8), item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113), store.s_store_name (#196), store.s_zip (#216)]
-    │                           │       │       │                       │       │           ├── join type: INNER
-    │                           │       │       │                       │       │           ├── build keys: [store.s_store_sk (#191)]
-    │                           │       │       │                       │       │           ├── probe keys: [store_sales.ss_store_sk (#7)]
-    │                           │       │       │                       │       │           ├── keys is null equal: [false]
-    │                           │       │       │                       │       │           ├── filters: []
-    │                           │       │       │                       │       │           ├── build join filters:
-    │                           │       │       │                       │       │           │   └── filter id:7, build key:store.s_store_sk (#191), probe targets:[store_sales.ss_store_sk (#7)@scan0], filter type:bloom,inlist,min_max
-    │                           │       │       │                       │       │           ├── estimated rows: 93203.92
-    │                           │       │       │                       │       │           ├── Exchange(Build)
-    │                           │       │       │                       │       │           │   ├── output columns: [store.s_store_sk (#191), store.s_store_name (#196), store.s_zip (#216)]
-    │                           │       │       │                       │       │           │   ├── exchange type: Broadcast
-    │                           │       │       │                       │       │           │   └── TableScan
-    │                           │       │       │                       │       │           │       ├── table: default.default.store
-    │                           │       │       │                       │       │           │       ├── scan id: 7
-    │                           │       │       │                       │       │           │       ├── output columns: [s_store_sk (#191), s_store_name (#196), s_zip (#216)]
-    │                           │       │       │                       │       │           │       ├── read rows: 0
-    │                           │       │       │                       │       │           │       ├── read size: 0
-    │                           │       │       │                       │       │           │       ├── partitions total: 0
-    │                           │       │       │                       │       │           │       ├── partitions scanned: 0
-    │                           │       │       │                       │       │           │       ├── push downs: [filters: [], limit: NONE]
-    │                           │       │       │                       │       │           │       └── estimated rows: 402.00
-    │                           │       │       │                       │       │           └── HashJoin(Probe)
-    │                           │       │       │                       │       │               ├── output columns: [store_sales.ss_customer_sk (#3), store_sales.ss_cdemo_sk (#4), store_sales.ss_hdemo_sk (#5), store_sales.ss_addr_sk (#6), store_sales.ss_store_sk (#7), store_sales.ss_promo_sk (#8), item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113)]
-    │                           │       │       │                       │       │               ├── join type: INNER
-    │                           │       │       │                       │       │               ├── build keys: [d1.d_date_sk (#107)]
-    │                           │       │       │                       │       │               ├── probe keys: [store_sales.ss_sold_date_sk (#0)]
-    │                           │       │       │                       │       │               ├── keys is null equal: [false]
-    │                           │       │       │                       │       │               ├── filters: []
-    │                           │       │       │                       │       │               ├── build join filters(distributed):
-    │                           │       │       │                       │       │               │   └── filter id:6, build key:d1.d_date_sk (#107), probe targets:[store_sales.ss_sold_date_sk (#0)@scan0], filter type:bloom,inlist,min_max
-    │                           │       │       │                       │       │               ├── estimated rows: 96135.85
-    │                           │       │       │                       │       │               ├── Exchange(Build)
-    │                           │       │       │                       │       │               │   ├── output columns: [d1.d_date_sk (#107), d1.d_year (#113)]
-    │                           │       │       │                       │       │               │   ├── exchange type: Hash(d1.d_date_sk (#107))
-    │                           │       │       │                       │       │               │   └── TableScan
-    │                           │       │       │                       │       │               │       ├── table: default.default.date_dim
-    │                           │       │       │                       │       │               │       ├── scan id: 4
-    │                           │       │       │                       │       │               │       ├── output columns: [d_date_sk (#107), d_year (#113)]
-    │                           │       │       │                       │       │               │       ├── read rows: 0
-    │                           │       │       │                       │       │               │       ├── read size: 0
-    │                           │       │       │                       │       │               │       ├── partitions total: 0
-    │                           │       │       │                       │       │               │       ├── partitions scanned: 0
-    │                           │       │       │                       │       │               │       ├── push downs: [filters: [], limit: NONE]
-    │                           │       │       │                       │       │               │       └── estimated rows: 73049.00
-    │                           │       │       │                       │       │               └── Exchange(Probe)
-    │                           │       │       │                       │       │                   ├── output columns: [store_sales.ss_sold_date_sk (#0), store_sales.ss_customer_sk (#3), store_sales.ss_cdemo_sk (#4), store_sales.ss_hdemo_sk (#5), store_sales.ss_addr_sk (#6), store_sales.ss_store_sk (#7), store_sales.ss_promo_sk (#8), item.i_product_name (#338), item.i_item_sk (#317)]
-    │                           │       │       │                       │       │                   ├── exchange type: Hash(store_sales.ss_sold_date_sk (#0))
-    │                           │       │       │                       │       │                   └── HashJoin
-    │                           │       │       │                       │       │                       ├── output columns: [store_sales.ss_sold_date_sk (#0), store_sales.ss_customer_sk (#3), store_sales.ss_cdemo_sk (#4), store_sales.ss_hdemo_sk (#5), store_sales.ss_addr_sk (#6), store_sales.ss_store_sk (#7), store_sales.ss_promo_sk (#8), item.i_product_name (#338), item.i_item_sk (#317)]
-    │                           │       │       │                       │       │                       ├── join type: INNER
-    │                           │       │       │                       │       │                       ├── build keys: [item.i_item_sk (#317), store_returns.sr_ticket_number (#32)]
-    │                           │       │       │                       │       │                       ├── probe keys: [store_sales.ss_item_sk (#2), store_sales.ss_ticket_number (#9)]
-    │                           │       │       │                       │       │                       ├── keys is null equal: [false, false]
-    │                           │       │       │                       │       │                       ├── filters: []
-    │                           │       │       │                       │       │                       ├── build join filters:
-    │                           │       │       │                       │       │                       │   ├── filter id:4, build key:item.i_item_sk (#317), probe targets:[store_sales.ss_item_sk (#2)@scan0], filter type:bloom,inlist,min_max
-    │                           │       │       │                       │       │                       │   └── filter id:5, build key:store_returns.sr_ticket_number (#32), probe targets:[store_sales.ss_ticket_number (#9)@scan0], filter type:bloom,inlist,min_max
-    │                           │       │       │                       │       │                       ├── estimated rows: 100664.04
-    │                           │       │       │                       │       │                       ├── Exchange(Build)
-    │                           │       │       │                       │       │                       │   ├── output columns: [store_returns.sr_ticket_number (#32), item.i_product_name (#338), item.i_item_sk (#317)]
-    │                           │       │       │                       │       │                       │   ├── exchange type: Broadcast
-    │                           │       │       │                       │       │                       │   └── HashJoin
-    │                           │       │       │                       │       │                       │       ├── output columns: [store_returns.sr_ticket_number (#32), item.i_product_name (#338), item.i_item_sk (#317)]
-    │                           │       │       │                       │       │                       │       ├── join type: INNER
-    │                           │       │       │                       │       │                       │       ├── build keys: [item.i_item_sk (#317)]
-    │                           │       │       │                       │       │                       │       ├── probe keys: [store_returns.sr_item_sk (#25)]
-    │                           │       │       │                       │       │                       │       ├── keys is null equal: [false]
-    │                           │       │       │                       │       │                       │       ├── filters: []
-    │                           │       │       │                       │       │                       │       ├── build join filters:
-    │                           │       │       │                       │       │                       │       │   └── filter id:3, build key:item.i_item_sk (#317), probe targets:[store_returns.sr_item_sk (#25)@scan1], filter type:bloom,inlist,min_max
-    │                           │       │       │                       │       │                       │       ├── estimated rows: 3236675.22
-    │                           │       │       │                       │       │                       │       ├── Exchange(Build)
-    │                           │       │       │                       │       │                       │       │   ├── output columns: [item.i_product_name (#338), item.i_item_sk (#317)]
-    │                           │       │       │                       │       │                       │       │   ├── exchange type: Broadcast
-    │                           │       │       │                       │       │                       │       │   └── HashJoin
-    │                           │       │       │                       │       │                       │       │       ├── output columns: [item.i_product_name (#338), item.i_item_sk (#317)]
-    │                           │       │       │                       │       │                       │       │       ├── join type: INNER
-    │                           │       │       │                       │       │                       │       │       ├── build keys: [item.i_item_sk (#317)]
-    │                           │       │       │                       │       │                       │       │       ├── probe keys: [cs_ui.cs_item_sk (#58)]
-    │                           │       │       │                       │       │                       │       │       ├── keys is null equal: [false]
-    │                           │       │       │                       │       │                       │       │       ├── filters: []
-    │                           │       │       │                       │       │                       │       │       ├── build join filters(distributed):
-    │                           │       │       │                       │       │                       │       │       │   └── filter id:2, build key:item.i_item_sk (#317), probe targets:[cs_ui.cs_item_sk (#58)@scan2, catalog_returns.cr_item_sk (#79)@scan3], filter type:bloom,inlist,min_max
-    │                           │       │       │                       │       │                       │       │       ├── estimated rows: 21459.56
-    │                           │       │       │                       │       │                       │       │       ├── Exchange(Build)
-    │                           │       │       │                       │       │                       │       │       │   ├── output columns: [item.i_item_sk (#317), item.i_product_name (#338)]
-    │                           │       │       │                       │       │                       │       │       │   ├── exchange type: Hash(item.i_item_sk (#317))
-    │                           │       │       │                       │       │                       │       │       │   └── TableScan
-    │                           │       │       │                       │       │                       │       │       │       ├── table: default.default.item
-    │                           │       │       │                       │       │                       │       │       │       ├── scan id: 18
-    │                           │       │       │                       │       │                       │       │       │       ├── output columns: [i_item_sk (#317), i_product_name (#338)]
-    │                           │       │       │                       │       │                       │       │       │       ├── read rows: 0
-    │                           │       │       │                       │       │                       │       │       │       ├── read size: 0
-    │                           │       │       │                       │       │                       │       │       │       ├── partitions total: 0
-    │                           │       │       │                       │       │                       │       │       │       ├── partitions scanned: 0
-    │                           │       │       │                       │       │                       │       │       │       ├── push downs: [filters: [contains(['blanched', 'medium', 'brown', 'chocolate', 'burlywood', 'drab'], item.i_color (#334)) and item.i_current_price (#322) >= 23 and item.i_current_price (#322) <= 33 and item.i_current_price (#322) >= 24 and item.i_current_price (#322) <= 38], limit: NONE]
-    │                           │       │       │                       │       │                       │       │       │       └── estimated rows: 18150.03
-    │                           │       │       │                       │       │                       │       │       └── Exchange(Probe)
-    │                           │       │       │                       │       │                       │       │           ├── output columns: [catalog_sales.cs_item_sk (#58)]
-    │                           │       │       │                       │       │                       │       │           ├── exchange type: Hash(cs_ui.cs_item_sk (#58))
-    │                           │       │       │                       │       │                       │       │           └── Filter
-    │                           │       │       │                       │       │                       │       │               ├── output columns: [catalog_sales.cs_item_sk (#58)]
-    │                           │       │       │                       │       │                       │       │               ├── filters: [is_true(sum(cs_ext_list_price) (#104) > 2 * sum(cr_refunded_cash + cr_reversed_charge + cr_store_credit) (#106))]
-    │                           │       │       │                       │       │                       │       │               ├── estimated rows: 31376.76
-    │                           │       │       │                       │       │                       │       │               └── AggregateFinal
-    │                           │       │       │                       │       │                       │       │                   ├── output columns: [sum(cs_ext_list_price) (#104), sum(cr_refunded_cash + cr_reversed_charge + cr_store_credit) (#106), catalog_sales.cs_item_sk (#58)]
-    │                           │       │       │                       │       │                       │       │                   ├── group by: [cs_item_sk]
-    │                           │       │       │                       │       │                       │       │                   ├── aggregate functions: [sum(cs_ext_list_price), sum(sum_arg_0)]
-    │                           │       │       │                       │       │                       │       │                   ├── estimated rows: 156883.81
-    │                           │       │       │                       │       │                       │       │                   └── Exchange
-    │                           │       │       │                       │       │                       │       │                       ├── output columns: [sum(cs_ext_list_price) (#104), sum(cr_refunded_cash + cr_reversed_charge + cr_store_credit) (#106), catalog_sales.cs_item_sk (#58)]
-    │                           │       │       │                       │       │                       │       │                       ├── exchange type: Hash(0)
-    │                           │       │       │                       │       │                       │       │                       └── AggregatePartial
-    │                           │       │       │                       │       │                       │       │                           ├── group by: [cs_item_sk]
-    │                           │       │       │                       │       │                       │       │                           ├── aggregate functions: [sum(cs_ext_list_price), sum(sum_arg_0)]
-    │                           │       │       │                       │       │                       │       │                           ├── estimated rows: 156883.81
-    │                           │       │       │                       │       │                       │       │                           └── EvalScalar
-    │                           │       │       │                       │       │                       │       │                               ├── output columns: [catalog_sales.cs_item_sk (#58), catalog_sales.cs_ext_list_price (#68), sum_arg_0 (#105)]
-    │                           │       │       │                       │       │                       │       │                               ├── expressions: [catalog_returns.cr_refunded_cash (#100) + catalog_returns.cr_reversed_charge (#101) + catalog_returns.cr_store_credit (#102)]
-    │                           │       │       │                       │       │                       │       │                               ├── estimated rows: 329237.65
-    │                           │       │       │                       │       │                       │       │                               └── HashJoin
-    │                           │       │       │                       │       │                       │       │                                   ├── output columns: [catalog_sales.cs_item_sk (#58), catalog_sales.cs_ext_list_price (#68), catalog_returns.cr_refunded_cash (#100), catalog_returns.cr_reversed_charge (#101), catalog_returns.cr_store_credit (#102)]
-    │                           │       │       │                       │       │                       │       │                                   ├── join type: INNER
-    │                           │       │       │                       │       │                       │       │                                   ├── build keys: [catalog_returns.cr_item_sk (#79), catalog_returns.cr_order_number (#93)]
-    │                           │       │       │                       │       │                       │       │                                   ├── probe keys: [catalog_sales.cs_item_sk (#58), catalog_sales.cs_order_number (#60)]
-    │                           │       │       │                       │       │                       │       │                                   ├── keys is null equal: [false, false]
-    │                           │       │       │                       │       │                       │       │                                   ├── filters: []
-    │                           │       │       │                       │       │                       │       │                                   ├── build join filters:
-    │                           │       │       │                       │       │                       │       │                                   │   ├── filter id:0, build key:catalog_returns.cr_item_sk (#79), probe targets:[catalog_sales.cs_item_sk (#58)@scan2], filter type:bloom,inlist,min_max
-    │                           │       │       │                       │       │                       │       │                                   │   └── filter id:1, build key:catalog_returns.cr_order_number (#93), probe targets:[catalog_sales.cs_order_number (#60)@scan2], filter type:bloom,inlist,min_max
-    │                           │       │       │                       │       │                       │       │                                   ├── estimated rows: 329237.65
-    │                           │       │       │                       │       │                       │       │                                   ├── Exchange(Build)
-    │                           │       │       │                       │       │                       │       │                                   │   ├── output columns: [catalog_returns.cr_item_sk (#79), catalog_returns.cr_order_number (#93), catalog_returns.cr_refunded_cash (#100), catalog_returns.cr_reversed_charge (#101), catalog_returns.cr_store_credit (#102)]
-    │                           │       │       │                       │       │                       │       │                                   │   ├── exchange type: Broadcast
-    │                           │       │       │                       │       │                       │       │                                   │   └── TableScan
-    │                           │       │       │                       │       │                       │       │                                   │       ├── table: default.default.catalog_returns
-    │                           │       │       │                       │       │                       │       │                                   │       ├── scan id: 3
-    │                           │       │       │                       │       │                       │       │                                   │       ├── output columns: [cr_item_sk (#79), cr_order_number (#93), cr_refunded_cash (#100), cr_reversed_charge (#101), cr_store_credit (#102)]
-    │                           │       │       │                       │       │                       │       │                                   │       ├── read rows: 0
-    │                           │       │       │                       │       │                       │       │                                   │       ├── read size: 0
-    │                           │       │       │                       │       │                       │       │                                   │       ├── partitions total: 0
-    │                           │       │       │                       │       │                       │       │                                   │       ├── partitions scanned: 0
-    │                           │       │       │                       │       │                       │       │                                   │       ├── push downs: [filters: [], limit: NONE]
-    │                           │       │       │                       │       │                       │       │                                   │       ├── apply join filters: [#2]
-    │                           │       │       │                       │       │                       │       │                                   │       └── estimated rows: 14404374.00
-    │                           │       │       │                       │       │                       │       │                                   └── TableScan(Probe)
-    │                           │       │       │                       │       │                       │       │                                       ├── table: default.default.catalog_sales
-    │                           │       │       │                       │       │                       │       │                                       ├── scan id: 2
-    │                           │       │       │                       │       │                       │       │                                       ├── output columns: [cs_item_sk (#58), cs_order_number (#60), cs_ext_list_price (#68)]
-    │                           │       │       │                       │       │                       │       │                                       ├── read rows: 0
-    │                           │       │       │                       │       │                       │       │                                       ├── read size: 0
-    │                           │       │       │                       │       │                       │       │                                       ├── partitions total: 0
-    │                           │       │       │                       │       │                       │       │                                       ├── partitions scanned: 0
-    │                           │       │       │                       │       │                       │       │                                       ├── push downs: [filters: [], limit: NONE]
-    │                           │       │       │                       │       │                       │       │                                       ├── apply join filters: [#2, #0, #1]
-    │                           │       │       │                       │       │                       │       │                                       └── estimated rows: 143997065.00
-    │                           │       │       │                       │       │                       │       └── TableScan(Probe)
-    │                           │       │       │                       │       │                       │           ├── table: default.default.store_returns
-    │                           │       │       │                       │       │                       │           ├── scan id: 1
-    │                           │       │       │                       │       │                       │           ├── output columns: [sr_item_sk (#25), sr_ticket_number (#32)]
-    │                           │       │       │                       │       │                       │           ├── read rows: 0
-    │                           │       │       │                       │       │                       │           ├── read size: 0
-    │                           │       │       │                       │       │                       │           ├── partitions total: 0
-    │                           │       │       │                       │       │                       │           ├── partitions scanned: 0
-    │                           │       │       │                       │       │                       │           ├── push downs: [filters: [], limit: NONE]
-    │                           │       │       │                       │       │                       │           ├── apply join filters: [#3]
-    │                           │       │       │                       │       │                       │           └── estimated rows: 28795080.00
-    │                           │       │       │                       │       │                       └── TableScan(Probe)
-    │                           │       │       │                       │       │                           ├── table: default.default.store_sales
-    │                           │       │       │                       │       │                           ├── scan id: 0
-    │                           │       │       │                       │       │                           ├── output columns: [ss_sold_date_sk (#0), ss_item_sk (#2), ss_customer_sk (#3), ss_cdemo_sk (#4), ss_hdemo_sk (#5), ss_addr_sk (#6), ss_store_sk (#7), ss_promo_sk (#8), ss_ticket_number (#9)]
-    │                           │       │       │                       │       │                           ├── read rows: 0
-    │                           │       │       │                       │       │                           ├── read size: 0
-    │                           │       │       │                       │       │                           ├── partitions total: 0
-    │                           │       │       │                       │       │                           ├── partitions scanned: 0
-    │                           │       │       │                       │       │                           ├── push downs: [filters: [], limit: NONE]
-    │                           │       │       │                       │       │                           ├── apply join filters: [#17, #8, #7, #6, #4, #5]
-    │                           │       │       │                       │       │                           └── estimated rows: 287997024.00
-    │                           │       │       │                       │       └── TableScan(Probe)
-    │                           │       │       │                       │           ├── table: default.default.customer_demographics
-    │                           │       │       │                       │           ├── scan id: 9
-    │                           │       │       │                       │           ├── output columns: [cd_demo_sk (#238), cd_marital_status (#240)]
-    │                           │       │       │                       │           ├── read rows: 0
-    │                           │       │       │                       │           ├── read size: 0
-    │                           │       │       │                       │           ├── partitions total: 0
-    │                           │       │       │                       │           ├── partitions scanned: 0
-    │                           │       │       │                       │           ├── push downs: [filters: [], limit: NONE]
-    │                           │       │       │                       │           ├── apply join filters: [#9]
-    │                           │       │       │                       │           └── estimated rows: 1920800.00
-    │                           │       │       │                       └── TableScan(Probe)
-    │                           │       │       │                           ├── table: default.default.customer
-    │                           │       │       │                           ├── scan id: 8
-    │                           │       │       │                           ├── output columns: [c_customer_sk (#220), c_current_cdemo_sk (#222), c_current_hdemo_sk (#223), c_current_addr_sk (#224), c_first_shipto_date_sk (#225), c_first_sales_date_sk (#226)]
-    │                           │       │       │                           ├── read rows: 0
-    │                           │       │       │                           ├── read size: 0
-    │                           │       │       │                           ├── partitions total: 0
-    │                           │       │       │                           ├── partitions scanned: 0
-    │                           │       │       │                           ├── push downs: [filters: [], limit: NONE]
-    │                           │       │       │                           ├── apply join filters: [#19, #12, #11, #10]
-    │                           │       │       │                           └── estimated rows: 2000000.00
-    │                           │       │       └── TableScan(Probe)
-    │                           │       │           ├── table: default.default.customer_demographics
-    │                           │       │           ├── scan id: 10
-    │                           │       │           ├── output columns: [cd_demo_sk (#247), cd_marital_status (#249)]
-    │                           │       │           ├── read rows: 0
-    │                           │       │           ├── read size: 0
-    │                           │       │           ├── partitions total: 0
-    │                           │       │           ├── partitions scanned: 0
-    │                           │       │           ├── push downs: [filters: [], limit: NONE]
-    │                           │       │           ├── apply join filters: [#13]
-    │                           │       │           └── estimated rows: 1920800.00
-    │                           │       └── TableScan(Probe)
-    │                           │           ├── table: default.default.customer_address
-    │                           │           ├── scan id: 14
-    │                           │           ├── output columns: [ca_address_sk (#285), ca_street_number (#287), ca_street_name (#288), ca_city (#291), ca_zip (#294)]
-    │                           │           ├── read rows: 0
-    │                           │           ├── read size: 0
-    │                           │           ├── partitions total: 0
-    │                           │           ├── partitions scanned: 0
-    │                           │           ├── push downs: [filters: [], limit: NONE]
-    │                           │           ├── apply join filters: [#14]
-    │                           │           └── estimated rows: 1000000.00
-    │                           └── TableScan(Probe)
-    │                               ├── table: default.default.customer_address
-    │                               ├── scan id: 15
-    │                               ├── output columns: [ca_address_sk (#298), ca_street_number (#300), ca_street_name (#301), ca_city (#304), ca_zip (#307)]
-    │                               ├── read rows: 0
-    │                               ├── read size: 0
-    │                               ├── partitions total: 0
-    │                               ├── partitions scanned: 0
-    │                               ├── push downs: [filters: [], limit: NONE]
-    │                               ├── apply join filters: [#15]
-    │                               └── estimated rows: 1000000.00
+    │                           │   └── TableScan
+    │                           │       ├── table: default.default.customer_demographics
+    │                           │       ├── scan id: 9
+    │                           │       ├── output columns: [cd_demo_sk (#238), cd_marital_status (#240)]
+    │                           │       ├── read rows: 0
+    │                           │       ├── read size: 0
+    │                           │       ├── partitions total: 0
+    │                           │       ├── partitions scanned: 0
+    │                           │       ├── push downs: [filters: [], limit: NONE]
+    │                           │       └── estimated rows: 1920800.00
+    │                           └── HashJoin(Probe)
+    │                               ├── output columns: [store_sales.ss_customer_sk (#3), store_sales.ss_cdemo_sk (#4), store_sales.ss_addr_sk (#6), item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113), store.s_store_name (#196), store.s_zip (#216)]
+    │                               ├── join type: INNER
+    │                               ├── build keys: [promotion.p_promo_sk (#256)]
+    │                               ├── probe keys: [store_sales.ss_promo_sk (#8)]
+    │                               ├── keys is null equal: [false]
+    │                               ├── filters: []
+    │                               ├── build join filters:
+    │                               │   └── filter id:10, build key:promotion.p_promo_sk (#256), probe targets:[store_sales.ss_promo_sk (#8)@scan0], filter type:bloom,inlist,min_max
+    │                               ├── estimated rows: 32689437.24
+    │                               ├── Exchange(Build)
+    │                               │   ├── output columns: [promotion.p_promo_sk (#256)]
+    │                               │   ├── exchange type: Broadcast
+    │                               │   └── TableScan
+    │                               │       ├── table: default.default.promotion
+    │                               │       ├── scan id: 11
+    │                               │       ├── output columns: [p_promo_sk (#256)]
+    │                               │       ├── read rows: 0
+    │                               │       ├── read size: 0
+    │                               │       ├── partitions total: 0
+    │                               │       ├── partitions scanned: 0
+    │                               │       ├── push downs: [filters: [], limit: NONE]
+    │                               │       └── estimated rows: 1000.00
+    │                               └── HashJoin(Probe)
+    │                                   ├── output columns: [store_sales.ss_customer_sk (#3), store_sales.ss_cdemo_sk (#4), store_sales.ss_addr_sk (#6), store_sales.ss_promo_sk (#8), item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113), store.s_store_name (#196), store.s_zip (#216)]
+    │                                   ├── join type: INNER
+    │                                   ├── build keys: [store.s_store_sk (#191)]
+    │                                   ├── probe keys: [store_sales.ss_store_sk (#7)]
+    │                                   ├── keys is null equal: [false]
+    │                                   ├── filters: []
+    │                                   ├── build join filters:
+    │                                   │   └── filter id:9, build key:store.s_store_sk (#191), probe targets:[store_sales.ss_store_sk (#7)@scan0], filter type:bloom,inlist,min_max
+    │                                   ├── estimated rows: 32894124.85
+    │                                   ├── Exchange(Build)
+    │                                   │   ├── output columns: [store.s_store_sk (#191), store.s_store_name (#196), store.s_zip (#216)]
+    │                                   │   ├── exchange type: Broadcast
+    │                                   │   └── TableScan
+    │                                   │       ├── table: default.default.store
+    │                                   │       ├── scan id: 7
+    │                                   │       ├── output columns: [s_store_sk (#191), s_store_name (#196), s_zip (#216)]
+    │                                   │       ├── read rows: 0
+    │                                   │       ├── read size: 0
+    │                                   │       ├── partitions total: 0
+    │                                   │       ├── partitions scanned: 0
+    │                                   │       ├── push downs: [filters: [], limit: NONE]
+    │                                   │       └── estimated rows: 402.00
+    │                                   └── HashJoin(Probe)
+    │                                       ├── output columns: [store_sales.ss_customer_sk (#3), store_sales.ss_cdemo_sk (#4), store_sales.ss_addr_sk (#6), store_sales.ss_store_sk (#7), store_sales.ss_promo_sk (#8), item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113)]
+    │                                       ├── join type: INNER
+    │                                       ├── build keys: [hd1.hd_demo_sk (#275)]
+    │                                       ├── probe keys: [store_sales.ss_hdemo_sk (#5)]
+    │                                       ├── keys is null equal: [false]
+    │                                       ├── filters: []
+    │                                       ├── build join filters:
+    │                                       │   └── filter id:8, build key:hd1.hd_demo_sk (#275), probe targets:[store_sales.ss_hdemo_sk (#5)@scan0], filter type:bloom,inlist,min_max
+    │                                       ├── estimated rows: 33928881.81
+    │                                       ├── Exchange(Build)
+    │                                       │   ├── output columns: [hd1.hd_demo_sk (#275)]
+    │                                       │   ├── exchange type: Broadcast
+    │                                       │   └── HashJoin
+    │                                       │       ├── output columns: [hd1.hd_demo_sk (#275)]
+    │                                       │       ├── join type: INNER
+    │                                       │       ├── build keys: [ib1.ib_income_band_sk (#311)]
+    │                                       │       ├── probe keys: [hd1.hd_income_band_sk (#276)]
+    │                                       │       ├── keys is null equal: [false]
+    │                                       │       ├── filters: []
+    │                                       │       ├── build join filters:
+    │                                       │       │   └── filter id:7, build key:ib1.ib_income_band_sk (#311), probe targets:[hd1.hd_income_band_sk (#276)@scan12], filter type:bloom,inlist,min_max
+    │                                       │       ├── estimated rows: 7200.00
+    │                                       │       ├── Exchange(Build)
+    │                                       │       │   ├── output columns: [ib1.ib_income_band_sk (#311)]
+    │                                       │       │   ├── exchange type: Broadcast
+    │                                       │       │   └── TableScan
+    │                                       │       │       ├── table: default.default.income_band
+    │                                       │       │       ├── scan id: 16
+    │                                       │       │       ├── output columns: [ib_income_band_sk (#311)]
+    │                                       │       │       ├── read rows: 0
+    │                                       │       │       ├── read size: 0
+    │                                       │       │       ├── partitions total: 0
+    │                                       │       │       ├── partitions scanned: 0
+    │                                       │       │       ├── push downs: [filters: [], limit: NONE]
+    │                                       │       │       └── estimated rows: 20.00
+    │                                       │       └── TableScan(Probe)
+    │                                       │           ├── table: default.default.household_demographics
+    │                                       │           ├── scan id: 12
+    │                                       │           ├── output columns: [hd_demo_sk (#275), hd_income_band_sk (#276)]
+    │                                       │           ├── read rows: 0
+    │                                       │           ├── read size: 0
+    │                                       │           ├── partitions total: 0
+    │                                       │           ├── partitions scanned: 0
+    │                                       │           ├── push downs: [filters: [], limit: NONE]
+    │                                       │           ├── apply join filters: [#7]
+    │                                       │           └── estimated rows: 7200.00
+    │                                       └── HashJoin(Probe)
+    │                                           ├── output columns: [store_sales.ss_customer_sk (#3), store_sales.ss_cdemo_sk (#4), store_sales.ss_hdemo_sk (#5), store_sales.ss_addr_sk (#6), store_sales.ss_store_sk (#7), store_sales.ss_promo_sk (#8), item.i_product_name (#338), item.i_item_sk (#317), d1.d_year (#113)]
+    │                                           ├── join type: INNER
+    │                                           ├── build keys: [d1.d_date_sk (#107)]
+    │                                           ├── probe keys: [store_sales.ss_sold_date_sk (#0)]
+    │                                           ├── keys is null equal: [false]
+    │                                           ├── filters: []
+    │                                           ├── build join filters:
+    │                                           │   └── filter id:6, build key:d1.d_date_sk (#107), probe targets:[store_sales.ss_sold_date_sk (#0)@scan0], filter type:bloom,inlist,min_max
+    │                                           ├── estimated rows: 35527272.67
+    │                                           ├── Exchange(Build)
+    │                                           │   ├── output columns: [d1.d_date_sk (#107), d1.d_year (#113)]
+    │                                           │   ├── exchange type: Broadcast
+    │                                           │   └── TableScan
+    │                                           │       ├── table: default.default.date_dim
+    │                                           │       ├── scan id: 4
+    │                                           │       ├── output columns: [d_date_sk (#107), d_year (#113)]
+    │                                           │       ├── read rows: 0
+    │                                           │       ├── read size: 0
+    │                                           │       ├── partitions total: 0
+    │                                           │       ├── partitions scanned: 0
+    │                                           │       ├── push downs: [filters: [], limit: NONE]
+    │                                           │       └── estimated rows: 73049.00
+    │                                           └── HashJoin(Probe)
+    │                                               ├── output columns: [store_sales.ss_sold_date_sk (#0), store_sales.ss_customer_sk (#3), store_sales.ss_cdemo_sk (#4), store_sales.ss_hdemo_sk (#5), store_sales.ss_addr_sk (#6), store_sales.ss_store_sk (#7), store_sales.ss_promo_sk (#8), item.i_product_name (#338), item.i_item_sk (#317)]
+    │                                               ├── join type: INNER
+    │                                               ├── build keys: [item.i_item_sk (#317), store_returns.sr_ticket_number (#32)]
+    │                                               ├── probe keys: [store_sales.ss_item_sk (#2), store_sales.ss_ticket_number (#9)]
+    │                                               ├── keys is null equal: [false, false]
+    │                                               ├── filters: []
+    │                                               ├── build join filters:
+    │                                               │   ├── filter id:4, build key:item.i_item_sk (#317), probe targets:[store_sales.ss_item_sk (#2)@scan0], filter type:bloom,inlist,min_max
+    │                                               │   └── filter id:5, build key:store_returns.sr_ticket_number (#32), probe targets:[store_sales.ss_ticket_number (#9)@scan0], filter type:bloom,inlist,min_max
+    │                                               ├── estimated rows: 37200677.85
+    │                                               ├── Exchange(Build)
+    │                                               │   ├── output columns: [store_returns.sr_ticket_number (#32), item.i_product_name (#338), item.i_item_sk (#317)]
+    │                                               │   ├── exchange type: Broadcast
+    │                                               │   └── HashJoin
+    │                                               │       ├── output columns: [store_returns.sr_ticket_number (#32), item.i_product_name (#338), item.i_item_sk (#317)]
+    │                                               │       ├── join type: INNER
+    │                                               │       ├── build keys: [item.i_item_sk (#317)]
+    │                                               │       ├── probe keys: [store_returns.sr_item_sk (#25)]
+    │                                               │       ├── keys is null equal: [false]
+    │                                               │       ├── filters: []
+    │                                               │       ├── build join filters:
+    │                                               │       │   └── filter id:3, build key:item.i_item_sk (#317), probe targets:[store_returns.sr_item_sk (#25)@scan1], filter type:bloom,inlist,min_max
+    │                                               │       ├── estimated rows: 2737509.14
+    │                                               │       ├── Exchange(Build)
+    │                                               │       │   ├── output columns: [item.i_product_name (#338), item.i_item_sk (#317)]
+    │                                               │       │   ├── exchange type: Broadcast
+    │                                               │       │   └── HashJoin
+    │                                               │       │       ├── output columns: [item.i_product_name (#338), item.i_item_sk (#317)]
+    │                                               │       │       ├── join type: INNER
+    │                                               │       │       ├── build keys: [item.i_item_sk (#317)]
+    │                                               │       │       ├── probe keys: [cs_ui.cs_item_sk (#58)]
+    │                                               │       │       ├── keys is null equal: [false]
+    │                                               │       │       ├── filters: []
+    │                                               │       │       ├── build join filters(distributed):
+    │                                               │       │       │   └── filter id:2, build key:item.i_item_sk (#317), probe targets:[cs_ui.cs_item_sk (#58)@scan2, catalog_returns.cr_item_sk (#79)@scan3], filter type:bloom,inlist,min_max
+    │                                               │       │       ├── estimated rows: 18150.03
+    │                                               │       │       ├── Exchange(Build)
+    │                                               │       │       │   ├── output columns: [item.i_item_sk (#317), item.i_product_name (#338)]
+    │                                               │       │       │   ├── exchange type: Hash(item.i_item_sk (#317))
+    │                                               │       │       │   └── TableScan
+    │                                               │       │       │       ├── table: default.default.item
+    │                                               │       │       │       ├── scan id: 18
+    │                                               │       │       │       ├── output columns: [i_item_sk (#317), i_product_name (#338)]
+    │                                               │       │       │       ├── read rows: 0
+    │                                               │       │       │       ├── read size: 0
+    │                                               │       │       │       ├── partitions total: 0
+    │                                               │       │       │       ├── partitions scanned: 0
+    │                                               │       │       │       ├── push downs: [filters: [contains(['blanched', 'medium', 'brown', 'chocolate', 'burlywood', 'drab'], item.i_color (#334)) and item.i_current_price (#322) >= 23 and item.i_current_price (#322) <= 33 and item.i_current_price (#322) >= 24 and item.i_current_price (#322) <= 38], limit: NONE]
+    │                                               │       │       │       └── estimated rows: 18150.03
+    │                                               │       │       └── Exchange(Probe)
+    │                                               │       │           ├── output columns: [catalog_sales.cs_item_sk (#58)]
+    │                                               │       │           ├── exchange type: Hash(cs_ui.cs_item_sk (#58))
+    │                                               │       │           └── Filter
+    │                                               │       │               ├── output columns: [catalog_sales.cs_item_sk (#58)]
+    │                                               │       │               ├── filters: [is_true(sum(cs_ext_list_price) (#104) > 2 * sum(cr_refunded_cash + cr_reversed_charge + cr_store_credit) (#106))]
+    │                                               │       │               ├── estimated rows: 38183.00
+    │                                               │       │               └── AggregateFinal
+    │                                               │       │                   ├── output columns: [sum(cs_ext_list_price) (#104), sum(cr_refunded_cash + cr_reversed_charge + cr_store_credit) (#106), catalog_sales.cs_item_sk (#58)]
+    │                                               │       │                   ├── group by: [cs_item_sk]
+    │                                               │       │                   ├── aggregate functions: [sum(cs_ext_list_price), sum(sum_arg_0)]
+    │                                               │       │                   ├── estimated rows: 190915.00
+    │                                               │       │                   └── Exchange
+    │                                               │       │                       ├── output columns: [sum(cs_ext_list_price) (#104), sum(cr_refunded_cash + cr_reversed_charge + cr_store_credit) (#106), catalog_sales.cs_item_sk (#58)]
+    │                                               │       │                       ├── exchange type: Hash(0)
+    │                                               │       │                       └── AggregatePartial
+    │                                               │       │                           ├── group by: [cs_item_sk]
+    │                                               │       │                           ├── aggregate functions: [sum(cs_ext_list_price), sum(sum_arg_0)]
+    │                                               │       │                           ├── estimated rows: 190915.00
+    │                                               │       │                           └── EvalScalar
+    │                                               │       │                               ├── output columns: [catalog_sales.cs_item_sk (#58), catalog_sales.cs_ext_list_price (#68), sum_arg_0 (#105)]
+    │                                               │       │                               ├── expressions: [catalog_returns.cr_refunded_cash (#100) + catalog_returns.cr_reversed_charge (#101) + catalog_returns.cr_store_credit (#102)]
+    │                                               │       │                               ├── estimated rows: 143856507.94
+    │                                               │       │                               └── HashJoin
+    │                                               │       │                                   ├── output columns: [catalog_sales.cs_item_sk (#58), catalog_sales.cs_ext_list_price (#68), catalog_returns.cr_refunded_cash (#100), catalog_returns.cr_reversed_charge (#101), catalog_returns.cr_store_credit (#102)]
+    │                                               │       │                                   ├── join type: INNER
+    │                                               │       │                                   ├── build keys: [catalog_returns.cr_item_sk (#79), catalog_returns.cr_order_number (#93)]
+    │                                               │       │                                   ├── probe keys: [catalog_sales.cs_item_sk (#58), catalog_sales.cs_order_number (#60)]
+    │                                               │       │                                   ├── keys is null equal: [false, false]
+    │                                               │       │                                   ├── filters: []
+    │                                               │       │                                   ├── build join filters:
+    │                                               │       │                                   │   ├── filter id:0, build key:catalog_returns.cr_item_sk (#79), probe targets:[catalog_sales.cs_item_sk (#58)@scan2], filter type:bloom,inlist,min_max
+    │                                               │       │                                   │   └── filter id:1, build key:catalog_returns.cr_order_number (#93), probe targets:[catalog_sales.cs_order_number (#60)@scan2], filter type:bloom,inlist,min_max
+    │                                               │       │                                   ├── estimated rows: 143856507.94
+    │                                               │       │                                   ├── Exchange(Build)
+    │                                               │       │                                   │   ├── output columns: [catalog_returns.cr_item_sk (#79), catalog_returns.cr_order_number (#93), catalog_returns.cr_refunded_cash (#100), catalog_returns.cr_reversed_charge (#101), catalog_returns.cr_store_credit (#102)]
+    │                                               │       │                                   │   ├── exchange type: Broadcast
+    │                                               │       │                                   │   └── TableScan
+    │                                               │       │                                   │       ├── table: default.default.catalog_returns
+    │                                               │       │                                   │       ├── scan id: 3
+    │                                               │       │                                   │       ├── output columns: [cr_item_sk (#79), cr_order_number (#93), cr_refunded_cash (#100), cr_reversed_charge (#101), cr_store_credit (#102)]
+    │                                               │       │                                   │       ├── read rows: 0
+    │                                               │       │                                   │       ├── read size: 0
+    │                                               │       │                                   │       ├── partitions total: 0
+    │                                               │       │                                   │       ├── partitions scanned: 0
+    │                                               │       │                                   │       ├── push downs: [filters: [], limit: NONE]
+    │                                               │       │                                   │       ├── apply join filters: [#2]
+    │                                               │       │                                   │       └── estimated rows: 14404374.00
+    │                                               │       │                                   └── TableScan(Probe)
+    │                                               │       │                                       ├── table: default.default.catalog_sales
+    │                                               │       │                                       ├── scan id: 2
+    │                                               │       │                                       ├── output columns: [cs_item_sk (#58), cs_order_number (#60), cs_ext_list_price (#68)]
+    │                                               │       │                                       ├── read rows: 0
+    │                                               │       │                                       ├── read size: 0
+    │                                               │       │                                       ├── partitions total: 0
+    │                                               │       │                                       ├── partitions scanned: 0
+    │                                               │       │                                       ├── push downs: [filters: [], limit: NONE]
+    │                                               │       │                                       ├── apply join filters: [#2, #0, #1]
+    │                                               │       │                                       └── estimated rows: 143997065.00
+    │                                               │       └── TableScan(Probe)
+    │                                               │           ├── table: default.default.store_returns
+    │                                               │           ├── scan id: 1
+    │                                               │           ├── output columns: [sr_item_sk (#25), sr_ticket_number (#32)]
+    │                                               │           ├── read rows: 0
+    │                                               │           ├── read size: 0
+    │                                               │           ├── partitions total: 0
+    │                                               │           ├── partitions scanned: 0
+    │                                               │           ├── push downs: [filters: [], limit: NONE]
+    │                                               │           ├── apply join filters: [#3]
+    │                                               │           └── estimated rows: 28795080.00
+    │                                               └── TableScan(Probe)
+    │                                                   ├── table: default.default.store_sales
+    │                                                   ├── scan id: 0
+    │                                                   ├── output columns: [ss_sold_date_sk (#0), ss_item_sk (#2), ss_customer_sk (#3), ss_cdemo_sk (#4), ss_hdemo_sk (#5), ss_addr_sk (#6), ss_store_sk (#7), ss_promo_sk (#8), ss_ticket_number (#9)]
+    │                                                   ├── read rows: 0
+    │                                                   ├── read size: 0
+    │                                                   ├── partitions total: 0
+    │                                                   ├── partitions scanned: 0
+    │                                                   ├── push downs: [filters: [], limit: NONE]
+    │                                                   ├── apply join filters: [#19, #12, #11, #10, #9, #8, #6, #4, #5]
+    │                                                   └── estimated rows: 287997024.00
     └── HashJoin
         ├── output columns: [item.i_item_sk (#660)]
         ├── join type: INNER
@@ -495,19 +489,19 @@ Exchange
         │   ├── filter id:20, build key:cs2.item_sk (#1003), probe targets:[cs1.item_sk (#660)@scan37], filter type:bloom,inlist,min_max
         │   ├── filter id:21, build key:cs2.store_name (#882), probe targets:[cs1.store_name (#539)@scan26], filter type:bloom,inlist,min_max
         │   └── filter id:22, build key:cs2.store_zip (#902), probe targets:[cs1.store_zip (#559)@scan26], filter type:bloom,inlist,min_max
-        ├── estimated rows: 1.20
+        ├── estimated rows: 90932943580.15
         ├── Exchange(Build)
         │   ├── output columns: [store.s_store_name (#882), store.s_zip (#902), item.i_item_sk (#1003)]
         │   ├── exchange type: Hash(cs2.item_sk (#1003), cs2.store_name (#882), cs2.store_zip (#902))
         │   └── MaterializeCTERef
         │       ├── cte_name: cross_sales
         │       ├── cte_schema: [s_store_name (#882), s_zip (#902), i_item_sk (#1003)]
-        │       └── estimated rows: 1.21
+        │       └── estimated rows: 40561782.71
         └── Exchange(Probe)
             ├── output columns: [store.s_store_name (#539), store.s_zip (#559), item.i_item_sk (#660)]
             ├── exchange type: Hash(cs1.item_sk (#660), cs1.store_name (#539), cs1.store_zip (#559))
             └── MaterializeCTERef
                 ├── cte_name: cross_sales
                 ├── cte_schema: [s_store_name (#539), s_zip (#559), i_item_sk (#660)]
-                └── estimated rows: 1.21
+                └── estimated rows: 40561782.71
 

--- a/src/query/sql/tests/it/optimizer/join_cardinality/equal_pair_estimates.txt
+++ b/src/query/sql/tests/it/optimizer/join_cardinality/equal_pair_estimates.txt
@@ -1,0 +1,288 @@
+=== inner ===
+description: Equal pair estimates with opposite side coverage combine all conditions independently of ON order.
+sql           : SELECT * FROM l INNER JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2
+left ddl      : CREATE TABLE l(k1 INT NOT NULL, k2 INT NOT NULL)
+left rows     : 100
+input stat    : left.k1 min=1, max=100, ndv=Some(100), null=0
+input stat    : left.k2 min=1, max=10, ndv=Some(10), null=0
+right ddl      : CREATE TABLE r(k1 INT NOT NULL, k2 INT NOT NULL)
+right rows     : 100
+input stat    : right.k1 min=1, max=10, ndv=Some(10), null=0
+input stat    : right.k2 min=1, max=100, ndv=Some(100), null=0
+join          : INNER cardinality=100.000
+stat          : l.k1 (#0) min=1, max=10, ndv=10.000, null=0.000, histogram=rows=100.000, ndv=10.000, buckets=[1..1:10.000/1.000, 2..2:10.000/1.000, 3..3:10.000/1.000, 4..4:10.000/1.000, 5..5:10.000/1.000, 6..6:10.000/1.000, 7..7:10.000/1.000, 8..8:10.000/1.000, 9..9:10.000/1.000, 10..10:10.000/1.000]
+stat          : l.k2 (#1) min=1, max=10, ndv=10.000, null=0.000, histogram=rows=100.000, ndv=10.000, buckets=[1..1:10.000/1.000, 2..2:10.000/1.000, 3..3:10.000/1.000, 4..4:10.000/1.000, 5..5:10.000/1.000, 6..6:10.000/1.000, 7..7:10.000/1.000, 8..8:10.000/1.000, 9..9:10.000/1.000, 10..10:10.000/1.000]
+stat          : r.k1 (#2) min=1, max=10, ndv=10.000, null=0.000, histogram=rows=100.000, ndv=10.000, buckets=[1..1:10.000/1.000, 2..2:10.000/1.000, 3..3:10.000/1.000, 4..4:10.000/1.000, 5..5:10.000/1.000, 6..6:10.000/1.000, 7..7:10.000/1.000, 8..8:10.000/1.000, 9..9:10.000/1.000, 10..10:10.000/1.000]
+stat          : r.k2 (#3) min=1, max=10, ndv=10.000, null=0.000, histogram=rows=100.000, ndv=10.000, buckets=[1..1:10.000/1.000, 2..2:10.000/1.000, 3..3:10.000/1.000, 4..4:10.000/1.000, 5..5:10.000/1.000, 6..6:10.000/1.000, 7..7:10.000/1.000, 8..8:10.000/1.000, 9..9:10.000/1.000, 10..10:10.000/1.000]
+
+=== inner ===
+description: Equal pair estimates with opposite side coverage combine all conditions independently of ON order.
+sql           : SELECT * FROM l INNER JOIN r ON l.k2 = r.k2 AND l.k1 = r.k1
+left ddl      : CREATE TABLE l(k1 INT NOT NULL, k2 INT NOT NULL)
+left rows     : 100
+input stat    : left.k1 min=1, max=100, ndv=Some(100), null=0
+input stat    : left.k2 min=1, max=10, ndv=Some(10), null=0
+right ddl      : CREATE TABLE r(k1 INT NOT NULL, k2 INT NOT NULL)
+right rows     : 100
+input stat    : right.k1 min=1, max=10, ndv=Some(10), null=0
+input stat    : right.k2 min=1, max=100, ndv=Some(100), null=0
+join          : INNER cardinality=100.000
+stat          : l.k1 (#0) min=1, max=10, ndv=10.000, null=0.000, histogram=rows=100.000, ndv=10.000, buckets=[1..1:10.000/1.000, 2..2:10.000/1.000, 3..3:10.000/1.000, 4..4:10.000/1.000, 5..5:10.000/1.000, 6..6:10.000/1.000, 7..7:10.000/1.000, 8..8:10.000/1.000, 9..9:10.000/1.000, 10..10:10.000/1.000]
+stat          : l.k2 (#1) min=1, max=10, ndv=10.000, null=0.000, histogram=rows=100.000, ndv=10.000, buckets=[1..1:10.000/1.000, 2..2:10.000/1.000, 3..3:10.000/1.000, 4..4:10.000/1.000, 5..5:10.000/1.000, 6..6:10.000/1.000, 7..7:10.000/1.000, 8..8:10.000/1.000, 9..9:10.000/1.000, 10..10:10.000/1.000]
+stat          : r.k1 (#2) min=1, max=10, ndv=10.000, null=0.000, histogram=rows=100.000, ndv=10.000, buckets=[1..1:10.000/1.000, 2..2:10.000/1.000, 3..3:10.000/1.000, 4..4:10.000/1.000, 5..5:10.000/1.000, 6..6:10.000/1.000, 7..7:10.000/1.000, 8..8:10.000/1.000, 9..9:10.000/1.000, 10..10:10.000/1.000]
+stat          : r.k2 (#3) min=1, max=10, ndv=10.000, null=0.000, histogram=rows=100.000, ndv=10.000, buckets=[1..1:10.000/1.000, 2..2:10.000/1.000, 3..3:10.000/1.000, 4..4:10.000/1.000, 5..5:10.000/1.000, 6..6:10.000/1.000, 7..7:10.000/1.000, 8..8:10.000/1.000, 9..9:10.000/1.000, 10..10:10.000/1.000]
+
+=== left_semi ===
+description: Equal pair estimates with opposite side coverage combine all conditions independently of ON order.
+sql           : SELECT * FROM l LEFT SEMI JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2
+left ddl      : CREATE TABLE l(k1 INT NOT NULL, k2 INT NOT NULL)
+left rows     : 100
+input stat    : left.k1 min=1, max=100, ndv=Some(100), null=0
+input stat    : left.k2 min=1, max=10, ndv=Some(10), null=0
+right ddl      : CREATE TABLE r(k1 INT NOT NULL, k2 INT NOT NULL)
+right rows     : 100
+input stat    : right.k1 min=1, max=10, ndv=Some(10), null=0
+input stat    : right.k2 min=1, max=100, ndv=Some(100), null=0
+join          : LEFT SEMI cardinality=10.000
+stat          : l.k1 (#0) min=1, max=10, ndv=10.000, null=0.000, histogram=rows=10.000, ndv=10.000, buckets=[1..1:1.000/1.000, 2..2:1.000/1.000, 3..3:1.000/1.000, 4..4:1.000/1.000, 5..5:1.000/1.000, 6..6:1.000/1.000, 7..7:1.000/1.000, 8..8:1.000/1.000, 9..9:1.000/1.000, 10..10:1.000/1.000]
+stat          : l.k2 (#1) min=1, max=10, ndv=6.513 (upper=10.000), null=0.000, histogram=rows=10.000, ndv=6.513, buckets=[1..1:1.000/1.000, 2..2:1.000/1.000, 3..3:1.000/1.000, 4..4:1.000/1.000, 5..5:1.000/1.000, 6..6:1.000/1.000, 7..7:1.000/1.000, 8..8:1.000/1.000, 9..9:1.000/1.000, 10..10:1.000/1.000]
+stat          : r.k1 (#2) min=1, max=10, ndv=10.000, null=0.000, histogram=none
+stat          : r.k2 (#3) min=1, max=10, ndv=10.000, null=0.000, histogram=none
+
+=== left_semi ===
+description: Equal pair estimates with opposite side coverage combine all conditions independently of ON order.
+sql           : SELECT * FROM l LEFT SEMI JOIN r ON l.k2 = r.k2 AND l.k1 = r.k1
+left ddl      : CREATE TABLE l(k1 INT NOT NULL, k2 INT NOT NULL)
+left rows     : 100
+input stat    : left.k1 min=1, max=100, ndv=Some(100), null=0
+input stat    : left.k2 min=1, max=10, ndv=Some(10), null=0
+right ddl      : CREATE TABLE r(k1 INT NOT NULL, k2 INT NOT NULL)
+right rows     : 100
+input stat    : right.k1 min=1, max=10, ndv=Some(10), null=0
+input stat    : right.k2 min=1, max=100, ndv=Some(100), null=0
+join          : LEFT SEMI cardinality=10.000
+stat          : l.k1 (#0) min=1, max=10, ndv=10.000, null=0.000, histogram=rows=10.000, ndv=10.000, buckets=[1..1:1.000/1.000, 2..2:1.000/1.000, 3..3:1.000/1.000, 4..4:1.000/1.000, 5..5:1.000/1.000, 6..6:1.000/1.000, 7..7:1.000/1.000, 8..8:1.000/1.000, 9..9:1.000/1.000, 10..10:1.000/1.000]
+stat          : l.k2 (#1) min=1, max=10, ndv=6.513 (upper=10.000), null=0.000, histogram=rows=10.000, ndv=6.513, buckets=[1..1:1.000/1.000, 2..2:1.000/1.000, 3..3:1.000/1.000, 4..4:1.000/1.000, 5..5:1.000/1.000, 6..6:1.000/1.000, 7..7:1.000/1.000, 8..8:1.000/1.000, 9..9:1.000/1.000, 10..10:1.000/1.000]
+stat          : r.k1 (#2) min=1, max=10, ndv=10.000, null=0.000, histogram=none
+stat          : r.k2 (#3) min=1, max=10, ndv=10.000, null=0.000, histogram=none
+
+=== right_semi ===
+description: Equal pair estimates with opposite side coverage combine all conditions independently of ON order.
+sql           : SELECT * FROM l RIGHT SEMI JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2
+left ddl      : CREATE TABLE l(k1 INT NOT NULL, k2 INT NOT NULL)
+left rows     : 100
+input stat    : left.k1 min=1, max=100, ndv=Some(100), null=0
+input stat    : left.k2 min=1, max=10, ndv=Some(10), null=0
+right ddl      : CREATE TABLE r(k1 INT NOT NULL, k2 INT NOT NULL)
+right rows     : 100
+input stat    : right.k1 min=1, max=10, ndv=Some(10), null=0
+input stat    : right.k2 min=1, max=100, ndv=Some(100), null=0
+join          : LEFT SEMI cardinality=10.000
+stat          : l.k1 (#0) min=1, max=10, ndv=10.000, null=0.000, histogram=none
+stat          : l.k2 (#1) min=1, max=10, ndv=10.000, null=0.000, histogram=none
+stat          : r.k1 (#2) min=1, max=10, ndv=6.513 (upper=10.000), null=0.000, histogram=rows=10.000, ndv=6.513, buckets=[1..1:1.000/1.000, 2..2:1.000/1.000, 3..3:1.000/1.000, 4..4:1.000/1.000, 5..5:1.000/1.000, 6..6:1.000/1.000, 7..7:1.000/1.000, 8..8:1.000/1.000, 9..9:1.000/1.000, 10..10:1.000/1.000]
+stat          : r.k2 (#3) min=1, max=10, ndv=10.000, null=0.000, histogram=rows=10.000, ndv=10.000, buckets=[1..1:1.000/1.000, 2..2:1.000/1.000, 3..3:1.000/1.000, 4..4:1.000/1.000, 5..5:1.000/1.000, 6..6:1.000/1.000, 7..7:1.000/1.000, 8..8:1.000/1.000, 9..9:1.000/1.000, 10..10:1.000/1.000]
+
+=== right_semi ===
+description: Equal pair estimates with opposite side coverage combine all conditions independently of ON order.
+sql           : SELECT * FROM l RIGHT SEMI JOIN r ON l.k2 = r.k2 AND l.k1 = r.k1
+left ddl      : CREATE TABLE l(k1 INT NOT NULL, k2 INT NOT NULL)
+left rows     : 100
+input stat    : left.k1 min=1, max=100, ndv=Some(100), null=0
+input stat    : left.k2 min=1, max=10, ndv=Some(10), null=0
+right ddl      : CREATE TABLE r(k1 INT NOT NULL, k2 INT NOT NULL)
+right rows     : 100
+input stat    : right.k1 min=1, max=10, ndv=Some(10), null=0
+input stat    : right.k2 min=1, max=100, ndv=Some(100), null=0
+join          : LEFT SEMI cardinality=10.000
+stat          : l.k1 (#0) min=1, max=10, ndv=10.000, null=0.000, histogram=none
+stat          : l.k2 (#1) min=1, max=10, ndv=10.000, null=0.000, histogram=none
+stat          : r.k1 (#2) min=1, max=10, ndv=6.513 (upper=10.000), null=0.000, histogram=rows=10.000, ndv=6.513, buckets=[1..1:1.000/1.000, 2..2:1.000/1.000, 3..3:1.000/1.000, 4..4:1.000/1.000, 5..5:1.000/1.000, 6..6:1.000/1.000, 7..7:1.000/1.000, 8..8:1.000/1.000, 9..9:1.000/1.000, 10..10:1.000/1.000]
+stat          : r.k2 (#3) min=1, max=10, ndv=10.000, null=0.000, histogram=rows=10.000, ndv=10.000, buckets=[1..1:1.000/1.000, 2..2:1.000/1.000, 3..3:1.000/1.000, 4..4:1.000/1.000, 5..5:1.000/1.000, 6..6:1.000/1.000, 7..7:1.000/1.000, 8..8:1.000/1.000, 9..9:1.000/1.000, 10..10:1.000/1.000]
+
+=== left_anti ===
+description: Equal pair estimates with opposite side coverage combine all conditions independently of ON order.
+sql           : SELECT * FROM l LEFT ANTI JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2
+left ddl      : CREATE TABLE l(k1 INT NOT NULL, k2 INT NOT NULL)
+left rows     : 100
+input stat    : left.k1 min=1, max=100, ndv=Some(100), null=0
+input stat    : left.k2 min=1, max=10, ndv=Some(10), null=0
+right ddl      : CREATE TABLE r(k1 INT NOT NULL, k2 INT NOT NULL)
+right rows     : 100
+input stat    : right.k1 min=1, max=10, ndv=Some(10), null=0
+input stat    : right.k2 min=1, max=100, ndv=Some(100), null=0
+join          : LEFT ANTI cardinality=90.000
+stat          : l.k1 (#0) min=1, max=100, ndv=90.000, null=0.000, histogram=none
+stat          : l.k2 (#1) min=1, max=10, ndv=10.000, null=0.000, histogram=none
+stat          : r.k1 (#2) min=1, max=10, ndv=10.000, null=0.000, histogram=none
+stat          : r.k2 (#3) min=1, max=100, ndv=90.000, null=0.000, histogram=none
+
+=== left_anti ===
+description: Equal pair estimates with opposite side coverage combine all conditions independently of ON order.
+sql           : SELECT * FROM l LEFT ANTI JOIN r ON l.k2 = r.k2 AND l.k1 = r.k1
+left ddl      : CREATE TABLE l(k1 INT NOT NULL, k2 INT NOT NULL)
+left rows     : 100
+input stat    : left.k1 min=1, max=100, ndv=Some(100), null=0
+input stat    : left.k2 min=1, max=10, ndv=Some(10), null=0
+right ddl      : CREATE TABLE r(k1 INT NOT NULL, k2 INT NOT NULL)
+right rows     : 100
+input stat    : right.k1 min=1, max=10, ndv=Some(10), null=0
+input stat    : right.k2 min=1, max=100, ndv=Some(100), null=0
+join          : LEFT ANTI cardinality=90.000
+stat          : l.k1 (#0) min=1, max=100, ndv=90.000, null=0.000, histogram=none
+stat          : l.k2 (#1) min=1, max=10, ndv=10.000, null=0.000, histogram=none
+stat          : r.k1 (#2) min=1, max=10, ndv=10.000, null=0.000, histogram=none
+stat          : r.k2 (#3) min=1, max=100, ndv=90.000, null=0.000, histogram=none
+
+=== right_anti ===
+description: Equal pair estimates with opposite side coverage combine all conditions independently of ON order.
+sql           : SELECT * FROM l RIGHT ANTI JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2
+left ddl      : CREATE TABLE l(k1 INT NOT NULL, k2 INT NOT NULL)
+left rows     : 100
+input stat    : left.k1 min=1, max=100, ndv=Some(100), null=0
+input stat    : left.k2 min=1, max=10, ndv=Some(10), null=0
+right ddl      : CREATE TABLE r(k1 INT NOT NULL, k2 INT NOT NULL)
+right rows     : 100
+input stat    : right.k1 min=1, max=10, ndv=Some(10), null=0
+input stat    : right.k2 min=1, max=100, ndv=Some(100), null=0
+join          : LEFT ANTI cardinality=90.000
+stat          : l.k1 (#0) min=1, max=100, ndv=90.000, null=0.000, histogram=none
+stat          : l.k2 (#1) min=1, max=10, ndv=10.000, null=0.000, histogram=none
+stat          : r.k1 (#2) min=1, max=10, ndv=10.000, null=0.000, histogram=none
+stat          : r.k2 (#3) min=1, max=100, ndv=90.000, null=0.000, histogram=none
+
+=== right_anti ===
+description: Equal pair estimates with opposite side coverage combine all conditions independently of ON order.
+sql           : SELECT * FROM l RIGHT ANTI JOIN r ON l.k2 = r.k2 AND l.k1 = r.k1
+left ddl      : CREATE TABLE l(k1 INT NOT NULL, k2 INT NOT NULL)
+left rows     : 100
+input stat    : left.k1 min=1, max=100, ndv=Some(100), null=0
+input stat    : left.k2 min=1, max=10, ndv=Some(10), null=0
+right ddl      : CREATE TABLE r(k1 INT NOT NULL, k2 INT NOT NULL)
+right rows     : 100
+input stat    : right.k1 min=1, max=10, ndv=Some(10), null=0
+input stat    : right.k2 min=1, max=100, ndv=Some(100), null=0
+join          : LEFT ANTI cardinality=90.000
+stat          : l.k1 (#0) min=1, max=100, ndv=90.000, null=0.000, histogram=none
+stat          : l.k2 (#1) min=1, max=10, ndv=10.000, null=0.000, histogram=none
+stat          : r.k1 (#2) min=1, max=10, ndv=10.000, null=0.000, histogram=none
+stat          : r.k2 (#3) min=1, max=100, ndv=90.000, null=0.000, histogram=none
+
+=== left_outer ===
+description: Equal pair estimates with opposite side coverage combine all conditions independently of ON order.
+sql           : SELECT * FROM l LEFT JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2
+left ddl      : CREATE TABLE l(k1 INT NOT NULL, k2 INT NOT NULL)
+left rows     : 100
+input stat    : left.k1 min=1, max=100, ndv=Some(100), null=0
+input stat    : left.k2 min=1, max=10, ndv=Some(10), null=0
+right ddl      : CREATE TABLE r(k1 INT NOT NULL, k2 INT NOT NULL)
+right rows     : 100
+input stat    : right.k1 min=1, max=10, ndv=Some(10), null=0
+input stat    : right.k2 min=1, max=100, ndv=Some(100), null=0
+join          : LEFT OUTER cardinality=190.000
+stat          : l.k1 (#0) min=1, max=100, ndv=100.000, null=0.000, histogram=none
+stat          : l.k2 (#1) min=1, max=10, ndv=10.000, null=0.000, histogram=none
+stat          : r.k1 (#2) min=1, max=10, ndv=6.513 (upper=10.000), null=90.000, histogram=none
+stat          : r.k2 (#3) min=1, max=100, ndv=10.000, null=90.000, histogram=none
+stat          : k1 (#4) min=1, max=10, ndv=10.000, null=90.000, histogram=none
+stat          : k2 (#5) min=1, max=10, ndv=10.000, null=90.000, histogram=none
+
+=== left_outer ===
+description: Equal pair estimates with opposite side coverage combine all conditions independently of ON order.
+sql           : SELECT * FROM l LEFT JOIN r ON l.k2 = r.k2 AND l.k1 = r.k1
+left ddl      : CREATE TABLE l(k1 INT NOT NULL, k2 INT NOT NULL)
+left rows     : 100
+input stat    : left.k1 min=1, max=100, ndv=Some(100), null=0
+input stat    : left.k2 min=1, max=10, ndv=Some(10), null=0
+right ddl      : CREATE TABLE r(k1 INT NOT NULL, k2 INT NOT NULL)
+right rows     : 100
+input stat    : right.k1 min=1, max=10, ndv=Some(10), null=0
+input stat    : right.k2 min=1, max=100, ndv=Some(100), null=0
+join          : LEFT OUTER cardinality=190.000
+stat          : l.k1 (#0) min=1, max=100, ndv=100.000, null=0.000, histogram=none
+stat          : l.k2 (#1) min=1, max=10, ndv=10.000, null=0.000, histogram=none
+stat          : r.k1 (#2) min=1, max=10, ndv=6.513 (upper=10.000), null=90.000, histogram=none
+stat          : r.k2 (#3) min=1, max=100, ndv=10.000, null=90.000, histogram=none
+stat          : k1 (#4) min=1, max=10, ndv=10.000, null=90.000, histogram=none
+stat          : k2 (#5) min=1, max=10, ndv=10.000, null=90.000, histogram=none
+
+=== right_outer ===
+description: Equal pair estimates with opposite side coverage combine all conditions independently of ON order.
+sql           : SELECT * FROM l RIGHT JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2
+left ddl      : CREATE TABLE l(k1 INT NOT NULL, k2 INT NOT NULL)
+left rows     : 100
+input stat    : left.k1 min=1, max=100, ndv=Some(100), null=0
+input stat    : left.k2 min=1, max=10, ndv=Some(10), null=0
+right ddl      : CREATE TABLE r(k1 INT NOT NULL, k2 INT NOT NULL)
+right rows     : 100
+input stat    : right.k1 min=1, max=10, ndv=Some(10), null=0
+input stat    : right.k2 min=1, max=100, ndv=Some(100), null=0
+join          : LEFT OUTER cardinality=190.000
+stat          : l.k1 (#0) min=1, max=100, ndv=10.000, null=90.000, histogram=none
+stat          : l.k2 (#1) min=1, max=10, ndv=6.513 (upper=10.000), null=90.000, histogram=none
+stat          : r.k1 (#2) min=1, max=10, ndv=10.000, null=0.000, histogram=none
+stat          : r.k2 (#3) min=1, max=100, ndv=100.000, null=0.000, histogram=none
+stat          : k1 (#4) min=1, max=10, ndv=10.000, null=90.000, histogram=none
+stat          : k2 (#5) min=1, max=10, ndv=10.000, null=90.000, histogram=none
+
+=== right_outer ===
+description: Equal pair estimates with opposite side coverage combine all conditions independently of ON order.
+sql           : SELECT * FROM l RIGHT JOIN r ON l.k2 = r.k2 AND l.k1 = r.k1
+left ddl      : CREATE TABLE l(k1 INT NOT NULL, k2 INT NOT NULL)
+left rows     : 100
+input stat    : left.k1 min=1, max=100, ndv=Some(100), null=0
+input stat    : left.k2 min=1, max=10, ndv=Some(10), null=0
+right ddl      : CREATE TABLE r(k1 INT NOT NULL, k2 INT NOT NULL)
+right rows     : 100
+input stat    : right.k1 min=1, max=10, ndv=Some(10), null=0
+input stat    : right.k2 min=1, max=100, ndv=Some(100), null=0
+join          : LEFT OUTER cardinality=190.000
+stat          : l.k1 (#0) min=1, max=100, ndv=10.000, null=90.000, histogram=none
+stat          : l.k2 (#1) min=1, max=10, ndv=6.513 (upper=10.000), null=90.000, histogram=none
+stat          : r.k1 (#2) min=1, max=10, ndv=10.000, null=0.000, histogram=none
+stat          : r.k2 (#3) min=1, max=100, ndv=100.000, null=0.000, histogram=none
+stat          : k1 (#4) min=1, max=10, ndv=10.000, null=90.000, histogram=none
+stat          : k2 (#5) min=1, max=10, ndv=10.000, null=90.000, histogram=none
+
+=== full_outer ===
+description: Equal pair estimates with opposite side coverage combine all conditions independently of ON order.
+sql           : SELECT * FROM l FULL JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2
+left ddl      : CREATE TABLE l(k1 INT NOT NULL, k2 INT NOT NULL)
+left rows     : 100
+input stat    : left.k1 min=1, max=100, ndv=Some(100), null=0
+input stat    : left.k2 min=1, max=10, ndv=Some(10), null=0
+right ddl      : CREATE TABLE r(k1 INT NOT NULL, k2 INT NOT NULL)
+right rows     : 100
+input stat    : right.k1 min=1, max=10, ndv=Some(10), null=0
+input stat    : right.k2 min=1, max=100, ndv=Some(100), null=0
+join          : FULL OUTER cardinality=280.000
+stat          : l.k1 (#0) min=1, max=100, ndv=100.000, null=90.000, histogram=none
+stat          : l.k2 (#1) min=1, max=10, ndv=10.000, null=90.000, histogram=none
+stat          : r.k1 (#2) min=1, max=10, ndv=10.000, null=90.000, histogram=none
+stat          : r.k2 (#3) min=1, max=100, ndv=100.000, null=90.000, histogram=none
+stat          : k1 (#4) min=1, max=100, ndv=100.000, null=90.000, histogram=none
+stat          : k2 (#5) min=1, max=10, ndv=10.000, null=90.000, histogram=none
+stat          : k1 (#6) min=1, max=10, ndv=10.000, null=90.000, histogram=none
+stat          : k2 (#7) min=1, max=100, ndv=100.000, null=90.000, histogram=none
+
+=== full_outer ===
+description: Equal pair estimates with opposite side coverage combine all conditions independently of ON order.
+sql           : SELECT * FROM l FULL JOIN r ON l.k2 = r.k2 AND l.k1 = r.k1
+left ddl      : CREATE TABLE l(k1 INT NOT NULL, k2 INT NOT NULL)
+left rows     : 100
+input stat    : left.k1 min=1, max=100, ndv=Some(100), null=0
+input stat    : left.k2 min=1, max=10, ndv=Some(10), null=0
+right ddl      : CREATE TABLE r(k1 INT NOT NULL, k2 INT NOT NULL)
+right rows     : 100
+input stat    : right.k1 min=1, max=10, ndv=Some(10), null=0
+input stat    : right.k2 min=1, max=100, ndv=Some(100), null=0
+join          : FULL OUTER cardinality=280.000
+stat          : l.k1 (#0) min=1, max=100, ndv=100.000, null=90.000, histogram=none
+stat          : l.k2 (#1) min=1, max=10, ndv=10.000, null=90.000, histogram=none
+stat          : r.k1 (#2) min=1, max=10, ndv=10.000, null=90.000, histogram=none
+stat          : r.k2 (#3) min=1, max=100, ndv=100.000, null=90.000, histogram=none
+stat          : k1 (#4) min=1, max=100, ndv=100.000, null=90.000, histogram=none
+stat          : k2 (#5) min=1, max=10, ndv=10.000, null=90.000, histogram=none
+stat          : k1 (#6) min=1, max=10, ndv=10.000, null=90.000, histogram=none
+stat          : k2 (#7) min=1, max=100, ndv=100.000, null=90.000, histogram=none
+

--- a/src/query/sql/tests/it/optimizer/join_cardinality/statistics.rs
+++ b/src/query/sql/tests/it/optimizer/join_cardinality/statistics.rs
@@ -154,6 +154,77 @@ async fn test_join_statistics_boundaries_golden() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_equal_pair_estimates_are_order_independent() -> Result<()> {
+    let mut file = open_golden_file("optimizer", "join_cardinality/equal_pair_estimates.txt")?;
+    for (name, join_type, queries) in [
+        ("inner", JoinType::Inner, [
+            "SELECT * FROM l INNER JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2",
+            "SELECT * FROM l INNER JOIN r ON l.k2 = r.k2 AND l.k1 = r.k1",
+        ]),
+        ("left_semi", JoinType::LeftSemi, [
+            "SELECT * FROM l LEFT SEMI JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2",
+            "SELECT * FROM l LEFT SEMI JOIN r ON l.k2 = r.k2 AND l.k1 = r.k1",
+        ]),
+        ("right_semi", JoinType::LeftSemi, [
+            "SELECT * FROM l RIGHT SEMI JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2",
+            "SELECT * FROM l RIGHT SEMI JOIN r ON l.k2 = r.k2 AND l.k1 = r.k1",
+        ]),
+        ("left_anti", JoinType::LeftAnti, [
+            "SELECT * FROM l LEFT ANTI JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2",
+            "SELECT * FROM l LEFT ANTI JOIN r ON l.k2 = r.k2 AND l.k1 = r.k1",
+        ]),
+        ("right_anti", JoinType::LeftAnti, [
+            "SELECT * FROM l RIGHT ANTI JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2",
+            "SELECT * FROM l RIGHT ANTI JOIN r ON l.k2 = r.k2 AND l.k1 = r.k1",
+        ]),
+        ("left_outer", JoinType::Left, [
+            "SELECT * FROM l LEFT JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2",
+            "SELECT * FROM l LEFT JOIN r ON l.k2 = r.k2 AND l.k1 = r.k1",
+        ]),
+        ("right_outer", JoinType::Left, [
+            "SELECT * FROM l RIGHT JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2",
+            "SELECT * FROM l RIGHT JOIN r ON l.k2 = r.k2 AND l.k1 = r.k1",
+        ]),
+        ("full_outer", JoinType::Full, [
+            "SELECT * FROM l FULL JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2",
+            "SELECT * FROM l FULL JOIN r ON l.k2 = r.k2 AND l.k1 = r.k1",
+        ]),
+    ] {
+        let mut estimates = Vec::new();
+        for sql in queries {
+            let case = SqlJoinStatisticsCase {
+                name,
+                description: "Equal pair estimates with opposite side coverage combine all conditions independently of ON order.",
+                sql,
+                expected_join_type: join_type,
+                left: sql_join_table("CREATE TABLE l(k1 INT NOT NULL, k2 INT NOT NULL)", 100, [
+                    (
+                        "k1",
+                        r#"{"min": 1, "max": 100, "ndv": 100, "null_count": 0}"#,
+                    ),
+                    ("k2", r#"{"min": 1, "max": 10, "ndv": 10, "null_count": 0}"#),
+                ])?,
+                right: sql_join_table("CREATE TABLE r(k1 INT NOT NULL, k2 INT NOT NULL)", 100, [
+                    ("k1", r#"{"min": 1, "max": 10, "ndv": 10, "null_count": 0}"#),
+                    (
+                        "k2",
+                        r#"{"min": 1, "max": 100, "ndv": 100, "null_count": 0}"#,
+                    ),
+                ])?,
+            };
+            let mut output = Vec::new();
+            write_sql_join_statistics_case(&mut output, &case).await?;
+            file.write_all(&output)?;
+            let output = String::from_utf8(output).unwrap();
+            estimates.push(output.split_once("join          :").unwrap().1.to_owned());
+        }
+        // Compare both cardinality and every propagated column statistic.
+        assert_eq!(estimates[0], estimates[1], "condition order changed {name}");
+    }
+    Ok(())
+}
+
 fn sql_join_statistics_cases() -> Result<Vec<SqlJoinStatisticsCase>> {
     Ok(vec![
         SqlJoinStatisticsCase {
@@ -439,7 +510,7 @@ fn sql_join_statistics_cases() -> Result<Vec<SqlJoinStatisticsCase>> {
         },
         SqlJoinStatisticsCase {
             name: "inner_two_key_equality",
-            description: "Multiple equality keys are applied cumulatively; a disjoint second key eliminates matches after the first key has narrowed statistics.",
+            description: "A disjoint equality key eliminates matches even when other keys overlap.",
             sql: "SELECT * FROM l INNER JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2",
             expected_join_type: JoinType::Inner,
             left: sql_join_table("CREATE TABLE l(k1 INT NOT NULL, k2 INT NOT NULL)", 100, [
@@ -452,8 +523,8 @@ fn sql_join_statistics_cases() -> Result<Vec<SqlJoinStatisticsCase>> {
             ])?,
         },
         SqlJoinStatisticsCase {
-            name: "inner_three_key_combined_decay",
-            description: "Three non-zero equality estimates use exponential backoff, then retain and scale every estimated equality-key histogram to the combined cardinality.",
+            name: "inner_three_key_strongest_condition",
+            description: "Three non-zero equality estimates use the strongest condition, then retain and scale every estimated equality-key histogram to the output cardinality.",
             sql: "SELECT * FROM l INNER JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2 AND l.k3 = r.k3",
             expected_join_type: JoinType::Inner,
             left: sql_join_table(
@@ -476,7 +547,7 @@ fn sql_join_statistics_cases() -> Result<Vec<SqlJoinStatisticsCase>> {
             )?,
         },
         SqlJoinStatisticsCase {
-            name: "inner_three_key_combined_decay_reordered",
+            name: "inner_three_key_strongest_condition_reordered",
             description: "Reordering the same three equality conditions leaves the combined cardinality and propagated column distributions unchanged.",
             sql: "SELECT * FROM l INNER JOIN r ON l.k3 = r.k3 AND l.k1 = r.k1 AND l.k2 = r.k2",
             expected_join_type: JoinType::Inner,
@@ -562,8 +633,8 @@ fn sql_join_statistics_cases() -> Result<Vec<SqlJoinStatisticsCase>> {
             )?,
         },
         SqlJoinStatisticsCase {
-            name: "inner_unknown_non_equi_uses_default_decay",
-            description: "A residual comparison between varying columns uses the default 0.5 selectivity in exponential-backoff cardinality and NDV scaling while leaving equality histogram propagation intact.",
+            name: "inner_unknown_non_equi_strongest_condition",
+            description: "A residual comparison between varying columns uses the default 0.5 selectivity; the strongest condition determines cardinality while equality histogram propagation remains intact.",
             sql: "SELECT * FROM l INNER JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2 AND l.k1 > r.k2",
             expected_join_type: JoinType::Inner,
             left: sql_join_table("CREATE TABLE l(k1 INT NOT NULL, k2 INT NOT NULL)", 100, [
@@ -579,8 +650,8 @@ fn sql_join_statistics_cases() -> Result<Vec<SqlJoinStatisticsCase>> {
             ])?,
         },
         SqlJoinStatisticsCase {
-            name: "inner_modeled_non_equi_joins_combined_decay",
-            description: "A cross-side residual comparison with a singleton operand has numeric selectivity, so it joins the equality estimate in exponential-backoff cardinality and NDV scaling while leaving equality histogram propagation intact.",
+            name: "inner_modeled_non_equi_preserves_ndv",
+            description: "A weaker residual comparison does not further reduce equality-key or non-key NDVs when backoff is disabled; equality histograms retain the strongest-condition row count.",
             sql: "SELECT * FROM l INNER JOIN r ON l.id = r.id AND l.k > r.c",
             expected_join_type: JoinType::Inner,
             left: sql_join_table("CREATE TABLE l(id INT NOT NULL, k INT NOT NULL)", 100, [
@@ -861,8 +932,8 @@ fn sql_join_statistics_cases() -> Result<Vec<SqlJoinStatisticsCase>> {
             )?,
         },
         SqlJoinStatisticsCase {
-            name: "left_semi_two_key_combined_decay",
-            description: "Multiple equality keys apply exponential backoff to preserved-side matched rows, then retain and scale every estimated equality-key histogram on that side.",
+            name: "left_semi_two_key_strongest_condition",
+            description: "Multiple equality keys combine preserved-side coverage using its minimum estimate, then scale equality-key histograms to the output.",
             sql: "SELECT * FROM l LEFT SEMI JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2",
             expected_join_type: JoinType::LeftSemi,
             left: sql_join_table("CREATE TABLE l(k1 INT NOT NULL, k2 INT NOT NULL)", 10, [
@@ -875,8 +946,8 @@ fn sql_join_statistics_cases() -> Result<Vec<SqlJoinStatisticsCase>> {
             ])?,
         },
         SqlJoinStatisticsCase {
-            name: "left_anti_two_key_combines_histogram_uncertainty",
-            description: "ANTI combines matched rows and histogram uncertainty from every equality key before applying its conservative overlap reserve.",
+            name: "left_anti_two_key_combined_histogram_uncertainty",
+            description: "ANTI combines matched and confirmed rows from all equality conditions before applying its conservative overlap reserve.",
             sql: "SELECT * FROM l LEFT ANTI JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2",
             expected_join_type: JoinType::LeftAnti,
             left: sql_join_table_with_histograms(

--- a/src/query/sql/tests/it/optimizer/join_cardinality/statistics.txt
+++ b/src/query/sql/tests/it/optimizer/join_cardinality/statistics.txt
@@ -249,7 +249,7 @@ stat          : payload (#1) all_null=true, null=10.000, histogram=none
 stat          : r.k (#2) min=1, max=10, ndv=10.000, null=0.000, histogram=rows=10.000, ndv=10.000, buckets=[1..1:1.000/1.000, 2..2:1.000/1.000, 3..3:1.000/1.000, 4..4:1.000/1.000, 5..5:1.000/1.000, 6..6:1.000/1.000, 7..7:1.000/1.000, 8..8:1.000/1.000, 9..9:1.000/1.000, 10..10:1.000/1.000]
 
 === inner_two_key_equality ===
-description: Multiple equality keys are applied cumulatively; a disjoint second key eliminates matches after the first key has narrowed statistics.
+description: A disjoint equality key eliminates matches even when other keys overlap.
 sql           : SELECT * FROM l INNER JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2
 left ddl      : CREATE TABLE l(k1 INT NOT NULL, k2 INT NOT NULL)
 left rows     : 100
@@ -261,8 +261,8 @@ input stat    : right.k1 min=1, max=10, ndv=Some(10), null=0
 input stat    : right.k2 min=20, max=21, ndv=Some(2), null=0
 join          : INNER cardinality=0.000
 
-=== inner_three_key_combined_decay ===
-description: Three non-zero equality estimates use exponential backoff, then retain and scale every estimated equality-key histogram to the combined cardinality.
+=== inner_three_key_strongest_condition ===
+description: Three non-zero equality estimates use the strongest condition, then retain and scale every estimated equality-key histogram to the output cardinality.
 sql           : SELECT * FROM l INNER JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2 AND l.k3 = r.k3
 left ddl      : CREATE TABLE l(k1 INT NOT NULL, k2 INT NOT NULL, k3 INT NOT NULL)
 left rows     : 10
@@ -274,15 +274,15 @@ right rows     : 10
 input stat    : right.k1 min=1, max=4, ndv=Some(4), null=0
 input stat    : right.k2 min=1, max=10, ndv=Some(10), null=0
 input stat    : right.k3 min=1, max=2, ndv=Some(2), null=0
-join          : INNER cardinality=4.204
-stat          : l.k1 (#0) min=1, max=4, ndv=2.735 (upper=4.000), null=0.000, histogram=rows=4.204, ndv=2.735, buckets=[1..1:1.051/1.000, 2..2:1.051/1.000, 3..3:1.051/1.000, 4..4:1.051/1.000]
-stat          : l.k2 (#1) min=1, max=10, ndv=4.204, null=0.000, histogram=rows=4.204, ndv=4.204, buckets=[1..1:0.420/1.000, 2..2:0.420/1.000, 3..3:0.420/1.000, 4..4:0.420/1.000, 5..5:0.420/1.000, 6..6:0.420/1.000, 7..7:0.420/1.000, 8..8:0.420/1.000, 9..9:0.420/1.000, 10..10:0.420/1.000]
-stat          : l.k3 (#2) min=1, max=2, ndv=1.777 (upper=2.000), null=0.000, histogram=rows=4.204, ndv=1.777, buckets=[1..1:2.102/1.000, 2..2:2.102/1.000]
-stat          : r.k1 (#3) min=1, max=4, ndv=2.735 (upper=4.000), null=0.000, histogram=rows=4.204, ndv=2.735, buckets=[1..1:1.051/1.000, 2..2:1.051/1.000, 3..3:1.051/1.000, 4..4:1.051/1.000]
-stat          : r.k2 (#4) min=1, max=10, ndv=4.204, null=0.000, histogram=rows=4.204, ndv=4.204, buckets=[1..1:0.420/1.000, 2..2:0.420/1.000, 3..3:0.420/1.000, 4..4:0.420/1.000, 5..5:0.420/1.000, 6..6:0.420/1.000, 7..7:0.420/1.000, 8..8:0.420/1.000, 9..9:0.420/1.000, 10..10:0.420/1.000]
-stat          : r.k3 (#5) min=1, max=2, ndv=1.777 (upper=2.000), null=0.000, histogram=rows=4.204, ndv=1.777, buckets=[1..1:2.102/1.000, 2..2:2.102/1.000]
+join          : INNER cardinality=10.000
+stat          : l.k1 (#0) min=1, max=4, ndv=3.836 (upper=4.000), null=0.000, histogram=rows=10.000, ndv=3.836, buckets=[1..1:2.500/1.000, 2..2:2.500/1.000, 3..3:2.500/1.000, 4..4:2.500/1.000]
+stat          : l.k2 (#1) min=1, max=10, ndv=10.000, null=0.000, histogram=rows=10.000, ndv=10.000, buckets=[1..1:1.000/1.000, 2..2:1.000/1.000, 3..3:1.000/1.000, 4..4:1.000/1.000, 5..5:1.000/1.000, 6..6:1.000/1.000, 7..7:1.000/1.000, 8..8:1.000/1.000, 9..9:1.000/1.000, 10..10:1.000/1.000]
+stat          : l.k3 (#2) min=1, max=2, ndv=1.992 (upper=2.000), null=0.000, histogram=rows=10.000, ndv=1.992, buckets=[1..1:5.000/1.000, 2..2:5.000/1.000]
+stat          : r.k1 (#3) min=1, max=4, ndv=3.836 (upper=4.000), null=0.000, histogram=rows=10.000, ndv=3.836, buckets=[1..1:2.500/1.000, 2..2:2.500/1.000, 3..3:2.500/1.000, 4..4:2.500/1.000]
+stat          : r.k2 (#4) min=1, max=10, ndv=10.000, null=0.000, histogram=rows=10.000, ndv=10.000, buckets=[1..1:1.000/1.000, 2..2:1.000/1.000, 3..3:1.000/1.000, 4..4:1.000/1.000, 5..5:1.000/1.000, 6..6:1.000/1.000, 7..7:1.000/1.000, 8..8:1.000/1.000, 9..9:1.000/1.000, 10..10:1.000/1.000]
+stat          : r.k3 (#5) min=1, max=2, ndv=1.992 (upper=2.000), null=0.000, histogram=rows=10.000, ndv=1.992, buckets=[1..1:5.000/1.000, 2..2:5.000/1.000]
 
-=== inner_three_key_combined_decay_reordered ===
+=== inner_three_key_strongest_condition_reordered ===
 description: Reordering the same three equality conditions leaves the combined cardinality and propagated column distributions unchanged.
 sql           : SELECT * FROM l INNER JOIN r ON l.k3 = r.k3 AND l.k1 = r.k1 AND l.k2 = r.k2
 left ddl      : CREATE TABLE l(k1 INT NOT NULL, k2 INT NOT NULL, k3 INT NOT NULL)
@@ -295,13 +295,13 @@ right rows     : 10
 input stat    : right.k1 min=1, max=4, ndv=Some(4), null=0
 input stat    : right.k2 min=1, max=10, ndv=Some(10), null=0
 input stat    : right.k3 min=1, max=2, ndv=Some(2), null=0
-join          : INNER cardinality=4.204
-stat          : l.k1 (#0) min=1, max=4, ndv=2.735 (upper=4.000), null=0.000, histogram=rows=4.204, ndv=2.735, buckets=[1..1:1.051/1.000, 2..2:1.051/1.000, 3..3:1.051/1.000, 4..4:1.051/1.000]
-stat          : l.k2 (#1) min=1, max=10, ndv=4.204, null=0.000, histogram=rows=4.204, ndv=4.204, buckets=[1..1:0.420/1.000, 2..2:0.420/1.000, 3..3:0.420/1.000, 4..4:0.420/1.000, 5..5:0.420/1.000, 6..6:0.420/1.000, 7..7:0.420/1.000, 8..8:0.420/1.000, 9..9:0.420/1.000, 10..10:0.420/1.000]
-stat          : l.k3 (#2) min=1, max=2, ndv=1.777 (upper=2.000), null=0.000, histogram=rows=4.204, ndv=1.777, buckets=[1..1:2.102/1.000, 2..2:2.102/1.000]
-stat          : r.k1 (#3) min=1, max=4, ndv=2.735 (upper=4.000), null=0.000, histogram=rows=4.204, ndv=2.735, buckets=[1..1:1.051/1.000, 2..2:1.051/1.000, 3..3:1.051/1.000, 4..4:1.051/1.000]
-stat          : r.k2 (#4) min=1, max=10, ndv=4.204, null=0.000, histogram=rows=4.204, ndv=4.204, buckets=[1..1:0.420/1.000, 2..2:0.420/1.000, 3..3:0.420/1.000, 4..4:0.420/1.000, 5..5:0.420/1.000, 6..6:0.420/1.000, 7..7:0.420/1.000, 8..8:0.420/1.000, 9..9:0.420/1.000, 10..10:0.420/1.000]
-stat          : r.k3 (#5) min=1, max=2, ndv=1.777 (upper=2.000), null=0.000, histogram=rows=4.204, ndv=1.777, buckets=[1..1:2.102/1.000, 2..2:2.102/1.000]
+join          : INNER cardinality=10.000
+stat          : l.k1 (#0) min=1, max=4, ndv=3.836 (upper=4.000), null=0.000, histogram=rows=10.000, ndv=3.836, buckets=[1..1:2.500/1.000, 2..2:2.500/1.000, 3..3:2.500/1.000, 4..4:2.500/1.000]
+stat          : l.k2 (#1) min=1, max=10, ndv=10.000, null=0.000, histogram=rows=10.000, ndv=10.000, buckets=[1..1:1.000/1.000, 2..2:1.000/1.000, 3..3:1.000/1.000, 4..4:1.000/1.000, 5..5:1.000/1.000, 6..6:1.000/1.000, 7..7:1.000/1.000, 8..8:1.000/1.000, 9..9:1.000/1.000, 10..10:1.000/1.000]
+stat          : l.k3 (#2) min=1, max=2, ndv=1.992 (upper=2.000), null=0.000, histogram=rows=10.000, ndv=1.992, buckets=[1..1:5.000/1.000, 2..2:5.000/1.000]
+stat          : r.k1 (#3) min=1, max=4, ndv=3.836 (upper=4.000), null=0.000, histogram=rows=10.000, ndv=3.836, buckets=[1..1:2.500/1.000, 2..2:2.500/1.000, 3..3:2.500/1.000, 4..4:2.500/1.000]
+stat          : r.k2 (#4) min=1, max=10, ndv=10.000, null=0.000, histogram=rows=10.000, ndv=10.000, buckets=[1..1:1.000/1.000, 2..2:1.000/1.000, 3..3:1.000/1.000, 4..4:1.000/1.000, 5..5:1.000/1.000, 6..6:1.000/1.000, 7..7:1.000/1.000, 8..8:1.000/1.000, 9..9:1.000/1.000, 10..10:1.000/1.000]
+stat          : r.k3 (#5) min=1, max=2, ndv=1.992 (upper=2.000), null=0.000, histogram=rows=10.000, ndv=1.992, buckets=[1..1:5.000/1.000, 2..2:5.000/1.000]
 
 === inner_repeated_column_uses_most_selective_histogram ===
 description: When one column participates in multiple equality expressions, its most selective local expression supplies the histogram and the combined selectivity scales every propagated equality-key histogram.
@@ -313,10 +313,10 @@ right ddl      : CREATE TABLE r(k1 SMALLINT NOT NULL, k2 INT NOT NULL)
 right rows     : 1000
 input stat    : right.k1 min=5, max=104, ndv=Some(100), null=0
 input stat    : right.k2 min=1, max=10, ndv=Some(10), null=0
-join          : INNER cardinality=189.737
-stat          : l.k (#0) min=5, max=10, ndv=6.000, null=0.000, histogram=rows=189.737, ndv=6.000, buckets=[5..5:31.623/1.000, 6..6:31.623/1.000, 7..7:31.623/1.000, 8..8:31.623/1.000, 9..9:31.623/1.000, 10..10:31.623/1.000]
-stat          : r.k1 (#1) min=5, max=10, ndv=6.000, null=0.000, histogram=rows=189.737, ndv=6.000, buckets=[5..5:31.623/1.000, 6..6:31.623/1.000, 7..7:31.623/1.000, 8..8:31.623/1.000, 9..9:31.623/1.000, 10..10:31.623/1.000]
-stat          : r.k2 (#2) min=1, max=10, ndv=10.000 (upper=10.000), null=0.000, histogram=rows=189.737, ndv=10.000, buckets=[1..1:18.974/1.000, 2..2:18.974/1.000, 3..3:18.974/1.000, 4..4:18.974/1.000, 5..5:18.974/1.000, 6..6:18.974/1.000, 7..7:18.974/1.000, 8..8:18.974/1.000, 9..9:18.974/1.000, 10..10:18.974/1.000]
+join          : INNER cardinality=600.000
+stat          : l.k (#0) min=5, max=10, ndv=6.000, null=0.000, histogram=rows=600.000, ndv=6.000, buckets=[5..5:100.000/1.000, 6..6:100.000/1.000, 7..7:100.000/1.000, 8..8:100.000/1.000, 9..9:100.000/1.000, 10..10:100.000/1.000]
+stat          : r.k1 (#1) min=5, max=10, ndv=6.000, null=0.000, histogram=rows=600.000, ndv=6.000, buckets=[5..5:100.000/1.000, 6..6:100.000/1.000, 7..7:100.000/1.000, 8..8:100.000/1.000, 9..9:100.000/1.000, 10..10:100.000/1.000]
+stat          : r.k2 (#2) min=1, max=10, ndv=10.000, null=0.000, histogram=rows=600.000, ndv=10.000, buckets=[1..1:60.000/1.000, 2..2:60.000/1.000, 3..3:60.000/1.000, 4..4:60.000/1.000, 5..5:60.000/1.000, 6..6:60.000/1.000, 7..7:60.000/1.000, 8..8:60.000/1.000, 9..9:60.000/1.000, 10..10:60.000/1.000]
 
 === inner_repeated_identity_column_combines_distributions ===
 description: When one identity column participates in multiple direct equalities, all matched distributions narrow its bounds while the most selective equality supplies its histogram shape.
@@ -328,10 +328,10 @@ right ddl      : CREATE TABLE r(k1 INT NOT NULL, k2 INT NOT NULL)
 right rows     : 1000
 input stat    : right.k1 min=10, max=80, ndv=Some(71), null=0
 input stat    : right.k2 min=30, max=1000, ndv=Some(971), null=0
-join          : INNER cardinality=1.462
-stat          : l.k (#0) min=30, max=80, ndv=1.462 (upper=1.462), null=0.000, histogram=rows=1.462, ndv=1.462, bucket_count=51, buckets=[30..30:0.029/0.205, 31..31:0.029/0.205, 32..32:0.029/0.205, ..., 78..78:0.029/0.205, 79..79:0.029/0.205, 80..80:0.029/0.205]
-stat          : r.k1 (#1) min=10, max=80, ndv=1.453 (upper=1.462), null=0.000, histogram=rows=1.462, ndv=1.453, bucket_count=71, buckets=[10..10:0.021/1.000, 11..11:0.021/1.000, 12..12:0.021/1.000, ..., 78..78:0.021/1.000, 79..79:0.021/1.000, 80..80:0.021/1.000]
-stat          : r.k2 (#2) min=30, max=100, ndv=1.462 (upper=1.462), null=0.000, histogram=rows=1.462, ndv=1.462, bucket_count=71, buckets=[30..30:0.021/0.205, 31..31:0.021/0.205, 32..32:0.021/0.205, ..., 98..98:0.021/0.205, 99..99:0.021/0.205, 100..100:0.021/0.205]
+join          : INNER cardinality=14.624
+stat          : l.k (#0) min=30, max=80, ndv=10.471, null=0.000, histogram=rows=14.624, ndv=10.471, bucket_count=51, buckets=[30..30:0.287/0.205, 31..31:0.287/0.205, 32..32:0.287/0.205, ..., 78..78:0.287/0.205, 79..79:0.287/0.205, 80..80:0.287/0.205]
+stat          : r.k1 (#1) min=10, max=80, ndv=13.672 (upper=14.624), null=0.000, histogram=rows=14.624, ndv=13.672, bucket_count=71, buckets=[10..10:0.206/1.000, 11..11:0.206/1.000, 12..12:0.206/1.000, ..., 78..78:0.206/1.000, 79..79:0.206/1.000, 80..80:0.206/1.000]
+stat          : r.k2 (#2) min=30, max=100, ndv=14.577 (upper=14.624), null=0.000, histogram=rows=14.624, ndv=14.577, bucket_count=71, buckets=[30..30:0.206/0.205, 31..31:0.206/0.205, 32..32:0.206/0.205, ..., 98..98:0.206/0.205, 99..99:0.206/0.205, 100..100:0.206/0.205]
 
 === inner_repeated_column_complex_winner_blocks_source_histogram ===
 description: When a complex equality expression is more selective than a direct equality using the same source column, it affects cardinality but cannot supply that source column's histogram.
@@ -343,13 +343,13 @@ right ddl      : CREATE TABLE r(k1 SMALLINT NOT NULL, k2 INT NOT NULL)
 right rows     : 1000
 input stat    : right.k1 min=1, max=10, ndv=Some(10), null=0
 input stat    : right.k2 min=1, max=1000, ndv=Some(1000), null=0
-join          : INNER cardinality=10.000
+join          : INNER cardinality=100.000
 stat          : l.k (#0) min=1, max=10, ndv=10.000, null=0.000, histogram=none
-stat          : r.k1 (#1) min=1, max=10, ndv=6.340 (upper=10.000), null=0.000, histogram=rows=10.000, ndv=6.340, buckets=[1..1:1.000/1.000, 2..2:1.000/1.000, 3..3:1.000/1.000, 4..4:1.000/1.000, 5..5:1.000/1.000, 6..6:1.000/1.000, 7..7:1.000/1.000, 8..8:1.000/1.000, 9..9:1.000/1.000, 10..10:1.000/1.000]
-stat          : r.k2 (#2) min=1, max=100, ndv=10.000, null=0.000, histogram=rows=10.000, ndv=10.000, buckets=[1..10:1.000/10.000, 11..20:1.000/10.000, 21..30:1.000/10.000, 31..40:1.000/10.000, 41..50:1.000/10.000, 51..60:1.000/10.000, 61..70:1.000/10.000, 71..80:1.000/10.000, 81..90:1.000/10.000, 91..100:1.000/10.000]
+stat          : r.k1 (#1) min=1, max=10, ndv=10.000 (upper=10.000), null=0.000, histogram=rows=100.000, ndv=10.000, buckets=[1..1:10.000/1.000, 2..2:10.000/1.000, 3..3:10.000/1.000, 4..4:10.000/1.000, 5..5:10.000/1.000, 6..6:10.000/1.000, 7..7:10.000/1.000, 8..8:10.000/1.000, 9..9:10.000/1.000, 10..10:10.000/1.000]
+stat          : r.k2 (#2) min=1, max=100, ndv=100.000, null=0.000, histogram=rows=100.000, ndv=100.000, buckets=[1..10:10.000/10.000, 11..20:10.000/10.000, 21..30:10.000/10.000, 31..40:10.000/10.000, 41..50:10.000/10.000, 51..60:10.000/10.000, 61..70:10.000/10.000, 71..80:10.000/10.000, 81..90:10.000/10.000, 91..100:10.000/10.000]
 
-=== inner_unknown_non_equi_uses_default_decay ===
-description: A residual comparison between varying columns uses the default 0.5 selectivity in exponential-backoff cardinality and NDV scaling while leaving equality histogram propagation intact.
+=== inner_unknown_non_equi_strongest_condition ===
+description: A residual comparison between varying columns uses the default 0.5 selectivity; the strongest condition determines cardinality while equality histogram propagation remains intact.
 sql           : SELECT * FROM l INNER JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2 AND l.k1 > r.k2
 left ddl      : CREATE TABLE l(k1 INT NOT NULL, k2 INT NOT NULL)
 left rows     : 100
@@ -359,14 +359,14 @@ right ddl      : CREATE TABLE r(k1 INT NOT NULL, k2 INT NOT NULL)
 right rows     : 100
 input stat    : right.k1 min=1, max=10, ndv=Some(10), null=0
 input stat    : right.k2 min=1, max=10, ndv=Some(10), null=0
-join          : INNER cardinality=26.591
-stat          : l.k1 (#0) min=1, max=10, ndv=7.071, null=0.000, histogram=rows=26.591, ndv=9.546, buckets=[1..1:2.659/1.000, 2..2:2.659/1.000, 3..3:2.659/1.000, 4..4:2.659/1.000, 5..5:2.659/1.000, 6..6:2.659/1.000, 7..7:2.659/1.000, 8..8:2.659/1.000, 9..9:2.659/1.000, 10..10:2.659/1.000]
-stat          : l.k2 (#1) min=1, max=10, ndv=7.071, null=0.000, histogram=rows=26.591, ndv=9.325, buckets=[1..1:2.659/1.000, 2..2:2.659/1.000, 3..3:2.659/1.000, 4..4:2.659/1.000, 5..5:2.659/1.000, 6..6:2.659/1.000, 7..7:2.659/1.000, 8..8:2.659/1.000, 9..9:2.659/1.000, 10..10:2.659/1.000]
-stat          : r.k1 (#2) min=1, max=10, ndv=9.546 (upper=10.000), null=0.000, histogram=rows=26.591, ndv=9.546, buckets=[1..1:2.659/1.000, 2..2:2.659/1.000, 3..3:2.659/1.000, 4..4:2.659/1.000, 5..5:2.659/1.000, 6..6:2.659/1.000, 7..7:2.659/1.000, 8..8:2.659/1.000, 9..9:2.659/1.000, 10..10:2.659/1.000]
-stat          : r.k2 (#3) min=1, max=10, ndv=9.325 (upper=10.000), null=0.000, histogram=rows=26.591, ndv=9.325, buckets=[1..1:2.659/1.000, 2..2:2.659/1.000, 3..3:2.659/1.000, 4..4:2.659/1.000, 5..5:2.659/1.000, 6..6:2.659/1.000, 7..7:2.659/1.000, 8..8:2.659/1.000, 9..9:2.659/1.000, 10..10:2.659/1.000]
+join          : INNER cardinality=100.000
+stat          : l.k1 (#0) min=1, max=10, ndv=10.000, null=0.000, histogram=rows=100.000, ndv=10.000, buckets=[1..1:10.000/1.000, 2..2:10.000/1.000, 3..3:10.000/1.000, 4..4:10.000/1.000, 5..5:10.000/1.000, 6..6:10.000/1.000, 7..7:10.000/1.000, 8..8:10.000/1.000, 9..9:10.000/1.000, 10..10:10.000/1.000]
+stat          : l.k2 (#1) min=1, max=10, ndv=10.000 (upper=10.000), null=0.000, histogram=rows=100.000, ndv=10.000, buckets=[1..1:10.000/1.000, 2..2:10.000/1.000, 3..3:10.000/1.000, 4..4:10.000/1.000, 5..5:10.000/1.000, 6..6:10.000/1.000, 7..7:10.000/1.000, 8..8:10.000/1.000, 9..9:10.000/1.000, 10..10:10.000/1.000]
+stat          : r.k1 (#2) min=1, max=10, ndv=10.000, null=0.000, histogram=rows=100.000, ndv=10.000, buckets=[1..1:10.000/1.000, 2..2:10.000/1.000, 3..3:10.000/1.000, 4..4:10.000/1.000, 5..5:10.000/1.000, 6..6:10.000/1.000, 7..7:10.000/1.000, 8..8:10.000/1.000, 9..9:10.000/1.000, 10..10:10.000/1.000]
+stat          : r.k2 (#3) min=1, max=10, ndv=10.000 (upper=10.000), null=0.000, histogram=rows=100.000, ndv=10.000, buckets=[1..1:10.000/1.000, 2..2:10.000/1.000, 3..3:10.000/1.000, 4..4:10.000/1.000, 5..5:10.000/1.000, 6..6:10.000/1.000, 7..7:10.000/1.000, 8..8:10.000/1.000, 9..9:10.000/1.000, 10..10:10.000/1.000]
 
-=== inner_modeled_non_equi_joins_combined_decay ===
-description: A cross-side residual comparison with a singleton operand has numeric selectivity, so it joins the equality estimate in exponential-backoff cardinality and NDV scaling while leaving equality histogram propagation intact.
+=== inner_modeled_non_equi_preserves_ndv ===
+description: A weaker residual comparison does not further reduce equality-key or non-key NDVs when backoff is disabled; equality histograms retain the strongest-condition row count.
 sql           : SELECT * FROM l INNER JOIN r ON l.id = r.id AND l.k > r.c
 left ddl      : CREATE TABLE l(id INT NOT NULL, k INT NOT NULL)
 left rows     : 100
@@ -376,10 +376,10 @@ right ddl      : CREATE TABLE r(id INT NOT NULL, c INT NOT NULL)
 right rows     : 100
 input stat    : right.c min=5, max=5, ndv=Some(1), null=0
 input stat    : right.id min=1, max=100, ndv=Some(100), null=0
-join          : INNER cardinality=97.468
-stat          : l.id (#0) min=1, max=100, ndv=95.000, null=0.000, histogram=rows=97.468, ndv=97.468, bucket_count=100, buckets=[1..1:0.975/1.000, 2..2:0.975/1.000, 3..3:0.975/1.000, ..., 98..98:0.975/1.000, 99..99:0.975/1.000, 100..100:0.975/1.000]
-stat          : l.k (#1) min=1, max=100, ndv=95.000, null=0.000, histogram=none
-stat          : r.id (#2) min=1, max=100, ndv=95.000, null=0.000, histogram=rows=97.468, ndv=97.468, bucket_count=100, buckets=[1..1:0.975/1.000, 2..2:0.975/1.000, 3..3:0.975/1.000, ..., 98..98:0.975/1.000, 99..99:0.975/1.000, 100..100:0.975/1.000]
+join          : INNER cardinality=100.000
+stat          : l.id (#0) min=1, max=100, ndv=100.000, null=0.000, histogram=rows=100.000, ndv=100.000, bucket_count=100, buckets=[1..1:1.000/1.000, 2..2:1.000/1.000, 3..3:1.000/1.000, ..., 98..98:1.000/1.000, 99..99:1.000/1.000, 100..100:1.000/1.000]
+stat          : l.k (#1) min=1, max=100, ndv=100.000, null=0.000, histogram=none
+stat          : r.id (#2) min=1, max=100, ndv=100.000, null=0.000, histogram=rows=100.000, ndv=100.000, bucket_count=100, buckets=[1..1:1.000/1.000, 2..2:1.000/1.000, 3..3:1.000/1.000, ..., 98..98:1.000/1.000, 99..99:1.000/1.000, 100..100:1.000/1.000]
 stat          : r.c (#3) min=5, max=5, ndv=1.000, null=0.000, histogram=none
 
 === inner_only_modeled_non_equi ===
@@ -392,7 +392,7 @@ right ddl      : CREATE TABLE r(c INT NOT NULL)
 right rows     : 10
 input stat    : right.c min=5, max=5, ndv=Some(1), null=0
 join          : INNER cardinality=950.000
-stat          : l.k (#0) min=1, max=100, ndv=95.000, null=0.000, histogram=none
+stat          : l.k (#0) min=1, max=100, ndv=100.000, null=0.000, histogram=none
 stat          : r.c (#1) min=5, max=5, ndv=1.000, null=0.000, histogram=none
 
 === inner_domain_true_non_equi ===
@@ -418,8 +418,8 @@ right ddl      : CREATE TABLE r(c INT NOT NULL)
 right rows     : 100
 input stat    : right.c min=1, max=100, ndv=Some(100), null=0
 join          : INNER cardinality=5000.000
-stat          : l.k (#0) min=1, max=100, ndv=50.000, null=0.000, histogram=none
-stat          : r.c (#1) min=1, max=100, ndv=50.000, null=0.000, histogram=none
+stat          : l.k (#0) min=1, max=100, ndv=100.000, null=0.000, histogram=none
+stat          : r.c (#1) min=1, max=100, ndv=100.000, null=0.000, histogram=none
 
 === inner_non_equi_missing_column_statistics ===
 description: A cross-side comparison with missing statistics reaches the selectivity estimator fallback without bypassing Join evaluation.
@@ -430,7 +430,7 @@ input stat    : left.k min=1, max=100, ndv=Some(100), null=0
 right ddl      : CREATE TABLE r(c INT NOT NULL)
 right rows     : 100
 join          : INNER cardinality=5000.000
-stat          : l.k (#0) min=1, max=100, ndv=50.000, null=0.000, histogram=none
+stat          : l.k (#0) min=1, max=100, ndv=100.000, null=0.000, histogram=none
 
 === left_outer_only_modeled_non_equi ===
 description: A non-equi LEFT join estimates rows matching at least one peer and never falls below the preserved left input.
@@ -489,10 +489,10 @@ input stat    : right.id min=1, max=100, ndv=Some(100), null=0
 join          : LEFT OUTER cardinality=100.000
 stat          : l.id (#0) min=1, max=100, ndv=100.000, null=0.000, histogram=none
 stat          : l.k (#1) min=1, max=100, ndv=100.000, null=0.000, histogram=none
-stat          : r.id (#2) min=1, max=100, ndv=97.468, null=2.532, histogram=none
-stat          : r.c (#3) min=5, max=5, ndv=1.000, null=2.532, histogram=none
-stat          : id (#4) min=1, max=100, ndv=100.000, null=2.532, histogram=none
-stat          : c (#5) min=5, max=5, ndv=1.000, null=2.532, histogram=none
+stat          : r.id (#2) min=1, max=100, ndv=100.000, null=0.000, histogram=none
+stat          : r.c (#3) min=5, max=5, ndv=1.000, null=0.000, histogram=none
+stat          : id (#4) min=1, max=100, ndv=100.000, null=0.000, histogram=none
+stat          : c (#5) min=5, max=5, ndv=1.000, null=0.000, histogram=none
 
 === left_semi_only_modeled_non_equi ===
 description: A non-equi LEFT SEMI join estimates left rows matching at least one right peer instead of preserving the full left input.
@@ -504,7 +504,7 @@ right ddl      : CREATE TABLE r(c INT NOT NULL)
 right rows     : 10
 input stat    : right.c min=5, max=5, ndv=Some(1), null=0
 join          : LEFT SEMI cardinality=100.000
-stat          : l.k (#0) min=1, max=100, ndv=95.000, null=0.000, histogram=none
+stat          : l.k (#0) min=1, max=100, ndv=100.000, null=0.000, histogram=none
 stat          : r.c (#1) min=5, max=5, ndv=1.000, null=0.000, histogram=none
 
 === right_semi_only_modeled_non_equi ===
@@ -602,8 +602,8 @@ stat          : l.k1 (#0) min=1, max=5, ndv=4.444, null=0.000, histogram=rows=8.
 stat          : l.k2 (#1) min=1, max=10, ndv=8.889, null=0.000, histogram=none
 stat          : r.k1 (#2) min=1, max=5, ndv=4.444, null=0.000, histogram=rows=8.889, ndv=4.444, buckets=[1..5:8.889/4.444]
 
-=== left_semi_two_key_combined_decay ===
-description: Multiple equality keys apply exponential backoff to preserved-side matched rows, then retain and scale every estimated equality-key histogram on that side.
+=== left_semi_two_key_strongest_condition ===
+description: Multiple equality keys combine preserved-side coverage using its minimum estimate, then scale equality-key histograms to the output.
 sql           : SELECT * FROM l LEFT SEMI JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2
 left ddl      : CREATE TABLE l(k1 INT NOT NULL, k2 INT NOT NULL)
 left rows     : 10
@@ -613,14 +613,14 @@ right ddl      : CREATE TABLE r(k1 INT NOT NULL, k2 INT NOT NULL)
 right rows     : 10
 input stat    : right.k1 min=1, max=4, ndv=Some(4), null=0
 input stat    : right.k2 min=1, max=2, ndv=Some(2), null=0
-join          : LEFT SEMI cardinality=1.265
-stat          : l.k1 (#0) min=1, max=4, ndv=1.265, null=0.000, histogram=rows=1.265, ndv=1.265, buckets=[1..1:0.316/1.000, 2..2:0.316/1.000, 3..3:0.316/1.000, 4..4:0.316/1.000]
-stat          : l.k2 (#1) min=1, max=2, ndv=1.265, null=0.000, histogram=rows=1.265, ndv=1.265, buckets=[1..1:0.632/1.000, 2..2:0.632/1.000]
-stat          : r.k1 (#2) min=1, max=4, ndv=1.265, null=0.000, histogram=none
-stat          : r.k2 (#3) min=1, max=2, ndv=1.265, null=0.000, histogram=none
+join          : LEFT SEMI cardinality=2.000
+stat          : l.k1 (#0) min=1, max=4, ndv=2.000, null=0.000, histogram=rows=2.000, ndv=2.000, buckets=[1..1:0.500/1.000, 2..2:0.500/1.000, 3..3:0.500/1.000, 4..4:0.500/1.000]
+stat          : l.k2 (#1) min=1, max=2, ndv=2.000, null=0.000, histogram=rows=2.000, ndv=2.000, buckets=[1..1:1.000/1.000, 2..2:1.000/1.000]
+stat          : r.k1 (#2) min=1, max=4, ndv=2.000, null=0.000, histogram=none
+stat          : r.k2 (#3) min=1, max=2, ndv=2.000, null=0.000, histogram=none
 
-=== left_anti_two_key_combines_histogram_uncertainty ===
-description: ANTI combines matched rows and histogram uncertainty from every equality key before applying its conservative overlap reserve.
+=== left_anti_two_key_combined_histogram_uncertainty ===
+description: ANTI combines matched and confirmed rows from all equality conditions before applying its conservative overlap reserve.
 sql           : SELECT * FROM l LEFT ANTI JOIN r ON l.k1 = r.k1 AND l.k2 = r.k2
 left ddl      : CREATE TABLE l(k1 VARCHAR NOT NULL, k2 INT NOT NULL)
 left rows     : 100
@@ -632,10 +632,10 @@ right rows     : 100
 input stat    : right.k1 min=a, max=z, ndv=Some(95), null=0
 input stat    : right.k2 min=1, max=10, ndv=Some(10), null=0
 input hist    : right.k1 present
-join          : LEFT ANTI cardinality=68.377
-stat          : l.k1 (#0) min=a, max=z, ndv=68.377, null=0.000, histogram=none
+join          : LEFT ANTI cardinality=10.000
+stat          : l.k1 (#0) min=a, max=z, ndv=10.000, null=0.000, histogram=none
 stat          : l.k2 (#1) min=1, max=10, ndv=10.000, null=0.000, histogram=none
-stat          : r.k1 (#2) min=a, max=z, ndv=68.377, null=0.000, histogram=none
+stat          : r.k1 (#2) min=a, max=z, ndv=10.000, null=0.000, histogram=none
 stat          : r.k2 (#3) min=1, max=10, ndv=10.000, null=0.000, histogram=none
 
 === left_outer_nullable_key ===

--- a/tests/sqllogictests/suites/mode/standalone/explain/explain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/explain.test
@@ -937,7 +937,7 @@ HashJoin
 ├── build join filters:
 │   ├── filter id:0, build key:scalar_subquery_2 (#2), probe targets:[a.id (#0)@scan0], filter type:bloom,inlist,min_max
 │   └── filter id:1, build key:id (#2), probe targets:[a.id (#0)@scan0], filter type:bloom,inlist,min_max
-├── estimated rows: 0.23
+├── estimated rows: 0.40
 ├── TableScan(Build)
 │   ├── table: default.default.b
 │   ├── scan id: 1

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/chain.test
@@ -150,24 +150,24 @@ query T
 explain select * from t, t2, t1 where t.a = t1.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t2.a (#1), t1.a (#2), t.a (#0)]
+├── output columns: [t1.a (#2), t2.a (#1), t.a (#0)]
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
-├── probe keys: [t2.a (#1)]
+├── probe keys: [t1.a (#2)]
 ├── keys is null equal: [false]
 ├── filters: []
 ├── build join filters:
-│   └── filter id:1, build key:t.a (#0), probe targets:[t2.a (#1)@scan1], filter type:bloom,inlist,min_max
+│   └── filter id:1, build key:t.a (#0), probe targets:[t1.a (#2)@scan2], filter type:bloom,inlist,min_max
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
-│   ├── output columns: [t1.a (#2), t.a (#0)]
+│   ├── output columns: [t2.a (#1), t.a (#0)]
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
-│   ├── probe keys: [t1.a (#2)]
+│   ├── probe keys: [t2.a (#1)]
 │   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── build join filters:
-│   │   └── filter id:0, build key:t.a (#0), probe targets:[t1.a (#2)@scan2], filter type:bloom,inlist,min_max
+│   │   └── filter id:0, build key:t.a (#0), probe targets:[t2.a (#1)@scan1], filter type:bloom,inlist,min_max
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
@@ -181,52 +181,52 @@ HashJoin
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
-│       ├── table: default.join_reorder.t1
-│       ├── scan id: 2
-│       ├── output columns: [a (#2)]
-│       ├── read rows: 10
+│       ├── table: default.join_reorder.t2
+│       ├── scan id: 1
+│       ├── output columns: [a (#1)]
+│       ├── read rows: 100
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
-│       └── estimated rows: 10.00
+│       └── estimated rows: 100.00
 └── TableScan(Probe)
-    ├── table: default.join_reorder.t2
-    ├── scan id: 1
-    ├── output columns: [a (#1)]
-    ├── read rows: 100
+    ├── table: default.join_reorder.t1
+    ├── scan id: 2
+    ├── output columns: [a (#2)]
+    ├── read rows: 10
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
-    └── estimated rows: 100.00
+    └── estimated rows: 10.00
 
 query T
 explain select * from t1, t, t2 where t.a = t1.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t2.a (#2), t.a (#1), t1.a (#0)]
+├── output columns: [t1.a (#0), t.a (#1), t2.a (#2)]
 ├── join type: INNER
-├── build keys: [t1.a (#0)]
-├── probe keys: [t2.a (#2)]
+├── build keys: [t2.a (#2)]
+├── probe keys: [t1.a (#0)]
 ├── keys is null equal: [false]
 ├── filters: []
 ├── build join filters:
-│   └── filter id:1, build key:t1.a (#0), probe targets:[t2.a (#2)@scan2], filter type:bloom,inlist,min_max
+│   └── filter id:1, build key:t2.a (#2), probe targets:[t1.a (#0)@scan0], filter type:bloom,inlist,min_max
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
-│   ├── output columns: [t1.a (#0), t.a (#1)]
+│   ├── output columns: [t2.a (#2), t.a (#1)]
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
-│   ├── probe keys: [t1.a (#0)]
+│   ├── probe keys: [t2.a (#2)]
 │   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── build join filters:
-│   │   └── filter id:0, build key:t.a (#1), probe targets:[t1.a (#0)@scan0], filter type:bloom,inlist,min_max
+│   │   └── filter id:0, build key:t.a (#1), probe targets:[t2.a (#2)@scan2], filter type:bloom,inlist,min_max
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
@@ -240,52 +240,52 @@ HashJoin
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
-│       ├── table: default.join_reorder.t1
-│       ├── scan id: 0
-│       ├── output columns: [a (#0)]
-│       ├── read rows: 10
+│       ├── table: default.join_reorder.t2
+│       ├── scan id: 2
+│       ├── output columns: [a (#2)]
+│       ├── read rows: 100
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
-│       └── estimated rows: 10.00
+│       └── estimated rows: 100.00
 └── TableScan(Probe)
-    ├── table: default.join_reorder.t2
-    ├── scan id: 2
-    ├── output columns: [a (#2)]
-    ├── read rows: 100
+    ├── table: default.join_reorder.t1
+    ├── scan id: 0
+    ├── output columns: [a (#0)]
+    ├── read rows: 10
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
-    └── estimated rows: 100.00
+    └── estimated rows: 10.00
 
 query T
 explain select * from t1, t2, t where t.a = t1.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t2.a (#1), t.a (#2), t1.a (#0)]
+├── output columns: [t1.a (#0), t2.a (#1), t.a (#2)]
 ├── join type: INNER
-├── build keys: [t1.a (#0)]
-├── probe keys: [t2.a (#1)]
+├── build keys: [t.a (#2)]
+├── probe keys: [t1.a (#0)]
 ├── keys is null equal: [false]
 ├── filters: []
 ├── build join filters:
-│   └── filter id:1, build key:t1.a (#0), probe targets:[t2.a (#1)@scan1], filter type:bloom,inlist,min_max
+│   └── filter id:1, build key:t.a (#2), probe targets:[t1.a (#0)@scan0], filter type:bloom,inlist,min_max
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
-│   ├── output columns: [t1.a (#0), t.a (#2)]
+│   ├── output columns: [t2.a (#1), t.a (#2)]
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
-│   ├── probe keys: [t1.a (#0)]
+│   ├── probe keys: [t2.a (#1)]
 │   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── build join filters:
-│   │   └── filter id:0, build key:t.a (#2), probe targets:[t1.a (#0)@scan0], filter type:bloom,inlist,min_max
+│   │   └── filter id:0, build key:t.a (#2), probe targets:[t2.a (#1)@scan1], filter type:bloom,inlist,min_max
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
@@ -299,29 +299,29 @@ HashJoin
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
-│       ├── table: default.join_reorder.t1
-│       ├── scan id: 0
-│       ├── output columns: [a (#0)]
-│       ├── read rows: 10
+│       ├── table: default.join_reorder.t2
+│       ├── scan id: 1
+│       ├── output columns: [a (#1)]
+│       ├── read rows: 100
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
-│       └── estimated rows: 10.00
+│       └── estimated rows: 100.00
 └── TableScan(Probe)
-    ├── table: default.join_reorder.t2
-    ├── scan id: 1
-    ├── output columns: [a (#1)]
-    ├── read rows: 100
+    ├── table: default.join_reorder.t1
+    ├── scan id: 0
+    ├── output columns: [a (#0)]
+    ├── read rows: 10
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
-    └── estimated rows: 100.00
+    └── estimated rows: 10.00
 
 query T
 explain select * from t2, t1, t where t.a = t1.a and t1.a = t2.a

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/cycles.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/cycles.test
@@ -79,24 +79,24 @@ query T
 explain select * from t, t2, t1 where t.a = t1.a and t1.a = t2.a and t2.a = t.a
 ----
 HashJoin
-├── output columns: [t2.a (#1), t1.a (#2), t.a (#0)]
+├── output columns: [t1.a (#2), t2.a (#1), t.a (#0)]
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
-├── probe keys: [t2.a (#1)]
+├── probe keys: [t1.a (#2)]
 ├── keys is null equal: [false]
 ├── filters: []
 ├── build join filters:
-│   └── filter id:1, build key:t.a (#0), probe targets:[t2.a (#1)@scan1], filter type:bloom,inlist,min_max
+│   └── filter id:1, build key:t.a (#0), probe targets:[t1.a (#2)@scan2], filter type:bloom,inlist,min_max
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
-│   ├── output columns: [t1.a (#2), t.a (#0)]
+│   ├── output columns: [t2.a (#1), t.a (#0)]
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
-│   ├── probe keys: [t1.a (#2)]
+│   ├── probe keys: [t2.a (#1)]
 │   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── build join filters:
-│   │   └── filter id:0, build key:t.a (#0), probe targets:[t1.a (#2)@scan2], filter type:bloom,inlist,min_max
+│   │   └── filter id:0, build key:t.a (#0), probe targets:[t2.a (#1)@scan1], filter type:bloom,inlist,min_max
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
@@ -110,52 +110,52 @@ HashJoin
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
-│       ├── table: default.join_reorder.t1
-│       ├── scan id: 2
-│       ├── output columns: [a (#2)]
-│       ├── read rows: 10
+│       ├── table: default.join_reorder.t2
+│       ├── scan id: 1
+│       ├── output columns: [a (#1)]
+│       ├── read rows: 100
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
-│       └── estimated rows: 10.00
+│       └── estimated rows: 100.00
 └── TableScan(Probe)
-    ├── table: default.join_reorder.t2
-    ├── scan id: 1
-    ├── output columns: [a (#1)]
-    ├── read rows: 100
+    ├── table: default.join_reorder.t1
+    ├── scan id: 2
+    ├── output columns: [a (#2)]
+    ├── read rows: 10
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
-    └── estimated rows: 100.00
+    └── estimated rows: 10.00
 
 query T
 explain select * from t1, t, t2 where t.a = t1.a and t1.a = t2.a and t2.a = t.a
 ----
 HashJoin
-├── output columns: [t2.a (#2), t.a (#1), t1.a (#0)]
+├── output columns: [t1.a (#0), t.a (#1), t2.a (#2)]
 ├── join type: INNER
-├── build keys: [t1.a (#0)]
-├── probe keys: [t2.a (#2)]
+├── build keys: [t2.a (#2)]
+├── probe keys: [t1.a (#0)]
 ├── keys is null equal: [false]
 ├── filters: []
 ├── build join filters:
-│   └── filter id:1, build key:t1.a (#0), probe targets:[t2.a (#2)@scan2], filter type:bloom,inlist,min_max
+│   └── filter id:1, build key:t2.a (#2), probe targets:[t1.a (#0)@scan0], filter type:bloom,inlist,min_max
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
-│   ├── output columns: [t1.a (#0), t.a (#1)]
+│   ├── output columns: [t2.a (#2), t.a (#1)]
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
-│   ├── probe keys: [t1.a (#0)]
+│   ├── probe keys: [t2.a (#2)]
 │   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── build join filters:
-│   │   └── filter id:0, build key:t.a (#1), probe targets:[t1.a (#0)@scan0], filter type:bloom,inlist,min_max
+│   │   └── filter id:0, build key:t.a (#1), probe targets:[t2.a (#2)@scan2], filter type:bloom,inlist,min_max
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
@@ -169,52 +169,52 @@ HashJoin
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
-│       ├── table: default.join_reorder.t1
-│       ├── scan id: 0
-│       ├── output columns: [a (#0)]
-│       ├── read rows: 10
+│       ├── table: default.join_reorder.t2
+│       ├── scan id: 2
+│       ├── output columns: [a (#2)]
+│       ├── read rows: 100
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
-│       └── estimated rows: 10.00
+│       └── estimated rows: 100.00
 └── TableScan(Probe)
-    ├── table: default.join_reorder.t2
-    ├── scan id: 2
-    ├── output columns: [a (#2)]
-    ├── read rows: 100
+    ├── table: default.join_reorder.t1
+    ├── scan id: 0
+    ├── output columns: [a (#0)]
+    ├── read rows: 10
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
-    └── estimated rows: 100.00
+    └── estimated rows: 10.00
 
 query T
 explain select * from t1, t2, t where t.a = t1.a and t1.a = t2.a and t2.a = t.a
 ----
 HashJoin
-├── output columns: [t2.a (#1), t.a (#2), t1.a (#0)]
+├── output columns: [t1.a (#0), t2.a (#1), t.a (#2)]
 ├── join type: INNER
-├── build keys: [t1.a (#0)]
-├── probe keys: [t2.a (#1)]
+├── build keys: [t.a (#2)]
+├── probe keys: [t1.a (#0)]
 ├── keys is null equal: [false]
 ├── filters: []
 ├── build join filters:
-│   └── filter id:1, build key:t1.a (#0), probe targets:[t2.a (#1)@scan1], filter type:bloom,inlist,min_max
+│   └── filter id:1, build key:t.a (#2), probe targets:[t1.a (#0)@scan0], filter type:bloom,inlist,min_max
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
-│   ├── output columns: [t1.a (#0), t.a (#2)]
+│   ├── output columns: [t2.a (#1), t.a (#2)]
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
-│   ├── probe keys: [t1.a (#0)]
+│   ├── probe keys: [t2.a (#1)]
 │   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── build join filters:
-│   │   └── filter id:0, build key:t.a (#2), probe targets:[t1.a (#0)@scan0], filter type:bloom,inlist,min_max
+│   │   └── filter id:0, build key:t.a (#2), probe targets:[t2.a (#1)@scan1], filter type:bloom,inlist,min_max
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
@@ -228,29 +228,29 @@ HashJoin
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
-│       ├── table: default.join_reorder.t1
-│       ├── scan id: 0
-│       ├── output columns: [a (#0)]
-│       ├── read rows: 10
+│       ├── table: default.join_reorder.t2
+│       ├── scan id: 1
+│       ├── output columns: [a (#1)]
+│       ├── read rows: 100
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
-│       └── estimated rows: 10.00
+│       └── estimated rows: 100.00
 └── TableScan(Probe)
-    ├── table: default.join_reorder.t2
-    ├── scan id: 1
-    ├── output columns: [a (#1)]
-    ├── read rows: 100
+    ├── table: default.join_reorder.t1
+    ├── scan id: 0
+    ├── output columns: [a (#0)]
+    ├── read rows: 10
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
-    └── estimated rows: 100.00
+    └── estimated rows: 10.00
 
 query T
 explain select * from t2, t1, t where t.a = t1.a and t1.a = t2.a and t2.a = t.a

--- a/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/star.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/join_reorder/star.test
@@ -79,24 +79,24 @@ query T
 explain select * from t, t2, t1 where t.a = t2.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t2.a (#1), t1.a (#2), t.a (#0)]
+├── output columns: [t1.a (#2), t2.a (#1), t.a (#0)]
 ├── join type: INNER
 ├── build keys: [t.a (#0)]
-├── probe keys: [t2.a (#1)]
+├── probe keys: [t1.a (#2)]
 ├── keys is null equal: [false]
 ├── filters: []
 ├── build join filters:
-│   └── filter id:1, build key:t.a (#0), probe targets:[t2.a (#1)@scan1], filter type:bloom,inlist,min_max
+│   └── filter id:1, build key:t.a (#0), probe targets:[t1.a (#2)@scan2], filter type:bloom,inlist,min_max
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
-│   ├── output columns: [t1.a (#2), t.a (#0)]
+│   ├── output columns: [t2.a (#1), t.a (#0)]
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#0)]
-│   ├── probe keys: [t1.a (#2)]
+│   ├── probe keys: [t2.a (#1)]
 │   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── build join filters:
-│   │   └── filter id:0, build key:t.a (#0), probe targets:[t1.a (#2)@scan2], filter type:bloom,inlist,min_max
+│   │   └── filter id:0, build key:t.a (#0), probe targets:[t2.a (#1)@scan1], filter type:bloom,inlist,min_max
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
@@ -110,52 +110,52 @@ HashJoin
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
-│       ├── table: default.join_reorder.t1
-│       ├── scan id: 2
-│       ├── output columns: [a (#2)]
-│       ├── read rows: 10
+│       ├── table: default.join_reorder.t2
+│       ├── scan id: 1
+│       ├── output columns: [a (#1)]
+│       ├── read rows: 100
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
-│       └── estimated rows: 10.00
+│       └── estimated rows: 100.00
 └── TableScan(Probe)
-    ├── table: default.join_reorder.t2
-    ├── scan id: 1
-    ├── output columns: [a (#1)]
-    ├── read rows: 100
+    ├── table: default.join_reorder.t1
+    ├── scan id: 2
+    ├── output columns: [a (#2)]
+    ├── read rows: 10
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
-    └── estimated rows: 100.00
+    └── estimated rows: 10.00
 
 query T
 explain select * from t1, t, t2 where t.a = t2.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t2.a (#2), t.a (#1), t1.a (#0)]
+├── output columns: [t1.a (#0), t.a (#1), t2.a (#2)]
 ├── join type: INNER
-├── build keys: [t1.a (#0)]
-├── probe keys: [t2.a (#2)]
+├── build keys: [t2.a (#2)]
+├── probe keys: [t1.a (#0)]
 ├── keys is null equal: [false]
 ├── filters: []
 ├── build join filters:
-│   └── filter id:1, build key:t1.a (#0), probe targets:[t2.a (#2)@scan2], filter type:bloom,inlist,min_max
+│   └── filter id:1, build key:t2.a (#2), probe targets:[t1.a (#0)@scan0], filter type:bloom,inlist,min_max
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
-│   ├── output columns: [t1.a (#0), t.a (#1)]
+│   ├── output columns: [t2.a (#2), t.a (#1)]
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#1)]
-│   ├── probe keys: [t1.a (#0)]
+│   ├── probe keys: [t2.a (#2)]
 │   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── build join filters:
-│   │   └── filter id:0, build key:t.a (#1), probe targets:[t1.a (#0)@scan0], filter type:bloom,inlist,min_max
+│   │   └── filter id:0, build key:t.a (#1), probe targets:[t2.a (#2)@scan2], filter type:bloom,inlist,min_max
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
@@ -169,52 +169,52 @@ HashJoin
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
-│       ├── table: default.join_reorder.t1
-│       ├── scan id: 0
-│       ├── output columns: [a (#0)]
-│       ├── read rows: 10
+│       ├── table: default.join_reorder.t2
+│       ├── scan id: 2
+│       ├── output columns: [a (#2)]
+│       ├── read rows: 100
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
-│       └── estimated rows: 10.00
+│       └── estimated rows: 100.00
 └── TableScan(Probe)
-    ├── table: default.join_reorder.t2
-    ├── scan id: 2
-    ├── output columns: [a (#2)]
-    ├── read rows: 100
+    ├── table: default.join_reorder.t1
+    ├── scan id: 0
+    ├── output columns: [a (#0)]
+    ├── read rows: 10
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
-    └── estimated rows: 100.00
+    └── estimated rows: 10.00
 
 query T
 explain select * from t1, t2, t where t.a = t2.a and t1.a = t2.a
 ----
 HashJoin
-├── output columns: [t2.a (#1), t.a (#2), t1.a (#0)]
+├── output columns: [t1.a (#0), t2.a (#1), t.a (#2)]
 ├── join type: INNER
-├── build keys: [t1.a (#0)]
-├── probe keys: [t2.a (#1)]
+├── build keys: [t.a (#2)]
+├── probe keys: [t1.a (#0)]
 ├── keys is null equal: [false]
 ├── filters: []
 ├── build join filters:
-│   └── filter id:1, build key:t1.a (#0), probe targets:[t2.a (#1)@scan1], filter type:bloom,inlist,min_max
+│   └── filter id:1, build key:t.a (#2), probe targets:[t1.a (#0)@scan0], filter type:bloom,inlist,min_max
 ├── estimated rows: 1.00
 ├── HashJoin(Build)
-│   ├── output columns: [t1.a (#0), t.a (#2)]
+│   ├── output columns: [t2.a (#1), t.a (#2)]
 │   ├── join type: INNER
 │   ├── build keys: [t.a (#2)]
-│   ├── probe keys: [t1.a (#0)]
+│   ├── probe keys: [t2.a (#1)]
 │   ├── keys is null equal: [false]
 │   ├── filters: []
 │   ├── build join filters:
-│   │   └── filter id:0, build key:t.a (#2), probe targets:[t1.a (#0)@scan0], filter type:bloom,inlist,min_max
+│   │   └── filter id:0, build key:t.a (#2), probe targets:[t2.a (#1)@scan1], filter type:bloom,inlist,min_max
 │   ├── estimated rows: 1.00
 │   ├── TableScan(Build)
 │   │   ├── table: default.join_reorder.t
@@ -228,29 +228,29 @@ HashJoin
 │   │   ├── push downs: [filters: [], limit: NONE]
 │   │   └── estimated rows: 1.00
 │   └── TableScan(Probe)
-│       ├── table: default.join_reorder.t1
-│       ├── scan id: 0
-│       ├── output columns: [a (#0)]
-│       ├── read rows: 10
+│       ├── table: default.join_reorder.t2
+│       ├── scan id: 1
+│       ├── output columns: [a (#1)]
+│       ├── read rows: 100
 │       ├── read size: < 1 KiB
 │       ├── partitions total: 1
 │       ├── partitions scanned: 1
 │       ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
 │       ├── push downs: [filters: [], limit: NONE]
 │       ├── apply join filters: [#0]
-│       └── estimated rows: 10.00
+│       └── estimated rows: 100.00
 └── TableScan(Probe)
-    ├── table: default.join_reorder.t2
-    ├── scan id: 1
-    ├── output columns: [a (#1)]
-    ├── read rows: 100
+    ├── table: default.join_reorder.t1
+    ├── scan id: 0
+    ├── output columns: [a (#0)]
+    ├── read rows: 10
     ├── read size: < 1 KiB
     ├── partitions total: 1
     ├── partitions scanned: 1
     ├── pruning stats: [segments: <read cost: <slt:ignore>, decompress cost: <slt:ignore>, range pruning: 1 to 1 cost: <slt:ignore>>, blocks: <range pruning: 1 to 1 cost: <slt:ignore>>]
     ├── push downs: [filters: [], limit: NONE]
     ├── apply join filters: [#1]
-    └── estimated rows: 100.00
+    └── estimated rows: 10.00
 
 query T
 explain select * from t2, t1, t where t.a = t2.a and t1.a = t2.a

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_full_outer.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_join_full_outer.test
@@ -250,7 +250,7 @@ HashJoin
 ├── probe keys: [t1.a (#0)]
 ├── keys is null equal: [false]
 ├── filters: [t2.a (#2) > 0]
-├── estimated rows: 5.37
+├── estimated rows: 5.00
 ├── TableScan(Build)
 │   ├── table: default.default.t2
 │   ├── scan id: 1

--- a/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_self_join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/push_down_filter/push_down_filter_join/push_down_filter_self_join.test
@@ -33,7 +33,7 @@ Sequence
     ├── filters: [b1.b (#3) < b2.b (#5)]
     ├── build join filters:
     │   └── filter id:0, build key:b2.a (#4), probe targets:[b1.a (#2)@scan1], filter type:bloom,inlist,min_max
-    ├── estimated rows: 28.28
+    ├── estimated rows: 40.00
     ├── MaterializeCTERef(Build)
     │   ├── cte_name: b
     │   ├── cte_schema: [a (#4), b (#5)]

--- a/tests/sqllogictests/suites/mode/standalone/explain/spatial_join.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/spatial_join.test
@@ -144,11 +144,11 @@ AggregateFinal
 ├── output columns: [count(r.id) (#4), l.id (#0)]
 ├── group by: [id]
 ├── aggregate functions: [count(id)]
-├── estimated rows: 1.00
+├── estimated rows: 2.00
 └── AggregatePartial
     ├── group by: [id]
     ├── aggregate functions: [count(id)]
-    ├── estimated rows: 1.00
+    ├── estimated rows: 2.00
     └── SpatialJoin
         ├── output columns: [r.id (#2), l.id (#0)]
         ├── build side: Right

--- a/tests/sqllogictests/suites/mode/standalone/explain/update.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/update.test
@@ -213,7 +213,7 @@ CommitSink
                 │   ├── filter id:0, build key:p.c_code (#9), probe targets:[c.c_code (#1)@scan0], filter type:bloom,inlist,min_max
                 │   ├── filter id:1, build key:p.id (#8), probe targets:[c.id (#0)@scan0], filter type:bloom,inlist,min_max
                 │   └── filter id:2, build key:p.me_id (#10), probe targets:[c.me_id (#2)@scan0], filter type:bloom,inlist,min_max
-                ├── estimated rows: 1.11
+                ├── estimated rows: 3.40
                 ├── TableScan(Build)
                 │   ├── table: default.default.t2
                 │   ├── scan id: 1

--- a/tests/sqllogictests/suites/tpch/join_order.test
+++ b/tests/sqllogictests/suites/tpch/join_order.test
@@ -240,15 +240,15 @@ HashJoin: INNER
         │       ├── Build
         │       │   └── HashJoin: INNER
         │       │       ├── Build
-        │       │       │   └── HashJoin: INNER
-        │       │       │       ├── Build
-        │       │       │       │   └── Scan: default.tpch_test.region (#5) (read rows: 5)
-        │       │       │       └── Probe
-        │       │       │           └── Scan: default.tpch_test.nation (#4) (read rows: 25)
+        │       │       │   └── Scan: default.tpch_test.region (#5) (read rows: 5)
         │       │       └── Probe
-        │       │           └── Scan: default.tpch_test.customer (#0) (read rows: 150000)
+        │       │           └── Scan: default.tpch_test.nation (#4) (read rows: 25)
         │       └── Probe
-        │           └── Scan: default.tpch_test.orders (#1) (read rows: 1500000)
+        │           └── HashJoin: INNER
+        │               ├── Build
+        │               │   └── Scan: default.tpch_test.customer (#0) (read rows: 150000)
+        │               └── Probe
+        │                   └── Scan: default.tpch_test.orders (#1) (read rows: 1500000)
         └── Probe
             └── Scan: default.tpch_test.lineitem (#2) (read rows: 6001215)
 
@@ -437,25 +437,25 @@ limit 5;
 ----
 HashJoin: INNER
 ├── Build
-│   └── Scan: default.tpch_test.nation (#5) (read rows: 25)
+│   └── HashJoin: INNER
+│       ├── Build
+│       │   └── HashJoin: INNER
+│       │       ├── Build
+│       │       │   └── Scan: default.tpch_test.nation (#5) (read rows: 25)
+│       │       └── Probe
+│       │           └── Scan: default.tpch_test.supplier (#1) (read rows: 10000)
+│       └── Probe
+│           └── HashJoin: INNER
+│               ├── Build
+│               │   └── HashJoin: INNER
+│               │       ├── Build
+│               │       │   └── Scan: default.tpch_test.part (#0) (read rows: 200000)
+│               │       └── Probe
+│               │           └── Scan: default.tpch_test.lineitem (#2) (read rows: 6001215)
+│               └── Probe
+│                   └── Scan: default.tpch_test.orders (#4) (read rows: 1500000)
 └── Probe
-    └── HashJoin: INNER
-        ├── Build
-        │   └── HashJoin: INNER
-        │       ├── Build
-        │       │   └── Scan: default.tpch_test.supplier (#1) (read rows: 10000)
-        │       └── Probe
-        │           └── HashJoin: INNER
-        │               ├── Build
-        │               │   └── HashJoin: INNER
-        │               │       ├── Build
-        │               │       │   └── Scan: default.tpch_test.part (#0) (read rows: 200000)
-        │               │       └── Probe
-        │               │           └── Scan: default.tpch_test.partsupp (#3) (read rows: 800000)
-        │               └── Probe
-        │                   └── Scan: default.tpch_test.lineitem (#2) (read rows: 6001215)
-        └── Probe
-            └── Scan: default.tpch_test.orders (#4) (read rows: 1500000)
+    └── Scan: default.tpch_test.partsupp (#3) (read rows: 800000)
 
 # Q10
 query T
@@ -972,23 +972,23 @@ where
 order by
     s_name;
 ----
-HashJoin: LEFT SEMI
+HashJoin: RIGHT SEMI
 ├── Build
 │   └── HashJoin: INNER
 │       ├── Build
-│       │   └── HashJoin: LEFT SEMI
-│       │       ├── Build
-│       │       │   └── Scan: default.tpch_test.part (#3) (read rows: 200000)
-│       │       └── Probe
-│       │           └── Scan: default.tpch_test.partsupp (#2) (read rows: 800000)
+│       │   └── Scan: default.tpch_test.nation (#1) (read rows: 25)
 │       └── Probe
-│           └── Scan: default.tpch_test.lineitem (#4) (read rows: 6001215)
+│           └── Scan: default.tpch_test.supplier (#0) (read rows: 10000)
 └── Probe
     └── HashJoin: INNER
         ├── Build
-        │   └── Scan: default.tpch_test.nation (#1) (read rows: 25)
+        │   └── HashJoin: LEFT SEMI
+        │       ├── Build
+        │       │   └── Scan: default.tpch_test.part (#3) (read rows: 200000)
+        │       └── Probe
+        │           └── Scan: default.tpch_test.partsupp (#2) (read rows: 800000)
         └── Probe
-            └── Scan: default.tpch_test.supplier (#0) (read rows: 10000)
+            └── Scan: default.tpch_test.lineitem (#4) (read rows: 6001215)
 
 # Q21
 query T


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Disables the join selectivity backoff introduced in #20414 with a compile-time switch to avoid severe underestimation for correlated or repeated join keys, which can lead to poor join ordering and excessive spilling.

Join cardinality now uses the strongest individual condition. Both sides’ matched-row estimates and histogram uncertainty come from the same strongest equality, and additional residual NDV scaling is disabled to keep downstream statistics consistent.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

<!--
See AI_POLICY.md. Agent-opened PRs are welcome; a responsible human on the author side must own the change.
The responsible human is NOT the reviewer — it is the submitter-side owner who has read the diff,
can explain each change, and will answer questions during review.
Write "None" for AI usage if no AI was involved.
-->

- AI usage: An AI coding agent assisted with implementation.
- Responsible human: @forsaken628 
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20453)
<!-- Reviewable:end -->
