### PR TITLE
refactor(query): centralize aggregate exchange serialization

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_exchange_codec.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_exchange_codec.rs
@@ -1,0 +1,743 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use databend_common_exception::ErrorCode;
+use databend_common_exception::Result;
+use databend_common_expression::BlockMetaInfoDowncast;
+use databend_common_expression::DataBlock;
+use databend_common_expression::FromData;
+use databend_common_expression::PayloadFlushState;
+use databend_common_expression::types::AccessType;
+use databend_common_expression::types::BinaryType;
+use databend_common_expression::types::Int64Type;
+use databend_common_expression::types::NumberType;
+use databend_common_expression::types::StringType;
+use databend_common_storages_parquet::deserialize_row_group_meta_from_bytes;
+use databend_common_storages_parquet::serialize_row_group_meta_to_bytes;
+
+use super::AggregateMeta;
+use super::AggregatePayload;
+use super::AggregateSerdeMeta;
+use super::AggregatorParams;
+use super::BUCKET_TYPE;
+use super::PARTITIONED_AGGREGATE_TYPE;
+use super::PartitionItem;
+use super::PartitionedData;
+use super::SPILLED_TYPE;
+use super::SerializedPayload;
+use super::SpilledPayload;
+use crate::servers::flight::v1::network::ExchangeDataCodec;
+
+/// Converts aggregate payloads and spill references to transportable blocks and
+/// restores their metadata after Arrow decoding. The packet-based aggregate
+/// transforms and Flight channel hooks share this conversion; local exchange
+/// keeps the original process-local payloads.
+pub struct AggregateExchangeDataCodec {
+    params: Arc<AggregatorParams>,
+}
+
+impl AggregateExchangeDataCodec {
+    pub fn create(params: Arc<AggregatorParams>) -> Arc<Self> {
+        Arc::new(Self { params })
+    }
+
+    fn validate_state_schema(&self, block: &DataBlock) -> Result<()> {
+        let expected = self.params.spill_schema();
+        if block.num_columns() != expected.num_fields() {
+            return Err(ErrorCode::BadBytes(format!(
+                "Aggregate transport schema mismatch: expected {} columns, got {}",
+                expected.num_fields(),
+                block.num_columns()
+            )));
+        }
+
+        for (index, (entry, field)) in block
+            .columns()
+            .iter()
+            .zip(expected.fields().iter())
+            .enumerate()
+        {
+            let actual = entry.data_type();
+            if &actual != field.data_type() {
+                return Err(ErrorCode::BadBytes(format!(
+                    "Aggregate transport schema mismatch at column {index}: expected {:?}, got {actual:?}",
+                    field.data_type()
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Streams one aggregate payload in bounded flush batches. Merge exchanges
+    /// consume these batches individually instead of materializing the payload.
+    pub fn encode_stream(&self, payload: AggregatePayload) -> SerializeAggregateStream {
+        SerializeAggregateStream::create(&self.params, payload)
+    }
+
+    fn encode_payload(&self, payload: AggregatePayload) -> Result<DataBlock> {
+        let mut blocks = self.encode_stream(payload).collect::<Result<Vec<_>>>()?;
+        let meta = blocks[0].take_meta().ok_or_else(|| {
+            ErrorCode::Internal("Aggregate payload transport block has no metadata")
+        })?;
+        let mut block = DataBlock::concat(&blocks)?;
+        block.replace_meta(meta);
+        Ok(block)
+    }
+
+    fn encode_partitioned(&self, data: PartitionedData) -> Result<Option<DataBlock>> {
+        match data {
+            PartitionedData::Empty => Ok(None),
+            PartitionedData::Serialized(data) if data.is_empty() => Ok(None),
+            PartitionedData::AggregatePayload(data) if data.is_empty() => Ok(None),
+            PartitionedData::BucketSpilled(data) if data.is_empty() => Ok(None),
+            PartitionedData::AggregatePayload(data) => {
+                let mut buckets = Vec::with_capacity(data.len());
+                let mut payload_row_counts = Vec::with_capacity(data.len());
+                let mut payload_blocks = Vec::with_capacity(data.len());
+
+                for payload in data {
+                    let block = payload.payload.aggregate_flush_all()?;
+                    if block.num_rows() == 0 {
+                        continue;
+                    }
+                    buckets.push(payload.bucket);
+                    payload_row_counts.push(block.num_rows());
+                    payload_blocks.push(block);
+                }
+
+                if payload_blocks.is_empty() {
+                    return Ok(None);
+                }
+
+                let block = DataBlock::concat(&payload_blocks)?.add_meta(Some(
+                    AggregateSerdeMeta::create_partitioned_payload(
+                        buckets,
+                        payload_row_counts,
+                        false,
+                    ),
+                ))?;
+                Ok(Some(block))
+            }
+            PartitionedData::BucketSpilled(data) => {
+                let rows = data.len();
+                let mut buckets = Vec::with_capacity(rows);
+                let mut locations = Vec::with_capacity(rows);
+                let mut row_groups = Vec::with_capacity(rows);
+
+                for payload in data {
+                    buckets.push(payload.bucket as i64);
+                    locations.push(payload.location);
+                    row_groups.push(serialize_row_group_meta_to_bytes(&payload.row_group)?);
+                }
+
+                let block = DataBlock::new_from_columns(vec![
+                    Int64Type::from_data(buckets),
+                    StringType::from_data(locations),
+                    BinaryType::from_data(row_groups),
+                ])
+                .add_meta(Some(AggregateSerdeMeta::create_spilled(rows as isize)))?;
+                Ok(Some(block))
+            }
+            PartitionedData::Mixed(data) => {
+                let block = PartitionItem::serialize_mixed(data)?;
+                if block.is_empty() && block.get_meta().is_none() {
+                    Ok(None)
+                } else {
+                    Ok(Some(block))
+                }
+            }
+            other => Err(ErrorCode::Internal(format!(
+                "Partitioned aggregate data is not transportable: {other:?}"
+            ))),
+        }
+    }
+
+    fn decode_partitioned_payload(
+        &self,
+        meta: &AggregateSerdeMeta,
+        block: DataBlock,
+    ) -> Result<Option<DataBlock>> {
+        if meta.is_empty {
+            return Ok(None);
+        }
+        self.validate_state_schema(&block)?;
+        if meta.buckets.len() != meta.payload_row_counts.len() {
+            return Err(ErrorCode::BadBytes(
+                "Invalid partitioned aggregate transport metadata",
+            ));
+        }
+
+        let mut offset = 0;
+        let mut payloads = Vec::with_capacity(meta.buckets.len());
+        for (bucket, rows) in meta.buckets.iter().zip(meta.payload_row_counts.iter()) {
+            let start = offset;
+            offset += *rows;
+            if offset > block.num_rows() {
+                return Err(ErrorCode::BadBytes(
+                    "Partitioned aggregate payload rows exceed block rows",
+                ));
+            }
+
+            payloads.push(SerializedPayload {
+                bucket: *bucket,
+                data_block: if *rows == 0 {
+                    DataBlock::empty()
+                } else {
+                    block.slice(start..offset)
+                },
+                max_partition_count: 0,
+            });
+        }
+
+        if offset != block.num_rows() {
+            return Err(ErrorCode::BadBytes(
+                "Partitioned aggregate payload rows do not match block rows",
+            ));
+        }
+
+        Ok(Some(DataBlock::empty_with_meta(
+            AggregateMeta::create_partitioned(None, PartitionedData::Serialized(payloads)),
+        )))
+    }
+
+    fn decode_spilled(
+        &self,
+        meta: &AggregateSerdeMeta,
+        block: DataBlock,
+    ) -> Result<Option<DataBlock>> {
+        if block.num_columns() != 3 {
+            return Err(ErrorCode::BadBytes(
+                "Spilled aggregate transport block must contain three columns",
+            ));
+        }
+
+        let columns = block
+            .columns()
+            .iter()
+            .map(|entry| {
+                entry
+                    .as_column()
+                    .cloned()
+                    .ok_or_else(|| ErrorCode::BadBytes("Spilled aggregate column is scalar"))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let buckets = NumberType::<i64>::try_downcast_column(&columns[0])
+            .map_err(|_| ErrorCode::BadBytes("Invalid spilled aggregate bucket column"))?;
+        let locations = StringType::try_downcast_column(&columns[1])
+            .map_err(|_| ErrorCode::BadBytes("Invalid spilled aggregate location column"))?;
+        let row_groups = BinaryType::try_downcast_column(&columns[2])
+            .map_err(|_| ErrorCode::BadBytes("Invalid spilled aggregate row-group column"))?;
+
+        let mut payloads = Vec::with_capacity(block.num_rows());
+        for index in 0..block.num_rows() {
+            let bucket = *buckets
+                .get(index)
+                .ok_or_else(|| ErrorCode::BadBytes("Missing spilled aggregate bucket value"))?
+                as isize;
+            let location = locations
+                .index(index)
+                .ok_or_else(|| ErrorCode::BadBytes("Missing spilled aggregate location"))?
+                .to_string();
+            let row_group_bytes = row_groups
+                .index(index)
+                .ok_or_else(|| ErrorCode::BadBytes("Missing spilled aggregate row group"))?;
+            let row_group = deserialize_row_group_meta_from_bytes(row_group_bytes)?;
+            payloads.push(SpilledPayload {
+                bucket,
+                location,
+                row_group,
+            });
+        }
+
+        if meta.shuffle_bucket == -1 {
+            return Err(ErrorCode::BadBytes(
+                "Row-shuffled spilled aggregate transport is unsupported",
+            ));
+        }
+
+        Ok(Some(DataBlock::empty_with_meta(
+            AggregateMeta::create_partitioned(None, PartitionedData::BucketSpilled(payloads)),
+        )))
+    }
+}
+
+impl ExchangeDataCodec for AggregateExchangeDataCodec {
+    fn encode(&self, mut block: DataBlock) -> Result<Option<DataBlock>> {
+        if block.is_empty() && block.get_meta().is_none() {
+            return Ok(None);
+        }
+
+        let meta = block
+            .take_meta()
+            .and_then(AggregateMeta::downcast_from)
+            .ok_or_else(|| {
+                ErrorCode::Internal("Aggregate exchange expected AggregateMeta input")
+            })?;
+
+        match meta {
+            AggregateMeta::AggregatePayload(payload) => self.encode_payload(payload).map(Some),
+            AggregateMeta::Partitioned { data, .. } => self.encode_partitioned(data),
+            other => Err(ErrorCode::Internal(format!(
+                "Aggregate exchange cannot encode metadata: {other:?}"
+            ))),
+        }
+    }
+
+    fn decode(&self, mut block: DataBlock) -> Result<Option<DataBlock>> {
+        let meta = block
+            .take_meta()
+            .and_then(AggregateSerdeMeta::downcast_from)
+            .ok_or_else(|| ErrorCode::BadBytes("Aggregate exchange expected AggregateSerdeMeta"))?;
+
+        match meta.typ {
+            BUCKET_TYPE => {
+                if meta.is_empty {
+                    block = block.slice(0..0);
+                } else {
+                    self.validate_state_schema(&block)?;
+                }
+                Ok(Some(DataBlock::empty_with_meta(
+                    AggregateMeta::create_serialized(meta.bucket, block, meta.max_partition_count),
+                )))
+            }
+            PARTITIONED_AGGREGATE_TYPE => self.decode_partitioned_payload(&meta, block),
+            SPILLED_TYPE => self.decode_spilled(&meta, block),
+            other => Err(ErrorCode::BadBytes(format!(
+                "Unknown aggregate transport metadata type {other}"
+            ))),
+        }
+    }
+}
+
+pub struct SerializeAggregateStream {
+    _params: Arc<AggregatorParams>,
+    payload: AggregatePayload,
+    flush_state: PayloadFlushState,
+    end_iter: bool,
+    nums: usize,
+}
+
+unsafe impl Send for SerializeAggregateStream {}
+
+unsafe impl Sync for SerializeAggregateStream {}
+
+impl SerializeAggregateStream {
+    fn create(params: &Arc<AggregatorParams>, payload: AggregatePayload) -> Self {
+        SerializeAggregateStream {
+            payload,
+            flush_state: PayloadFlushState::default(),
+            _params: params.clone(),
+            end_iter: false,
+            nums: 0,
+        }
+    }
+}
+
+impl Iterator for SerializeAggregateStream {
+    type Item = Result<DataBlock>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Result::transpose(self.next_impl())
+    }
+}
+
+impl SerializeAggregateStream {
+    fn next_impl(&mut self) -> Result<Option<DataBlock>> {
+        if self.end_iter {
+            return Ok(None);
+        }
+
+        let AggregatePayload {
+            bucket,
+            ref payload,
+            max_partition_count,
+        } = self.payload;
+        match payload.aggregate_flush(&mut self.flush_state)? {
+            Some(block) => {
+                self.nums += 1;
+                Ok(Some(block.add_meta(Some(
+                    AggregateSerdeMeta::create_agg_payload(bucket, max_partition_count, false),
+                ))?))
+            }
+            None => {
+                self.end_iter = true;
+                // always return at least one block
+                if self.nums == 0 {
+                    self.nums += 1;
+                    let block = payload.empty_block(1);
+                    Ok(Some(block.add_meta(Some(
+                        AggregateSerdeMeta::create_agg_payload(bucket, max_partition_count, true),
+                    ))?))
+                } else {
+                    Ok(None)
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use std::sync::Arc;
+
+    use arrow_ipc::writer::IpcWriteOptions;
+    use arrow_schema::Schema as ArrowSchema;
+    use bumpalo::Bump;
+    use databend_common_expression::BlockMetaInfoDowncast;
+    use databend_common_expression::DataField;
+    use databend_common_expression::DataSchemaRefExt;
+    use databend_common_expression::FromData;
+    use databend_common_expression::aggregate::AggregatePayload;
+    use databend_common_expression::aggregate::SerializedPayload as ExpressionSerializedPayload;
+    use databend_common_expression::types::DataType;
+    use databend_common_expression::types::Int64Type;
+    use databend_common_expression::types::NumberDataType;
+    use parquet::basic::Repetition;
+    use parquet::file::metadata::RowGroupMetaData;
+    use parquet::schema::types::SchemaDescriptor;
+    use parquet::schema::types::Type;
+
+    use super::*;
+    use crate::servers::flight::v1::network::inbound_channel::deserialize_flight_data;
+    use crate::servers::flight::v1::network::outbound_channel::serialize_block;
+
+    pub(crate) fn params() -> Arc<AggregatorParams> {
+        let data_type = DataType::Number(NumberDataType::Int64);
+        AggregatorParams::try_create(
+            DataSchemaRefExt::create(vec![DataField::new("group", data_type.clone())]),
+            vec![data_type],
+            &[0],
+            &[],
+            &[],
+            true,
+            1024,
+            1024 * 1024,
+        )
+        .unwrap()
+    }
+
+    fn nullable_params() -> Arc<AggregatorParams> {
+        let data_type = DataType::Nullable(Box::new(DataType::Number(NumberDataType::Int64)));
+        AggregatorParams::try_create(
+            DataSchemaRefExt::create(vec![DataField::new("group", data_type.clone())]),
+            vec![data_type],
+            &[0],
+            &[],
+            &[],
+            true,
+            1024,
+            1024 * 1024,
+        )
+        .unwrap()
+    }
+
+    pub(crate) fn payload_block(values: Vec<i64>) -> DataBlock {
+        let params = params();
+        let serialized = ExpressionSerializedPayload {
+            bucket: 7,
+            data_block: DataBlock::new_from_columns(vec![Int64Type::from_data(values)]),
+            max_partition_count: 8,
+        };
+        let payload = serialized
+            .convert_to_single_payload(
+                params.group_data_types.clone(),
+                vec![],
+                0,
+                Arc::new(Bump::new()),
+            )
+            .unwrap();
+
+        DataBlock::empty_with_meta(Box::new(AggregateMeta::AggregatePayload(
+            AggregatePayload {
+                bucket: 7,
+                payload,
+                max_partition_count: 8,
+            },
+        )))
+    }
+
+    fn flight_round_trip(
+        block: DataBlock,
+        schema: &databend_common_expression::DataSchemaRef,
+    ) -> DataBlock {
+        let mut packets = serialize_block(block, &IpcWriteOptions::default(), None).unwrap();
+        assert_eq!(packets.len(), 1);
+        deserialize_flight_data(
+            packets.pop().unwrap(),
+            schema,
+            &Arc::new(ArrowSchema::from(schema.as_ref())),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_payload_remote_round_trip() {
+        let params = params();
+        let codec = AggregateExchangeDataCodec::create(params.clone());
+
+        let transport = codec
+            .encode(payload_block(vec![11, 22, 33]))
+            .unwrap()
+            .unwrap();
+        let serde_meta = transport
+            .get_meta()
+            .and_then(AggregateSerdeMeta::downcast_ref_from)
+            .unwrap();
+        assert_eq!(serde_meta.typ, BUCKET_TYPE);
+        assert_eq!(serde_meta.bucket, 7);
+        assert_eq!(serde_meta.max_partition_count, 8);
+        assert!(!serde_meta.is_empty);
+
+        let transport = flight_round_trip(transport, &params.spill_schema());
+        let mut restored = codec.decode(transport).unwrap().unwrap();
+        let restored = restored
+            .take_meta()
+            .and_then(AggregateMeta::downcast_from)
+            .unwrap();
+        let AggregateMeta::Serialized(restored) = restored else {
+            panic!("expected serialized aggregate payload")
+        };
+        assert_eq!(restored.bucket, 7);
+        assert_eq!(restored.max_partition_count, 8);
+        assert_eq!(restored.data_block.num_rows(), 3);
+        let column = restored.data_block.get_by_offset(0).to_column();
+        let values = Int64Type::try_downcast_column(&column).unwrap();
+        assert_eq!(values.as_slice(), &[11, 22, 33]);
+    }
+
+    #[test]
+    fn test_empty_payload_remote_round_trip() {
+        let params = params();
+        let codec = AggregateExchangeDataCodec::create(params.clone());
+        let payload = databend_common_expression::Payload::new(
+            Arc::new(Bump::new()),
+            params.group_data_types.clone(),
+            vec![],
+            None,
+        );
+        let block = DataBlock::empty_with_meta(Box::new(AggregateMeta::AggregatePayload(
+            AggregatePayload {
+                bucket: 3,
+                payload,
+                max_partition_count: 0,
+            },
+        )));
+
+        let transport = codec.encode(block).unwrap().unwrap();
+        let serde_meta = transport
+            .get_meta()
+            .and_then(AggregateSerdeMeta::downcast_ref_from)
+            .unwrap();
+        assert!(serde_meta.is_empty);
+
+        let transport = flight_round_trip(transport, &params.spill_schema());
+        let mut restored = codec.decode(transport).unwrap().unwrap();
+        let restored = restored
+            .take_meta()
+            .and_then(AggregateMeta::downcast_from)
+            .unwrap();
+        let AggregateMeta::Serialized(restored) = restored else {
+            panic!("expected serialized aggregate payload")
+        };
+        assert_eq!(restored.bucket, 3);
+        assert_eq!(restored.data_block.num_rows(), 0);
+    }
+
+    #[test]
+    fn test_nullable_group_key_remote_round_trip() {
+        let params = nullable_params();
+        let codec = AggregateExchangeDataCodec::create(params.clone());
+        let group_column = Int64Type::from_opt_data(vec![Some(5), None, Some(-2)]);
+        let serialized = ExpressionSerializedPayload {
+            bucket: 2,
+            data_block: DataBlock::new_from_columns(vec![group_column.clone()]),
+            max_partition_count: 4,
+        };
+        let payload = serialized
+            .convert_to_single_payload(
+                params.group_data_types.clone(),
+                vec![],
+                0,
+                Arc::new(Bump::new()),
+            )
+            .unwrap();
+        let block = DataBlock::empty_with_meta(Box::new(AggregateMeta::AggregatePayload(
+            AggregatePayload {
+                bucket: 2,
+                payload,
+                max_partition_count: 4,
+            },
+        )));
+
+        let transport = codec.encode(block).unwrap().unwrap();
+        let transport = flight_round_trip(transport, &params.spill_schema());
+        let mut restored = codec.decode(transport).unwrap().unwrap();
+        let restored = restored
+            .take_meta()
+            .and_then(AggregateMeta::downcast_from)
+            .unwrap();
+        let AggregateMeta::Serialized(restored) = restored else {
+            panic!("expected serialized aggregate payload")
+        };
+        assert_eq!(
+            restored.data_block.get_by_offset(0).to_column(),
+            group_column
+        );
+    }
+
+    #[tokio::test]
+    async fn test_local_channel_preserves_aggregate_payload() {
+        let params = params();
+        let codec = AggregateExchangeDataCodec::create(params.clone());
+        let channel_set = crate::servers::flight::v1::network::NetworkInboundChannelSet::new(1);
+        let channel = crate::servers::flight::v1::network::create_local_channels(&channel_set)
+            .pop()
+            .unwrap();
+        let receiver = channel_set.create_receiver_with_codec(0, &params.spill_schema(), codec);
+
+        channel
+            .add_block(payload_block(vec![11, 22, 33]))
+            .await
+            .unwrap();
+        let mut received = receiver.recv().await.unwrap().unwrap();
+        let received = received
+            .take_meta()
+            .and_then(AggregateMeta::downcast_from)
+            .unwrap();
+        let AggregateMeta::AggregatePayload(received) = received else {
+            panic!("local channel materialized aggregate payload")
+        };
+        assert_eq!(received.bucket, 7);
+        assert_eq!(received.payload.len(), 3);
+    }
+
+    #[test]
+    fn test_partitioned_payload_remote_round_trip() {
+        let params = params();
+        let codec = AggregateExchangeDataCodec::create(params.clone());
+        let transport = DataBlock::new_from_columns(vec![Int64Type::from_data(vec![10, 20, 30])])
+            .add_meta(Some(AggregateSerdeMeta::create_partitioned_payload(
+                vec![4, 9],
+                vec![2, 1],
+                false,
+            )))
+            .unwrap();
+
+        let transport = flight_round_trip(transport, &params.spill_schema());
+        let mut restored = codec.decode(transport).unwrap().unwrap();
+        let restored = restored
+            .take_meta()
+            .and_then(AggregateMeta::downcast_from)
+            .unwrap();
+        let AggregateMeta::Partitioned {
+            data: PartitionedData::Serialized(payloads),
+            ..
+        } = restored
+        else {
+            panic!("expected partitioned serialized payload")
+        };
+        assert_eq!(payloads.len(), 2);
+        assert_eq!(payloads[0].bucket, 4);
+        assert_eq!(payloads[0].data_block.num_rows(), 2);
+        assert_eq!(payloads[1].bucket, 9);
+        assert_eq!(payloads[1].data_block.num_rows(), 1);
+    }
+
+    #[test]
+    fn test_spilled_payload_remote_round_trip() {
+        let params = params();
+        let codec = AggregateExchangeDataCodec::create(params.clone());
+        let schema = Type::group_type_builder("schema")
+            .with_repetition(Repetition::REPEATED)
+            .build()
+            .unwrap();
+        let descriptor = SchemaDescriptor::new(Arc::new(schema));
+        let row_group = RowGroupMetaData::builder(descriptor.into())
+            .set_num_rows(17)
+            .build()
+            .unwrap();
+        let block = DataBlock::empty_with_meta(AggregateMeta::create_partitioned(
+            None,
+            PartitionedData::BucketSpilled(vec![SpilledPayload {
+                bucket: 6,
+                location: "memory://aggregate-spill".to_string(),
+                row_group,
+            }]),
+        ));
+
+        let transport = codec.encode(block).unwrap().unwrap();
+        let serde_meta = transport
+            .get_meta()
+            .and_then(AggregateSerdeMeta::downcast_ref_from)
+            .unwrap();
+        assert_eq!(serde_meta.typ, SPILLED_TYPE);
+
+        // The spilled metadata overrides the aggregate state schema during
+        // generic Arrow Flight decoding.
+        let transport = flight_round_trip(transport, &params.spill_schema());
+        let mut restored = codec.decode(transport).unwrap().unwrap();
+        let restored = restored
+            .take_meta()
+            .and_then(AggregateMeta::downcast_from)
+            .unwrap();
+        let AggregateMeta::Partitioned {
+            data: PartitionedData::BucketSpilled(payloads),
+            ..
+        } = restored
+        else {
+            panic!("expected spilled aggregate payload")
+        };
+        assert_eq!(payloads.len(), 1);
+        assert_eq!(payloads[0].bucket, 6);
+        assert_eq!(payloads[0].location, "memory://aggregate-spill");
+        assert_eq!(payloads[0].row_group.num_rows(), 17);
+    }
+
+    #[test]
+    fn test_rejects_malformed_partitioned_payload() {
+        let codec = AggregateExchangeDataCodec::create(params());
+        let block = DataBlock::new_from_columns(vec![Int64Type::from_data(vec![10, 20])])
+            .add_meta(Some(AggregateSerdeMeta::create_partitioned_payload(
+                vec![1],
+                vec![3],
+                false,
+            )))
+            .unwrap();
+        let error = codec.decode(block).unwrap_err();
+        assert!(error.message().contains("exceed block rows"));
+    }
+
+    #[test]
+    fn test_rejects_transport_schema_mismatch() {
+        let codec = AggregateExchangeDataCodec::create(params());
+        let block = DataBlock::new_from_columns(vec![StringType::from_data(vec!["wrong"])])
+            .add_meta(Some(AggregateSerdeMeta::create_agg_payload(0, 0, false)))
+            .unwrap();
+        let error = codec.decode(block).unwrap_err();
+        assert!(error.message().contains("schema mismatch"));
+    }
+
+    #[test]
+    fn test_rejects_non_aggregate_metadata() {
+        let codec = AggregateExchangeDataCodec::create(params());
+        let error = codec
+            .encode(DataBlock::new_from_columns(vec![Int64Type::from_data(
+                vec![1],
+            )]))
+            .unwrap_err();
+        assert!(error.message().contains("expected AggregateMeta"));
+    }
+}

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_exchange_codec.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_exchange_codec.rs
@@ -54,33 +54,6 @@ impl AggregateExchangeDataCodec {
         Arc::new(Self { params })
     }
 
-    fn validate_state_schema(&self, block: &DataBlock) -> Result<()> {
-        let expected = self.params.spill_schema();
-        if block.num_columns() != expected.num_fields() {
-            return Err(ErrorCode::BadBytes(format!(
-                "Aggregate transport schema mismatch: expected {} columns, got {}",
-                expected.num_fields(),
-                block.num_columns()
-            )));
-        }
-
-        for (index, (entry, field)) in block
-            .columns()
-            .iter()
-            .zip(expected.fields().iter())
-            .enumerate()
-        {
-            let actual = entry.data_type();
-            if !field.data_type().matches_physical_type(&actual) {
-                return Err(ErrorCode::BadBytes(format!(
-                    "Aggregate transport schema mismatch at column {index}: expected {:?}, got {actual:?}",
-                    field.data_type()
-                )));
-            }
-        }
-        Ok(())
-    }
-
     /// Streams one aggregate payload in bounded flush batches. Merge exchanges
     /// consume these batches individually instead of materializing the payload.
     pub fn encode_stream(&self, payload: AggregatePayload) -> SerializeAggregateStream {
@@ -173,7 +146,6 @@ impl AggregateExchangeDataCodec {
         if meta.is_empty {
             return Ok(None);
         }
-        self.validate_state_schema(&block)?;
         if meta.buckets.len() != meta.payload_row_counts.len() {
             return Err(ErrorCode::BadBytes(
                 "Invalid partitioned aggregate transport metadata",
@@ -306,8 +278,6 @@ impl ExchangeDataCodec for AggregateExchangeDataCodec {
             BUCKET_TYPE => {
                 if meta.is_empty {
                     block = block.slice(0..0);
-                } else {
-                    self.validate_state_schema(&block)?;
                 }
                 Ok(Some(DataBlock::empty_with_meta(
                     AggregateMeta::create_serialized(meta.bucket, block, meta.max_partition_count),
@@ -780,16 +750,6 @@ pub(crate) mod tests {
             .unwrap();
         let error = codec.decode(block).unwrap_err();
         assert!(error.message().contains("exceed block rows"));
-    }
-
-    #[test]
-    fn test_rejects_transport_schema_mismatch() {
-        let codec = AggregateExchangeDataCodec::create(params());
-        let block = DataBlock::new_from_columns(vec![StringType::from_data(vec!["wrong"])])
-            .add_meta(Some(AggregateSerdeMeta::create_agg_payload(0, 0, false)))
-            .unwrap();
-        let error = codec.decode(block).unwrap_err();
-        assert!(error.message().contains("schema mismatch"));
     }
 
     #[test]

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_exchange_codec.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_exchange_codec.rs
@@ -71,7 +71,7 @@ impl AggregateExchangeDataCodec {
             .enumerate()
         {
             let actual = entry.data_type();
-            if &actual != field.data_type() {
+            if !field.data_type().matches_physical_type(&actual) {
                 return Err(ErrorCode::BadBytes(format!(
                     "Aggregate transport schema mismatch at column {index}: expected {:?}, got {actual:?}",
                     field.data_type()
@@ -397,14 +397,18 @@ pub(crate) mod tests {
     use arrow_schema::Schema as ArrowSchema;
     use bumpalo::Bump;
     use databend_common_expression::BlockMetaInfoDowncast;
+    use databend_common_expression::Column;
     use databend_common_expression::DataField;
     use databend_common_expression::DataSchemaRefExt;
     use databend_common_expression::FromData;
     use databend_common_expression::aggregate::AggregatePayload;
     use databend_common_expression::aggregate::SerializedPayload as ExpressionSerializedPayload;
+    use databend_common_expression::types::AggregateStateDataType;
+    use databend_common_expression::types::BooleanType;
     use databend_common_expression::types::DataType;
     use databend_common_expression::types::Int64Type;
     use databend_common_expression::types::NumberDataType;
+    use databend_common_expression::types::UInt64Type;
     use parquet::basic::Repetition;
     use parquet::file::metadata::RowGroupMetaData;
     use parquet::schema::types::SchemaDescriptor;
@@ -596,6 +600,64 @@ pub(crate) mod tests {
             restored.data_block.get_by_offset(0).to_column(),
             group_column
         );
+    }
+
+    #[test]
+    fn test_nullable_aggregate_state_group_key_remote_round_trip() {
+        let uint64 = DataType::Number(NumberDataType::UInt64);
+        let group_type = DataType::AggregateState(Box::new(AggregateStateDataType {
+            function_name: "sum".to_string(),
+            params: vec![],
+            argument_types: vec![uint64.clone()],
+            state_type: Box::new(DataType::Tuple(vec![uint64, DataType::Boolean])),
+        }))
+        .wrap_nullable();
+        let params = AggregatorParams::try_create(
+            DataSchemaRefExt::create(vec![DataField::new("group", group_type.clone())]),
+            vec![group_type],
+            &[0],
+            &[],
+            &[],
+            true,
+            1024,
+            1024 * 1024,
+        )
+        .unwrap();
+        let codec = AggregateExchangeDataCodec::create(params.clone());
+        let group_column = Column::Tuple(vec![
+            UInt64Type::from_data(vec![10, 0, 30]),
+            BooleanType::from_data(vec![true, false, true]),
+        ])
+        .wrap_nullable(Some([true, false, true].into_iter().collect()));
+
+        // GROUP BY sum_state uses the logical AggregateState schema, while
+        // Arrow restores the nullable tuple that physically stores each state.
+        for meta in [
+            AggregateSerdeMeta::create_agg_payload(2, 4, false),
+            AggregateSerdeMeta::create_partitioned_payload(vec![2], vec![3], false),
+        ] {
+            let transport = DataBlock::new_from_columns(vec![group_column.clone()])
+                .add_meta(Some(meta))
+                .unwrap();
+            let transport = flight_round_trip(transport, &params.spill_schema());
+            let mut restored = codec.decode(transport).unwrap().unwrap();
+            let restored = restored
+                .take_meta()
+                .and_then(AggregateMeta::downcast_from)
+                .unwrap();
+            let payload = match restored {
+                AggregateMeta::Serialized(payload) => payload,
+                AggregateMeta::Partitioned {
+                    data: PartitionedData::Serialized(mut payloads),
+                    ..
+                } => payloads.remove(0),
+                _ => panic!("expected serialized aggregate payload"),
+            };
+            assert_eq!(
+                payload.data_block.get_by_offset(0).to_column(),
+                group_column
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_exchange_injector.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/aggregate_exchange_injector.rs
@@ -21,6 +21,7 @@ use databend_common_settings::FlightCompression;
 
 use crate::physical_plans::AggregateShuffleMode;
 use crate::pipelines::processors::transforms::aggregator::AggregateBucketScatter;
+use crate::pipelines::processors::transforms::aggregator::AggregateExchangeDataCodec;
 use crate::pipelines::processors::transforms::aggregator::AggregateRowScatter;
 use crate::pipelines::processors::transforms::aggregator::AggregatorParams;
 use crate::pipelines::processors::transforms::aggregator::TransformAggregateDeserializer;
@@ -130,7 +131,12 @@ impl ExchangeInjector for AggregateInjector {
         pipeline: &mut Pipeline,
     ) -> Result<()> {
         pipeline.add_transform(|input, output| {
-            TransformAggregateDeserializer::try_create(input, output, &params.schema)
+            TransformAggregateDeserializer::try_create(
+                input,
+                output,
+                &params.schema,
+                AggregateExchangeDataCodec::create(self.aggregator_params.clone()),
+            )
         })
     }
 
@@ -140,7 +146,12 @@ impl ExchangeInjector for AggregateInjector {
         pipeline: &mut Pipeline,
     ) -> Result<()> {
         pipeline.add_transform(|input, output| {
-            TransformAggregateDeserializer::try_create(input, output, &params.schema)
+            TransformAggregateDeserializer::try_create(
+                input,
+                output,
+                &params.schema,
+                AggregateExchangeDataCodec::create(self.aggregator_params.clone()),
+            )
         })?;
         Ok(())
     }

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/mod.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod aggregate_exchange_codec;
 mod aggregate_exchange_injector;
 mod aggregate_meta;
 mod aggregate_spiller;
@@ -25,6 +26,8 @@ mod transform_aggregate_final;
 mod transform_aggregate_partial;
 mod transform_single_key;
 
+pub use aggregate_exchange_codec::AggregateExchangeDataCodec;
+pub use aggregate_exchange_codec::SerializeAggregateStream;
 pub use aggregate_exchange_injector::AggregateInjector;
 pub use aggregate_meta::*;
 pub use aggregate_spiller::*;

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/serde/mod.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/serde/mod.rs
@@ -25,7 +25,6 @@ pub use transform_deserializer::*;
 pub use transform_exchange_aggregate_serializer::*;
 
 pub mod exchange_defines {
-    use arrow_schema::Schema;
     use databend_common_expression::DataField;
     use databend_common_expression::DataSchema;
     use databend_common_expression::types::DataType;
@@ -37,10 +36,5 @@ pub mod exchange_defines {
             DataField::new("location", DataType::String),
             DataField::new("row_group", DataType::Binary),
         ])
-    }
-
-    pub fn spilled_arrow_schema() -> Schema {
-        let schema = spilled_schema();
-        Schema::from(&schema)
     }
 }

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/serde/serde_meta.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/serde/serde_meta.rs
@@ -15,6 +15,7 @@
 use databend_common_expression::BlockMetaInfo;
 use databend_common_expression::BlockMetaInfoDowncast;
 use databend_common_expression::BlockMetaInfoPtr;
+use databend_common_expression::DataSchemaRef;
 
 pub const BUCKET_TYPE: usize = 1;
 pub const SPILLED_TYPE: usize = 2;
@@ -91,5 +92,10 @@ impl BlockMetaInfo for AggregateSerdeMeta {
 
     fn clone_self(&self) -> Box<dyn BlockMetaInfo> {
         Box::new(self.clone())
+    }
+
+    fn override_block_schema(&self) -> Option<DataSchemaRef> {
+        (self.typ == SPILLED_TYPE)
+            .then(|| std::sync::Arc::new(super::exchange_defines::spilled_schema()))
     }
 }

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_aggregate_serializer.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_aggregate_serializer.rs
@@ -18,19 +18,18 @@ use std::sync::Arc;
 use databend_common_exception::Result;
 use databend_common_expression::BlockMetaInfoDowncast;
 use databend_common_expression::DataBlock;
-use databend_common_expression::PayloadFlushState;
 use databend_common_pipeline::core::Event;
 use databend_common_pipeline::core::InputPort;
 use databend_common_pipeline::core::OutputPort;
 use databend_common_pipeline::core::Processor;
 use databend_common_pipeline::core::ProcessorPtr;
 
+use crate::pipelines::processors::transforms::aggregator::AggregateExchangeDataCodec;
 use crate::pipelines::processors::transforms::aggregator::AggregateMeta;
-use crate::pipelines::processors::transforms::aggregator::AggregatePayload;
-use crate::pipelines::processors::transforms::aggregator::AggregateSerdeMeta;
 use crate::pipelines::processors::transforms::aggregator::AggregatorParams;
+use crate::pipelines::processors::transforms::aggregator::SerializeAggregateStream;
 pub struct TransformAggregateSerializer {
-    params: Arc<AggregatorParams>,
+    codec: Arc<AggregateExchangeDataCodec>,
 
     input: Arc<InputPort>,
     output: Arc<OutputPort>,
@@ -48,7 +47,7 @@ impl TransformAggregateSerializer {
             TransformAggregateSerializer {
                 input,
                 output,
-                params,
+                codec: AggregateExchangeDataCodec::create(params),
                 input_data: None,
                 output_data: None,
             },
@@ -123,74 +122,53 @@ impl TransformAggregateSerializer {
             unreachable!()
         };
 
-        self.input_data = Some(SerializeAggregateStream::create(&self.params, p));
+        self.input_data = Some(self.codec.encode_stream(p));
         Ok(Event::Sync)
     }
 }
 
-pub struct SerializeAggregateStream {
-    _params: Arc<AggregatorParams>,
-    payload: AggregatePayload,
-    flush_state: PayloadFlushState,
-    end_iter: bool,
-    nums: usize,
-}
+#[cfg(test)]
+mod tests {
+    use databend_common_expression::types::AccessType;
+    use databend_common_expression::types::Int64Type;
 
-unsafe impl Send for SerializeAggregateStream {}
+    use super::*;
+    use crate::pipelines::processors::transforms::aggregator::AggregateSerdeMeta;
+    use crate::pipelines::processors::transforms::aggregator::aggregate_exchange_codec::tests::params;
+    use crate::pipelines::processors::transforms::aggregator::aggregate_exchange_codec::tests::payload_block;
 
-unsafe impl Sync for SerializeAggregateStream {}
-
-impl SerializeAggregateStream {
-    pub fn create(params: &Arc<AggregatorParams>, payload: AggregatePayload) -> Self {
-        SerializeAggregateStream {
-            payload,
-            flush_state: PayloadFlushState::default(),
-            _params: params.clone(),
-            end_iter: false,
-            nums: 0,
-        }
-    }
-}
-
-impl Iterator for SerializeAggregateStream {
-    type Item = Result<DataBlock>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        Result::transpose(self.next_impl())
-    }
-}
-
-impl SerializeAggregateStream {
-    fn next_impl(&mut self) -> Result<Option<DataBlock>> {
-        if self.end_iter {
-            return Ok(None);
-        }
-
-        let AggregatePayload {
-            bucket,
-            ref payload,
-            max_partition_count,
-        } = self.payload;
-        match payload.aggregate_flush(&mut self.flush_state)? {
-            Some(block) => {
-                self.nums += 1;
-                Ok(Some(block.add_meta(Some(
-                    AggregateSerdeMeta::create_agg_payload(bucket, max_partition_count, false),
-                ))?))
-            }
-            None => {
-                self.end_iter = true;
-                // always return at least one block
-                if self.nums == 0 {
-                    self.nums += 1;
-                    let block = payload.empty_block(1);
-                    Ok(Some(block.add_meta(Some(
-                        AggregateSerdeMeta::create_agg_payload(bucket, max_partition_count, true),
-                    ))?))
-                } else {
-                    Ok(None)
-                }
+    #[test]
+    fn test_merge_serializer_keeps_payload_flush_batches() -> Result<()> {
+        let mut serializer = TransformAggregateSerializer {
+            codec: AggregateExchangeDataCodec::create(params()),
+            input: InputPort::create(),
+            output: OutputPort::create(),
+            input_data: None,
+            output_data: None,
+        };
+        serializer.transform_input_data(payload_block((0..5000).collect()))?;
+        let mut batches = 0;
+        let mut values = Vec::new();
+        while serializer.input_data.is_some() {
+            serializer.process()?;
+            if let Some(block) = serializer.output_data.take() {
+                batches += 1;
+                let meta = block
+                    .get_meta()
+                    .and_then(AggregateSerdeMeta::downcast_ref_from)
+                    .unwrap();
+                assert_eq!((meta.bucket, meta.max_partition_count), (7, 8));
+                let column = block.get_by_offset(0).to_column();
+                values
+                    .extend_from_slice(Int64Type::try_downcast_column(&column).unwrap().as_slice());
             }
         }
+        assert!(
+            batches > 1,
+            "merge exchange must not concatenate the whole payload"
+        );
+        values.sort_unstable();
+        assert_eq!(values, (0..5000).collect::<Vec<_>>());
+        Ok(())
     }
 }

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_deserializer.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_deserializer.rs
@@ -20,10 +20,6 @@ use databend_common_exception::Result;
 use databend_common_expression::BlockMetaInfoDowncast;
 use databend_common_expression::DataBlock;
 use databend_common_expression::DataSchemaRef;
-use databend_common_expression::types::AccessType;
-use databend_common_expression::types::BinaryType;
-use databend_common_expression::types::NumberType;
-use databend_common_expression::types::StringType;
 use databend_common_io::prelude::BinaryRead;
 use databend_common_io::prelude::bincode_deserialize_from_slice;
 use databend_common_pipeline::core::InputPort;
@@ -31,25 +27,18 @@ use databend_common_pipeline::core::OutputPort;
 use databend_common_pipeline::core::ProcessorPtr;
 use databend_common_pipeline_transforms::processors::AccumulatingTransform;
 use databend_common_pipeline_transforms::processors::AccumulatingTransformer;
-use databend_common_storages_parquet::deserialize_row_group_meta_from_bytes;
 
-use crate::pipelines::processors::transforms::aggregator::AggregateMeta;
 use crate::pipelines::processors::transforms::aggregator::AggregateSerdeMeta;
-use crate::pipelines::processors::transforms::aggregator::BUCKET_TYPE;
-use crate::pipelines::processors::transforms::aggregator::PARTITIONED_AGGREGATE_TYPE;
-use crate::pipelines::processors::transforms::aggregator::PartitionedData;
-use crate::pipelines::processors::transforms::aggregator::SPILLED_TYPE;
-use crate::pipelines::processors::transforms::aggregator::SerializedPayload;
-use crate::pipelines::processors::transforms::aggregator::SpilledPayload;
-use crate::pipelines::processors::transforms::aggregator::exchange_defines;
 use crate::servers::flight::v1::exchange::serde::ExchangeDeserializeMeta;
 use crate::servers::flight::v1::exchange::serde::deserialize_block;
+use crate::servers::flight::v1::network::ExchangeDataCodec;
 use crate::servers::flight::v1::packets::DataPacket;
 use crate::servers::flight::v1::packets::FragmentData;
 
 pub struct TransformDeserializer {
     schema: DataSchemaRef,
     arrow_schema: Arc<ArrowSchema>,
+    codec: Arc<dyn ExchangeDataCodec>,
 }
 
 impl TransformDeserializer {
@@ -57,6 +46,7 @@ impl TransformDeserializer {
         input: Arc<InputPort>,
         output: Arc<OutputPort>,
         schema: &DataSchemaRef,
+        codec: Arc<dyn ExchangeDataCodec>,
     ) -> Result<ProcessorPtr> {
         let arrow_schema = ArrowSchema::from(schema.as_ref());
 
@@ -66,6 +56,7 @@ impl TransformDeserializer {
             TransformDeserializer {
                 arrow_schema: Arc::new(arrow_schema),
                 schema: schema.clone(),
+                codec,
             },
         )))
     }
@@ -87,137 +78,33 @@ impl TransformDeserializer {
             return Ok(vec![DataBlock::new_with_meta(vec![], 0, meta)]);
         }
 
-        let Some(meta) = meta
+        let is_aggregate = meta
             .as_ref()
             .and_then(AggregateSerdeMeta::downcast_ref_from)
-        else {
-            let data_block =
-                deserialize_block(dict, fragment_data, &self.schema, self.arrow_schema.clone())?;
-            return match data_block.num_columns() == 0 {
-                true => Ok(vec![DataBlock::new_with_meta(
-                    vec![],
-                    row_count as usize,
-                    meta,
-                )]),
-                false => Ok(vec![data_block.add_meta(meta)?]),
-            };
+            .is_some();
+        let dynamic_schema = if is_aggregate {
+            meta.as_ref().and_then(|meta| meta.override_block_schema())
+        } else {
+            None
+        };
+        let (schema, arrow_schema) = match dynamic_schema {
+            Some(schema) => {
+                let arrow_schema = Arc::new(ArrowSchema::from(schema.as_ref()));
+                (schema, arrow_schema)
+            }
+            None => (self.schema.clone(), self.arrow_schema.clone()),
+        };
+        let block = deserialize_block(dict, fragment_data, &schema, arrow_schema)?;
+        let block = if block.num_columns() == 0 {
+            DataBlock::new_with_meta(vec![], row_count as usize, meta)
+        } else {
+            block.add_meta(meta)?
         };
 
-        match meta.typ {
-            BUCKET_TYPE => {
-                let mut block = deserialize_block(
-                    dict,
-                    fragment_data,
-                    &self.schema,
-                    self.arrow_schema.clone(),
-                )?;
-
-                if meta.is_empty {
-                    block = block.slice(0..0);
-                }
-
-                Ok(vec![DataBlock::empty_with_meta(
-                    AggregateMeta::create_serialized(meta.bucket, block, meta.max_partition_count),
-                )])
-            }
-            PARTITIONED_AGGREGATE_TYPE => {
-                let data_block = deserialize_block(
-                    dict,
-                    fragment_data,
-                    &self.schema,
-                    self.arrow_schema.clone(),
-                )?;
-
-                if meta.is_empty {
-                    return Ok(vec![]);
-                }
-
-                if meta.buckets.len() != meta.payload_row_counts.len() {
-                    return Err(ErrorCode::Internal(
-                        "Invalid partitioned aggregate serde meta".to_string(),
-                    ));
-                }
-
-                let mut offset = 0;
-                let mut metas = Vec::with_capacity(meta.buckets.len());
-                for (bucket, rows) in meta.buckets.iter().zip(meta.payload_row_counts.iter()) {
-                    let rows = *rows;
-                    let start = offset;
-                    offset += rows;
-                    if offset > data_block.num_rows() {
-                        return Err(ErrorCode::Internal(
-                            "Partitioned aggregate payload rows exceed block rows".to_string(),
-                        ));
-                    }
-
-                    let payload_block = if rows == 0 {
-                        DataBlock::empty()
-                    } else {
-                        data_block.slice(start..offset)
-                    };
-
-                    metas.push(SerializedPayload {
-                        bucket: *bucket,
-                        data_block: payload_block,
-                        max_partition_count: 0,
-                    });
-                }
-
-                if offset != data_block.num_rows() {
-                    return Err(ErrorCode::Internal(
-                        "Partitioned aggregate payload rows do not match block rows".to_string(),
-                    ));
-                }
-                Ok(vec![DataBlock::empty_with_meta(
-                    AggregateMeta::create_partitioned(None, PartitionedData::Serialized(metas)),
-                )])
-            }
-            SPILLED_TYPE => {
-                let data_schema = Arc::new(exchange_defines::spilled_schema());
-                let arrow_schema = Arc::new(exchange_defines::spilled_arrow_schema());
-                let data_block =
-                    deserialize_block(dict, fragment_data, &data_schema, arrow_schema.clone())?;
-
-                let columns = data_block
-                    .columns()
-                    .iter()
-                    .map(|c| c.as_column().unwrap().clone())
-                    .collect::<Vec<_>>();
-
-                let buckets = NumberType::<i64>::try_downcast_column(&columns[0]).unwrap();
-                let locations = StringType::try_downcast_column(&columns[1]).unwrap();
-                let row_groups = BinaryType::try_downcast_column(&columns[2]).unwrap();
-
-                let mut spilled_payloads = Vec::with_capacity(data_block.num_rows());
-                for index in 0..data_block.num_rows() {
-                    unsafe {
-                        let bucket = *buckets.get_unchecked(index) as isize;
-                        let location = locations.value_unchecked(index).to_string();
-                        let row_group_bytes = row_groups.index_unchecked(index);
-                        let row_group = deserialize_row_group_meta_from_bytes(row_group_bytes)?;
-
-                        spilled_payloads.push(SpilledPayload {
-                            bucket,
-                            location,
-                            row_group,
-                        });
-                    }
-                }
-
-                let shuffle_bucket = meta.shuffle_bucket;
-                if shuffle_bucket == -1 {
-                    todo!()
-                } else {
-                    let partitioned = AggregateMeta::create_partitioned(
-                        None,
-                        PartitionedData::BucketSpilled(spilled_payloads),
-                    );
-                    return Ok(vec![DataBlock::empty_with_meta(partitioned)]);
-                }
-            }
-            other => Err(ErrorCode::Internal(format!(
-                "Unknown aggregate serde meta type {other}"
-            ))),
+        if is_aggregate {
+            Ok(self.codec.decode(block)?.into_iter().collect())
+        } else {
+            Ok(vec![block])
         }
     }
 }
@@ -259,3 +146,138 @@ impl AccumulatingTransform for TransformDeserializer {
 }
 
 pub type TransformAggregateDeserializer = TransformDeserializer;
+
+#[cfg(test)]
+mod tests {
+    use arrow_flight::FlightData;
+    use arrow_ipc::writer::IpcWriteOptions;
+    use databend_common_expression::FromData;
+    use databend_common_expression::types::Int64Type;
+    use parquet::file::metadata::RowGroupMetaData;
+    use parquet::schema::types::SchemaDescriptor;
+    use parquet::schema::types::Type;
+
+    use super::*;
+    use crate::pipelines::processors::transforms::aggregator::AggregateExchangeDataCodec;
+    use crate::pipelines::processors::transforms::aggregator::AggregateMeta;
+    use crate::pipelines::processors::transforms::aggregator::PartitionedData;
+    use crate::pipelines::processors::transforms::aggregator::SpilledPayload;
+    use crate::pipelines::processors::transforms::aggregator::aggregate_exchange_codec::tests::params;
+    use crate::pipelines::processors::transforms::aggregator::aggregate_exchange_codec::tests::payload_block;
+    use crate::servers::flight::v1::exchange::serde::ExchangeSerializeMeta;
+    use crate::servers::flight::v1::exchange::serde::serialize_block;
+
+    fn decoder() -> TransformDeserializer {
+        let params = params();
+        let schema = params.spill_schema();
+        TransformDeserializer {
+            arrow_schema: Arc::new(ArrowSchema::from(schema.as_ref())),
+            schema,
+            codec: AggregateExchangeDataCodec::create(params),
+        }
+    }
+
+    fn packet_round_trip(block: DataBlock) -> Result<Vec<DataBlock>> {
+        let mut serialized = serialize_block(0, block, &IpcWriteOptions::default())?;
+        let meta = serialized
+            .take_meta()
+            .and_then(ExchangeSerializeMeta::downcast_from)
+            .unwrap();
+        // The Flight envelope appends the packet tag consumed by get_meta().
+        let packets = meta
+            .packet
+            .into_iter()
+            .map(|packet| DataPacket::try_from(FlightData::try_from(packet)?))
+            .collect::<Result<Vec<_>>>()?;
+        decoder().transform(DataBlock::empty_with_meta(ExchangeDeserializeMeta::create(
+            packets,
+        )))
+    }
+
+    #[test]
+    fn test_legacy_packets_decode_aggregate_and_ordinary_blocks() -> Result<()> {
+        let transport = AggregateExchangeDataCodec::create(params())
+            .encode(payload_block(vec![11, 22]))?
+            .unwrap();
+        let mut restored = packet_round_trip(transport)?;
+        let Some(AggregateMeta::Serialized(payload)) = restored[0]
+            .take_meta()
+            .and_then(AggregateMeta::downcast_from)
+        else {
+            panic!("payload was not decoded")
+        };
+        assert_eq!((payload.bucket, payload.max_partition_count), (7, 8));
+        assert_eq!(
+            payload.data_block.columns(),
+            DataBlock::new_from_columns(vec![Int64Type::from_data(vec![11, 22])]).columns()
+        );
+
+        let ordinary = DataBlock::new_from_columns(vec![Int64Type::from_data(vec![3, 4])]);
+        let restored = packet_round_trip(ordinary.clone())?;
+        assert_eq!(restored[0].columns(), ordinary.columns());
+        let local = decoder().transform(payload_block(vec![5]))?;
+        assert!(matches!(
+            local[0]
+                .get_meta()
+                .and_then(AggregateMeta::downcast_ref_from),
+            Some(AggregateMeta::AggregatePayload(_))
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn test_legacy_packets_preserve_zero_row_partition_and_spill_schema() -> Result<()> {
+        let transport = DataBlock::new_from_columns(vec![Int64Type::from_data(vec![10, 20])])
+            .add_meta(Some(AggregateSerdeMeta::create_partitioned_payload(
+                vec![4, 9],
+                vec![0, 2],
+                false,
+            )))?;
+        let mut restored = packet_round_trip(transport)?;
+        let Some(AggregateMeta::Partitioned {
+            data: PartitionedData::Serialized(payloads),
+            ..
+        }) = restored[0]
+            .take_meta()
+            .and_then(AggregateMeta::downcast_from)
+        else {
+            panic!("partitioned payload was not decoded")
+        };
+        assert_eq!(payloads.len(), 2);
+        assert_eq!(payloads[0].bucket, 4);
+        assert_eq!(payloads[0].data_block.num_columns(), 0);
+        assert_eq!(payloads[1].data_block.num_rows(), 2);
+
+        let schema = Type::group_type_builder("schema").build().unwrap();
+        let row_group =
+            RowGroupMetaData::builder(Arc::new(SchemaDescriptor::new(Arc::new(schema))))
+                .set_num_rows(17)
+                .build()
+                .unwrap();
+        let block = DataBlock::empty_with_meta(AggregateMeta::create_partitioned(
+            None,
+            PartitionedData::BucketSpilled(vec![SpilledPayload {
+                bucket: 6,
+                location: "memory://spill".to_string(),
+                row_group,
+            }]),
+        ));
+        let transport = AggregateExchangeDataCodec::create(params())
+            .encode(block)?
+            .unwrap();
+        let mut restored = packet_round_trip(transport)?;
+        let Some(AggregateMeta::Partitioned {
+            data: PartitionedData::BucketSpilled(payloads),
+            ..
+        }) = restored[0]
+            .take_meta()
+            .and_then(AggregateMeta::downcast_from)
+        else {
+            panic!("spill reference was not decoded")
+        };
+        assert_eq!(payloads[0].bucket, 6);
+        assert_eq!(payloads[0].location, "memory://spill");
+        assert_eq!(payloads[0].row_group.num_rows(), 17);
+        Ok(())
+    }
+}

--- a/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_exchange_aggregate_serializer.rs
+++ b/src/query/service/src/pipelines/processors/transforms/aggregator/serde/transform_exchange_aggregate_serializer.rs
@@ -19,11 +19,8 @@ use arrow_ipc::writer::IpcWriteOptions;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::BlockMetaInfoDowncast;
+use databend_common_expression::BlockMetaInfoPtr;
 use databend_common_expression::DataBlock;
-use databend_common_expression::FromData;
-use databend_common_expression::types::BinaryType;
-use databend_common_expression::types::Int64Type;
-use databend_common_expression::types::StringType;
 use databend_common_pipeline::core::InputPort;
 use databend_common_pipeline::core::OutputPort;
 use databend_common_pipeline::core::Processor;
@@ -31,22 +28,19 @@ use databend_common_pipeline_transforms::UnknownMode;
 use databend_common_pipeline_transforms::processors::BlockMetaTransform;
 use databend_common_pipeline_transforms::processors::BlockMetaTransformer;
 use databend_common_settings::FlightCompression;
-use databend_common_storages_parquet::serialize_row_group_meta_to_bytes;
 
+use crate::pipelines::processors::transforms::aggregator::AggregateExchangeDataCodec;
 use crate::pipelines::processors::transforms::aggregator::AggregateMeta;
-use crate::pipelines::processors::transforms::aggregator::AggregateSerdeMeta;
 use crate::pipelines::processors::transforms::aggregator::AggregatorParams;
-use crate::pipelines::processors::transforms::aggregator::PartitionItem;
-use crate::pipelines::processors::transforms::aggregator::PartitionedData;
-use crate::pipelines::processors::transforms::aggregator::SerializeAggregateStream;
 use crate::servers::flight::v1::exchange::ExchangeShuffleMeta;
 use crate::servers::flight::v1::exchange::serde::serialize_block;
+use crate::servers::flight::v1::network::ExchangeDataCodec;
 
 pub struct TransformExchangeAggregateSerializer {
     local_pos: usize,
     options: IpcWriteOptions,
 
-    params: Arc<AggregatorParams>,
+    codec: Arc<AggregateExchangeDataCodec>,
 }
 
 impl TransformExchangeAggregateSerializer {
@@ -71,7 +65,7 @@ impl TransformExchangeAggregateSerializer {
             input,
             output,
             TransformExchangeAggregateSerializer {
-                params,
+                codec: AggregateExchangeDataCodec::create(params),
                 local_pos,
                 options: IpcWriteOptions::default()
                     .try_with_compression(compression)
@@ -93,110 +87,85 @@ impl BlockMetaTransform<ExchangeShuffleMeta> for TransformExchangeAggregateSeria
                 continue;
             }
 
-            match block.take_meta().and_then(AggregateMeta::downcast_from) {
-                Some(AggregateMeta::AggregatePayload(p)) => {
-                    let block_number = p.exchange_block_number();
-
-                    if index == self.local_pos {
-                        serialized_blocks.push(
-                            block.add_meta(Some(Box::new(AggregateMeta::AggregatePayload(p))))?,
-                        );
-                        continue;
+            let (block_number, meta): (isize, BlockMetaInfoPtr) =
+                match block.take_meta().and_then(AggregateMeta::downcast_from) {
+                    Some(AggregateMeta::AggregatePayload(payload)) => (
+                        payload.exchange_block_number(),
+                        Box::new(AggregateMeta::AggregatePayload(payload)),
+                    ),
+                    Some(AggregateMeta::Partitioned { data, .. }) => {
+                        (-1, AggregateMeta::create_partitioned(None, data))
                     }
-
-                    let stream = SerializeAggregateStream::create(&self.params, p);
-                    let mut stream_blocks = stream.into_iter().collect::<Result<Vec<_>>>()?;
-                    debug_assert!(!stream_blocks.is_empty());
-                    let mut c = DataBlock::concat(&stream_blocks)?;
-                    if let Some(meta) = stream_blocks[0].take_meta() {
-                        c.replace_meta(meta);
+                    _ => {
+                        return Err(ErrorCode::Internal(
+                            "Unexpected aggregate exchange metadata",
+                        ));
                     }
-                    let c = serialize_block(block_number, c, &self.options)?;
-                    serialized_blocks.push(c);
-                }
-                Some(AggregateMeta::Partitioned { data, .. }) => {
-                    if index == self.local_pos {
-                        serialized_blocks.push(
-                            block.add_meta(Some(AggregateMeta::create_partitioned(None, data)))?,
-                        );
-                        continue;
-                    }
-                    let data_block = match data {
-                        PartitionedData::Empty => DataBlock::empty(),
-                        PartitionedData::Serialized(data) if data.is_empty() => DataBlock::empty(),
-                        PartitionedData::AggregatePayload(data) if data.is_empty() => {
-                            DataBlock::empty()
-                        }
-                        PartitionedData::BucketSpilled(data) if data.is_empty() => {
-                            DataBlock::empty()
-                        }
-                        PartitionedData::AggregatePayload(data) => {
-                            let mut buckets = Vec::with_capacity(data.len());
-                            let mut payload_row_counts = Vec::with_capacity(data.len());
-                            let mut payload_blocks = Vec::with_capacity(data.len());
-
-                            for payload in data {
-                                let block = payload.payload.aggregate_flush_all()?;
-                                if block.num_rows() == 0 {
-                                    continue;
-                                }
-                                buckets.push(payload.bucket);
-                                payload_row_counts.push(block.num_rows());
-                                payload_blocks.push(block);
-                            }
-
-                            // Only create empty block when ALL payloads are empty
-                            if payload_blocks.is_empty() {
-                                DataBlock::empty()
-                            } else {
-                                let merged_block = DataBlock::concat(&payload_blocks)?;
-                                merged_block.add_meta(Some(
-                                    AggregateSerdeMeta::create_partitioned_payload(
-                                        buckets,
-                                        payload_row_counts,
-                                        false,
-                                    ),
-                                ))?
-                            }
-                        }
-                        PartitionedData::BucketSpilled(data) => {
-                            let bucket_num = data.len();
-                            let mut bucket_column = Vec::with_capacity(bucket_num);
-                            let mut row_group_column = Vec::with_capacity(bucket_num);
-                            let mut location_column = Vec::with_capacity(bucket_num);
-
-                            for payload in data {
-                                bucket_column.push(payload.bucket as i64);
-                                location_column.push(payload.location);
-                                row_group_column
-                                    .push(serialize_row_group_meta_to_bytes(&payload.row_group)?);
-                            }
-                            let data_block = DataBlock::new_from_columns(vec![
-                                Int64Type::from_data(bucket_column),
-                                StringType::from_data(location_column),
-                                BinaryType::from_data(row_group_column),
-                            ]);
-
-                            data_block.add_meta(Some(AggregateSerdeMeta::create_spilled(
-                                bucket_num as isize,
-                            )))?
-                        }
-                        PartitionedData::Mixed(data) => PartitionItem::serialize_mixed(data)?,
-                        data => {
-                            return Err(ErrorCode::Internal(format!(
-                                "Partitioned meta cannot be serialized from this payload batch: {data:?}"
-                            )));
-                        }
-                    };
-                    let serialized = serialize_block(-1, data_block, &self.options)?;
-                    serialized_blocks.push(serialized);
-                }
-                _ => unreachable!("unexpected aggregate meta"),
-            };
+                };
+            block.replace_meta(meta);
+            if index == self.local_pos {
+                serialized_blocks.push(block);
+                continue;
+            }
+            let transport = self.codec.encode(block)?.unwrap_or_else(DataBlock::empty);
+            serialized_blocks.push(serialize_block(block_number, transport, &self.options)?);
         }
 
         Ok(vec![DataBlock::empty_with_meta(
             ExchangeShuffleMeta::create(serialized_blocks),
         )])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipelines::processors::transforms::aggregator::PartitionedData;
+    use crate::pipelines::processors::transforms::aggregator::aggregate_exchange_codec::tests::params;
+    use crate::pipelines::processors::transforms::aggregator::aggregate_exchange_codec::tests::payload_block;
+    use crate::servers::flight::v1::exchange::serde::ExchangeSerializeMeta;
+
+    #[test]
+    fn test_shuffle_codec_preserves_local_payload_and_remote_routing() -> Result<()> {
+        let mut serializer = TransformExchangeAggregateSerializer {
+            local_pos: 0,
+            options: IpcWriteOptions::default(),
+            codec: AggregateExchangeDataCodec::create(params()),
+        };
+        let mut result = serializer.transform(ExchangeShuffleMeta {
+            blocks: vec![
+                payload_block(vec![11, 22]),
+                payload_block(vec![33, 44]),
+                DataBlock::empty_with_meta(AggregateMeta::create_partitioned(
+                    Some(2),
+                    PartitionedData::Empty,
+                )),
+            ],
+        })?;
+        let result = result[0]
+            .take_meta()
+            .and_then(ExchangeShuffleMeta::downcast_from)
+            .unwrap();
+        assert_eq!(result.blocks.len(), 3);
+        let Some(AggregateMeta::AggregatePayload(local)) = result.blocks[0]
+            .get_meta()
+            .and_then(AggregateMeta::downcast_ref_from)
+        else {
+            panic!("local payload was serialized")
+        };
+        assert_eq!(local.payload.len(), 2);
+        let remote = result.blocks[1]
+            .get_meta()
+            .and_then(ExchangeSerializeMeta::downcast_ref_from)
+            .unwrap();
+        assert_eq!(remote.block_number, 8007);
+        assert!(!remote.packet.is_empty());
+        let empty = result.blocks[2]
+            .get_meta()
+            .and_then(ExchangeSerializeMeta::downcast_ref_from)
+            .unwrap();
+        assert_eq!(empty.block_number, -1);
+        assert!(empty.packet.is_empty());
+        Ok(())
     }
 }

--- a/src/query/service/src/servers/flight/v1/network/exchange_data_codec.rs
+++ b/src/query/service/src/servers/flight/v1/network/exchange_data_codec.rs
@@ -1,0 +1,54 @@
+// Copyright 2021 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use databend_common_exception::Result;
+use databend_common_expression::DataBlock;
+
+/// Converts an operator's in-memory block representation to and from a
+/// transport-safe block representation.
+///
+/// Local channels deliberately bypass this interface. The outbound side only
+/// calls `encode` before Arrow Flight serialization, and the inbound side only
+/// calls `decode` after Arrow Flight deserialization. This lets operators keep
+/// process-local metadata (for example aggregate payloads) without teaching
+/// the network layer about that metadata.
+pub trait ExchangeDataCodec: Send + Sync + 'static {
+    /// Converts one block before remote serialization. `Ok(None)` discards the
+    /// block without sending a packet. Errors propagate to the sender.
+    fn encode(&self, block: DataBlock) -> Result<Option<DataBlock>>;
+
+    /// Converts one block after remote deserialization. `Ok(None)` skips this
+    /// block, not the rest of the stream. Errors propagate to the receiver.
+    fn decode(&self, block: DataBlock) -> Result<Option<DataBlock>>;
+}
+
+pub struct DefaultExchangeDataCodec;
+
+impl DefaultExchangeDataCodec {
+    pub fn create() -> Arc<dyn ExchangeDataCodec> {
+        Arc::new(Self)
+    }
+}
+
+impl ExchangeDataCodec for DefaultExchangeDataCodec {
+    fn encode(&self, block: DataBlock) -> Result<Option<DataBlock>> {
+        Ok(Some(block))
+    }
+
+    fn decode(&self, block: DataBlock) -> Result<Option<DataBlock>> {
+        Ok(Some(block))
+    }
+}

--- a/src/query/service/src/servers/flight/v1/network/inbound_channel.rs
+++ b/src/query/service/src/servers/flight/v1/network/inbound_channel.rs
@@ -32,6 +32,8 @@ use databend_common_io::prelude::BinaryRead;
 use databend_common_io::prelude::bincode_deserialize_from_stream;
 use tokio::sync::Semaphore;
 
+use super::DefaultExchangeDataCodec;
+use super::ExchangeDataCodec;
 use super::inbound_quota::QueueItem;
 use super::inbound_quota::SubQueue;
 
@@ -78,6 +80,15 @@ impl NetworkInboundChannelSet {
 
     pub fn create_receiver(&self, t_idx: usize, schema: &DataSchemaRef) -> Arc<dyn InboundChannel> {
         NetworkInboundReceiver::create(schema, self.channels[t_idx].clone())
+    }
+
+    pub fn create_receiver_with_codec(
+        &self,
+        t_idx: usize,
+        schema: &DataSchemaRef,
+        codec: Arc<dyn ExchangeDataCodec>,
+    ) -> Arc<dyn InboundChannel> {
+        NetworkInboundReceiver::create_with_codec(schema, self.channels[t_idx].clone(), codec)
     }
 }
 
@@ -182,6 +193,7 @@ pub struct NetworkInboundReceiver {
     channel: Arc<NetworkInboundChannel>,
     schema: DataSchemaRef,
     arrow_schema: Arc<ArrowSchema>,
+    codec: Arc<dyn ExchangeDataCodec>,
 }
 
 impl NetworkInboundReceiver {
@@ -189,10 +201,19 @@ impl NetworkInboundReceiver {
         schema: &DataSchemaRef,
         channel: Arc<NetworkInboundChannel>,
     ) -> Arc<dyn InboundChannel> {
+        Self::create_with_codec(schema, channel, DefaultExchangeDataCodec::create())
+    }
+
+    pub fn create_with_codec(
+        schema: &DataSchemaRef,
+        channel: Arc<NetworkInboundChannel>,
+        codec: Arc<dyn ExchangeDataCodec>,
+    ) -> Arc<dyn InboundChannel> {
         Arc::new(Self {
             channel,
             arrow_schema: Arc::new(ArrowSchema::from(schema.as_ref())),
             schema: schema.clone(),
+            codec,
         })
     }
 }
@@ -210,16 +231,18 @@ impl InboundChannel for NetworkInboundReceiver {
     }
 
     async fn recv(&self) -> Result<Option<DataBlock>, ErrorCode> {
-        match self.channel.recv_raw().await {
-            None => Ok(None),
-            Some(QueueItem::LocalData(v)) => Ok(Some(v.into_data())),
-            Some(QueueItem::RemoteData(r)) => {
-                let flight_data = strip_tid(r.into_data());
-                Ok(Some(deserialize_flight_data(
-                    flight_data,
-                    &self.schema,
-                    &self.arrow_schema,
-                )?))
+        loop {
+            match self.channel.recv_raw().await {
+                None => return Ok(None),
+                Some(QueueItem::LocalData(v)) => return Ok(Some(v.into_data())),
+                Some(QueueItem::RemoteData(r)) => {
+                    let flight_data = strip_tid(r.into_data());
+                    let block =
+                        deserialize_flight_data(flight_data, &self.schema, &self.arrow_schema)?;
+                    if let Some(block) = self.codec.decode(block)? {
+                        return Ok(Some(block));
+                    }
+                }
             }
         }
     }
@@ -365,12 +388,21 @@ pub(crate) fn deserialize_flight_data(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use arrow_flight::FlightData;
+    use arrow_ipc::writer::IpcWriteOptions;
     use bytes::BufMut;
     use bytes::Bytes;
     use bytes::BytesMut;
+    use databend_common_expression::DataField;
+    use databend_common_expression::DataSchemaRefExt;
+    use databend_common_expression::FromData;
+    use databend_common_expression::types::ArgType;
+    use databend_common_expression::types::Int64Type;
 
     use super::*;
+    use crate::servers::flight::v1::network::outbound_channel::serialize_block;
 
     const BATCH_MARKER: u8 = 0x02;
 
@@ -477,5 +509,122 @@ mod tests {
             let restored_tid = u16::from_le_bytes([item.app_metadata[0], item.app_metadata[1]]);
             assert_eq!(restored_tid, tid);
         }
+    }
+
+    struct RejectRemoteCodec;
+
+    impl ExchangeDataCodec for RejectRemoteCodec {
+        fn encode(
+            &self,
+            _block: DataBlock,
+        ) -> databend_common_exception::Result<Option<DataBlock>> {
+            panic!("local channel must not encode")
+        }
+
+        fn decode(
+            &self,
+            _block: DataBlock,
+        ) -> databend_common_exception::Result<Option<DataBlock>> {
+            panic!("local channel must not decode")
+        }
+    }
+
+    struct SelectiveDecodeCodec;
+
+    impl ExchangeDataCodec for SelectiveDecodeCodec {
+        fn encode(
+            &self,
+            _block: DataBlock,
+        ) -> databend_common_exception::Result<Option<DataBlock>> {
+            panic!("inbound channel never encodes")
+        }
+
+        fn decode(&self, block: DataBlock) -> databend_common_exception::Result<Option<DataBlock>> {
+            match block.num_rows() {
+                1 => Ok(None),
+                2 => Err(ErrorCode::BadBytes("invalid codec payload")),
+                _ => Ok(Some(DataBlock::new_from_columns(vec![
+                    Int64Type::from_data(vec![4, 5]),
+                ]))),
+            }
+        }
+    }
+
+    async fn send_remote_block(sender: &NetworkInboundSender, block: DataBlock) {
+        let mut packets = serialize_block(block, &IpcWriteOptions::default(), None).unwrap();
+        assert_eq!(packets.len(), 1);
+        let packet = packets.pop().unwrap();
+        let mut metadata = 0_u16.to_le_bytes().to_vec();
+        metadata.extend_from_slice(&packet.app_metadata);
+        sender
+            .add_data(FlightData {
+                app_metadata: metadata.into(),
+                ..packet
+            })
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_local_channel_bypasses_exchange_codec() {
+        let channel_set = NetworkInboundChannelSet::new(1);
+        let channel = crate::servers::flight::v1::network::create_local_channels(&channel_set)
+            .pop()
+            .unwrap();
+        let schema =
+            DataSchemaRefExt::create(vec![DataField::new("value", Int64Type::data_type())]);
+        let receiver =
+            channel_set.create_receiver_with_codec(0, &schema, Arc::new(RejectRemoteCodec));
+        let block = DataBlock::new_from_columns(vec![Int64Type::from_data(vec![1, 2, 3])]);
+
+        channel.add_block(block).await.unwrap();
+        let received = receiver.recv().await.unwrap().unwrap();
+        assert_eq!(received.num_rows(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_remote_channel_codec_skips_blocks_without_ending_stream() {
+        let channel_set = NetworkInboundChannelSet::new(1);
+        let sender = NetworkInboundSender::new(&channel_set, 1024 * 1024);
+        let schema =
+            DataSchemaRefExt::create(vec![DataField::new("value", Int64Type::data_type())]);
+        let receiver =
+            channel_set.create_receiver_with_codec(0, &schema, Arc::new(SelectiveDecodeCodec));
+        for values in [vec![1], vec![1, 2, 3], vec![1]] {
+            send_remote_block(
+                &sender,
+                DataBlock::new_from_columns(vec![Int64Type::from_data(values)]),
+            )
+            .await;
+        }
+        drop(sender);
+
+        let received = receiver.recv().await.unwrap().unwrap();
+        assert_eq!(received.num_rows(), 2);
+        assert_eq!(
+            received.columns(),
+            DataBlock::new_from_columns(vec![Int64Type::from_data(vec![4, 5])]).columns()
+        );
+        assert!(receiver.recv().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_remote_channel_propagates_decode_errors() {
+        let channel_set = NetworkInboundChannelSet::new(1);
+        let sender = NetworkInboundSender::new(&channel_set, 1024 * 1024);
+        let schema =
+            DataSchemaRefExt::create(vec![DataField::new("value", Int64Type::data_type())]);
+        let receiver =
+            channel_set.create_receiver_with_codec(0, &schema, Arc::new(SelectiveDecodeCodec));
+        send_remote_block(
+            &sender,
+            DataBlock::new_from_columns(vec![Int64Type::from_data(vec![1, 2])]),
+        )
+        .await;
+        drop(sender);
+
+        let error = receiver.recv().await.unwrap_err();
+        assert_eq!(error.code(), ErrorCode::BAD_BYTES);
+        assert_eq!(error.message(), "invalid codec payload");
     }
 }

--- a/src/query/service/src/servers/flight/v1/network/mod.rs
+++ b/src/query/service/src/servers/flight/v1/network/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod exchange_data_codec;
 pub mod inbound_channel;
 pub mod inbound_quota;
 pub mod local_channel;
@@ -21,6 +22,8 @@ pub mod outbound_transport;
 
 pub use databend_common_pipeline::core::SyncTaskHandle;
 pub use databend_common_pipeline::core::SyncTaskSet;
+pub use exchange_data_codec::DefaultExchangeDataCodec;
+pub use exchange_data_codec::ExchangeDataCodec;
 pub use inbound_channel::InboundChannel;
 pub use inbound_channel::NetworkInboundChannelSet;
 pub use inbound_channel::NetworkInboundReceiver;

--- a/src/query/service/src/servers/flight/v1/network/outbound_channel.rs
+++ b/src/query/service/src/servers/flight/v1/network/outbound_channel.rs
@@ -35,6 +35,8 @@ use databend_common_io::prelude::BinaryWrite;
 use databend_common_io::prelude::bincode_serialize_into_buf;
 use databend_common_settings::FlightCompression;
 
+use super::DefaultExchangeDataCodec;
+use super::ExchangeDataCodec;
 use super::outbound_buffer::ExchangeSinkBuffer;
 
 /// Outbound channel trait for sending data blocks.
@@ -160,6 +162,7 @@ pub struct RemoteChannel {
     channel_id: usize,
     buffer: Arc<ExchangeSinkBuffer>,
     ipc_options: IpcWriteOptions,
+    codec: Arc<dyn ExchangeDataCodec>,
 }
 
 impl RemoteChannel {
@@ -169,11 +172,28 @@ impl RemoteChannel {
         buffer: Arc<ExchangeSinkBuffer>,
         compression: Option<FlightCompression>,
     ) -> Result<Arc<dyn OutboundChannel>> {
+        Self::create_with_codec(
+            dest_idx,
+            channel_id,
+            buffer,
+            compression,
+            DefaultExchangeDataCodec::create(),
+        )
+    }
+
+    pub fn create_with_codec(
+        dest_idx: usize,
+        channel_id: usize,
+        buffer: Arc<ExchangeSinkBuffer>,
+        compression: Option<FlightCompression>,
+        codec: Arc<dyn ExchangeDataCodec>,
+    ) -> Result<Arc<dyn OutboundChannel>> {
         Ok(Arc::new(Self {
             dest_idx,
             channel_id,
             buffer,
             ipc_options: make_ipc_options(compression)?,
+            codec,
         }))
     }
 }
@@ -187,9 +207,11 @@ impl OutboundChannel for RemoteChannel {
     }
 
     async fn add_block(&self, block: DataBlock) -> Result<()> {
+        let Some(block) = self.codec.encode(block)? else {
+            return Ok(());
+        };
         Profile::record_usize_profile(ProfileStatisticsName::ExchangeRows, block.num_rows());
         Profile::record_usize_profile(ProfileStatisticsName::ExchangeBytes, block.memory_size());
-
         let flight_data_list = serialize_block(block, &self.ipc_options, None)?;
 
         let tid_prefix = (self.channel_id as u16).to_le_bytes();
@@ -284,6 +306,7 @@ mod tests {
     use arrow_flight::FlightData;
     use arrow_schema::Schema as ArrowSchema;
     use databend_common_base::runtime::Runtime;
+    use databend_common_exception::ErrorCode;
     use databend_common_expression::DataBlock;
     use databend_common_expression::FromData;
     use databend_common_expression::types::Int32Type;
@@ -324,6 +347,22 @@ mod tests {
         DataBlock::new_from_columns(vec![col])
     }
 
+    struct SelectiveEncodeCodec;
+
+    impl ExchangeDataCodec for SelectiveEncodeCodec {
+        fn encode(&self, block: DataBlock) -> Result<Option<DataBlock>> {
+            match block.num_rows() {
+                1 => Ok(None),
+                2 => Err(ErrorCode::BadBytes("invalid codec payload")),
+                _ => Ok(Some(make_block(4))),
+            }
+        }
+
+        fn decode(&self, _block: DataBlock) -> Result<Option<DataBlock>> {
+            unreachable!("outbound channel never decodes")
+        }
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn test_remote_channel_send_block() {
         let rt = test_runtime();
@@ -346,6 +385,34 @@ mod tests {
         // Cleanup
         pong_tx.send(Ok(FlightData::default())).await.unwrap();
         tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_remote_channel_codec_encodes_skips_and_propagates_errors() {
+        let rt = test_runtime();
+        let (exchange, send_rx, pong_tx) = create_mock_exchange(1);
+        let buffer = Arc::new(
+            ExchangeSinkBuffer::create(vec![exchange], ExchangeBufferConfig::default(), &rt)
+                .unwrap(),
+        );
+        let channel =
+            RemoteChannel::create_with_codec(0, 0, buffer, None, Arc::new(SelectiveEncodeCodec))
+                .unwrap();
+
+        channel.add_block(make_block(1)).await.unwrap();
+        let error = channel.add_block(make_block(2)).await.unwrap_err();
+        assert_eq!(error.code(), ErrorCode::BAD_BYTES);
+        assert_eq!(error.message(), "invalid codec payload");
+        channel.add_block(make_block(3)).await.unwrap();
+
+        // The first packet must be the accepted block after encoding.
+        let flight_data = strip_tid(send_rx.recv().await.unwrap());
+        let schema = Arc::new(make_block(4).infer_schema());
+        let arrow_schema = Arc::new(ArrowSchema::from(schema.as_ref()));
+        let decoded = deserialize_flight_data(flight_data, &schema, &arrow_schema).unwrap();
+        assert_eq!(decoded.num_rows(), 4);
+
+        pong_tx.send(Ok(FlightData::default())).await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/tests/sqllogictests/suites/mode/cluster/group_exchange_codec.test
+++ b/tests/sqllogictests/suites/mode/cluster/group_exchange_codec.test
@@ -1,0 +1,61 @@
+# Exercise aggregate state transport with nullable keys and values.
+statement ok
+set group_by_shuffle_mode = 'before_merge';
+
+statement ok
+set force_aggregate_shuffle_mode = 'row';
+
+query IIII
+SELECT count(*), sum(c), sum(n), sum(s)
+FROM (
+    SELECT k, count(*) AS c, count(v) AS n, sum(v) AS s
+    FROM (
+        SELECT if(number % 3 = 0, NULL, number % 3) AS k,
+               if(number % 5 = 0, NULL, number) AS v
+        FROM numbers_mt(12000)
+    )
+    GROUP BY k
+);
+----
+3 12000 9600 57600000
+
+statement ok
+set force_aggregate_shuffle_mode = 'bucket';
+
+query IIII
+SELECT count(*), sum(c), sum(n), sum(s)
+FROM (
+    SELECT k, count(*) AS c, count(v) AS n, sum(v) AS s
+    FROM (
+        SELECT if(number % 3 = 0, NULL, number % 3) AS k,
+               if(number % 5 = 0, NULL, number) AS v
+        FROM numbers_mt(12000)
+    )
+    GROUP BY k
+);
+----
+3 12000 9600 57600000
+
+# Spill references use a different transport schema than aggregate states.
+statement ok
+set force_aggregate_data_spill = 1;
+
+query IIII
+SELECT count(*), sum(c), sum(n), sum(s)
+FROM (
+    SELECT k, count(*) AS c, count(v) AS n, sum(v) AS s
+    FROM (
+        SELECT if(number % 3 = 0, NULL, number % 3) AS k,
+               if(number % 5 = 0, NULL, number) AS v
+        FROM numbers_mt(12000)
+    )
+    GROUP BY k
+);
+----
+3 12000 9600 57600000
+
+statement ok
+set force_aggregate_data_spill = 0;
+
+statement ok
+set force_aggregate_shuffle_mode = 'auto';


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Aggregate shuffle serialization and deserialization duplicate the conversion between process-local payloads, aggregate state columns, and spill references. Move that conversion into `AggregateExchangeDataCodec` and use it from the existing aggregate exchange processors.

- The shuffle serializer encodes remote destinations through the codec while preserving local payloads and packet block numbers.
- The merge serializer uses the codec's shared flush stream so it continues emitting bounded batches.
- The aggregate deserializer decodes Arrow packets and delegates aggregate metadata restoration to the codec, replacing the duplicated payload and spill branches. Spill metadata supplies its transport schema.
- Flight channels expose the same codec interface, with pass-through defaults for existing channel callers and local delivery bypassing conversion.

This is a standalone split from #20153. It changes the implementation of the existing aggregate transport; the optimizer, shuffle placement, and channel orchestration remain as they are on main. The aggregate codec is used by production processors in this PR.


After this PR:
```
TransformExchangeAggregateSerializer
  → aggregate codec.encode()
  → exchange/serde::serialize_block()
  → network
```

Our goal is:
```
Shuffle DataBlock
  → LocalChannel：passthrough payload
  → RemoteChannel（outbound_channel）
      → aggregate codec.encode()
      → serialize_block()
      → network
```

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Coverage includes channel encoding/decoding and skipped blocks, aggregate payload and spill round trips, nullable keys, malformed input, merge flush batching, shuffle routing/local bypass, and decoding through the existing packet-based receiver. A cluster SQL regression covers nullable keys and values with count/sum under row shuffle, bucket shuffle, and forced spilling.

Validation:

- `cargo clippy -p databend-query --lib --tests --locked -- -D warnings` passed.
- `cargo test -p databend-query --lib --locked -- aggregate_exchange_codec aggregator::serde:: servers::flight::v1::network::` passed: 43 tests.
- Rustfmt and `git diff --check` passed.

The new cluster SQL regression is added for cluster CI and has not been run locally.

## Type of change

- [x] Refactoring

## AI assistance

- AI usage: An AI coding agent extracted the shared codecs from #20153, connected the existing aggregate processors, removed duplicate conversion code, and added regression coverage and documentation.
- Responsible human: @dqhl76
- [x] The responsible human has read every line of this diff and can explain each change

Draft awaiting the responsible human's review of the expanded diff.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20460)
<!-- Reviewable:end -->
