### PR TITLE
chore: meta: upgrade server and client to adjust logging level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3530,7 +3530,7 @@ dependencies = [
  "databend-enterprise-query",
  "databend-meta",
  "databend-meta-cli-config",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "databend-meta-runtime",
  "databend-query",
  "form_urlencoded",
@@ -3716,7 +3716,7 @@ dependencies = [
  "databend-common-statistics",
  "databend-common-storage",
  "databend-common-users",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "databend-meta-runtime",
  "databend-storages-common-session",
  "databend-storages-common-table-meta",
@@ -3830,7 +3830,7 @@ dependencies = [
  "databend-common-meta-app",
  "databend-common-storage",
  "databend-common-tracing",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "log",
  "serde",
  "serde_ignored",
@@ -4193,7 +4193,7 @@ dependencies = [
  "databend-common-meta-store",
  "databend-common-proto-conv",
  "databend-common-version",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "databend-meta-plugin-cache",
  "databend-meta-runtime",
  "enumflags2",
@@ -4222,7 +4222,7 @@ dependencies = [
  "databend-common-meta-app",
  "databend-common-meta-store",
  "databend-common-proto-conv",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "databend-meta-runtime",
  "display-more 0.2.6",
  "fastrace",
@@ -4257,7 +4257,7 @@ dependencies = [
  "databend-common-expression",
  "databend-common-io",
  "databend-common-meta-app-storage",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "derive_more 1.0.0",
  "display-more 0.2.6",
  "encoding_rs",
@@ -4303,7 +4303,7 @@ dependencies = [
  "databend-common-tracing",
  "databend-meta",
  "databend-meta-admin",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "databend-meta-runtime",
  "databend-meta-test-harness",
  "display-more 0.2.6",
@@ -4347,7 +4347,7 @@ dependencies = [
  "databend-common-meta-api",
  "databend-common-meta-app",
  "databend-common-proto-conv",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "fastrace",
  "log",
  "maplit",
@@ -4363,7 +4363,7 @@ dependencies = [
  "databend-common-meta-schema-api-test-suite",
  "databend-common-meta-store",
  "databend-common-version",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "databend-meta-runtime",
  "databend-meta-test-harness",
  "fastrace",
@@ -4379,7 +4379,7 @@ dependencies = [
  "databend-base",
  "databend-common-tracing",
  "databend-meta",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "databend-meta-plugin-semaphore",
  "databend-meta-runtime",
  "fastrace",
@@ -4473,7 +4473,7 @@ dependencies = [
  "databend-common-io",
  "databend-common-meta-app",
  "databend-common-protos",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "enumflags2",
  "fastrace",
  "log",
@@ -4580,7 +4580,7 @@ dependencies = [
  "databend-enterprise-data-mask-feature",
  "databend-enterprise-materialized-view",
  "databend-enterprise-row-access-policy-feature",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "databend-meta-runtime",
  "databend-storages-common-cache",
  "databend-storages-common-session",
@@ -4644,7 +4644,7 @@ dependencies = [
  "databend-common-statistics",
  "databend-common-storage",
  "databend-common-users",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "databend-meta-runtime",
  "databend-storages-common-session",
  "databend-storages-common-table-meta",
@@ -4720,7 +4720,7 @@ dependencies = [
  "databend-common-pipeline",
  "databend-common-storage",
  "databend-common-storages-parquet",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "databend-storages-common-blocks",
  "databend-storages-common-table-meta",
  "log",
@@ -4821,7 +4821,7 @@ dependencies = [
  "databend-common-users",
  "databend-enterprise-fail-safe",
  "databend-enterprise-vacuum-handler",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "databend-storages-common-blocks",
  "databend-storages-common-cache",
  "databend-storages-common-index",
@@ -4888,7 +4888,7 @@ dependencies = [
  "databend-common-storages-orc",
  "databend-common-storages-parquet",
  "databend-common-users",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "databend-storages-common-cache",
  "databend-storages-common-stage",
  "databend-storages-common-table-meta",
@@ -4972,7 +4972,7 @@ dependencies = [
  "databend-common-pipeline",
  "databend-common-pipeline-transforms",
  "databend-common-users",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "databend-storages-common-table-meta",
  "databend_educe",
  "futures",
@@ -5131,7 +5131,7 @@ dependencies = [
  "databend-common-storages-fuse",
  "databend-common-storages-stream",
  "databend-common-users",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "databend-storages-common-cache",
  "databend-storages-common-table-meta",
  "futures",
@@ -5225,7 +5225,7 @@ dependencies = [
  "databend-common-meta-store",
  "databend-common-metrics",
  "databend-common-version",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "databend-meta-plugin-cache",
  "databend-meta-runtime",
  "divan",
@@ -5286,7 +5286,7 @@ dependencies = [
  "databend-common-exception",
  "databend-common-meta-app",
  "databend-common-meta-store",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
 ]
 
 [[package]]
@@ -5311,7 +5311,7 @@ dependencies = [
  "databend-common-catalog",
  "databend-common-exception",
  "databend-common-meta-app",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
 ]
 
 [[package]]
@@ -5355,7 +5355,7 @@ dependencies = [
  "databend-enterprise-stream-handler",
  "databend-enterprise-table-ref-handler",
  "databend-enterprise-vacuum-handler",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "databend-meta-runtime",
  "databend-query",
  "databend-storages-common-cache",
@@ -5383,7 +5383,7 @@ dependencies = [
  "databend-common-config",
  "databend-common-exception",
  "databend-common-management",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
 ]
 
 [[package]]
@@ -5395,7 +5395,7 @@ dependencies = [
  "databend-common-exception",
  "databend-common-meta-app",
  "databend-common-meta-store",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
 ]
 
 [[package]]
@@ -5532,8 +5532,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta"
-version = "260629.4.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.4.0#911d188fb801666f2c775248a8dbe5f987c2be1d"
+version = "260629.5.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.5.0#cc80af6f1cfa0760d2e9b7c47ecf8c0f0150ae12"
 dependencies = [
  "anyerror",
  "anyhow",
@@ -5543,20 +5543,20 @@ dependencies = [
  "base2histogram",
  "chrono",
  "databend-base",
- "databend-meta-client 260629.4.0",
- "databend-meta-kvapi 260629.4.0",
+ "databend-meta-client 260629.5.0",
+ "databend-meta-kvapi 260629.5.0",
  "databend-meta-leveled-store",
  "databend-meta-metrics",
  "databend-meta-raft-config",
  "databend-meta-raft-log",
- "databend-meta-runtime-api 260629.4.0",
+ "databend-meta-runtime-api 260629.5.0",
  "databend-meta-sled-store",
  "databend-meta-snapshot-db",
  "databend-meta-snapshot-store",
  "databend-meta-state-machine",
  "databend-meta-store-compat",
- "databend-meta-types 260629.4.0",
- "databend-meta-version 260629.4.0",
+ "databend-meta-types 260629.5.0",
+ "databend-meta-version 260629.5.0",
  "derive_more 2.1.1",
  "display-more 0.2.6",
  "fastrace",
@@ -5617,8 +5617,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-base"
-version = "260629.4.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.4.0#911d188fb801666f2c775248a8dbe5f987c2be1d"
+version = "260629.5.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.5.0#cc80af6f1cfa0760d2e9b7c47ecf8c0f0150ae12"
 dependencies = [
  "anyerror",
  "deepsize",
@@ -5651,7 +5651,7 @@ dependencies = [
  "databend-meta",
  "databend-meta-admin",
  "databend-meta-cli-config",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "databend-meta-plugin-semaphore",
  "databend-meta-runtime",
  "databend-meta-ver",
@@ -5689,19 +5689,19 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client"
-version = "260205.13.3"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.3#b09503d8a970f7ac61a8e8d4c84a1b9a27707525"
+version = "260205.13.4"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.4#163b21d130f3a4dbd17e190f94f23d07c7bcb598"
 dependencies = [
  "anyerror",
  "arrow-flight",
  "async-backtrace",
  "chrono",
  "databend-base",
- "databend-meta-kvapi 260205.13.3",
- "databend-meta-kvapi-test-suite 260205.13.3",
- "databend-meta-runtime-api 260205.13.3",
- "databend-meta-types 260205.13.3",
- "databend-meta-version 260205.13.3",
+ "databend-meta-kvapi 260205.13.4",
+ "databend-meta-kvapi-test-suite 260205.13.4",
+ "databend-meta-runtime-api 260205.13.4",
+ "databend-meta-types 260205.13.4",
+ "databend-meta-version 260205.13.4",
  "derive_more 2.1.1",
  "display-more 0.2.6",
  "fastrace",
@@ -5721,8 +5721,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client"
-version = "260629.4.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.4.0#911d188fb801666f2c775248a8dbe5f987c2be1d"
+version = "260629.5.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.5.0#cc80af6f1cfa0760d2e9b7c47ecf8c0f0150ae12"
 dependencies = [
  "anyerror",
  "arrow-flight",
@@ -5731,10 +5731,10 @@ dependencies = [
  "chrono",
  "databend-base",
  "databend-meta-client-types",
- "databend-meta-kvapi 260629.4.0",
- "databend-meta-kvapi-test-suite 260629.4.0",
- "databend-meta-runtime-api 260629.4.0",
- "databend-meta-version 260629.4.0",
+ "databend-meta-kvapi 260629.5.0",
+ "databend-meta-kvapi-test-suite 260629.5.0",
+ "databend-meta-runtime-api 260629.5.0",
+ "databend-meta-version 260629.5.0",
  "derive_more 2.1.1",
  "display-more 0.2.6",
  "fastrace",
@@ -5755,8 +5755,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-client-types"
-version = "260629.4.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.4.0#911d188fb801666f2c775248a8dbe5f987c2be1d"
+version = "260629.5.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.5.0#cc80af6f1cfa0760d2e9b7c47ecf8c0f0150ae12"
 dependencies = [
  "anyerror",
  "databend-meta-proto",
@@ -5779,18 +5779,18 @@ dependencies = [
  "databend-common-meta-api",
  "databend-common-meta-app",
  "databend-common-meta-store",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "databend-meta-test-harness",
  "tokio",
 ]
 
 [[package]]
 name = "databend-meta-kvapi"
-version = "260205.13.3"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.3#b09503d8a970f7ac61a8e8d4c84a1b9a27707525"
+version = "260205.13.4"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.4#163b21d130f3a4dbd17e190f94f23d07c7bcb598"
 dependencies = [
  "async-trait",
- "databend-meta-types 260205.13.3",
+ "databend-meta-types 260205.13.4",
  "display-more 0.2.6",
  "futures-util",
  "log",
@@ -5800,8 +5800,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi"
-version = "260629.4.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.4.0#911d188fb801666f2c775248a8dbe5f987c2be1d"
+version = "260629.5.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.5.0#cc80af6f1cfa0760d2e9b7c47ecf8c0f0150ae12"
 dependencies = [
  "async-trait",
  "databend-meta-client-types",
@@ -5814,12 +5814,12 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi-test-suite"
-version = "260205.13.3"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.3#b09503d8a970f7ac61a8e8d4c84a1b9a27707525"
+version = "260205.13.4"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.4#163b21d130f3a4dbd17e190f94f23d07c7bcb598"
 dependencies = [
  "anyhow",
- "databend-meta-kvapi 260205.13.3",
- "databend-meta-types 260205.13.3",
+ "databend-meta-kvapi 260205.13.4",
+ "databend-meta-types 260205.13.4",
  "display-more 0.2.6",
  "fastrace",
  "futures-util",
@@ -5830,12 +5830,12 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-kvapi-test-suite"
-version = "260629.4.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.4.0#911d188fb801666f2c775248a8dbe5f987c2be1d"
+version = "260629.5.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.5.0#cc80af6f1cfa0760d2e9b7c47ecf8c0f0150ae12"
 dependencies = [
  "anyhow",
  "databend-meta-client-types",
- "databend-meta-kvapi 260629.4.0",
+ "databend-meta-kvapi 260629.5.0",
  "display-more 0.2.6",
  "fastrace",
  "futures-util",
@@ -5846,14 +5846,14 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-leveled-store"
-version = "260629.4.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.4.0#911d188fb801666f2c775248a8dbe5f987c2be1d"
+version = "260629.5.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.5.0#cc80af6f1cfa0760d2e9b7c47ecf8c0f0150ae12"
 dependencies = [
  "anyhow",
  "async-trait",
  "databend-base",
  "databend-meta-snapshot-db",
- "databend-meta-types 260629.4.0",
+ "databend-meta-types 260629.5.0",
  "display-more 0.2.6",
  "futures",
  "futures-async-stream",
@@ -5872,12 +5872,12 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-metrics"
-version = "260629.4.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.4.0#911d188fb801666f2c775248a8dbe5f987c2be1d"
+version = "260629.5.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.5.0#cc80af6f1cfa0760d2e9b7c47ecf8c0f0150ae12"
 dependencies = [
  "databend-base",
  "databend-meta-raft-log",
- "databend-meta-types 260629.4.0",
+ "databend-meta-types 260629.5.0",
  "log",
  "prometheus-client 0.22.3",
 ]
@@ -5888,7 +5888,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "databend-meta-runtime",
  "databend-meta-test-harness",
  "fastrace",
@@ -5906,7 +5906,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "codeq 0.5.2",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "databend-meta-runtime",
  "databend-meta-test-harness",
  "display-more 0.2.6",
@@ -5924,8 +5924,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-proto"
-version = "260629.4.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.4.0#911d188fb801666f2c775248a8dbe5f987c2be1d"
+version = "260629.5.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.5.0#cc80af6f1cfa0760d2e9b7c47ecf8c0f0150ae12"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -5948,12 +5948,12 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-raft-config"
-version = "260629.4.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.4.0#911d188fb801666f2c775248a8dbe5f987c2be1d"
+version = "260629.5.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.5.0#cc80af6f1cfa0760d2e9b7c47ecf8c0f0150ae12"
 dependencies = [
  "anyerror",
- "databend-meta-runtime-api 260629.4.0",
- "databend-meta-types 260629.4.0",
+ "databend-meta-runtime-api 260629.5.0",
+ "databend-meta-types 260629.5.0",
  "hostname",
  "log",
  "maplit",
@@ -5970,11 +5970,11 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-raft-log"
-version = "260629.4.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.4.0#911d188fb801666f2c775248a8dbe5f987c2be1d"
+version = "260629.5.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.5.0#cc80af6f1cfa0760d2e9b7c47ecf8c0f0150ae12"
 dependencies = [
  "anyerror",
- "databend-meta-types 260629.4.0",
+ "databend-meta-types 260629.5.0",
  "deepsize",
  "display-more 0.2.6",
  "fastrace",
@@ -5997,7 +5997,7 @@ dependencies = [
  "databend-common-metrics",
  "databend-common-tracing",
  "databend-meta",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "fastrace",
  "hyper-util",
  "tokio",
@@ -6007,8 +6007,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-runtime-api"
-version = "260205.13.3"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.3#b09503d8a970f7ac61a8e8d4c84a1b9a27707525"
+version = "260205.13.4"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.4#163b21d130f3a4dbd17e190f94f23d07c7bcb598"
 dependencies = [
  "env_logger 0.11.8",
  "hickory-resolver",
@@ -6020,8 +6020,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-runtime-api"
-version = "260629.4.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.4.0#911d188fb801666f2c775248a8dbe5f987c2be1d"
+version = "260629.5.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.5.0#cc80af6f1cfa0760d2e9b7c47ecf8c0f0150ae12"
 dependencies = [
  "env_logger 0.11.8",
  "log",
@@ -6032,12 +6032,12 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-sled-store"
-version = "260629.4.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.4.0#911d188fb801666f2c775248a8dbe5f987c2be1d"
+version = "260629.5.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.5.0#cc80af6f1cfa0760d2e9b7c47ecf8c0f0150ae12"
 dependencies = [
  "anyerror",
  "byteorder",
- "databend-meta-types 260629.4.0",
+ "databend-meta-types 260629.5.0",
  "fastrace",
  "log",
  "serde",
@@ -6050,11 +6050,11 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-snapshot-db"
-version = "260629.4.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.4.0#911d188fb801666f2c775248a8dbe5f987c2be1d"
+version = "260629.5.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.5.0#cc80af6f1cfa0760d2e9b7c47ecf8c0f0150ae12"
 dependencies = [
  "bincode 2.0.1",
- "databend-meta-types 260629.4.0",
+ "databend-meta-types 260629.5.0",
  "futures-util",
  "log",
  "map-api",
@@ -6067,14 +6067,14 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-snapshot-store"
-version = "260629.4.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.4.0#911d188fb801666f2c775248a8dbe5f987c2be1d"
+version = "260629.5.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.5.0#cc80af6f1cfa0760d2e9b7c47ecf8c0f0150ae12"
 dependencies = [
  "databend-meta-leveled-store",
  "databend-meta-raft-config",
- "databend-meta-runtime-api 260629.4.0",
+ "databend-meta-runtime-api 260629.5.0",
  "databend-meta-snapshot-db",
- "databend-meta-types 260629.4.0",
+ "databend-meta-types 260629.5.0",
  "futures",
  "futures-util",
  "log",
@@ -6087,19 +6087,19 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-state-machine"
-version = "260629.4.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.4.0#911d188fb801666f2c775248a8dbe5f987c2be1d"
+version = "260629.5.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.5.0#cc80af6f1cfa0760d2e9b7c47ecf8c0f0150ae12"
 dependencies = [
  "async-trait",
  "databend-base",
- "databend-meta-kvapi 260629.4.0",
+ "databend-meta-kvapi 260629.5.0",
  "databend-meta-leveled-store",
  "databend-meta-metrics",
  "databend-meta-raft-config",
- "databend-meta-runtime-api 260629.4.0",
+ "databend-meta-runtime-api 260629.5.0",
  "databend-meta-snapshot-db",
  "databend-meta-snapshot-store",
- "databend-meta-types 260629.4.0",
+ "databend-meta-types 260629.5.0",
  "display-more 0.2.6",
  "fastrace",
  "futures",
@@ -6116,19 +6116,19 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-store-compat"
-version = "260629.4.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.4.0#911d188fb801666f2c775248a8dbe5f987c2be1d"
+version = "260629.5.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.5.0#cc80af6f1cfa0760d2e9b7c47ecf8c0f0150ae12"
 dependencies = [
  "anyerror",
  "anyhow",
  "databend-meta-leveled-store",
  "databend-meta-raft-config",
  "databend-meta-raft-log",
- "databend-meta-runtime-api 260629.4.0",
+ "databend-meta-runtime-api 260629.5.0",
  "databend-meta-sled-store",
  "databend-meta-snapshot-db",
  "databend-meta-snapshot-store",
- "databend-meta-types 260629.4.0",
+ "databend-meta-types 260629.5.0",
  "derive_more 2.1.1",
  "fastrace",
  "fs_extra",
@@ -6147,14 +6147,14 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-test-harness"
-version = "260629.4.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.4.0#911d188fb801666f2c775248a8dbe5f987c2be1d"
+version = "260629.5.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.5.0#cc80af6f1cfa0760d2e9b7c47ecf8c0f0150ae12"
 dependencies = [
  "anyhow",
  "databend-base",
  "databend-meta",
- "databend-meta-runtime-api 260629.4.0",
- "databend-meta-types 260629.4.0",
+ "databend-meta-runtime-api 260629.5.0",
+ "databend-meta-types 260629.5.0",
  "fastrace",
  "log",
  "maplit",
@@ -6166,8 +6166,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-types"
-version = "260205.13.3"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.3#b09503d8a970f7ac61a8e8d4c84a1b9a27707525"
+version = "260205.13.4"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.4#163b21d130f3a4dbd17e190f94f23d07c7bcb598"
 dependencies = [
  "anyerror",
  "deepsize",
@@ -6195,8 +6195,8 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-types"
-version = "260629.4.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.4.0#911d188fb801666f2c775248a8dbe5f987c2be1d"
+version = "260629.5.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.5.0#cc80af6f1cfa0760d2e9b7c47ecf8c0f0150ae12"
 dependencies = [
  "anyerror",
  "databend-meta-base",
@@ -6225,16 +6225,16 @@ dependencies = [
 
 [[package]]
 name = "databend-meta-version"
-version = "260205.13.3"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.3#b09503d8a970f7ac61a8e8d4c84a1b9a27707525"
+version = "260205.13.4"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260205.13.4#163b21d130f3a4dbd17e190f94f23d07c7bcb598"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "databend-meta-version"
-version = "260629.4.0"
-source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.4.0#911d188fb801666f2c775248a8dbe5f987c2be1d"
+version = "260629.5.0"
+source = "git+https://github.com/databendlabs/databend-meta.git?tag=v260629.5.0#cc80af6f1cfa0760d2e9b7c47ecf8c0f0150ae12"
 dependencies = [
  "semver",
 ]
@@ -6341,7 +6341,7 @@ dependencies = [
  "databend-enterprise-stream-handler",
  "databend-enterprise-table-ref-handler",
  "databend-enterprise-vacuum-handler",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "databend-meta-plugin-semaphore",
  "databend-meta-runtime",
  "databend-query-script-udf-support",
@@ -6666,7 +6666,7 @@ dependencies = [
  "databend-common-exception",
  "databend-common-meta-app",
  "databend-common-storage",
- "databend-meta-client 260205.13.3",
+ "databend-meta-client 260205.13.4",
  "databend-storages-common-blocks",
  "databend-storages-common-table-meta",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,11 +162,11 @@ databend-storages-common-stage = { path = "src/query/storages/common/stage" }
 databend-storages-common-table-meta = { path = "src/query/storages/common/table_meta" }
 
 # External meta service
-databend-meta = "260629.4.0"
-databend-meta-test-harness = "260629.4.0"
+databend-meta = "260629.5.0"
+databend-meta-test-harness = "260629.5.0"
 
 # External meta client
-databend-meta-client = "260205.13.3"
+databend-meta-client = "260205.13.4"
 structkey = "0.1.1"
 
 # Crates.io dependencies
@@ -605,9 +605,9 @@ async-recursion = { git = "https://github.com/datafuse-extras/async-recursion.gi
 backtrace = { git = "https://github.com/rust-lang/backtrace-rs.git", rev = "72265be" }
 csv-core = { git = "https://github.com/youngsofun/rust-csv.git", rev = "44a0b3c" }
 databend-base = { git = "https://github.com/databendlabs/databend-base", tag = "v0.4.0" }
-databend-meta = { git = "https://github.com/databendlabs/databend-meta.git", tag = "v260629.4.0" }
-databend-meta-client = { git = "https://github.com/databendlabs/databend-meta.git", tag = "v260205.13.3" }
-databend-meta-test-harness = { git = "https://github.com/databendlabs/databend-meta.git", tag = "v260629.4.0" }
+databend-meta = { git = "https://github.com/databendlabs/databend-meta.git", tag = "v260629.5.0" }
+databend-meta-client = { git = "https://github.com/databendlabs/databend-meta.git", tag = "v260205.13.4" }
+databend-meta-test-harness = { git = "https://github.com/databendlabs/databend-meta.git", tag = "v260629.5.0" }
 deltalake = { git = "https://github.com/delta-io/delta-rs", rev = "9954bff" }
 jsonb = { git = "https://github.com/databendlabs/jsonb.git", rev = "fba895c" }
 lance-arrow = { git = "https://github.com/datafuse-extras/lance", rev = "85f9401d3246d52a287bca21457dbae0466858ee" }


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### chore: meta: upgrade server and client to adjust logging level
# Summary

Use databend-meta 260629.5.0 and databend-meta-client 260205.13.4 so
query nodes emit routine Meta connection lifecycle events at DEBUG.

# Details

The server, test harness, and lockfile now resolve from matching release
tags. The gRPC compatibility range and APIs are unchanged.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test  - _Explain why_

## Type of change

- [x] Other

## AI assistance

- AI usage: An AI coding agent generated code and wrote tests; I reviewed and confirmed every line before committing it.
- Responsible human: @drmingdrmer
- [x] The responsible human has read every line of this diff and can explain each change

## Related Issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20471)
<!-- Reviewable:end -->
