### PR TITLE
fix(storage): read virtual columns when prewhere keeps no rows of a block

### DIFF
--- a/src/query/service/tests/it/storages/fuse/operations/virtual_column_pruner_reader.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/virtual_column_pruner_reader.rs
@@ -48,6 +48,8 @@ use jsonb::OwnedJsonb;
 use jsonb::keypath::OwnedKeyPath;
 use jsonb::keypath::OwnedKeyPaths;
 use jsonb::keypath::parse_key_paths;
+use parquet::arrow::arrow_reader::RowSelection;
+use parquet::arrow::arrow_reader::RowSelector;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_virtual_column_pruner_reader() -> anyhow::Result<()> {
@@ -341,6 +343,33 @@ async fn test_virtual_column_pruner_reader() -> anyhow::Result<()> {
         &result_block.get_by_offset(16).to_column(),
         &expected_root_array_k,
     );
+
+    // A prewhere predicate can reject every row of a block that survived
+    // min/max pruning. The deserializer then receives an empty data block and
+    // a row selection that keeps nothing; the virtual column reader must still
+    // produce zero-row columns instead of failing on the empty parquet batch.
+    let virtual_data = reader
+        .read_parquet_data_by_merge_io(
+            &read_settings,
+            &Some(&virtual_block_meta_index),
+            block.num_rows(),
+        )
+        .await
+        .expect("virtual block read result");
+    let empty_selection = RowSelection::from(vec![RowSelector::skip(block.num_rows())]);
+    let empty_block = reader.deserialize_virtual_columns(
+        block.slice(0..0),
+        Some(virtual_data),
+        Some(empty_selection),
+    )?;
+    assert_eq!(empty_block.num_rows(), 0);
+    assert_eq!(
+        empty_block.num_columns(),
+        block.num_columns() + column_ids.len()
+    );
+    for entry in empty_block.columns() {
+        assert_eq!(entry.to_column().len(), 0);
+    }
 
     Ok(())
 }

--- a/src/query/storages/fuse/src/io/read/block/parquet/deserialize.rs
+++ b/src/query/storages/fuse/src/io/read/block/parquet/deserialize.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 
 use arrow_array::RecordBatch;
+use arrow_array::RecordBatchReader;
 use arrow_schema::Schema;
 use databend_common_expression::ColumnId;
 use databend_common_expression::TableSchema;
@@ -75,7 +76,14 @@ pub fn column_chunks_to_record_batch(
         num_rows,
         selection,
     )?;
-    let record = record_reader.next().unwrap()?;
+    let record = match record_reader.next() {
+        Some(record) => record?,
+        // The reader yields nothing when `selection` keeps no rows, e.g. a prewhere
+        // predicate filtered out every row of the block while the block itself
+        // survived min/max pruning. Return an empty batch with the projected schema
+        // so callers can build zero-row columns without special casing.
+        None => RecordBatch::new_empty(record_reader.schema()),
+    };
     assert!(record_reader.next().is_none());
     Ok(record)
 }

--- a/tests/sqllogictests/suites/query/virtual_column.test
+++ b/tests/sqllogictests/suites/query/virtual_column.test
@@ -782,6 +782,128 @@ FROM test2;
 9 "Richard" 33 "Austin" NULL "109" "10.9"
 10 "Lisa" 26 "Chicago" NULL NULL "10.10"
 
