### PR TITLE
fix(query): keep time functions consistent across distributed execution

### DIFF
--- a/src/query/service/src/history_tables/global_history_log.rs
+++ b/src/query/service/src/history_tables/global_history_log.rs
@@ -509,7 +509,7 @@ impl GlobalHistoryLog {
 
         let cluster_id = dummy_cluster.get_cluster_id()?;
         let session = create_session(&self.tenant_id, &cluster_id).await?;
-        session.create_query_context_with_cluster(dummy_cluster, self.version)
+        session.create_query_context_with_cluster(dummy_cluster, self.version, None)
     }
 }
 

--- a/src/query/service/src/interpreters/access_log/access_logger.rs
+++ b/src/query/service/src/interpreters/access_log/access_logger.rs
@@ -44,7 +44,7 @@ pub struct AccessLogger {
 impl AccessLogger {
     pub fn create(ctx: Arc<QueryContext>) -> Self {
         let query_id = ctx.get_id().to_string();
-        let query_start = convert_query_log_timestamp(ctx.get_created_time());
+        let query_start = convert_query_log_timestamp(ctx.get_query_created_time());
         let user_name = ctx.get_current_user().map(|u| u.name).unwrap_or_default();
 
         Self {

--- a/src/query/service/src/interpreters/common/query_log.rs
+++ b/src/query/service/src/interpreters/common/query_log.rs
@@ -156,7 +156,7 @@ impl InterpreterQueryLog {
         // Stats.
         let event_time = convert_query_log_timestamp(now);
         let event_date = (event_time / (24 * 3_600_000_000)) as i32;
-        let query_start_time = convert_query_log_timestamp(ctx.get_created_time());
+        let query_start_time = convert_query_log_timestamp(ctx.get_query_created_time());
         let query_queued_duration_ms = ctx.get_query_queued_duration().as_millis() as i64;
 
         let written_rows = 0u64;
@@ -321,7 +321,7 @@ impl InterpreterQueryLog {
         // Stats.
         let event_time = convert_query_log_timestamp(now);
         let event_date = (event_time / (24 * 3_600_000_000)) as i32;
-        let query_start_time = convert_query_log_timestamp(ctx.get_created_time());
+        let query_start_time = convert_query_log_timestamp(ctx.get_query_created_time());
         let query_duration_ms = ctx.get_query_duration_ms();
         let query_queued_duration_ms = ctx.get_query_queued_duration().as_millis() as i64;
         let data_metrics = ctx.get_data_metrics();

--- a/src/query/service/src/interpreters/interpreter_metrics.rs
+++ b/src/query/service/src/interpreters/interpreter_metrics.rs
@@ -51,7 +51,7 @@ impl InterpreterMetrics {
 
     fn record_query_detail(ctx: &QueryContext, labels: &Vec<(&'static str, String)>) {
         let query_duration_ms = SystemTime::now()
-            .duration_since(ctx.get_created_time())
+            .duration_since(ctx.get_query_created_time())
             .map(|d| d.as_micros() as f64 / 1000.0)
             .unwrap_or(0.0);
 

--- a/src/query/service/src/interpreters/util.rs
+++ b/src/query/service/src/interpreters/util.rs
@@ -151,7 +151,7 @@ impl Client for ScriptClient {
         let ctx = self
             .ctx
             .get_current_session()
-            .create_query_context_with_cluster(self.ctx.get_cluster(), &BUILD_INFO)?;
+            .create_query_context_with_cluster(self.ctx.get_cluster(), &BUILD_INFO, None)?;
         Self::inherit_query_ctx(&self.ctx, &ctx);
 
         let mut planner = Planner::new(ctx.clone());

--- a/src/query/service/src/schedulers/fragments/query_fragment_actions.rs
+++ b/src/query/service/src/schedulers/fragments/query_fragment_actions.rs
@@ -200,6 +200,7 @@ impl QueryFragmentsActions {
         self.statistics_connections(&mut builder)?;
 
         Ok(QueryEnv {
+            query_created_time: self.ctx.get_query_created_time(),
             workload_group,
             query_id: self.ctx.get_id(),
             cluster: self.ctx.get_cluster(),

--- a/src/query/service/src/servers/flight/v1/packets/packet_publisher.rs
+++ b/src/query/service/src/servers/flight/v1/packets/packet_publisher.rs
@@ -17,6 +17,7 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::ops::Deref;
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use databend_common_base::runtime::PerfConfig;
 use databend_common_catalog::cluster_info::Cluster;
@@ -156,6 +157,7 @@ impl DataflowDiagramBuilder {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct QueryEnv {
     pub query_id: String,
+    pub query_created_time: SystemTime,
     pub cluster: Arc<Cluster>,
     pub settings: Arc<Settings>,
     pub query_kind: QueryKind,
@@ -206,6 +208,7 @@ impl QueryEnv {
                 local_id: GlobalConfig::instance().query.node_id.clone(),
             }),
             GlobalConfig::version(),
+            Some(self.query_created_time),
         )?;
 
         query_ctx.update_init_query_id(self.query_id.clone());

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -34,7 +34,6 @@ use std::time::UNIX_EPOCH;
 
 use async_channel::Receiver;
 use async_channel::Sender;
-use chrono::Utc;
 use chrono_tz::Tz;
 use databend_base::uniq_id::GlobalUniq;
 #[cfg(feature = "storage-stage")]

--- a/src/query/service/src/sessions/query_ctx.rs
+++ b/src/query/service/src/sessions/query_ctx.rs
@@ -614,8 +614,8 @@ impl QueryContext {
         self.attach_query_lineage((!lineage.targets.is_empty()).then_some(lineage));
     }
 
-    pub fn get_created_time(&self) -> SystemTime {
-        self.shared.created_time
+    pub fn get_query_created_time(&self) -> SystemTime {
+        self.shared.query_created_time
     }
 
     pub fn set_finish_time(&self, time: SystemTime) {

--- a/src/query/service/src/sessions/query_ctx/context.rs
+++ b/src/query/service/src/sessions/query_ctx/context.rs
@@ -285,7 +285,7 @@ impl TableContextSettings for QueryContext {
         let tz = tz_string.parse::<Tz>().map_err(|e| {
             ErrorCode::InvalidTimezone(format!("Timezone validation failed: {}", e))
         })?;
-        let now = Utc::now();
+        let now = self.get_query_created_time().into();
         let numeric_cast_option = settings.get_numeric_cast_option()?;
         let rounding_mode = numeric_cast_option.as_str() == "rounding";
         let disable_variant_check = settings.get_disable_variant_check()?;

--- a/src/query/service/src/sessions/query_ctx_shared.rs
+++ b/src/query/service/src/sessions/query_ctx_shared.rs
@@ -131,7 +131,13 @@ pub struct QueryContextShared {
     pub(super) data_operator: DataOperator,
     executor: Arc<RwLock<Weak<PipelineExecutor>>>,
     stage_attachment: Arc<RwLock<Option<StageAttachment>>>,
+    /// Local context creation time.
     pub(super) created_time: SystemTime,
+    /// Query creation time on the coordinator, propagated unchanged to workers.
+    /// On workers, this is query metadata independent of the local wall clock.
+    /// Do not combine it with worker-local wall-clock timestamps to calculate
+    /// elapsed time; use `created_time` for local context timing instead.
+    pub(super) query_created_time: SystemTime,
     // now it is only set in query_log::log_query_finished
     pub(super) finish_time: RwLock<Option<SystemTime>>,
     pub(super) copy_state: CopyState,
@@ -199,7 +205,10 @@ impl QueryContextShared {
         session: Arc<Session>,
         cluster_cache: Arc<Cluster>,
         version: BuildInfoRef,
+        query_created_time: Option<SystemTime>,
     ) -> Result<Arc<QueryContextShared>> {
+        let created_time = SystemTime::now();
+        let query_created_time = query_created_time.unwrap_or(created_time);
         Ok(Arc::new(QueryContextShared {
             query_settings: Settings::create(session.get_current_tenant()),
             catalog_manager: CatalogManager::instance(),
@@ -228,7 +237,8 @@ impl QueryContextShared {
             affect: Arc::new(Mutex::new(None)),
             executor: Arc::new(RwLock::new(Weak::new())),
             stage_attachment: Arc::new(RwLock::new(None)),
-            created_time: SystemTime::now(),
+            created_time,
+            query_created_time,
             finish_time: Default::default(),
             copy_state: Default::default(),
             mutation_state: Default::default(),
@@ -710,8 +720,8 @@ impl QueryContextShared {
         *stage_attachment = Some(attachment);
     }
 
-    pub fn get_created_time(&self) -> SystemTime {
-        self.created_time
+    pub fn get_query_created_time(&self) -> SystemTime {
+        self.query_created_time
     }
 
     pub fn get_status_info(&self) -> String {

--- a/src/query/service/src/sessions/queue_mgr.rs
+++ b/src/query/service/src/sessions/queue_mgr.rs
@@ -594,7 +594,7 @@ impl QueryEntry {
             retry_timeout,
             need_acquire_to_queue,
             query_id: ctx.get_id(),
-            create_time: ctx.get_created_time(),
+            create_time: ctx.get_query_created_time(),
             sql: plan_extras.statement.to_mask_sql(),
             user_info: ctx.get_current_user()?,
             timeout: match settings.get_statement_queued_timeout()? {

--- a/src/query/service/src/sessions/session.rs
+++ b/src/query/service/src/sessions/session.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use databend_common_base::runtime::ThreadTracker;
 use databend_common_base::runtime::drop_guard;
@@ -162,16 +163,17 @@ impl Session {
         } else {
             ClusterDiscovery::instance().discover(&config).await?
         };
-        self.create_query_context_with_cluster(cluster, version)
+        self.create_query_context_with_cluster(cluster, version, None)
     }
 
     pub fn create_query_context_with_cluster(
         self: &Arc<Self>,
         cluster: Arc<Cluster>,
         version: BuildInfoRef,
+        query_created_time: Option<SystemTime>,
     ) -> Result<Arc<QueryContext>> {
         let session = self.clone();
-        let shared = QueryContextShared::try_create(session, cluster, version)?;
+        let shared = QueryContextShared::try_create(session, cluster, version, query_created_time)?;
 
         if let Some(mem_stat) = ThreadTracker::mem_stat() {
             let settings = self.get_settings();

--- a/src/query/service/src/task/service.rs
+++ b/src/query/service/src/task/service.rs
@@ -751,7 +751,7 @@ impl TaskService {
         };
 
         let session = create_session(user, role).await?;
-        session.create_query_context_with_cluster(dummy_cluster, &BUILD_INFO)
+        session.create_query_context_with_cluster(dummy_cluster, &BUILD_INFO, None)
     }
 
     async fn create_task_context(&self, user: UserInfo, task: &Task) -> Result<Arc<QueryContext>> {

--- a/src/query/service/src/test_kits/fixture.rs
+++ b/src/query/service/src/test_kits/fixture.rs
@@ -318,6 +318,7 @@ impl TestFixture {
             self.default_session.clone(),
             Cluster::create(nodes, local_id),
             &BUILD_INFO,
+            None,
         )?);
 
         dummy_query_context.get_settings().set_max_threads(8)?;

--- a/src/query/service/tests/it/sessions/query_ctx.rs
+++ b/src/query/service/tests/it/sessions/query_ctx.rs
@@ -76,11 +76,16 @@ async fn test_query_created_time_propagation() -> anyhow::Result<()> {
     use databend_query::sessions::QueryContext;
     use databend_query::sessions::TableContextCluster;
     use databend_query::sessions::TableContextQueryIdentity;
+    use databend_query::sessions::TableContextSettings;
 
     let fixture = TestFixture::setup().await?;
     let session = fixture.new_session_with_type(SessionType::MySQL).await?;
 
     let ctx = session.create_query_context(&BUILD_INFO).await?;
+    assert_eq!(
+        ctx.get_function_context()?.now,
+        chrono::DateTime::<chrono::Utc>::from(ctx.get_query_created_time())
+    );
     assert_eq!(
         session.process_info().created_time,
         ctx.get_query_created_time()
@@ -96,6 +101,8 @@ async fn test_query_created_time_propagation() -> anyhow::Result<()> {
         Some(query_created_time),
     )?;
     assert_eq!(ctx.get_query_created_time(), query_created_time);
+    let expected_now: chrono::DateTime<chrono::Utc> = query_created_time.into();
+    assert_eq!(ctx.get_function_context()?.now, expected_now);
 
     let env = QueryFragmentsActions::create(ctx.clone()).get_query_env()?;
     assert_eq!(env.query_created_time, query_created_time);
@@ -105,15 +112,22 @@ async fn test_query_created_time_propagation() -> anyhow::Result<()> {
     let worker = received.create_query_ctx().await?;
     assert_eq!(worker.get_id(), ctx.get_id());
     assert_eq!(worker.get_query_created_time(), query_created_time);
+    assert_eq!(worker.get_function_context()?.now, expected_now);
     let worker_info = worker.get_current_session().process_info();
     assert!(worker_info.created_time >= before_worker);
     assert_ne!(worker_info.created_time, query_created_time);
     let derived = QueryContext::create_from(&worker);
     assert_eq!(derived.get_query_created_time(), query_created_time);
+    assert_eq!(derived.get_function_context()?.now, expected_now);
+    assert_eq!(worker.get_function_context()?.now, expected_now);
 
     drop(ctx);
     let next_time = query_created_time + Duration::from_secs(60);
     let next = session.create_query_context_with_cluster(cluster, &BUILD_INFO, Some(next_time))?;
     assert_eq!(next.get_query_created_time(), next_time);
+    assert_eq!(
+        next.get_function_context()?.now,
+        chrono::DateTime::<chrono::Utc>::from(next_time)
+    );
     Ok(())
 }

--- a/src/query/service/tests/it/sessions/query_ctx.rs
+++ b/src/query/service/tests/it/sessions/query_ctx.rs
@@ -63,3 +63,57 @@ async fn test_get_storage_accessor_fs() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_query_created_time_propagation() -> anyhow::Result<()> {
+    use std::time::Duration;
+    use std::time::SystemTime;
+
+    use databend_common_catalog::session_type::SessionType;
+    use databend_common_version::BUILD_INFO;
+    use databend_query::schedulers::QueryFragmentsActions;
+    use databend_query::servers::flight::v1::packets::QueryEnv;
+    use databend_query::sessions::QueryContext;
+    use databend_query::sessions::TableContextCluster;
+    use databend_query::sessions::TableContextQueryIdentity;
+
+    let fixture = TestFixture::setup().await?;
+    let session = fixture.new_session_with_type(SessionType::MySQL).await?;
+
+    let ctx = session.create_query_context(&BUILD_INFO).await?;
+    assert_eq!(
+        session.process_info().created_time,
+        ctx.get_query_created_time()
+    );
+    let cluster = ctx.get_cluster();
+    drop(ctx);
+
+    // Use an explicit historical timestamp to catch worker-local clock sampling.
+    let query_created_time = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+    let ctx = session.create_query_context_with_cluster(
+        cluster.clone(),
+        &BUILD_INFO,
+        Some(query_created_time),
+    )?;
+    assert_eq!(ctx.get_query_created_time(), query_created_time);
+
+    let env = QueryFragmentsActions::create(ctx.clone()).get_query_env()?;
+    assert_eq!(env.query_created_time, query_created_time);
+    let serialized = serde_json::to_value(&env)?;
+    let received: QueryEnv = serde_json::from_value(serialized)?;
+    let before_worker = SystemTime::now();
+    let worker = received.create_query_ctx().await?;
+    assert_eq!(worker.get_id(), ctx.get_id());
+    assert_eq!(worker.get_query_created_time(), query_created_time);
+    let worker_info = worker.get_current_session().process_info();
+    assert!(worker_info.created_time >= before_worker);
+    assert_ne!(worker_info.created_time, query_created_time);
+    let derived = QueryContext::create_from(&worker);
+    assert_eq!(derived.get_query_created_time(), query_created_time);
+
+    drop(ctx);
+    let next_time = query_created_time + Duration::from_secs(60);
+    let next = session.create_query_context_with_cluster(cluster, &BUILD_INFO, Some(next_time))?;
+    assert_eq!(next.get_query_created_time(), next_time);
+    Ok(())
+}

--- a/tests/sqllogictests/suites/base/01_system/01_0009_system_processes.test
+++ b/tests/sqllogictests/suites/base/01_system/01_0009_system_processes.test
@@ -2,3 +2,9 @@ query B
 SELECT count(*)>0 FROM system.processes
 ----
 1
+
+# now() uses the coordinator query creation time, including during planning.
+query B
+SELECT count(*) > 0 FROM system.processes WHERE created_time = now()
+----
+1

--- a/tests/sqllogictests/suites/base/03_common/03_0027_insert_default.test
+++ b/tests/sqllogictests/suites/base/03_common/03_0027_insert_default.test
@@ -109,3 +109,82 @@ select c1VARCHAR, c2VARCHAR, ts2 from t0 order by ts2 desc limit 2;
 
 statement ok
 drop table t0
+
+# Regression for https://github.com/databendlabs/databend/issues/20420.
+# This base-suite case runs in standalone and cluster CI. Small blocks and
+# multiple threads exercise the parallel missing-default-column path.
+statement ok
+SET max_threads = 4
+
+statement ok
+SET max_block_size = 1024
+
+statement ok
+CREATE TABLE default_time_stability (
+    batch UInt8,
+    n UInt64,
+    explicit_ts Timestamp,
+    explicit_date Date,
+    default_ts Timestamp DEFAULT now(),
+    default_date Date DEFAULT today()
+)
+
+# Capture a boundary AFTER CREATE TABLE, then delay INSERT so a default frozen
+# at DDL time cannot pass the timestamp comparison below.
+statement ok
+CREATE TABLE default_time_boundary AS SELECT now() AS ts
+
+statement ok
+SELECT sleep(1)
+
+statement ok
+INSERT INTO default_time_stability(batch, n, explicit_ts, explicit_date)
+SELECT 1, number, now(), today() FROM numbers_mt(65536)
+
+query IIIII
+SELECT count(*), count(DISTINCT default_ts), count(DISTINCT default_date),
+       count_if(default_ts != explicit_ts), count_if(default_date != explicit_date)
+FROM default_time_stability WHERE batch = 1
+----
+65536 1 1 0 0
+
+query B
+SELECT min(default_ts) > (SELECT ts FROM default_time_boundary)
+FROM default_time_stability
+----
+1
+
+# A separate statement must capture a new timestamp, while every processor
+# within that statement still agrees with its explicit projection.
+statement ok
+SELECT sleep(1)
+
+statement ok
+INSERT INTO default_time_stability(batch, n, explicit_ts, explicit_date)
+SELECT 2, number, now(), today() FROM numbers_mt(65536)
+
+query IIIII rowsort
+SELECT batch, count(*), count(DISTINCT default_ts),
+       count_if(default_ts != explicit_ts), count_if(default_date != explicit_date)
+FROM default_time_stability GROUP BY batch
+----
+1 65536 1 0 0
+2 65536 1 0 0
+
+query B
+SELECT (SELECT max(default_ts) FROM default_time_stability WHERE batch = 1)
+     < (SELECT min(default_ts) FROM default_time_stability WHERE batch = 2)
+----
+1
+
+statement ok
+DROP TABLE default_time_stability
+
+statement ok
+DROP TABLE default_time_boundary
+
+statement ok
+UNSET max_block_size
+
+statement ok
+UNSET max_threads


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- Use the coordinator's query creation time for `FunctionContext.now` and propagate it to workers through `QueryEnv`. This keeps time functions consistent across planning,  distributed execution, and delayed evaluation within the same query.

- Preserve local context creation time for elapsed-time calculations and processlist reporting. Add regression coverage for timestamp propagation and function-context consistency.

- fixes: #20420 #19656

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

<!--
See AI_POLICY.md. Agent-opened PRs are welcome; a responsible human on the author side must own the change.
The responsible human is NOT the reviewer — it is the submitter-side owner who has read the diff,
can explain each change, and will answer questions during review.
Write "None" for AI usage if no AI was involved.
-->

- AI usage: An AI coding agent assisted with implementation.
- Responsible human: @forsaken628
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20464)
<!-- Reviewable:end -->
