### PR TITLE
fix(query): use lazy partitions for initial materialized view refresh

### DIFF
--- a/src/query/ee/src/materialized_view/refresh.rs
+++ b/src/query/ee/src/materialized_view/refresh.rs
@@ -601,11 +601,21 @@ impl<'a> MaterializedViewRefresh<'a> {
             return Ok(RefreshStrategy::CheckpointOnly);
         }
 
-        let (checkpoint_seq, start_snapshot) = match checkpoint.clone() {
-            Some((checkpoint_seq, Some(start_snapshot))) => (checkpoint_seq, Some(start_snapshot)),
-            None | Some((_, None)) => (0, None),
+        // 3. With no previous data endpoint, scan the captured source snapshot directly. A changes
+        // scan would eagerly expand every block on the coordinator; a normal scan can distribute
+        // lazy segment partitions. Keep the captured table attached so later source commits cannot
+        // move the scan past the checkpoint we will persist.
+        let Some((checkpoint_seq, Some(start_snapshot))) = checkpoint else {
+            self.attach_source(
+                &self.catalog,
+                source_database,
+                source_table_name,
+                Arc::new(source_table.clone()),
+            )?;
+            return self.rebuild_strategy(physical_query);
         };
-        let starts_from_empty_endpoint = start_snapshot.is_none();
+        let checkpoint_seq = *checkpoint_seq;
+        let start_snapshot = Some(start_snapshot.clone());
         let changes_source_name =
             format!("_mv_changes_{}_{}", self.mv_table.get_id(), checkpoint_seq);
         let changes = source_table
@@ -622,12 +632,9 @@ impl<'a> MaterializedViewRefresh<'a> {
             )
             .await?;
 
-        // 3. Aggregate states cannot retract UPDATE/DELETE effects. Recompute globally merged states
+        // 4. Aggregate states cannot retract UPDATE/DELETE effects. Recompute globally merged states
         // from the current source and replace all persisted state rows.
-        if !starts_from_empty_endpoint
-            && self.is_aggregating
-            && changes.mode == StreamMode::Standard
-        {
+        if self.is_aggregating && changes.mode == StreamMode::Standard {
             self.attach_source(
                 &self.catalog,
                 source_database,
@@ -656,12 +663,6 @@ impl<'a> MaterializedViewRefresh<'a> {
             "invalid materialized view physical query",
         )?;
         Self::apply_changes_query(&mut query, changes_query.clone(), "INSERT")?;
-        // 4. The first refresh consumes all tracked inserts with INSERT OVERWRITE. For aggregate MVs,
-        // this also establishes a globally merged baseline.
-        if starts_from_empty_endpoint {
-            return Ok(RefreshStrategy::Rebuild(self.target_insert(query, true)));
-        }
-
         // 5. Standard non-aggregate changes apply UPDATE/DELETE/INSERT through one internal MERGE.
         if changes.mode == StreamMode::Standard {
             let source = self.build_standard_refresh_source(physical_query, &changes_query)?;

--- a/tests/sqllogictests/suites/ee/07_ee_materialized_view/07_0004_materialized_view_initial_refresh.test
+++ b/tests/sqllogictests/suites/ee/07_ee_materialized_view/07_0004_materialized_view_initial_refresh.test
@@ -1,0 +1,187 @@
+## Copyright 2023 Databend Cloud
+##
+## Licensed under the Elastic License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     https://www.elastic.co/licensing/elastic-license
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+statement ok
+create or replace database test_mv_initial_refresh
+
+statement ok
+use test_mv_initial_refresh
+
+statement ok
+set enable_compact_after_write = 0
+
+statement ok
+set enable_distributed_pruning = 1
+
+statement ok
+create table source (id int, amount int, active boolean) change_tracking = true
+
+statement ok
+insert into source values (1, 10, true), (2, 20, false)
+
+# The initial scan must preserve change$row_id for rows with mutation/compaction history.
+statement ok
+update source set amount = 11 where id = 1
+
+statement ok
+optimize table source compact
+
+statement ok
+insert into source values (3, 30, true)
+
+statement ok
+insert into source values (4, 40, true)
+
+# Four segments also exceed the node count in the three-node test cluster.
+statement ok
+insert into source values (9, 90, false)
+
+statement ok
+create materialized view detail_mv as select id, amount from source where active
+
+statement ok
+create materialized view aggregate_mv as select sum(amount) as total from source where active
+
+statement ok
+refresh materialized view detail_mv
+
+statement ok
+refresh materialized view aggregate_mv
+
+query II
+select id, amount from detail_mv order by id
+----
+1 11
+3 30
+4 40
+
+query I
+select total from aggregate_mv
+----
+81
+
+# Inspect persisted storage too: MV reads can otherwise hide an incomplete refresh.
+query I
+select sum(row_count) from fuse_block('test_mv_initial_refresh', 'detail_mv')
+----
+3
+
+# Append-only refresh must start after the initial snapshot, without duplicating the baseline.
+statement ok
+insert into source values (5, 50, true)
+
+statement ok
+refresh materialized view detail_mv
+
+statement ok
+refresh materialized view aggregate_mv
+
+query I
+select sum(row_count) from fuse_block('test_mv_initial_refresh', 'detail_mv')
+----
+4
+
+query I
+select total from aggregate_mv
+----
+131
+
+# Move the original rows to new blocks, then exercise MERGE against their stable row IDs.
+statement ok
+optimize table source compact
+
+statement ok
+update source set amount = 12 where id = 1
+
+statement ok
+update source set active = not active where id in (2, 3)
+
+statement ok
+delete from source where id = 4
+
+statement ok
+refresh materialized view detail_mv
+
+statement ok
+refresh materialized view aggregate_mv
+
+query II
+select id, amount from detail_mv order by id
+----
+1 12
+2 20
+5 50
+
+query I
+select sum(row_count) from fuse_block('test_mv_initial_refresh', 'detail_mv')
+----
+3
+
+query I
+select total from aggregate_mv
+----
+82
+
+# A refresh checkpoint with no source snapshot must also rebuild on the next nonempty endpoint.
+statement ok
+truncate table source
+
+statement ok
+refresh materialized view detail_mv
+
+statement ok
+refresh materialized view aggregate_mv
+
+statement ok
+insert into source values (6, 60, true)
+
+statement ok
+insert into source values (7, 70, true)
+
+statement ok
+insert into source values (8, 80, false)
+
+statement ok
+insert into source values (9, 90, false)
+
+statement ok
+refresh materialized view detail_mv
+
+statement ok
+refresh materialized view aggregate_mv
+
+query II
+select id, amount from detail_mv order by id
+----
+6 60
+7 70
+
+query I
+select sum(row_count) from fuse_block('test_mv_initial_refresh', 'detail_mv')
+----
+2
+
+query I
+select total from aggregate_mv
+----
+130
+
+statement ok
+unset enable_compact_after_write
+
+statement ok
+unset enable_distributed_pruning
+
+statement ok
+drop database test_mv_initial_refresh


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Closes #20468

Initial materialized view refreshes currently use a CHANGE_TRACKING scan with an empty starting endpoint. This eagerly expands all block partitions on the coordinator before distributing the physical plan, even when distributed pruning is enabled.

Read the captured source table directly with INSERT OVERWRITE when there is no previous data snapshot. This allows the normal FUSE scan to distribute lazy segment partitions under its existing settings and thresholds. The captured source endpoint remains pinned, and refreshes with an existing data checkpoint retain their incremental behavior. The same path handles rebuilding after a checkpoint against an empty source.

The SQL regression covers detail and aggregate MVs, compaction history before the first refresh, append-only refreshes, updates/deletes with stable source row IDs, and restarting from an empty source checkpoint. It also checks persisted MV row counts.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:
- Passed: `rustfmt --edition 2024 --check src/query/ee/src/materialized_view/refresh.rs`.
- Passed: `git diff --cached --check`.
- Passed: `cargo clippy -p databend-enterprise-query --lib -- -D warnings` (5m 18s).
- Added SQL logic coverage; not executed locally against a rebuilt query binary.
- Large-table performance and the reported Flight timeout have not been reproduced or verified locally.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent investigated the refresh path and drafted the implementation, SQL regression coverage, and PR description.
- Responsible human: @dqhl76
- [x] The responsible human has read every line of this diff and can explain each change

Draft pending the responsible human's final diff review. No review is requested yet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20467)
<!-- Reviewable:end -->
