### PR TITLE
refactor(storage): reduce clustering information metadata overhead

### DIFF
--- a/src/query/storages/common/table_meta/src/meta/statistics.rs
+++ b/src/query/storages/common/table_meta/src/meta/statistics.rs
@@ -35,10 +35,12 @@ use uuid::Uuid;
 
 use crate::meta::ClusterStatistics;
 use crate::meta::ColumnStatistics;
+use crate::meta::CompactSegmentInfo;
 use crate::meta::SegmentStatistics;
 use crate::meta::SpatialStatistics;
 use crate::meta::VectorColumnStatistics;
 use crate::meta::VectorDistanceType;
+use crate::meta::format::MetaEncoding;
 use crate::meta::format::compress;
 use crate::meta::format::encode;
 use crate::meta::format::read_and_deserialize;
@@ -75,6 +77,48 @@ impl ClusterKeyInfo {
     pub fn cluster_key_id(&self) -> u32 {
         self.cluster_key.0
     }
+}
+
+/// Read reusable cluster bounds from the existing named BlockMeta encoding without
+/// constructing unrelated metadata. `None` asks the caller to use the full decoder
+/// for legacy bincode or column-domain inference. No new persisted format is involved.
+pub fn read_cluster_stats(
+    segment: &CompactSegmentInfo,
+    key_id: u32,
+) -> Result<Option<Vec<ClusterStatistics>>> {
+    // Read only this field from the existing named encoding; skip unrelated metadata.
+    #[derive(Deserialize)]
+    struct ClusterStatsOpt {
+        cluster_stats: Option<ClusterStatistics>,
+    }
+
+    let raw = &segment.raw_block_metas;
+    if matches!(raw.encoding, MetaEncoding::Bincode)
+        || segment
+            .summary
+            .cluster_stats
+            .as_ref()
+            .is_none_or(|stats| stats.cluster_key_id != key_id)
+    {
+        return Ok(None);
+    }
+    let blocks: Vec<ClusterStatsOpt> = read_and_deserialize(
+        &mut raw.bytes.as_slice(),
+        raw.bytes.len() as u64,
+        &raw.encoding,
+        &raw.compression,
+    )?;
+    let mut stats = Vec::with_capacity(blocks.len());
+    for block in blocks {
+        let Some(value) = block.cluster_stats else {
+            return Ok(None);
+        };
+        if value.cluster_key_id != key_id {
+            return Ok(None);
+        }
+        stats.push(value);
+    }
+    Ok(Some(stats))
 }
 
 /// Return the trailing Hilbert MBR bounds when the persisted layout is valid.

