### PR TITLE
fix(query): avoid spilling small final aggregate buffers

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_spiller.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_spiller.rs
@@ -339,6 +339,17 @@ pub struct AggregateSpiller<P: PartitionStream = SharedPartitionStream> {
     payload_writers: AggregatePayloadWriters,
 }
 
+impl AggregateSpiller<LocalPartitionStream> {
+    /// Take buffered states only if this round has not written any blocks. Once
+    /// a writer exists, the tails must stay with the spilled states for merging.
+    pub(super) fn take_pending_if_unspilled(&mut self) -> Option<Vec<(usize, DataBlock)>> {
+        if self.payload_writers.writers.iter().any(Option::is_some) {
+            return None;
+        }
+        Some(self.partition_stream.finish())
+    }
+}
+
 impl<P: PartitionStream> AggregateSpiller<P> {
     pub fn try_create(
         ctx: Arc<QueryContext>,

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/statistics.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/statistics.rs
@@ -18,6 +18,13 @@ use databend_common_base::base::convert_byte_size;
 use databend_common_base::base::convert_number_size;
 use databend_common_expression::AggregateHashTable;
 
+#[derive(Debug)]
+pub enum FinalAggregateFinishMode {
+    InMemory,
+    Buffered,
+    Spilled,
+}
+
 pub struct AggregationStatistics {
     stage: &'static str,
     start: Instant,
@@ -60,23 +67,19 @@ impl AggregationStatistics {
         );
     }
 
-    pub fn log_finish_statistics_values(&mut self, output_rows: usize, hash_index_resizes: usize) {
-        self.log_finish(output_rows, hash_index_resizes, None);
-    }
-
-    pub fn log_task_finish_statistics(
+    pub fn log_final_finish_statistics(
         &mut self,
-        task_id: u64,
+        task_id: Option<u64>,
         processor_id: usize,
         spill_depth: usize,
         output_rows: usize,
         hash_index_resizes: usize,
-        spilled: bool,
+        finish_mode: FinalAggregateFinishMode,
     ) {
         self.log_finish(
             output_rows,
             hash_index_resizes,
-            Some((task_id, processor_id, spill_depth, spilled)),
+            Some((task_id, processor_id, spill_depth, finish_mode)),
         );
     }
 
@@ -84,7 +87,7 @@ impl AggregationStatistics {
         &mut self,
         output_rows: usize,
         hash_index_resizes: usize,
-        task: Option<(u64, usize, usize, bool)>,
+        task: Option<(Option<u64>, usize, usize, FinalAggregateFinishMode)>,
     ) {
         let elapsed = self.start.elapsed().as_secs_f64();
         let real_elapsed = self
@@ -94,14 +97,16 @@ impl AggregationStatistics {
             .unwrap_or(elapsed);
 
         match task {
-            Some((task_id, processor_id, spill_depth, spilled)) => {
+            Some((task_id, processor_id, spill_depth, finish_mode)) => {
+                let task_id = task_id.map_or_else(|| "input".to_string(), |id| id.to_string());
                 log::info!(
-                    "{}[{}] Task completed: task_id={}, spill_depth={}, spilled={}, {} → {} rows in {:.2}s (real: {:.2}s), throughput: {} rows/sec, {}/sec, total: {}, hash index resizes: {}",
+                    "{}[{}] Task completed: task_id={}, spill_depth={}, spilled={}, finish_mode={:?}, {} → {} rows in {:.2}s (real: {:.2}s), throughput: {} rows/sec, {}/sec, total: {}, hash index resizes: {}",
                     self.stage,
                     processor_id,
                     task_id,
                     spill_depth,
-                    spilled,
+                    matches!(finish_mode, FinalAggregateFinishMode::Spilled),
+                    finish_mode,
                     self.processed_rows,
                     output_rows,
                     elapsed,

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_final.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_final.rs
@@ -47,6 +47,7 @@ use crate::pipelines::processors::transforms::aggregator::PartitionedData;
 use crate::pipelines::processors::transforms::aggregator::SerializedPayload;
 use crate::pipelines::processors::transforms::aggregator::SpilledPayload;
 use crate::pipelines::processors::transforms::aggregator::statistics::AggregationStatistics;
+use crate::pipelines::processors::transforms::aggregator::statistics::FinalAggregateFinishMode;
 use crate::pipelines::processors::transforms::aggregator::transform_aggregate_partial::HashTable;
 use crate::sessions::QueryContext;
 use crate::sessions::TableContextSettings;
@@ -329,26 +330,38 @@ impl TransformFinalAggregate {
         spilled_depth: usize,
         tx: Sender<FinalAggregateTask>,
     ) -> Result<()> {
-        if self.spilled_occurred {
+        let pending_blocks = if self.spilled_occurred {
             self.spill_out()?;
-            // If no partition reached the stream threshold, merge the buffered
-            // states locally instead of writing another spill level.
-            if let Some(pending_blocks) = self.spiller.take_pending_if_unspilled() {
-                self.spilled_occurred = false;
-                for (bucket, data_block) in pending_blocks {
-                    check_interrupt()?;
-                    // These states were already counted as input. Do not check
-                    // spill again under the same sustained memory pressure.
-                    self.merge_serialized(SerializedPayload {
-                        bucket: bucket as isize,
-                        data_block,
-                        max_partition_count: SPILL_BUCKET_NUM,
-                    })?;
-                }
-            }
-        }
+            self.spiller.take_pending_if_unspilled()
+        } else {
+            None
+        };
 
-        if self.spilled_occurred {
+        let (output_rows, hash_index_resizes, finish_mode) = if let Some(pending_blocks) =
+            pending_blocks
+        {
+            // Disjoint buckets can be output and released one at a time without
+            // another spill check or buffering results to form larger blocks.
+            let mut output_rows = 0;
+            let mut hash_index_resizes = 0;
+            for (bucket, data_block) in pending_blocks {
+                self.ensure_spill_depth(spilled_depth);
+                // These states were already counted as input.
+                self.merge_serialized(SerializedPayload {
+                    bucket: bucket as isize,
+                    data_block,
+                    max_partition_count: SPILL_BUCKET_NUM,
+                })?;
+                let (rows, resizes) = self.output_hashtable(None)?;
+                output_rows += rows;
+                hash_index_resizes += resizes;
+            }
+            (
+                output_rows,
+                hash_index_resizes,
+                FinalAggregateFinishMode::Buffered,
+            )
+        } else if self.spilled_occurred {
             let (output_rows, hash_index_resizes) = match &self.hashtable {
                 HashTable::AggregateHashTable(ht) => {
                     (ht.payload.len(), ht.hash_index_resize_count())
@@ -356,71 +369,72 @@ impl TransformFinalAggregate {
                 _ => unreachable!("[TRANSFORM-AGGREGATOR] Invalid hash table state before spill"),
             };
             self.spill_finish(spilled_depth, tx)?;
-            if let Some(task_id) = task_id {
-                self.statistics.log_task_finish_statistics(
-                    task_id,
-                    self._id,
-                    spilled_depth,
-                    output_rows,
-                    hash_index_resizes,
-                    true,
-                );
-            } else {
-                self.statistics.reset();
-            }
-
-            self.spilled_occurred = false;
-            let _ = mem::take(&mut self.hashtable);
-            return Ok(());
-        }
-
-        if let HashTable::AggregateHashTable(hashtable) = mem::take(&mut self.hashtable) {
-            let output_rows = hashtable.payload.len();
-            let hash_index_resizes = hashtable.hash_index_resize_count();
-            let mut output_stream = BlockPartitionStream::create(
+            (
+                output_rows,
+                hash_index_resizes,
+                FinalAggregateFinishMode::Spilled,
+            )
+        } else {
+            let output_stream = BlockPartitionStream::create(
                 self.params.max_block_rows,
                 self.params.max_block_bytes,
                 1,
             );
-            self.flush_state.clear();
+            let (output_rows, hash_index_resizes) = self.output_hashtable(Some(output_stream))?;
+            (
+                output_rows,
+                hash_index_resizes,
+                FinalAggregateFinishMode::InMemory,
+            )
+        };
 
-            // Consuming the hash table drops its index before result materialization. Each
-            // payload owns its arena, so finishing one partition also releases its states.
-            for payload in hashtable.into_payloads() {
-                loop {
-                    check_interrupt()?;
-                    let Some(block) = payload.merge_result(&mut self.flush_state)? else {
-                        self.flush_state.clear();
-                        break;
-                    };
+        self.statistics.log_final_finish_statistics(
+            task_id,
+            self._id,
+            spilled_depth,
+            output_rows,
+            hash_index_resizes,
+            finish_mode,
+        );
+        self.spilled_occurred = false;
+        let _ = mem::take(&mut self.hashtable);
+        Ok(())
+    }
 
+    fn output_hashtable(
+        &mut self,
+        mut output_stream: Option<BlockPartitionStream>,
+    ) -> Result<(usize, usize)> {
+        let HashTable::AggregateHashTable(hashtable) = mem::take(&mut self.hashtable) else {
+            unreachable!("[TRANSFORM-AGGREGATOR] Invalid hash table state before output")
+        };
+        let output_rows = hashtable.payload.len();
+        let hash_index_resizes = hashtable.hash_index_resize_count();
+        self.flush_state.clear();
+
+        // Consuming the hash table drops its index before result materialization. Each
+        // payload owns its arena, so finishing one partition also releases its states.
+        for payload in hashtable.into_payloads() {
+            loop {
+                check_interrupt()?;
+                let Some(block) = payload.merge_result(&mut self.flush_state)? else {
+                    self.flush_state.clear();
+                    break;
+                };
+                if let Some(output_stream) = output_stream.as_mut() {
                     let num_rows = block.num_rows();
                     let ready = output_stream.partition(vec![0; num_rows], block, true);
                     self.output_data
                         .extend(ready.into_iter().map(|(_, block)| block));
+                } else {
+                    self.output_data.push_back(block);
                 }
             }
-
-            if let Some(block) = output_stream.finalize_partition(0) {
-                self.output_data.push_back(block);
-            }
-
-            if let Some(task_id) = task_id {
-                self.statistics.log_task_finish_statistics(
-                    task_id,
-                    self._id,
-                    spilled_depth,
-                    output_rows,
-                    hash_index_resizes,
-                    false,
-                );
-            } else {
-                self.statistics
-                    .log_finish_statistics_values(output_rows, hash_index_resizes);
-            }
         }
-
-        Ok(())
+        if let Some(block) = output_stream.and_then(|mut stream| stream.finalize_partition(0)) {
+            self.output_data.push_back(block);
+        }
+        Ok((output_rows, hash_index_resizes))
     }
 
     fn spill_finish(&mut self, spilled_depth: usize, tx: Sender<FinalAggregateTask>) -> Result<()> {

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_final.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_final.rs
@@ -211,6 +211,11 @@ impl TransformFinalAggregate {
         let bytes = payload.data_block.memory_size();
         self.statistics.record_block(rows, bytes);
 
+        self.merge_serialized(payload)?;
+        self.check_spill(need_check_spill)
+    }
+
+    fn merge_serialized(&mut self, payload: SerializedPayload) -> Result<()> {
         let partitioned_payload = payload.convert_to_partitioned_payload(
             self.params.group_data_types.clone(),
             self.params.aggregate_functions.clone(),
@@ -223,7 +228,7 @@ impl TransformFinalAggregate {
             ht.combine_payloads(&partitioned_payload, &mut self.flush_state)?;
         }
 
-        self.check_spill(need_check_spill)
+        Ok(())
     }
 
     fn handle_aggregate_payload(
@@ -243,7 +248,8 @@ impl TransformFinalAggregate {
     }
 
     fn check_spill(&mut self, need_check_spill: bool) -> Result<()> {
-        // If already trigger spilled for this task, we continue to spill the remaining part
+        // Once a task spills, all remaining input must follow it so a group cannot
+        // be finalized separately from its already spilled states.
         if self.spilled_occurred || (need_check_spill && self.settings.check_spill()) {
             self.spill_out()?;
         }
@@ -324,6 +330,25 @@ impl TransformFinalAggregate {
         tx: Sender<FinalAggregateTask>,
     ) -> Result<()> {
         if self.spilled_occurred {
+            self.spill_out()?;
+            // If no partition reached the stream threshold, merge the buffered
+            // states locally instead of writing another spill level.
+            if let Some(pending_blocks) = self.spiller.take_pending_if_unspilled() {
+                self.spilled_occurred = false;
+                for (bucket, data_block) in pending_blocks {
+                    check_interrupt()?;
+                    // These states were already counted as input. Do not check
+                    // spill again under the same sustained memory pressure.
+                    self.merge_serialized(SerializedPayload {
+                        bucket: bucket as isize,
+                        data_block,
+                        max_partition_count: SPILL_BUCKET_NUM,
+                    })?;
+                }
+            }
+        }
+
+        if self.spilled_occurred {
             let (output_rows, hash_index_resizes) = match &self.hashtable {
                 HashTable::AggregateHashTable(ht) => {
                     (ht.payload.len(), ht.hash_index_resize_count())
@@ -399,8 +424,6 @@ impl TransformFinalAggregate {
     }
 
     fn spill_finish(&mut self, spilled_depth: usize, tx: Sender<FinalAggregateTask>) -> Result<()> {
-        self.spill_out()?;
-
         let spilled_payload = self.spiller.spill_finish()?;
         let mut chunks = (0..SPILL_BUCKET_NUM).map(|_| vec![]).collect::<Vec<_>>();
         for payload in spilled_payload.into_iter() {

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_final.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/transform_aggregate_final.rs
@@ -119,7 +119,9 @@ impl TransformFinalAggregate {
             ctx.clone(),
             SPILL_BUCKET_NUM,
             params.spill_schema(),
-            LocalPartitionStream::new(0, params.max_block_bytes, SPILL_BUCKET_NUM),
+            // Final processors own separate spill buffers, unlike partial aggregation,
+            // so halve the threshold to reduce per-processor memory usage.
+            LocalPartitionStream::new(0, params.max_block_bytes / 2, SPILL_BUCKET_NUM),
         )?;
 
         Ok(Box::new(TransformFinalAggregate {

--- a/tests/sqllogictests/suites/base/03_common/03_0053_final_aggregate_buffered.test
+++ b/tests/sqllogictests/suites/base/03_common/03_0053_final_aggregate_buffered.test
@@ -1,0 +1,78 @@
+statement ok
+SET max_threads = 1;
+
+statement ok
+SET max_block_size = 1024;
+
+statement ok
+SET max_block_bytes = 2097152;
+
+statement ok
+SET force_aggregate_shuffle_mode = 'row';
+
+statement ok
+SET max_aggregate_spill_level = 3;
+
+statement ok
+SET force_aggregate_data_spill = 0;
+
+# Each group occurs three times across input blocks; groups 0 and 1 occur four times.
+query III
+SELECT count(), count(DISTINCT k),
+       count_if(c != if(k < 2, 4, 3)
+                OR s != 3 * k + 3 * 16385 + if(k < 2, k + 3 * 16385, 0)
+                OR d != c OR lo != k OR hi != k + if(k < 2, 3, 2) * 16385)
+FROM (
+    SELECT number % 16385 AS k, count() AS c, sum(number) AS s,
+           count(DISTINCT number) AS d, min(number) AS lo, max(number) AS hi
+    FROM numbers_mt(49157)
+    GROUP BY k
+);
+----
+16385 16385 0
+
+statement ok
+SET force_aggregate_data_spill = 1;
+
+# Force sustained spill pressure. Final buckets stay below the stream threshold,
+# but contain enough groups for multiple result batches, including their tails.
+query III
+SELECT count(), count(DISTINCT k),
+       count_if(c != if(k < 2, 4, 3)
+                OR s != 3 * k + 3 * 16385 + if(k < 2, k + 3 * 16385, 0)
+                OR d != c OR lo != k OR hi != k + if(k < 2, 3, 2) * 16385)
+FROM (
+    SELECT number % 16385 AS k, count() AS c, sum(number) AS s,
+           count(DISTINCT number) AS d, min(number) AS lo, max(number) AS hi
+    FROM numbers_mt(49157)
+    GROUP BY k
+);
+----
+16385 16385 0
+
+query III
+SELECT number, count(), sum(number) FROM numbers(1) GROUP BY number;
+----
+0 1 0
+
+query II
+SELECT number, count() FROM numbers(0) GROUP BY number;
+----
+
+statement ok
+UNSET force_aggregate_data_spill;
+
+statement ok
+UNSET max_aggregate_spill_level;
+
+statement ok
+UNSET force_aggregate_shuffle_mode;
+
+statement ok
+UNSET max_block_bytes;
+
+statement ok
+UNSET max_block_size;
+
+statement ok
+UNSET max_threads;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Under sustained memory pressure, final aggregation can repeatedly spill even a single small group until it reaches the recursion limit. Complete small buffered partitions locally when no spill writer was created, for both the initial round and recursive rounds.

After draining the remaining hash table, `finish` selects one of three paths and records `finish_mode` in the statistics log:

- `InMemory`: emit the hash table through the existing output block coalescing stream.
- `Buffered`: merge and output each disjoint bucket directly, releasing its hash table before restoring the next bucket. Do not recheck spill or count the buffered input twice.
- `Spilled`: if any bucket has a writer, flush all remaining tails and enqueue the recursive tasks.

Once spill buffering starts, subsequent input follows it even if memory pressure falls. `force_aggregate_data_spill` still triggers buffering, but does not guarantee a final spill file below the stream threshold.

Use `max_block_bytes / 2` for final spill buffers (25 MiB per bucket by default), since each final processor owns its buffers; partial aggregation keeps its shared buffers and original threshold. Processing buckets individually reduces overlapping aggregate states, but does not impose a hard cap on restored-state or queued-result memory.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Added `03_0053_final_aggregate_buffered.test` to check normal and forced-spill aggregation across 16,385 groups, including repeated groups, multiple result batches and tails, single-row input, and empty input. Expected counts, sums, distinct counts, minima, and maxima are checked independently.

Validation:

- Passed `cargo clippy -p databend-query --lib -- -D warnings`, rustfmt, and `git diff --check`.
- The SQL file's 19 records passed over HTTP using the existing pre-change binary (`117f9e153d`), validating SQL and expected results. Execution against this branch remains pending.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent drafted the implementation, SQL regression coverage, and PR description.
- Responsible human: @dqhl76
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20459)
<!-- Reviewable:end -->