+# A prewhere predicate on a regular column may keep no rows of a block that
+# still survives min/max pruning. Reading the materialized virtual columns of
+# such a block must yield zero rows instead of failing. Each insert below
+# forms its own segment with a different virtual schema (paths, physical
+# types, missing paths), so the empty-selection path is exercised against
+# every schema shape with several projections.
+statement ok
+drop table if exists t_empty_prewhere
+
+statement ok
+create table t_empty_prewhere(id int, val json) storage_format = 'parquet' enable_virtual_column = true
+
+# segment 1: a is UInt64, b is String
+statement ok
+insert into t_empty_prewhere values (1, '{"a":1,"b":"x"}'), (3, '{"a":3,"b":"z"}')
+
+# segment 2: a is String, plus Boolean c and nested d.e
+statement ok
+insert into t_empty_prewhere values (11, '{"a":"s1","c":true,"d":{"e":1}}'), (13, '{"a":"s3","c":false,"d":{"e":3}}')
+
+# segment 3: a is missing, f stays Variant
+statement ok
+insert into t_empty_prewhere values (21, '{"d":{"e":21},"f":[1,2]}'), (23, '{"d":{"e":23},"b":"w"}')
+
+statement ok
+refresh virtual column on t_empty_prewhere
+
+# segment 4: materialized by a second refresh, only a
+statement ok
+insert into t_empty_prewhere values (31, '{"a":31}'), (33, '{"a":33}')
+
+statement ok
+refresh virtual column on t_empty_prewhere
+
+query IT
+select virtual_column_count, virtual_schema from fuse_virtual_column_segment_schema('test_virtual_column', 't_empty_prewhere') order by virtual_schema
+----
+1 [{"column_id":0,"path":"val.a"}]
+1 [{"column_id":0,"path":"val.a"},{"column_id":1,"path":"val.b"}]
+1 [{"column_id":0,"path":"val.a"},{"column_id":1,"path":"val.c"},{"column_id":2,"path":"val.d.e"}]
+1 [{"column_id":0,"path":"val.b"},{"column_id":1,"path":"val.d.e"},{"column_id":2,"path":"val.f"}]
+
+query TTTTT
+show virtual columns from t_empty_prewhere
+----
+test_virtual_column t_empty_prewhere val a UInt64, String
+test_virtual_column t_empty_prewhere val b String
+test_virtual_column t_empty_prewhere val c Boolean
+test_virtual_column t_empty_prewhere val d.e UInt64
+test_virtual_column t_empty_prewhere val f Variant
+
+# `id % 2 = 0` cannot prune any block by statistics, yet matches no row, so
+# every block reaches the reader with an empty row selection.
+query T
+select val['a'] from t_empty_prewhere where id % 2 = 0
+----
+
+query TT
+select val['b'], val['c'] from t_empty_prewhere where id % 2 = 0
+----
+
+query TT
+select val['d']['e'], val['f'][0] from t_empty_prewhere where id % 2 = 0
+----
+
+query ITT
+select id, val, val['a'] from t_empty_prewhere where id % 2 = 0
+----
+
+query TI
+select val['a']::string, val['d']['e']::int from t_empty_prewhere where id % 2 = 0
+----
+
+query ITT
+select count(), max(val['a']), min(val['d']['e']) from t_empty_prewhere where id % 2 = 0
+----
+0 NULL NULL
+
+query I
+select count() from t_empty_prewhere where id % 2 = 0 and val['a'] = 2
+----
+0
+
+# Range predicates that only keep a single block, then reject all of its rows.
+query T
+select val['a'] from t_empty_prewhere where id > 1 and id < 3
+----
+
+query TT
+select val['a'], val['c'] from t_empty_prewhere where id > 11 and id < 13
+----
+
+query TT
+select val['a'], val['d']['e'] from t_empty_prewhere where id > 21 and id < 23
+----
+
+query TT
+select val['a'], val['b'] from t_empty_prewhere where id > 31 and id < 33
+----
+
+# Blocks with zero selected rows mixed with blocks that keep some rows.
+query ITT
+select id, val['a'], val['d']['e'] from t_empty_prewhere where id >= 3 and id < 13 and id != 11 order by id
+----
+3 3 NULL
+
+query ITTT
+select id, val['a'], val['b'], val['d']['e'] from t_empty_prewhere where id >= 3 and id < 33 and id % 10 != 1 order by id
+----
+3 3 "z" NULL
+13 "s3" NULL 3
+23 NULL "w" 23
+
+query I
+select id from t_empty_prewhere where id % 2 = 1 and val['d']['e'] > 20 order by id
+----
+21
+23
+
+statement ok
+drop table t_empty_prewhere
+
 statement ok
 set enable_experimental_virtual_column = 0;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Reading materialized virtual columns panicked with `called Option::unwrap() on a None value` when a prewhere predicate rejected every row of a block that still survived min/max pruning.

Minimal reproduction on `main`:

```sql
set enable_experimental_virtual_column = 1;
create table t (id int, v json) enable_virtual_column = true;
insert into t values (1, '{"a":1}'), (3, '{"a":3}');
refresh virtual column on t;
-- stays inside the block's [1, 3] range, so the block is not pruned,
-- but prewhere keeps no row of it
select v['a'] from t where id > 1 and id < 3;
```

Root cause: `column_chunks_to_record_batch` unwrapped the first batch from `ParquetRecordBatchReader`, but the reader yields `None` when the row selection keeps no rows. The regular column path (`BlockReader::deserialize_parquet_chunks`) already short-circuits on `result_rows == 0`; the virtual column reader passes the empty selection straight through and hit the `unwrap`.

The virtual column file is only materialized by `REFRESH VIRTUAL COLUMN`, recluster or compact, so tables that only ever received inserts are not affected.

## Changes

- `column_chunks_to_record_batch` returns `RecordBatch::new_empty(projected schema)` instead of unwrapping when the reader yields nothing, so callers build zero-row columns without special casing.
- `test_virtual_column_pruner_reader` additionally feeds an empty row selection through the reader; the existing setup covers every read plan kind (Direct / FromParent / Shared / Object / Missing / Coalesce). This assertion panics at `deserialize.rs:78` without the fix.
- `query/virtual_column.test` builds four segments with different virtual schemas (paths, physical types of the same path, missing paths, a segment materialized by a second refresh) and queries them with several projections whose prewhere predicate keeps no rows: `id % 2 = 0` hits every block with an empty selection, range predicates isolate each block, and mixed cases keep rows in some blocks only.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:

```
cargo test -p databend-query --test it -- virtual_column_pruner_reader
databend-sqllogictests --handlers http --run_dir query --run_file virtual_column.test   # 139 passed
cargo clippy -p databend-common-storages-fuse --no-deps -- -D warnings
```

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: A coding agent investigated the panic from the backtrace, reduced it to the minimal reproduction above, wrote the fix in `deserialize.rs`, the reader test extension and the sqllogictest section, and ran the validation commands listed above. Test data and names are synthetic.
- Responsible human: @zhang2014
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20470)
<!-- Reviewable:end -->
