### PR TITLE
fix(storage): shuffle resolved addresses for new connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4940,6 +4940,7 @@ dependencies = [
  "opendal 0.54.1",
  "parquet 58.1.0",
  "prometheus-client 0.22.3",
+ "rand 0.8.5",
  "regex",
  "reqwest",
  "serde",
@@ -15550,8 +15551,7 @@ dependencies = [
 [[package]]
 name = "reqwest-hickory-resolver"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4466c6958bbbd3024ace15426f7b5369222c0ad517167d10056fd5cc76aec99b"
+source = "git+https://github.com/dqhl76/reqwest-hickory-resolver?rev=5ad03257a3c702d34b9643878efb5a3536323d2d#5ad03257a3c702d34b9643878efb5a3536323d2d"
 dependencies = [
  "hickory-resolver",
  "rand 0.9.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15551,7 +15551,7 @@ dependencies = [
 [[package]]
 name = "reqwest-hickory-resolver"
 version = "0.2.0"
-source = "git+https://github.com/dqhl76/reqwest-hickory-resolver?rev=5ad03257a3c702d34b9643878efb5a3536323d2d#5ad03257a3c702d34b9643878efb5a3536323d2d"
+source = "git+https://github.com/datafuse-extras/reqwest-hickory-resolver?rev=5ad03257a3c702d34b9643878efb5a3536323d2d#5ad03257a3c702d34b9643878efb5a3536323d2d"
 dependencies = [
  "hickory-resolver",
  "rand 0.9.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -655,6 +655,7 @@ map-api = { git = "https://github.com/databendlabs/map-api", tag = "v0.5.0" }
 orc-rust = { git = "https://github.com/datafuse-extras/orc-rust", rev = "fc17101f1c96e1ea7c7a19e931110471a4bd7e21" }
 parquet = { git = "https://github.com/datafuse-extras/arrow-rs.git", rev = "bbbe79543" }
 recursive = { git = "https://github.com/datafuse-extras/recursive.git", rev = "16e433a" }
+reqwest-hickory-resolver = { git = "https://github.com/dqhl76/reqwest-hickory-resolver", rev = "5ad03257a3c702d34b9643878efb5a3536323d2d" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1" }
 state-machine-api = { git = "https://github.com/databendlabs/state-machine-api.git", tag = "v0.4.0" }
 sub-cache = { git = "https://github.com/databendlabs/sub-cache", tag = "v0.2.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -655,7 +655,7 @@ map-api = { git = "https://github.com/databendlabs/map-api", tag = "v0.5.0" }
 orc-rust = { git = "https://github.com/datafuse-extras/orc-rust", rev = "fc17101f1c96e1ea7c7a19e931110471a4bd7e21" }
 parquet = { git = "https://github.com/datafuse-extras/arrow-rs.git", rev = "bbbe79543" }
 recursive = { git = "https://github.com/datafuse-extras/recursive.git", rev = "16e433a" }
-reqwest-hickory-resolver = { git = "https://github.com/dqhl76/reqwest-hickory-resolver", rev = "5ad03257a3c702d34b9643878efb5a3536323d2d" }
+reqwest-hickory-resolver = { git = "https://github.com/datafuse-extras/reqwest-hickory-resolver", rev = "5ad03257a3c702d34b9643878efb5a3536323d2d" }
 sled = { git = "https://github.com/datafuse-extras/sled", tag = "v0.34.7-datafuse.1" }
 state-machine-api = { git = "https://github.com/databendlabs/state-machine-api.git", tag = "v0.4.0" }
 sub-cache = { git = "https://github.com/databendlabs/sub-cache", tag = "v0.2.1" }

--- a/src/common/storage/Cargo.toml
+++ b/src/common/storage/Cargo.toml
@@ -35,6 +35,7 @@ lru = { workspace = true }
 opendal = { workspace = true }
 parquet = { workspace = true }
 prometheus-client = { workspace = true }
+rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/src/common/storage/src/http_client.rs
+++ b/src/common/storage/src/http_client.rs
@@ -18,6 +18,7 @@ use std::mem;
 use std::net::SocketAddr;
 use std::num::NonZeroUsize;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
 use std::time::Instant;
@@ -36,6 +37,11 @@ use opendal::raw::HttpBody;
 use opendal::raw::HttpFetch;
 use opendal::raw::parse_content_encoding;
 use opendal::raw::parse_content_length;
+use rand::seq::SliceRandom;
+use reqwest::dns::Addrs;
+use reqwest::dns::Name;
+use reqwest::dns::Resolve;
+use reqwest::dns::Resolving;
 use url::Url;
 
 use crate::EndpointPolicyScope;
@@ -62,6 +68,24 @@ struct PinnedClientCacheKey {
     resolved_addrs: Vec<SocketAddr>,
 }
 
+struct PinnedEndpointResolver {
+    host: String,
+    resolved_addrs: Vec<SocketAddr>,
+    fallback: Arc<dyn Resolve>,
+}
+
+impl Resolve for PinnedEndpointResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        if name.as_str().eq_ignore_ascii_case(&self.host) {
+            let mut addrs = self.resolved_addrs.clone();
+            addrs.shuffle(&mut rand::thread_rng());
+            Box::pin(future::ready(Ok(Box::new(addrs.into_iter()) as Addrs)))
+        } else {
+            self.fallback.resolve(name)
+        }
+    }
+}
+
 pub struct StorageHttpClient {
     client: reqwest::Client,
     pool_max_idle_per_host: usize,
@@ -70,16 +94,9 @@ pub struct StorageHttpClient {
     endpoint_policy_scope: EndpointPolicyScope,
     // Per-endpoint pinned clients keyed by (scheme, host, port, resolved_addrs).
     //
-    // We cannot reuse `client` for External-scope endpoints because reqwest
-    // would perform a fresh DNS lookup for every request, reopening the TOCTOU
-    // window between policy validation and the actual connection. An attacker
-    // who controls DNS could pass validation with a public IP and then switch
-    // the record to an internal address before reqwest connects.
-    //
-    // Instead, after check_storage_endpoint_url resolves and validates the IPs,
-    // we build a dedicated client with resolve_to_addrs pinned to those checked
-    // addresses. That client never re-resolves the host, so the connection is
-    // guaranteed to reach the validated IP regardless of subsequent DNS changes.
+    // Each client's endpoint resolver uses the validated address set and shuffles
+    // it for each new connection. Pinning connections to checked addresses
+    // protects against DNS rebinding between validation and connection setup.
     pinned_clients: Mutex<LruCache<PinnedClientCacheKey, reqwest::Client>>,
     // TTL cache for endpoint check results keyed by (scheme, host, port).
     // Avoids calling resolve_global_dns on every HttpFetch::fetch for the same
@@ -142,11 +159,14 @@ impl StorageHttpClient {
                 let mut builder = storage_http_client_builder()
                     .http1_only()
                     .use_native_tls()
-                    .dns_resolver(get_global_hickory_resolver())
+                    .dns_resolver(Arc::new(PinnedEndpointResolver {
+                        host: host.clone(),
+                        resolved_addrs: resolved_addrs.to_vec(),
+                        fallback: get_global_hickory_resolver(),
+                    }))
                     .redirect(reqwest::redirect::Policy::none())
                     .pool_max_idle_per_host(self.pool_max_idle_per_host)
-                    .connect_timeout(Duration::from_secs(self.connect_timeout))
-                    .resolve_to_addrs(&host, resolved_addrs);
+                    .connect_timeout(Duration::from_secs(self.connect_timeout));
 
                 if self.keepalive != 0 {
                     builder = builder.tcp_keepalive(Duration::from_secs(self.keepalive));
@@ -349,6 +369,56 @@ mod tests {
 
     fn addr(value: &str) -> SocketAddr {
         value.parse().unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_pinned_resolver_shuffles_checked_addresses() {
+        use std::collections::HashSet;
+        use std::future;
+        use std::sync::Arc;
+
+        use reqwest::dns::Addrs;
+        use reqwest::dns::Name;
+        use reqwest::dns::Resolve;
+        use reqwest::dns::Resolving;
+
+        struct ProxyResolver;
+
+        impl Resolve for ProxyResolver {
+            fn resolve(&self, name: Name) -> Resolving {
+                assert_eq!(name.as_str(), "proxy.example");
+                let addrs: Addrs = Box::new(std::iter::once(addr("127.0.0.1:8080")));
+                Box::pin(future::ready(Ok(addrs)))
+            }
+        }
+
+        let expected: Vec<_> = (1..=8)
+            .map(|last| SocketAddr::from(([192, 0, 2, last], 443)))
+            .collect();
+        let resolver = super::PinnedEndpointResolver {
+            host: "storage.example".to_string(),
+            resolved_addrs: expected.clone(),
+            fallback: Arc::new(ProxyResolver),
+        };
+        let mut first_addresses = HashSet::new();
+        for _ in 0..32 {
+            let mut actual: Vec<_> = resolver
+                .resolve("STORAGE.EXAMPLE".parse().unwrap())
+                .await
+                .unwrap()
+                .collect();
+            first_addresses.insert(actual[0]);
+            actual.sort_unstable();
+            assert_eq!(actual, expected);
+        }
+        assert!(first_addresses.len() > 1);
+
+        let proxy: Vec<_> = resolver
+            .resolve("proxy.example".parse().unwrap())
+            .await
+            .unwrap()
+            .collect();
+        assert_eq!(proxy, [addr("127.0.0.1:8080")]);
     }
 
     fn make_client(scope: EndpointPolicyScope) -> StorageHttpClient {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Repeated S3 connections can keep preferring the same IP when a hostname resolves to multiple addresses. The global resolver clones its RNG state on each lookup, while external storage clients retain the initial address order through `resolve_to_addrs()`.

Patch `reqwest-hickory-resolver` 0.2.0 to use advancing thread-local RNG state, pinned to [5ad03257a3c702d34b9643878efb5a3536323d2d](https://github.com/datafuse-extras/reqwest-hickory-resolver/commit/5ad03257a3c702d34b9643878efb5a3536323d2d). This preserves the existing reqwest/hickory versions, DNS cache, and lazy initialization. Upstream discussion: https://github.com/Xuanwo/reqwest-hickory-resolver/issues/24;

For external storage endpoints, use a resolver that shuffles the validated address set on each connection lookup. Keep endpoint validation, client caching, connection pooling, and proxy hostname resolution. Existing pooled connections continue to be reused; address selection changes when opening new connections.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

The regression test checks that repeated resolutions vary the preferred address, preserve the validated address set, match the endpoint hostname case-insensitively, and delegate proxy resolution to the fallback resolver.

Local checks passed: `cargo clippy --locked -p databend-common-storage --lib --tests -- -D warnings`, `cargo test --locked -p databend-common-storage --lib http_client::tests` (9 tests), and formatting checks.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

## AI assistance

- AI usage: An AI coding agent implemented the resolver backport, dependency patch, pinned endpoint resolver, regression test, and PR description.
- Responsible human: @dqhl76
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20475)
<!-- Reviewable:end -->