--- a/src/query/storages/common/table_meta/src/meta/statistics.rs
+++ b/src/query/storages/common/table_meta/src/meta/statistics.rs
@@ -740,10 +740,171 @@ pub fn merge_column_count_min_sketch_mut(lhs: &mut BlockCountMinSketch, rhs: Blo
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use databend_common_expression::types::NumberScalar;
 
     use super::*;
+    use crate::meta::BlockMeta;
     use crate::meta::ClusterStatistics;
+    use crate::meta::SegmentInfo;
+    use crate::meta::Statistics;
+    use crate::meta::format::MetaCompression;
+    use crate::meta::v3::frozen;
+    use crate::meta::v4::RawBlockMeta;
+
+    // Use the actual frozen type so the bincode fixture has its historical positional layout.
+    fn cluster_stats_test_blocks() -> Vec<frozen::BlockMeta> {
+        [
+            (uint_scalar(1), uint_scalar(3), 0),
+            (uint_scalar(2), uint_scalar(2), -1),
+            (Scalar::Null, Scalar::Null, -1),
+        ]
+        .into_iter()
+        .enumerate()
+        .map(|(i, (min, max, level))| frozen::BlockMeta {
+            row_count: 10,
+            block_size: 80,
+            file_size: 40,
+            col_stats: HashMap::from([(0, frozen::ColumnStatistics {
+                min: min.clone().into(),
+                max: max.clone().into(),
+                null_count: if min == Scalar::Null { 10 } else { 0 },
+                in_memory_size: 80,
+                distinct_of_values: Some(1),
+            })]),
+            col_metas: HashMap::from([(
+                0,
+                frozen::ColumnMeta::Parquet(frozen::ParquetColumnMeta {
+                    offset: 0,
+                    len: 40,
+                    num_values: 10,
+                }),
+            )]),
+            cluster_stats: Some(frozen::ClusterStatistics {
+                cluster_key_id: 7,
+                min: vec![min.into()],
+                max: vec![max.into()],
+                level,
+                pages: None,
+            }),
+            location: (format!("block-{i}.parquet"), 0),
+            bloom_filter_index_location: None,
+            bloom_filter_index_size: 0,
+            compression: frozen::Compression::Lz4Raw,
+        })
+        .collect()
+    }
+
+    fn encode_cluster_stats_segment(
+        blocks: &[impl Serialize],
+        summary: Option<ClusterStatistics>,
+        encoding: MetaEncoding,
+        compression: MetaCompression,
+    ) -> Result<CompactSegmentInfo> {
+        use crate::meta::Versioned;
+
+        Ok(CompactSegmentInfo {
+            format_version: SegmentInfo::VERSION,
+            summary: Statistics {
+                block_count: blocks.len() as u64,
+                cluster_stats: summary,
+                ..Default::default()
+            },
+            raw_block_metas: RawBlockMeta {
+                bytes: compress(&compression, encode(&encoding, &blocks)?)?,
+                encoding,
+                compression,
+            },
+        })
+    }
+
+    #[test]
+    fn read_cluster_stats_named_encoding_matches_full_decode() -> Result<()> {
+        let blocks = cluster_stats_test_blocks()
+            .into_iter()
+            .map(|block| Arc::new(BlockMeta::from(block)))
+            .collect::<Vec<_>>();
+        let expected = blocks
+            .iter()
+            .map(|block| block.cluster_stats.clone().unwrap())
+            .collect::<Vec<_>>();
+        for encoding in [MetaEncoding::MessagePack, MetaEncoding::Json] {
+            for compression in [MetaCompression::None, MetaCompression::Zstd] {
+                let compact = encode_cluster_stats_segment(
+                    &blocks,
+                    Some(expected[0].clone()),
+                    encoding.clone(),
+                    compression,
+                )?;
+                let actual = read_cluster_stats(&compact, 7)?.expect("reusable block statistics");
+                // Exact equality covers endpoint order, NULLs, constant ranges and levels.
+                assert_eq!(actual, expected);
+                assert_eq!(compact.block_metas()?, blocks);
+                assert_eq!(
+                    actual
+                        .iter()
+                        .filter(|stats| stats.min() == stats.max())
+                        .count(),
+                    2
+                );
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn read_cluster_stats_fallback_preserves_full_metadata() -> Result<()> {
+        let legacy_blocks = cluster_stats_test_blocks();
+        // Encode real frozen bincode blocks, rather than changing a named encoding's tag.
+        let legacy = encode_cluster_stats_segment(
+            &legacy_blocks,
+            Some(ClusterStatistics::new(
+                7,
+                vec![uint_scalar(1)],
+                vec![Scalar::Null],
+                0,
+            )),
+            MetaEncoding::Bincode,
+            MetaCompression::Zstd,
+        )?;
+        let blocks = legacy_blocks
+            .into_iter()
+            .map(|block| Arc::new(BlockMeta::from(block)))
+            .collect::<Vec<_>>();
+        assert!(read_cluster_stats(&legacy, 7)?.is_none());
+        assert_eq!(legacy.block_metas()?, blocks);
+
+        let current = blocks[0].cluster_stats.clone();
+        let mut stale = current.clone();
+        stale.as_mut().unwrap().cluster_key_id = 6;
+        for encoding in [MetaEncoding::MessagePack, MetaEncoding::Json] {
+            // Matching summary must not hide missing or stale statistics in an individual block.
+            for (case, summary, block_stats, requested_key) in [
+                ("summary missing", None, current.clone(), 7),
+                ("summary stale", stale.clone(), current.clone(), 7),
+                ("block missing", current.clone(), None, 7),
+                ("block stale", current.clone(), stale.clone(), 7),
+                ("different key", current.clone(), current.clone(), 8),
+            ] {
+                let mut source = blocks.clone();
+                Arc::make_mut(&mut source[0]).cluster_stats = block_stats;
+                let compact = encode_cluster_stats_segment(
+                    &source,
+                    summary,
+                    encoding.clone(),
+                    MetaCompression::Zstd,
+                )?;
+                assert!(
+                    read_cluster_stats(&compact, requested_key)?.is_none(),
+                    "{encoding:?}: {case}"
+                );
+                // Fallback preserves the column statistics required for range inference.
+                assert_eq!(compact.block_metas()?, source, "{encoding:?}: {case}");
+            }
+        }
+        Ok(())
+    }
 
     fn uint_scalar(value: u64) -> Scalar {
         Scalar::Number(NumberScalar::UInt64(value))

--- a/src/query/storages/fuse/src/table_functions/clustering_information.rs
+++ b/src/query/storages/fuse/src/table_functions/clustering_information.rs
@@ -47,7 +47,9 @@ use databend_storages_common_table_meta::meta::CompactSegmentInfo;
 use databend_storages_common_table_meta::meta::SegmentInfo;
 use databend_storages_common_table_meta::meta::TableSnapshot;
 use databend_storages_common_table_meta::meta::read_cluster_stats;
+use databend_storages_common_table_meta::meta::valid_cluster_stats_hilbert_minmax;
 use databend_storages_common_table_meta::table::ClusterType;
+use databend_storages_common_table_meta::table::HILBERT_CLUSTER_DIMENSIONS;
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
 use jsonb::Value as JsonbValue;
@@ -327,7 +329,8 @@ impl ClusteringInformationImpl<'_> {
             metadata.constant_block_count = block_count;
             return Ok(metadata);
         }
-        let hilbert_key_id = key.default_key_id.filter(|_| key.is_hilbert);
+        let is_hilbert = key.is_hilbert;
+        let cluster_key_id = key.default_key_id;
         let prepared_exprs = Arc::new(prepare_cluster_key_exprs(
             &key.stats_exprs,
             self.table.schema().as_ref(),
@@ -353,17 +356,10 @@ impl ClusteringInformationImpl<'_> {
                 let schema = self.table.schema();
                 let types = key_types.clone();
                 let exprs = prepared_exprs.clone();
-                let default_key_id = key.default_key_id;
                 tasks.pending.push(runtime.spawn(async move {
                     let segment =
                         SegmentsIO::read_compact_segment(operator, location, schema, true).await?;
-                    collect_segment_endpoints(
-                        &segment,
-                        &types,
-                        &exprs,
-                        default_key_id,
-                        hilbert_key_id,
-                    )
+                    collect_segment_endpoints(&segment, &types, &exprs, cluster_key_id, is_hilbert)
                 }));
             }
             let Some(result) = tasks.pending.next().await else {
@@ -580,8 +576,8 @@ fn collect_segment_endpoints(
     segment: &CompactSegmentInfo,
     key_types: &[DataType],
     prepared_exprs: &[PreparedClusterKeyExpr],
-    default_key_id: Option<u32>,
-    hilbert_key_id: Option<u32>,
+    cluster_key_id: Option<u32>,
+    is_hilbert: bool,
 ) -> Result<SegmentEndpoints> {
     debug_assert!(!key_types.is_empty());
     let mut builders = key_types
@@ -589,10 +585,21 @@ fn collect_segment_endpoints(
         .map(|ty| ColumnBuilder::with_capacity(ty, segment.summary.block_count as usize * 2))
         .collect::<Vec<_>>();
     let mut constant_block_count = 0;
-    let projected = match default_key_id {
+    let projected = match cluster_key_id {
         Some(id) => read_cluster_stats(segment, id)?,
         _ => None,
     };
+    // Match hilbert_bounds_for_diagnostics before appending any endpoints. Invalid or
+    // prefixed bounds must use column-domain inference, not truncate to the first two values.
+    let projected = projected.filter(|stats| {
+        !is_hilbert
+            || stats.iter().all(|stats| {
+                stats.min().len() == HILBERT_CLUSTER_DIMENSIONS
+                    && stats.max().len() == HILBERT_CLUSTER_DIMENSIONS
+                    && valid_cluster_stats_hilbert_minmax(stats, HILBERT_CLUSTER_DIMENSIONS)
+                        .is_some()
+            })
+    });
     if let Some(stats) = projected {
         for stats in stats {
             constant_block_count += u64::from(stats.min() == stats.max());
@@ -604,7 +611,7 @@ fn collect_segment_endpoints(
         // existing domain inference. Full metadata is released on this worker, not the consumer.
         let segment = SegmentInfo::try_from(segment)?;
         for block in segment.blocks {
-            if let Some(id) = hilbert_key_id {
+            if let (true, Some(id)) = (is_hilbert, cluster_key_id) {
                 let bounds = hilbert_bounds_for_diagnostics(
                     prepared_exprs,
                     &block.col_stats,
@@ -621,7 +628,7 @@ fn collect_segment_endpoints(
                     prepared_exprs,
                     &block.col_stats,
                     block.cluster_stats.as_ref(),
-                    default_key_id,
+                    cluster_key_id,
                 );
                 constant_block_count += u64::from(min == max);
                 push_endpoint(&mut builders, &min);

--- a/src/query/storages/fuse/src/table_functions/clustering_information.rs
+++ b/src/query/storages/fuse/src/table_functions/clustering_information.rs
@@ -17,12 +17,15 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use chrono::Utc;
+use databend_common_base::runtime::JoinHandle;
+use databend_common_base::runtime::Runtime;
 use databend_common_catalog::plan::DataSourcePlan;
 use databend_common_catalog::table_args::TableArgs;
 use databend_common_catalog::table_args::parse_table_name;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::BlockEntry;
+use databend_common_expression::Column;
 use databend_common_expression::ColumnBuilder;
 use databend_common_expression::DataBlock;
 use databend_common_expression::Expr;
@@ -40,9 +43,13 @@ use databend_common_pipeline_transforms::sorts::core::RowConverter;
 use databend_common_pipeline_transforms::sorts::core::VariableRowConverter;
 use databend_common_sql::analyze_cluster_keys;
 use databend_common_sql::parse_cluster_keys;
+use databend_storages_common_table_meta::meta::CompactSegmentInfo;
 use databend_storages_common_table_meta::meta::SegmentInfo;
 use databend_storages_common_table_meta::meta::TableSnapshot;
+use databend_storages_common_table_meta::meta::read_cluster_stats;
 use databend_storages_common_table_meta::table::ClusterType;
+use futures::StreamExt;
+use futures::stream::FuturesUnordered;
 use jsonb::Value as JsonbValue;
 use log::info;
 use serde::Deserialize;
@@ -52,6 +59,7 @@ use crate::FuseTable;
 use crate::Table;
 use crate::io::SegmentsIO;
 use crate::sessions::TableContext;
+use crate::statistics::PreparedClusterKeyExpr;
 use crate::statistics::cluster_key_types_for_depth;
 use crate::statistics::get_min_max_stats;
 use crate::statistics::hilbert_bounds_for_diagnostics;
@@ -199,6 +207,36 @@ struct CollectedMetadata {
     constant_block_count: u64,
 }
 
+impl CollectedMetadata {
+    fn new(key_types: Vec<DataType>, block_count: usize) -> Self {
+        let endpoint_builders = (!key_types.is_empty()).then(|| {
+            key_types
+                .iter()
+                .map(|ty| ColumnBuilder::with_capacity(ty, block_count.saturating_mul(2)))
+                .collect()
+        });
+        Self {
+            key_types,
+            endpoint_builders,
+            block_count,
+            constant_block_count: 0,
+        }
+    }
+
+    fn append(&mut self, (columns, constant_block_count): SegmentEndpoints) {
+        // Every block contributes a min/max pair to each endpoint column.
+        debug_assert!(!columns.is_empty());
+        debug_assert!(columns[0].len().is_multiple_of(2));
+        self.constant_block_count += constant_block_count;
+        if let Some(builders) = self.endpoint_builders.as_mut() {
+            debug_assert_eq!(builders.len(), columns.len());
+            for (builder, column) in builders.iter_mut().zip(&columns) {
+                builder.append_column(column);
+            }
+        }
+    }
+}
+
 struct ClusteringInformationImpl<'a> {
     ctx: Arc<dyn TableContext>,
     table: &'a FuseTable,
@@ -277,80 +315,66 @@ impl ClusteringInformationImpl<'_> {
                 key_types.len()
             )));
         }
-        let capacity = snapshot.summary.block_count as usize;
+        let block_count = snapshot.summary.block_count;
         // `clustering_information` intentionally measures only the declared cluster-key domains
         // across the whole table. PARTITION BY boundaries are outside this function's metric, even
         // though pruning and recluster execution are partition-local. Changing that established
         // definition and its reported values should be handled in a separate compatibility PR.
-        let mut endpoint_builders = (!key_types.is_empty()).then(|| {
-            key_types
-                .iter()
-                .map(|ty| ColumnBuilder::with_capacity(ty, capacity.saturating_mul(2)))
-                .collect::<Vec<_>>()
-        });
-        let hilbert_key_id = key.default_key_id.filter(|_| key.is_hilbert);
-        let prepared_exprs =
-            prepare_cluster_key_exprs(&key.stats_exprs, self.table.schema().as_ref());
-        let segments_io = SegmentsIO::create(
-            self.ctx.clone(),
-            self.table.operator.clone(),
-            self.table.schema(),
-        );
-        let mut constant_block_count = 0u64;
-        let mut block_count = 0usize;
-        let chunk_size = self.ctx.get_settings().get_max_threads()?.max(1) as usize * 4;
-
-        for chunk in snapshot.segments.chunks(chunk_size) {
-            let segments = segments_io
-                .read_segments::<SegmentInfo>(chunk, true)
-                .await?;
-            for segment in segments {
-                let segment = segment?;
-                for block in segment.blocks {
-                    block_count += 1;
-                    if let Some(cluster_key_id) = hilbert_key_id {
-                        let bounds = hilbert_bounds_for_diagnostics(
-                            &prepared_exprs,
-                            &block.col_stats,
-                            block.cluster_stats.as_ref(),
-                            cluster_key_id,
-                        );
-                        constant_block_count +=
-                            u64::from(bounds[0] == bounds[1] && bounds[2] == bounds[3]);
-                        let builders = endpoint_builders.as_mut().ok_or_else(|| {
-                            ErrorCode::Internal(
-                                "Hilbert clustering information has no endpoint columns"
-                                    .to_string(),
-                            )
-                        })?;
-                        builders[0].push(bounds[0].as_ref());
-                        builders[0].push(bounds[1].as_ref());
-                        builders[1].push(bounds[2].as_ref());
-                        builders[1].push(bounds[3].as_ref());
-                    } else if let Some(builders) = endpoint_builders.as_mut() {
-                        let (min, max) = get_min_max_stats(
-                            &prepared_exprs,
-                            &block.col_stats,
-                            block.cluster_stats.as_ref(),
-                            key.default_key_id,
-                        );
-                        debug_assert_eq!(min.len(), max.len());
-                        constant_block_count += u64::from(min == max);
-                        push_endpoint(builders, &min);
-                        push_endpoint(builders, &max);
-                    } else {
-                        constant_block_count += 1;
-                    }
-                }
-            }
+        let mut metadata = CollectedMetadata::new(key_types.clone(), block_count as usize);
+        if key_types.is_empty() {
+            // With no scalar key domains, every block is constant. Snapshot counts suffice;
+            // there are no endpoints to collect, so skip segment IO and worker creation.
+            metadata.constant_block_count = block_count;
+            return Ok(metadata);
         }
-
-        Ok(CollectedMetadata {
-            key_types,
-            endpoint_builders,
-            block_count,
-            constant_block_count,
-        })
+        let hilbert_key_id = key.default_key_id.filter(|_| key.is_hilbert);
+        let prepared_exprs = Arc::new(prepare_cluster_key_exprs(
+            &key.stats_exprs,
+            self.table.schema().as_ref(),
+        ));
+        let threads = self.ctx.get_settings().get_max_threads()?.max(1) as usize;
+        // One request-scoped runtime; no per-batch startup or batch-wide completion barrier.
+        let runtime = Runtime::with_worker_threads(threads, Some("clustering-metadata".into()))?;
+        // Abort outstanding tasks on error/cancellation before dropping the runtime.
+        let mut tasks = MetadataTasks::default();
+        let max_in_flight = threads * 2;
+        let mut locations = snapshot.segments.iter();
+        let key_types = Arc::new(key_types);
+        loop {
+            self.ctx
+                .check_aborting()
+                .map_err(|err| err.with_context("failed to collect clustering metadata"))?;
+            while tasks.pending.len() < max_in_flight {
+                let Some(location) = locations.next() else {
+                    break;
+                };
+                let location = location.clone();
+                let operator = self.table.operator.clone();
+                let schema = self.table.schema();
+                let types = key_types.clone();
+                let exprs = prepared_exprs.clone();
+                let default_key_id = key.default_key_id;
+                tasks.pending.push(runtime.spawn(async move {
+                    let segment =
+                        SegmentsIO::read_compact_segment(operator, location, schema, true).await?;
+                    collect_segment_endpoints(
+                        &segment,
+                        &types,
+                        &exprs,
+                        default_key_id,
+                        hilbert_key_id,
+                    )
+                }));
+            }
+            let Some(result) = tasks.pending.next().await else {
+                break;
+            };
+            let segment = result.map_err(|e| {
+                ErrorCode::Internal(format!("clustering metadata task failed: {e}"))
+            })??;
+            metadata.append(segment);
+        }
+        Ok(metadata)
     }
 
     fn build_hilbert_response(
@@ -509,16 +533,16 @@ impl ClusteringInformationImpl<'_> {
                 info,
             });
         };
+        let total_block_count = snapshot.summary.block_count;
         let timestamp = snapshot.timestamp.unwrap_or(now).timestamp_micros();
         info!(
             "clustering_information: started table={} cluster_type={} segments={} blocks={}",
             self.table.table_info.desc,
             cluster_type,
             snapshot.segments.len(),
-            snapshot.summary.block_count,
+            total_block_count,
         );
 
-        let total_block_count = snapshot.summary.block_count;
         let metadata_start = Instant::now();
         let metadata = self.collect_metadata(&snapshot, &key).await?;
         info!(
@@ -534,6 +558,81 @@ impl ClusteringInformationImpl<'_> {
             self.build_linear_response(key, timestamp, total_block_count, metadata, total_start)
         }
     }
+}
+
+// Endpoint columns and constant block count.
+type SegmentEndpoints = (Vec<Column>, u64);
+
+#[derive(Default)]
+struct MetadataTasks {
+    pending: FuturesUnordered<JoinHandle<Result<SegmentEndpoints>>>,
+}
+
+impl Drop for MetadataTasks {
+    fn drop(&mut self) {
+        for task in self.pending.iter() {
+            task.abort();
+        }
+    }
+}
+
+fn collect_segment_endpoints(
+    segment: &CompactSegmentInfo,
+    key_types: &[DataType],
+    prepared_exprs: &[PreparedClusterKeyExpr],
+    default_key_id: Option<u32>,
+    hilbert_key_id: Option<u32>,
+) -> Result<SegmentEndpoints> {
+    debug_assert!(!key_types.is_empty());
+    let mut builders = key_types
+        .iter()
+        .map(|ty| ColumnBuilder::with_capacity(ty, segment.summary.block_count as usize * 2))
+        .collect::<Vec<_>>();
+    let mut constant_block_count = 0;
+    let projected = match default_key_id {
+        Some(id) => read_cluster_stats(segment, id)?,
+        _ => None,
+    };
+    if let Some(stats) = projected {
+        for stats in stats {
+            constant_block_count += u64::from(stats.min() == stats.max());
+            push_endpoint(&mut builders, stats.min());
+            push_endpoint(&mut builders, stats.max());
+        }
+    } else {
+        // Custom keys, stale/missing statistics and legacy positional encoding retain the
+        // existing domain inference. Full metadata is released on this worker, not the consumer.
+        let segment = SegmentInfo::try_from(segment)?;
+        for block in segment.blocks {
+            if let Some(id) = hilbert_key_id {
+                let bounds = hilbert_bounds_for_diagnostics(
+                    prepared_exprs,
+                    &block.col_stats,
+                    block.cluster_stats.as_ref(),
+                    id,
+                );
+                constant_block_count += u64::from(bounds[0] == bounds[1] && bounds[2] == bounds[3]);
+                builders[0].push(bounds[0].as_ref());
+                builders[0].push(bounds[1].as_ref());
+                builders[1].push(bounds[2].as_ref());
+                builders[1].push(bounds[3].as_ref());
+            } else {
+                let (min, max) = get_min_max_stats(
+                    prepared_exprs,
+                    &block.col_stats,
+                    block.cluster_stats.as_ref(),
+                    default_key_id,
+                );
+                constant_block_count += u64::from(min == max);
+                push_endpoint(&mut builders, &min);
+                push_endpoint(&mut builders, &max);
+            }
+        }
+    }
+    Ok((
+        builders.into_iter().map(ColumnBuilder::build).collect(),
+        constant_block_count,
+    ))
 }
 
 fn push_endpoint(builders: &mut [ColumnBuilder], endpoint: &[Scalar]) {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Reduce metadata processing overhead in `clustering_information` without changing the metadata file format/version or the overlap/depth algorithms.

- Reuse one request-scoped runtime instead of creating a runtime for each segment batch.
- Keep at most `2 * max_threads` segment tasks in flight and consume completed results without a batch-wide barrier. Abort outstanding tasks when the task collection is dropped.
- Extract endpoints on workers and return compact columns rather than transferring complete BlockMeta graphs to the consumer.
- Read only cluster statistics from the existing named MessagePack/JSON encoding when the segment and block key IDs match. Retain full decoding for legacy bincode, custom keys, and missing/stale statistics.
- Use snapshot counts directly when there are no scalar key domains, avoiding segment reads and worker creation.

## Performance comparison

Compare the combined effect of the two optimizations on **1,048,576 blocks per scenario**:

- **A — Before #20411:** historical Linear diagnostics from `7bc00ee552`.
- **B — After #20411:** optimized endpoint sorting/sweep, with the original metadata processing.
- **C — This PR:** the same optimized algorithms plus the current metadata processing improvements.

Eight workers, sixteen in-flight tasks; two runs with reversed variant order, one excluded warmup round per run, and ten measured samples per variant in total. Values are pooled medians of metadata processing plus calculation time. Shared sweep aggregates and constant-block counts matched across all three versions.

| Segments x blocks / columns / key | A: before #20411 | B: algorithm optimization | C: current | Combined time reduction (A→C) | Combined speedup |
| --- | ---: | ---: | ---: | ---: | ---: |
| 131072 x 8 / 8 / int | 3009.07 ms | 2318.67 ms | 520.55 ms | 82.7% | 5.78x |
| 8192 x 128 / 8 / int | 2926.87 ms | 2373.21 ms | 404.77 ms | 86.2% | 7.23x |
| 8192 x 128 / 128 / int | 12985.63 ms | 12096.48 ms | 3759.83 ms | 71.0% | 3.45x |
| 8192 x 128 / 8 / string | 7720.52 ms | 6784.08 ms | 3063.95 ms | 60.3% | 2.52x |
| 1024 x 1024 / 8 / int | 1995.12 ms | 1446.20 ms | 433.57 ms | 78.3% | 4.60x |

This PR's incremental total-time reductions **B→C** are 77.5%, 82.9%, 68.9%, 54.8%, and 70.0%, respectively. Combined A→C gains must not be attributed to this PR alone.

For the normal numeric-key scenario, calculation time decreased from approximately **646 ms to 80 ms** after #20411; this PR then reduced metadata processing from approximately **2290 ms to 320 ms**. For the long-common-prefix string workload, #20411 did not show a clear calculation-phase speedup; the combined benefit primarily comes from metadata processing and representation changes.

Wide-fixture separate-process maximum RSS: **1,726,504 KiB → 1,243,348 KiB → 929,044 KiB** (A/B/C), a combined reduction of **46.2%**. These are process high-water marks including fixture construction, warmup, and repeated runs, not isolated query peaks.

**Measurement boundaries:** this is a local component benchmark, not three complete historical SQL services. 

## Tests
- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding assistant helped draft and simplify metadata processing changes, run local performance experiments, and prepare this summary. The responsible human reviewed the final diff and directed the implementation choices.
- Responsible human: @zhyass
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20465)
<!-- Reviewable:end -->
