### PR TITLE
fix(query): decorrelate correlated join conditions

### DIFF
--- a/src/query/service/tests/it/sql/exec/correlated_subquery_regression.rs
+++ b/src/query/service/tests/it/sql/exec/correlated_subquery_regression.rs
@@ -66,3 +66,51 @@ async fn correlated_exists_subquery_over_union_all_regression() -> anyhow::Resul
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn correlated_join_condition_subquery_regression() -> anyhow::Result<()> {
+    let cases = [
+        (
+            r"
+                SELECT *
+                FROM (VALUES (1), (2)) t1(a)
+                WHERE EXISTS (
+                    SELECT 1
+                    FROM (VALUES (1), (2)) t2(a)
+                    JOIN (VALUES (1)) t3(c) ON t2.a = t1.a
+                )
+            ",
+            2,
+        ),
+        (
+            r"
+                SELECT *
+                FROM (VALUES (1), (2)) t1(a)
+                WHERE EXISTS (
+                    SELECT 1
+                    FROM (VALUES (1), (2)) t2(a)
+                    JOIN (VALUES (1)) t3(c) ON t2.a > t1.a
+                )
+            ",
+            1,
+        ),
+        (
+            r"
+                SELECT *
+                FROM (VALUES (1), (2)) t1(a)
+                WHERE EXISTS (
+                    SELECT 1
+                    FROM (VALUES (1), (2)) t2(a)
+                    LEFT JOIN (VALUES (1)) t3(c) ON t2.a = t1.a
+                )
+            ",
+            2,
+        ),
+    ];
+
+    for (sql, expected_rows) in cases {
+        assert_eq!(execute_query_rows(sql).await?, expected_rows);
+    }
+
+    Ok(())
+}

--- a/src/query/service/tests/it/sql/exec/correlated_subquery_regression.rs
+++ b/src/query/service/tests/it/sql/exec/correlated_subquery_regression.rs
@@ -71,6 +71,7 @@ async fn correlated_exists_subquery_over_union_all_regression() -> anyhow::Resul
 async fn correlated_join_condition_subquery_regression() -> anyhow::Result<()> {
     let cases = [
         (
+            "inner_join_on",
             r"
                 SELECT *
                 FROM (VALUES (1), (2)) t1(a)
@@ -83,6 +84,7 @@ async fn correlated_join_condition_subquery_regression() -> anyhow::Result<()> {
             2,
         ),
         (
+            "non_equi_join_on",
             r"
                 SELECT *
                 FROM (VALUES (1), (2)) t1(a)
@@ -95,6 +97,7 @@ async fn correlated_join_condition_subquery_regression() -> anyhow::Result<()> {
             1,
         ),
         (
+            "left_join_on",
             r"
                 SELECT *
                 FROM (VALUES (1), (2)) t1(a)
@@ -108,8 +111,80 @@ async fn correlated_join_condition_subquery_regression() -> anyhow::Result<()> {
         ),
     ];
 
-    for (sql, expected_rows) in cases {
-        assert_eq!(execute_query_rows(sql).await?, expected_rows);
+    for (case_name, sql, expected_rows) in cases {
+        let rows = execute_query_rows(sql)
+            .await
+            .map_err(|err| anyhow::anyhow!("{case_name}: {err}"))?;
+        assert_eq!(rows, expected_rows, "{case_name}");
+    }
+
+    let additional_cases = [
+        (
+            "aggregate_group_by",
+            r"
+                SELECT *
+                FROM (VALUES (1), (2)) t1(a)
+                WHERE EXISTS (
+                    SELECT t2.b
+                    FROM (VALUES (10), (20)) t2(b)
+                    GROUP BY t1.a, t2.b
+                )
+            ",
+            2,
+        ),
+        (
+            "distinct_outer_column",
+            r"
+                SELECT *
+                FROM (VALUES (1), (2)) t1(a)
+                WHERE EXISTS (
+                    SELECT DISTINCT t1.a
+                    FROM (VALUES (10), (20)) t2(b)
+                )
+            ",
+            2,
+        ),
+        (
+            "window_partition_by_outer_column",
+            r"
+                SELECT (SELECT row_number() OVER (
+                            PARTITION BY t1.a ORDER BY t2.b
+                        )
+                        FROM (VALUES (10), (20)) t2(b)
+                        LIMIT 1)
+                FROM (VALUES (1), (2)) t1(a)
+            ",
+            2,
+        ),
+        (
+            "window_order_by_outer_column",
+            r"
+                SELECT (SELECT row_number() OVER (
+                            ORDER BY t1.a, t2.b
+                        )
+                        FROM (VALUES (10), (20)) t2(b)
+                        LIMIT 1)
+                FROM (VALUES (1), (2)) t1(a)
+            ",
+            2,
+        ),
+        (
+            "window_argument_outer_column",
+            r"
+                SELECT (SELECT sum(t1.a + t2.b) OVER ()
+                        FROM (VALUES (10), (20)) t2(b)
+                        LIMIT 1)
+                FROM (VALUES (1), (2)) t1(a)
+            ",
+            2,
+        ),
+    ];
+
+    for (case_name, sql, expected_rows) in additional_cases {
+        let rows = execute_query_rows(sql)
+            .await
+            .map_err(|err| anyhow::anyhow!("{case_name}: {err}"))?;
+        assert_eq!(rows, expected_rows, "{case_name}");
     }
 
     Ok(())

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/flatten_plan.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/flatten_plan.rs
@@ -479,6 +479,12 @@ impl SubqueryDecorrelatorOptimizer {
                         left_need_cross_join = true;
                     } else if right_prop.output_columns.contains(&col) {
                         right_need_cross_join = true;
+                    } else {
+                        // The correlated column is only referenced by the join condition. It
+                        // must still be materialized on one side of the join before the
+                        // condition can be evaluated. Use the left side for outer-only
+                        // predicates, which also preserves LEFT JOIN semantics.
+                        left_need_cross_join = true;
                     }
                 }
             }

--- a/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/flatten_plan.rs
+++ b/src/query/sql/src/planner/optimizer/optimizers/operator/decorrelate/flatten_plan.rs
@@ -598,7 +598,7 @@ impl SubqueryDecorrelatorOptimizer {
                         self.flatten_scalar(&item.scalar, correlated_columns, &derived_columns)?;
                     Ok(ScalarItem {
                         scalar,
-                        index: item.index,
+                        index: derived_columns.resolve_or_self(item.index),
                     })
                 }
                 Item::Index(old) => Ok(Self::scalar_item_from_index(
@@ -674,10 +674,15 @@ impl SubqueryDecorrelatorOptimizer {
         }) {
             flatten_info.from_count_func = false;
         }
-        Ok((
-            flatten_plan.build_unary(subquery.plan.clone()),
-            derived_columns,
-        ))
+        let mut sort = sort.clone();
+        sort.replace_columns(|old| {
+            if correlated_columns.contains(&old) {
+                derived_columns.must_resolve(old)
+            } else {
+                Ok(old)
+            }
+        })?;
+        Ok((flatten_plan.build_unary(sort), derived_columns))
     }
 
     fn flatten_sub_limit(
@@ -877,6 +882,107 @@ impl SubqueryDecorrelatorOptimizer {
         ))
     }
 
+    fn flatten_window_function(
+        &self,
+        function: &WindowFuncType,
+        correlated_columns: &ColumnSet,
+        derived_columns: &DerivedColumnScope,
+    ) -> Result<WindowFuncType> {
+        let mut function = function.clone();
+        match &mut function {
+            WindowFuncType::Aggregate(aggregate) => {
+                for expr in aggregate.exprs_mut() {
+                    *expr = self.flatten_scalar(expr, correlated_columns, derived_columns)?;
+                }
+            }
+            WindowFuncType::LagLead(function) => {
+                function.arg = Box::new(self.flatten_scalar(
+                    &function.arg,
+                    correlated_columns,
+                    derived_columns,
+                )?);
+                if let Some(default) = &mut function.default {
+                    *default = Box::new(self.flatten_scalar(
+                        default,
+                        correlated_columns,
+                        derived_columns,
+                    )?);
+                }
+            }
+            WindowFuncType::NthValue(function) => {
+                function.arg = Box::new(self.flatten_scalar(
+                    &function.arg,
+                    correlated_columns,
+                    derived_columns,
+                )?);
+            }
+            WindowFuncType::RowNumber
+            | WindowFuncType::Rank
+            | WindowFuncType::DenseRank
+            | WindowFuncType::PercentRank
+            | WindowFuncType::Ntile(_)
+            | WindowFuncType::CumeDist => {}
+        }
+        Ok(function)
+    }
+
+    fn flatten_window(
+        &self,
+        window: &Window,
+        correlated_columns: &ColumnSet,
+        derived_columns: &DerivedColumnScope,
+    ) -> Result<Window> {
+        let mut window = window.clone();
+        window.arguments = window
+            .arguments
+            .into_iter()
+            .map(|mut item| {
+                item.index = derived_columns.resolve_or_self(item.index);
+                item.scalar =
+                    self.flatten_scalar(&item.scalar, correlated_columns, derived_columns)?;
+                Ok(item)
+            })
+            .collect::<Result<_>>()?;
+        window.partition_by = window
+            .partition_by
+            .into_iter()
+            .map(|mut item| {
+                item.index = derived_columns.resolve_or_self(item.index);
+                item.scalar =
+                    self.flatten_scalar(&item.scalar, correlated_columns, derived_columns)?;
+                Ok(item)
+            })
+            .collect::<Result<_>>()?;
+        window.order_by = window
+            .order_by
+            .into_iter()
+            .map(|mut item| {
+                item.order_by_item.index =
+                    derived_columns.resolve_or_self(item.order_by_item.index);
+                item.order_by_item.scalar = self.flatten_scalar(
+                    &item.order_by_item.scalar,
+                    correlated_columns,
+                    derived_columns,
+                )?;
+                Ok(item)
+            })
+            .collect::<Result<_>>()?;
+        window.function =
+            self.flatten_window_function(&window.function, correlated_columns, derived_columns)?;
+
+        let metadata = self.ctx.metadata_read();
+        for correlated_column in correlated_columns {
+            window.partition_by.push(Self::scalar_item_from_index(
+                derived_columns.must_resolve(*correlated_column)?,
+                "outer.",
+                &metadata,
+            ));
+        }
+        drop(metadata);
+
+        Ok(window)
+    }
+
     fn flatten_sub_window(
         &mut self,
         outer: &SExpr,
@@ -886,11 +992,6 @@ impl SubqueryDecorrelatorOptimizer {
         flatten_info: &mut FlattenInfo,
         derived_columns: &DerivedColumnScope,
     ) -> Result<FlattenPlanResult> {
-        if !window.used_columns()?.is_disjoint(correlated_columns) {
-            return Err(ErrorCode::SemanticError(
-                "correlated columns in window functions not supported",
-            ));
-        }
         let (flatten_plan, derived_columns) = self.flatten_plan_with_scope(
             outer,
             subquery.unary_child(),
@@ -899,36 +1000,9 @@ impl SubqueryDecorrelatorOptimizer {
             true,
             derived_columns,
         )?;
-        let metadata = self.ctx.metadata_read();
-        let partition_by = window
-            .partition_by
-            .iter()
-            .cloned()
-            .map(Ok)
-            .chain(correlated_columns.iter().copied().map(|old| {
-                Ok(Self::scalar_item_from_index(
-                    derived_columns.must_resolve(old)?,
-                    "outer.",
-                    &metadata,
-                ))
-            }))
-            .collect::<Result<_>>()?;
-        drop(metadata);
+        let window = self.flatten_window(window, correlated_columns, &derived_columns)?;
 
-        Ok((
-            flatten_plan.build_unary(Window {
-                span: window.span,
-                index: window.index,
-                function: window.function.clone(),
-                arguments: window.arguments.clone(),
-                partition_by,
-                order_by: window.order_by.clone(),
-                frame: window.frame.clone(),
-                limit: window.limit,
-                top: window.top,
-            }),
-            derived_columns,
-        ))
+        Ok((flatten_plan.build_unary(window), derived_columns))
     }
 
     fn flatten_sub_window_group(
@@ -940,11 +1014,6 @@ impl SubqueryDecorrelatorOptimizer {
         flatten_info: &mut FlattenInfo,
         derived_columns: &DerivedColumnScope,
     ) -> Result<FlattenPlanResult> {
-        if !window_group.used_columns()?.is_disjoint(correlated_columns) {
-            return Err(ErrorCode::SemanticError(
-                "correlated columns in window functions not supported",
-            ));
-        }
         let (flatten_plan, derived_columns) = self.flatten_plan_with_scope(
             outer,
             subquery.unary_child(),
@@ -954,43 +1023,30 @@ impl SubqueryDecorrelatorOptimizer {
             derived_columns,
         )?;
 
-        let metadata = self.ctx.metadata_read();
         let windows = window_group
             .windows
             .iter()
-            .map(|window| {
-                let partition_by = window
-                    .partition_by
-                    .iter()
-                    .cloned()
-                    .map(Ok)
-                    .chain(correlated_columns.iter().copied().map(|old| {
-                        Ok(Self::scalar_item_from_index(
-                            derived_columns.must_resolve(old)?,
-                            "outer.",
-                            &metadata,
-                        ))
-                    }))
-                    .collect::<Result<_>>()?;
-                Ok(Window {
-                    span: window.span,
-                    index: window.index,
-                    function: window.function.clone(),
-                    arguments: window.arguments.clone(),
-                    partition_by,
-                    order_by: window.order_by.clone(),
-                    frame: window.frame.clone(),
-                    limit: window.limit,
-                    top: window.top,
+            .map(|window| self.flatten_window(window, correlated_columns, &derived_columns))
+            .collect::<Result<Vec<_>>>()?;
+        let scalar_items = window_group
+            .scalar_items
+            .iter()
+            .map(|item| {
+                Ok(ScalarItem {
+                    index: derived_columns.resolve_or_self(item.index),
+                    scalar: self.flatten_scalar(
+                        &item.scalar,
+                        correlated_columns,
+                        &derived_columns,
+                    )?,
                 })
             })
             .collect::<Result<Vec<_>>>()?;
-        drop(metadata);
 
         Ok((
             flatten_plan.build_unary(WindowGroup {
                 windows,
-                scalar_items: window_group.scalar_items.clone(),
+                scalar_items,
             }),
             derived_columns,
         ))

--- a/src/query/sql/src/planner/plans/aggregate.rs
+++ b/src/query/sql/src/planner/plans/aggregate.rs
@@ -351,11 +351,8 @@ impl Operator for Aggregate {
         }
 
         // Derive outer columns
-        let outer_columns = input_prop
-            .outer_columns
-            .difference(&output_columns)
-            .cloned()
-            .collect();
+        let outer_columns =
+            self.derive_outer_columns(input_prop.outer_columns.clone(), &input_prop.output_columns);
 
         // Derive used columns
         let mut used_columns = self.used_columns()?;

--- a/src/query/sql/src/planner/plans/aggregate.rs
+++ b/src/query/sql/src/planner/plans/aggregate.rs
@@ -350,9 +350,18 @@ impl Operator for Aggregate {
             output_columns.insert(agg.index);
         }
 
-        // Derive outer columns
-        let outer_columns =
-            self.derive_outer_columns(input_prop.outer_columns.clone(), &input_prop.output_columns);
+        // GROUPING SETS rewrites use local producer symbols that are not necessarily
+        // exposed by the child property. Treating those symbols as outer references
+        // makes unrelated full outer joins fail during decorrelation.
+        let outer_columns = if self.grouping_sets.is_some() {
+            input_prop
+                .outer_columns
+                .difference(&output_columns)
+                .cloned()
+                .collect()
+        } else {
+            self.derive_outer_columns(input_prop.outer_columns.clone(), &input_prop.output_columns)
+        };
 
         // Derive used columns
         let mut used_columns = self.used_columns()?;

--- a/src/query/sql/src/planner/plans/eval_scalar.rs
+++ b/src/query/sql/src/planner/plans/eval_scalar.rs
@@ -162,15 +162,8 @@ impl Operator for EvalScalar {
         }
 
         // Derive outer columns
-        let mut outer_columns = input_prop
-            .outer_columns
-            .difference(&input_prop.output_columns)
-            .cloned()
-            .collect::<ColumnSet>();
-        for item in &self.items {
-            item.scalar.collect_used_columns(&mut outer_columns);
-        }
-        outer_columns.retain(|column| !input_prop.output_columns.contains(column));
+        let outer_columns =
+            self.derive_outer_columns(input_prop.outer_columns.clone(), &input_prop.output_columns);
 
         // Derive used columns
         let mut used_columns = self.used_columns()?;

--- a/src/query/sql/src/planner/plans/exchange.rs
+++ b/src/query/sql/src/planner/plans/exchange.rs
@@ -50,7 +50,18 @@ impl Operator for Exchange {
     }
 
     fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<Arc<RelationalProperty>> {
-        rel_expr.derive_relational_prop_child(0)
+        let child_prop = rel_expr.derive_relational_prop_child(0)?;
+        let outer_columns =
+            self.derive_outer_columns(child_prop.outer_columns.clone(), &child_prop.output_columns);
+        let mut used_columns = child_prop.used_columns.clone();
+        used_columns.extend(self.scalar_expr_iter().flat_map(ScalarExpr::used_columns));
+        Ok(Arc::new(RelationalProperty {
+            output_columns: child_prop.output_columns.clone(),
+            outer_columns,
+            used_columns,
+            orderings: child_prop.orderings.clone(),
+            partition_orderings: child_prop.partition_orderings.clone(),
+        }))
     }
 
     fn derive_physical_prop(&self, _rel_expr: &RelExpr) -> Result<PhysicalProperty> {

--- a/src/query/sql/src/planner/plans/filter.rs
+++ b/src/query/sql/src/planner/plans/filter.rs
@@ -58,11 +58,8 @@ impl Operator for Filter {
         let output_columns = input_prop.output_columns.clone();
 
         // Derive outer columns
-        let mut outer_columns = input_prop.outer_columns.clone();
-        for scalar in &self.predicates {
-            scalar.collect_used_columns(&mut outer_columns);
-        }
-        outer_columns.retain(|column| !output_columns.contains(column));
+        let outer_columns =
+            self.derive_outer_columns(input_prop.outer_columns.clone(), &input_prop.output_columns);
 
         // Derive used columns
         let mut used_columns = self.used_columns()?;

--- a/src/query/sql/src/planner/plans/join.rs
+++ b/src/query/sql/src/planner/plans/join.rs
@@ -491,6 +491,9 @@ impl Operator for Join {
             condition.left.collect_used_columns(&mut outer_columns);
             condition.right.collect_used_columns(&mut outer_columns);
         }
+        for condition in &self.non_equi_conditions {
+            condition.collect_used_columns(&mut outer_columns);
+        }
         outer_columns.retain(|column| !output_columns.contains(column));
 
         // Derive used columns
@@ -925,6 +928,39 @@ mod tests {
         let physical_prop = RelExpr::with_s_expr(&s_expr).derive_physical_prop()?;
 
         assert_eq!(physical_prop.distribution, right_distribution);
+        Ok(())
+    }
+
+    #[test]
+    fn test_non_equi_join_predicate_tracks_outer_columns() -> Result<()> {
+        let join = Join {
+            // `#2 = #0`, where #0 comes from an enclosing query block.
+            non_equi_conditions: vec![function_call(
+                "eq",
+                vec![
+                    column(2, DataType::Number(NumberDataType::Int32)),
+                    column(0, DataType::Number(NumberDataType::Int32)),
+                ],
+                DataType::Boolean,
+            )],
+            join_type: JoinType::Inner,
+            ..Default::default()
+        };
+        let s_expr = SExpr::create_binary(
+            join,
+            SExpr::create_leaf(Scan {
+                columns: column_set(&[2]),
+                ..Default::default()
+            }),
+            SExpr::create_leaf(Scan {
+                columns: column_set(&[4]),
+                ..Default::default()
+            }),
+        );
+
+        let prop = RelExpr::with_s_expr(&s_expr).derive_relational_prop()?;
+
+        assert_eq!(prop.outer_columns, column_set(&[0]));
         Ok(())
     }
 

--- a/src/query/sql/src/planner/plans/join.rs
+++ b/src/query/sql/src/planner/plans/join.rs
@@ -484,17 +484,18 @@ impl Operator for Join {
         output_columns.extend(right_prop.output_columns.iter().copied());
 
         // Derive outer columns
-        let mut outer_columns = left_prop.outer_columns.clone();
-        outer_columns.extend(right_prop.outer_columns.iter().copied());
-
-        for condition in &self.equi_conditions {
-            condition.left.collect_used_columns(&mut outer_columns);
-            condition.right.collect_used_columns(&mut outer_columns);
-        }
-        for condition in &self.non_equi_conditions {
-            condition.collect_used_columns(&mut outer_columns);
-        }
-        outer_columns.retain(|column| !output_columns.contains(column));
+        let outer_columns = self.derive_outer_columns(
+            left_prop
+                .outer_columns
+                .union(&right_prop.outer_columns)
+                .cloned()
+                .collect(),
+            &left_prop
+                .output_columns
+                .union(&right_prop.output_columns)
+                .cloned()
+                .collect(),
+        );
 
         // Derive used columns
         let mut used_columns = self.used_columns()?;

--- a/src/query/sql/src/planner/plans/join.rs
+++ b/src/query/sql/src/planner/plans/join.rs
@@ -484,18 +484,17 @@ impl Operator for Join {
         output_columns.extend(right_prop.output_columns.iter().copied());
 
         // Derive outer columns
-        let outer_columns = self.derive_outer_columns(
-            left_prop
-                .outer_columns
-                .union(&right_prop.outer_columns)
-                .cloned()
-                .collect(),
-            &left_prop
-                .output_columns
-                .union(&right_prop.output_columns)
-                .cloned()
-                .collect(),
-        );
+        let mut outer_columns = left_prop.outer_columns.clone();
+        outer_columns.extend(right_prop.outer_columns.iter().copied());
+
+        for condition in &self.equi_conditions {
+            condition.left.collect_used_columns(&mut outer_columns);
+            condition.right.collect_used_columns(&mut outer_columns);
+        }
+        for condition in &self.non_equi_conditions {
+            condition.collect_used_columns(&mut outer_columns);
+        }
+        outer_columns.retain(|column| !output_columns.contains(column));
 
         // Derive used columns
         let mut used_columns = self.used_columns()?;

--- a/src/query/sql/src/planner/plans/operator.rs
+++ b/src/query/sql/src/planner/plans/operator.rs
@@ -22,6 +22,7 @@ use enum_as_inner::EnumAsInner;
 
 use super::MutationSource;
 use super::SubqueryExpr;
+use crate::ColumnSet;
 use crate::ScalarExpr;
 use crate::impl_match_rel_op;
 use crate::impl_try_from_rel_operator;
@@ -58,6 +59,23 @@ use crate::plans::WindowGroup;
 use crate::plans::r_cte_scan::RecursiveCteScan;
 use crate::plans::sequence::Sequence;
 
+pub(crate) fn derive_outer_columns<'a, I>(
+    mut outer_columns: ColumnSet,
+    available_columns: &ColumnSet,
+    scalar_exprs: I,
+) -> ColumnSet
+where
+    I: IntoIterator<Item = &'a ScalarExpr>,
+{
+    let mut scalar_columns = ColumnSet::new();
+    for scalar in scalar_exprs {
+        scalar.collect_used_columns(&mut scalar_columns);
+    }
+    scalar_columns.retain(|column| !available_columns.contains(column));
+    outer_columns.extend(scalar_columns);
+    outer_columns
+}
+
 pub trait Operator {
     /// Get relational operator kind
     fn rel_op(&self) -> RelOp;
@@ -69,6 +87,14 @@ pub trait Operator {
 
     fn scalar_expr_iter(&self) -> Box<dyn Iterator<Item = &ScalarExpr> + '_> {
         Box::new(std::iter::empty())
+    }
+
+    fn derive_outer_columns(
+        &self,
+        outer_columns: ColumnSet,
+        available_columns: &ColumnSet,
+    ) -> ColumnSet {
+        derive_outer_columns(outer_columns, available_columns, self.scalar_expr_iter())
     }
 
     /// Derive relational property
@@ -282,4 +308,123 @@ impl_try_from_rel_operator! {
     MaterializedCTE,
     MaterializedCTERef,
     Sequence
+}
+
+#[cfg(test)]
+mod tests {
+    use databend_common_expression::types::DataType;
+    use databend_common_expression::types::NumberDataType;
+
+    use super::*;
+    use crate::ColumnBindingBuilder;
+    use crate::Symbol;
+    use crate::Visibility;
+    use crate::optimizer::ir::SExpr;
+    use crate::plans::BoundColumnRef;
+    use crate::plans::ScalarItem;
+    use crate::plans::Scan;
+    use crate::plans::SortItem;
+    use crate::plans::WindowFuncType;
+    use crate::plans::WindowPartition;
+
+    fn column(index: usize) -> ScalarExpr {
+        ScalarExpr::BoundColumnRef(BoundColumnRef {
+            span: None,
+            column: ColumnBindingBuilder::new(
+                format!("c{index}"),
+                Symbol::new(index),
+                Box::new(DataType::Number(NumberDataType::Int32)),
+                Visibility::Visible,
+            )
+            .build(),
+        })
+    }
+
+    fn column_set(indices: &[usize]) -> ColumnSet {
+        indices.iter().copied().map(Symbol::new).collect()
+    }
+
+    fn scan(columns: &[usize]) -> SExpr {
+        SExpr::create_leaf(Scan {
+            columns: column_set(columns),
+            ..Default::default()
+        })
+    }
+
+    fn assert_outer_columns(name: &str, s_expr: &SExpr) -> Result<()> {
+        let property = RelExpr::with_s_expr(s_expr).derive_relational_prop()?;
+        assert_eq!(property.outer_columns, column_set(&[0]), "{name}");
+        Ok(())
+    }
+
+    #[test]
+    fn test_relational_properties_track_scalar_outer_columns() -> Result<()> {
+        let aggregate = Aggregate {
+            group_items: vec![ScalarItem {
+                scalar: column(0),
+                index: Symbol::new(2),
+            }],
+            ..Default::default()
+        };
+        assert_outer_columns("aggregate", &SExpr::create_unary(aggregate, scan(&[1])))?;
+
+        let window = Window {
+            span: None,
+            index: Symbol::new(2),
+            function: WindowFuncType::RowNumber,
+            arguments: vec![],
+            partition_by: vec![ScalarItem {
+                scalar: column(0),
+                index: Symbol::new(3),
+            }],
+            order_by: vec![],
+            frame: Default::default(),
+            limit: None,
+            top: None,
+        };
+        assert_outer_columns("window", &SExpr::create_unary(window, scan(&[1])))?;
+
+        let union = UnionAll {
+            left_outputs: vec![(Symbol::new(2), Some(column(0)))],
+            right_outputs: vec![(Symbol::new(2), None)],
+            cte_scan_names: vec![],
+            logical_recursive_cte_id: None,
+            output_indexes: vec![Symbol::new(2)],
+        };
+        assert_outer_columns(
+            "union",
+            &SExpr::create_binary(union, scan(&[1]), scan(&[1])),
+        )?;
+
+        let sort = Sort {
+            items: vec![],
+            limit: None,
+            after_exchange: None,
+            pre_projection: None,
+            window_partition: Some(WindowPartition {
+                partition_by: vec![ScalarItem {
+                    scalar: column(0),
+                    index: Symbol::new(3),
+                }],
+                top: None,
+                func: WindowFuncType::RowNumber,
+            }),
+        };
+        assert_outer_columns("sort", &SExpr::create_unary(sort, scan(&[1, 3])))?;
+
+        let top_n = TopN {
+            items: vec![SortItem {
+                index: Symbol::new(0),
+                asc: true,
+                nulls_first: false,
+            }],
+            limit: 1,
+            offset: 0,
+            lazy_columns: ColumnSet::new(),
+            after_exchange: None,
+        };
+        assert_outer_columns("top_n", &SExpr::create_unary(top_n, scan(&[1])))?;
+
+        Ok(())
+    }
 }

--- a/src/query/sql/src/planner/plans/project_set.rs
+++ b/src/query/sql/src/planner/plans/project_set.rs
@@ -75,12 +75,8 @@ impl Operator for ProjectSet {
         used_columns.extend(srf_used_columns.iter().copied());
 
         // Derive outer columns
-        let mut outer_columns = child_prop.outer_columns.clone();
-        outer_columns.extend(
-            srf_used_columns
-                .difference(&child_prop.output_columns)
-                .copied(),
-        );
+        let outer_columns =
+            self.derive_outer_columns(child_prop.outer_columns.clone(), &child_prop.output_columns);
 
         Ok(Arc::new(RelationalProperty {
             output_columns,

--- a/src/query/sql/src/planner/plans/sort.rs
+++ b/src/query/sql/src/planner/plans/sort.rs
@@ -30,6 +30,7 @@ use crate::optimizer::ir::StatInfo;
 use crate::optimizer::ir::cap_stat_info_by_rows;
 use crate::plans::Operator;
 use crate::plans::RelOp;
+use crate::plans::ScalarExpr;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Sort {
@@ -48,7 +49,15 @@ pub struct Sort {
 
 impl Sort {
     pub fn used_columns(&self) -> ColumnSet {
-        self.items.iter().map(|item| item.index).collect()
+        let mut used_columns: ColumnSet = self.items.iter().map(|item| item.index).collect();
+        if let Some(window) = &self.window_partition {
+            for item in &window.partition_by {
+                used_columns.insert(item.index);
+                item.scalar.collect_used_columns(&mut used_columns);
+            }
+            window.func.collect_used_columns(&mut used_columns);
+        }
+        used_columns
     }
 
     pub fn replace_column(&mut self, old: Symbol, new: Symbol) {
@@ -66,9 +75,15 @@ impl Sort {
             }
         }
 
-        if self.window_partition.is_some() {
-            unimplemented!()
-        };
+        if let Some(window) = &mut self.window_partition {
+            for item in &mut window.partition_by {
+                if item.index == old {
+                    item.index = new;
+                }
+                let _ = item.scalar.replace_column(old, new);
+            }
+            window.func.replace_column(old, new);
+        }
     }
 
     pub fn replace_columns<F>(&mut self, mut replace: F) -> Result<()>
@@ -83,9 +98,13 @@ impl Sort {
             }
         }
 
-        if self.window_partition.is_some() {
-            unimplemented!()
-        };
+        if let Some(window) = &mut self.window_partition {
+            for item in &mut window.partition_by {
+                item.index = replace(item.index)?;
+                item.scalar.replace_columns(&mut replace)?;
+            }
+            window.func.replace_columns(&mut replace)?;
+        }
 
         Ok(())
     }
@@ -101,6 +120,17 @@ pub struct SortItem {
 impl Operator for Sort {
     fn rel_op(&self) -> RelOp {
         RelOp::Sort
+    }
+
+    fn scalar_expr_iter(&self) -> Box<dyn Iterator<Item = &ScalarExpr> + '_> {
+        let partition_items = self.window_partition.iter().flat_map(|partition| {
+            partition
+                .partition_by
+                .iter()
+                .map(|item| &item.scalar)
+                .chain(partition.func.scalar_expr_iter())
+        });
+        Box::new(partition_items)
     }
 
     fn derive_physical_prop(&self, rel_expr: &RelExpr) -> Result<PhysicalProperty> {
@@ -185,8 +215,15 @@ impl Operator for Sort {
         let input_prop = rel_expr.derive_relational_prop_child(0)?;
 
         let output_columns = input_prop.output_columns.clone();
-        let outer_columns = input_prop.outer_columns.clone();
-        let used_columns = input_prop.used_columns.clone();
+        let mut outer_columns =
+            self.derive_outer_columns(input_prop.outer_columns.clone(), &input_prop.output_columns);
+        outer_columns.extend(
+            self.used_columns()
+                .difference(&input_prop.output_columns)
+                .copied(),
+        );
+        let mut used_columns = input_prop.used_columns.clone();
+        used_columns.extend(self.used_columns());
 
         // Derive orderings
         let orderings = self.items.clone();

--- a/src/query/sql/src/planner/plans/top_n.rs
+++ b/src/query/sql/src/planner/plans/top_n.rs
@@ -101,10 +101,16 @@ impl Operator for TopN {
 
     fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<Arc<RelationalProperty>> {
         let input_prop = rel_expr.derive_relational_prop_child(0)?;
+        let mut outer_columns = input_prop.outer_columns.clone();
+        outer_columns.extend(
+            self.used_columns()
+                .difference(&input_prop.output_columns)
+                .copied(),
+        );
 
         Ok(Arc::new(RelationalProperty {
             output_columns: input_prop.output_columns.clone(),
-            outer_columns: input_prop.outer_columns.clone(),
+            outer_columns,
             used_columns: input_prop.used_columns.clone(),
             orderings: self.items.clone(),
             partition_orderings: None,

--- a/src/query/sql/src/planner/plans/union_all.rs
+++ b/src/query/sql/src/planner/plans/union_all.rs
@@ -55,11 +55,11 @@ pub struct UnionAll {
 impl UnionAll {
     pub fn used_columns(&self) -> Result<ColumnSet> {
         let mut used_columns = ColumnSet::new();
-        for (idx, _) in &self.left_outputs {
+        for (idx, expr) in self.left_outputs.iter().chain(&self.right_outputs) {
             used_columns.insert(*idx);
-        }
-        for (idx, _) in &self.right_outputs {
-            used_columns.insert(*idx);
+            if let Some(expr) = expr {
+                expr.collect_used_columns(&mut used_columns);
+            }
         }
         Ok(used_columns)
     }
@@ -255,18 +255,34 @@ impl Operator for UnionAll {
         2
     }
 
+    fn scalar_expr_iter(&self) -> Box<dyn Iterator<Item = &ScalarExpr> + '_> {
+        Box::new(
+            self.left_outputs
+                .iter()
+                .chain(&self.right_outputs)
+                .filter_map(|(_, expr)| expr.as_ref()),
+        )
+    }
+
     fn derive_relational_prop(&self, rel_expr: &RelExpr) -> Result<Arc<RelationalProperty>> {
         let left_prop = rel_expr.derive_relational_prop_child(0)?;
         let right_prop = rel_expr.derive_relational_prop_child(1)?;
 
-        // Derive output columns
         let output_columns = self.output_indexes.iter().cloned().collect();
         // Derive outer columns
-        let mut outer_columns = left_prop.outer_columns.clone();
-        outer_columns = outer_columns
-            .union(&right_prop.outer_columns)
+        let available_columns = left_prop
+            .output_columns
+            .union(&right_prop.output_columns)
             .cloned()
             .collect();
+        let outer_columns = self.derive_outer_columns(
+            left_prop
+                .outer_columns
+                .union(&right_prop.outer_columns)
+                .cloned()
+                .collect(),
+            &available_columns,
+        );
 
         // Derive used columns
         let mut used_columns = self.used_columns()?;

--- a/src/query/sql/src/planner/plans/window.rs
+++ b/src/query/sql/src/planner/plans/window.rs
@@ -537,8 +537,18 @@ impl Operator for WindowGroup {
             output_columns.insert(window.index);
         }
 
+        let mut available_columns = input_prop.output_columns.clone();
+        for item in &self.scalar_items {
+            available_columns.insert(item.index);
+        }
+        for window in &self.windows {
+            available_columns.insert(window.index);
+            available_columns.extend(window.arguments.iter().map(|item| item.index));
+            available_columns.extend(window.partition_by.iter().map(|item| item.index));
+            available_columns.extend(window.order_by.iter().map(|item| item.order_by_item.index));
+        }
         let outer_columns =
-            self.derive_outer_columns(input_prop.outer_columns.clone(), &input_prop.output_columns);
+            self.derive_outer_columns(input_prop.outer_columns.clone(), &available_columns);
 
         let mut used_columns = self.used_columns()?;
         used_columns.extend(input_prop.used_columns.clone());
@@ -632,8 +642,13 @@ impl Operator for Window {
         output_columns.insert(self.index);
 
         // Derive outer columns
+        let mut available_columns = input_prop.output_columns.clone();
+        available_columns.insert(self.index);
+        available_columns.extend(self.arguments.iter().map(|item| item.index));
+        available_columns.extend(self.partition_by.iter().map(|item| item.index));
+        available_columns.extend(self.order_by.iter().map(|item| item.order_by_item.index));
         let outer_columns =
-            self.derive_outer_columns(input_prop.outer_columns.clone(), &input_prop.output_columns);
+            self.derive_outer_columns(input_prop.outer_columns.clone(), &available_columns);
 
         // Derive used columns
         let mut used_columns = self.used_columns()?;

--- a/src/query/sql/src/planner/plans/window.rs
+++ b/src/query/sql/src/planner/plans/window.rs
@@ -537,11 +537,8 @@ impl Operator for WindowGroup {
             output_columns.insert(window.index);
         }
 
-        let outer_columns = input_prop
-            .outer_columns
-            .difference(&output_columns)
-            .cloned()
-            .collect();
+        let outer_columns =
+            self.derive_outer_columns(input_prop.outer_columns.clone(), &input_prop.output_columns);
 
         let mut used_columns = self.used_columns()?;
         used_columns.extend(input_prop.used_columns.clone());
@@ -635,11 +632,8 @@ impl Operator for Window {
         output_columns.insert(self.index);
 
         // Derive outer columns
-        let outer_columns = input_prop
-            .outer_columns
-            .difference(&output_columns)
-            .cloned()
-            .collect();
+        let outer_columns =
+            self.derive_outer_columns(input_prop.outer_columns.clone(), &input_prop.output_columns);
 
         // Derive used columns
         let mut used_columns = self.used_columns()?;
@@ -746,6 +740,54 @@ impl WindowFuncType {
             WindowFuncType::NthValue(_) => "nth_value".to_string(),
             WindowFuncType::Ntile(_) => "ntile".to_string(),
             WindowFuncType::CumeDist => "cume_dist".to_string(),
+        }
+    }
+
+    pub fn replace_column(&mut self, old: Symbol, new: Symbol) {
+        let _ = self.replace_columns(|column| Ok(if column == old { new } else { column }));
+    }
+
+    pub fn replace_columns<F>(&mut self, mut replace: F) -> Result<()>
+    where F: FnMut(Symbol) -> Result<Symbol> {
+        match self {
+            WindowFuncType::Aggregate(aggregate) => {
+                for expr in aggregate.exprs_mut() {
+                    expr.replace_columns(&mut replace)?;
+                }
+            }
+            WindowFuncType::LagLead(function) => {
+                function.arg.replace_columns(&mut replace)?;
+                if let Some(default) = &mut function.default {
+                    default.replace_columns(&mut replace)?;
+                }
+            }
+            WindowFuncType::NthValue(function) => {
+                function.arg.replace_columns(&mut replace)?;
+            }
+            WindowFuncType::RowNumber
+            | WindowFuncType::Rank
+            | WindowFuncType::DenseRank
+            | WindowFuncType::PercentRank
+            | WindowFuncType::Ntile(_)
+            | WindowFuncType::CumeDist => {}
+        }
+        Ok(())
+    }
+
+    pub fn scalar_expr_iter(&self) -> Box<dyn Iterator<Item = &ScalarExpr> + '_> {
+        match self {
+            WindowFuncType::Aggregate(aggregate) => Box::new(aggregate.exprs()),
+            WindowFuncType::LagLead(function) => Box::new(
+                std::iter::once(function.arg.as_ref())
+                    .chain(function.default.iter().map(|expr| expr.as_ref())),
+            ),
+            WindowFuncType::NthValue(function) => Box::new(std::iter::once(function.arg.as_ref())),
+            WindowFuncType::RowNumber
+            | WindowFuncType::Rank
+            | WindowFuncType::DenseRank
+            | WindowFuncType::PercentRank
+            | WindowFuncType::Ntile(_)
+            | WindowFuncType::CumeDist => Box::new(std::iter::empty()),
         }
     }
 

--- a/src/query/sql/tests/it/optimizer/decorrelate_correlated_aliases.txt
+++ b/src/query/sql/tests/it/optimizer/decorrelate_correlated_aliases.txt
@@ -125,31 +125,43 @@ EvalScalar
 optimized_plan:
 Exchange(Merge)
 └── EvalScalar
-    ├── scalars: [a (#0) AS (#0), b (#1) AS (#1), marker (#6) AS (#9)]
+    ├── scalars: [a (#0) AS (#0), b (#1) AS (#1), marker (#8) AS (#12)]
     └── Filter
-        ├── filters: [is_true(marker (#6))]
+        ├── filters: [is_true(marker (#8))]
         └── Join(RightMark)
-            ├── build keys: [a (#2), b (#3)]
+            ├── build keys: [a (#6), b (#7)]
             ├── probe keys: [a (#0), b (#1)]
             ├── other filters: []
             ├── Exchange(Broadcast)
             │   └── EvalScalar
-            │       ├── scalars: [a (#2) AS (#2), b (#3) AS (#3), 1 AS (#5), a (#7) AS (#8)]
-            │       └── EvalScalar
-            │           ├── scalars: [a (#2) AS (#2), b (#3) AS (#3), a (#0) AS (#7)]
-            │           └── Filter
-            │               ├── filters: [eq(a (#2), a (#0))]
-            │               └── Join(Cross)
-            │                   ├── build keys: []
-            │                   ├── probe keys: []
-            │                   ├── other filters: []
-            │                   ├── Exchange(Broadcast)
-            │                   │   └── ConstantTableScan
-            │                   │       ├── columns: [c (#4)]
-            │                   │       └── num_rows: [1]
-            │                   └── ConstantTableScan
-            │                       ├── columns: [a (#2), b (#3)]
-            │                       └── num_rows: [1]
+            │       ├── scalars: [a (#2) AS (#2), 1 AS (#5), a (#6) AS (#6), b (#7) AS (#7), b (#3) AS (#9), a (#2) AS (#10), b (#3) AS (#11)]
+            │       └── Join(Cross)
+            │           ├── build keys: []
+            │           ├── probe keys: []
+            │           ├── other filters: []
+            │           ├── Exchange(Broadcast)
+            │           │   └── ConstantTableScan
+            │           │       ├── columns: [c (#4)]
+            │           │       └── num_rows: [1]
+            │           └── Join(Inner)
+            │               ├── build keys: [a (#2), b (#3)]
+            │               ├── probe keys: [a (#6), b (#7)]
+            │               ├── other filters: []
+            │               ├── Exchange(Broadcast)
+            │               │   └── ConstantTableScan
+            │               │       ├── columns: [a (#2), b (#3)]
+            │               │       └── num_rows: [1]
+            │               └── Aggregate(Final)
+            │                   ├── group items: [a (#6) AS (#6), b (#7) AS (#7)]
+            │                   ├── aggregate functions: []
+            │                   └── Aggregate(Partial)
+            │                       ├── group items: [a (#6) AS (#6), b (#7) AS (#7)]
+            │                       ├── aggregate functions: []
+            │                       └── Exchange(Hash)
+            │                           ├── Exchange(Hash): keys: [a (#6)]
+            │                           └── ConstantTableScan
+            │                               ├── columns: [a (#6), b (#7)]
+            │                               └── num_rows: [1]
             └── ConstantTableScan
                 ├── columns: [a (#0), b (#1)]
                 └── num_rows: [1]

--- a/tests/sqllogictests/suites/query/join/correlated_join_condition.test
+++ b/tests/sqllogictests/suites/query/join/correlated_join_condition.test
@@ -70,3 +70,57 @@ WHERE EXISTS (
 )
 ----
 1
+
+query I rowsort
+SELECT *
+FROM (VALUES (1), (2)) t1(a)
+WHERE EXISTS (
+    SELECT t2.b
+    FROM (VALUES (10), (20)) t2(b)
+    GROUP BY t1.a, t2.b
+)
+----
+1
+2
+
+query I rowsort
+SELECT *
+FROM (VALUES (1), (2)) t1(a)
+WHERE EXISTS (
+    SELECT DISTINCT t1.a
+    FROM (VALUES (10), (20)) t2(b)
+)
+----
+1
+2
+
+query I rowsort
+SELECT (SELECT row_number() OVER (
+            PARTITION BY t1.a ORDER BY t2.b
+        )
+        FROM (VALUES (10), (20)) t2(b)
+        LIMIT 1)
+FROM (VALUES (1), (2)) t1(a)
+----
+1
+1
+
+query I rowsort
+SELECT (SELECT row_number() OVER (
+            ORDER BY t1.a, t2.b
+        )
+        FROM (VALUES (10), (20)) t2(b)
+        LIMIT 1)
+FROM (VALUES (1), (2)) t1(a)
+----
+1
+1
+
+query I rowsort
+SELECT (SELECT sum(t1.a + t2.b) OVER ()
+        FROM (VALUES (10), (20)) t2(b)
+        LIMIT 1)
+FROM (VALUES (1), (2)) t1(a)
+----
+32
+34

--- a/tests/sqllogictests/suites/query/join/correlated_join_condition.test
+++ b/tests/sqllogictests/suites/query/join/correlated_join_condition.test
@@ -1,0 +1,72 @@
+# Correlated references in a subquery JOIN ON condition must be materialized
+# before decorrelation.
+
+statement ok
+use default
+
+query I rowsort
+SELECT *
+FROM (VALUES (1), (2)) t1(a)
+WHERE EXISTS (
+    SELECT 1
+    FROM (VALUES (1), (2)) t2(a)
+    JOIN (VALUES (1)) t3(c) ON t2.a = t1.a
+)
+----
+1
+2
+
+query I rowsort
+SELECT *
+FROM (VALUES (1), (2)) t1(a)
+WHERE EXISTS (
+    SELECT 1
+    FROM (VALUES (1), (2)) t2(a)
+    JOIN (VALUES (1)) t3(c) ON t2.a > t1.a
+)
+----
+1
+
+query I rowsort
+SELECT *
+FROM (VALUES (1), (2)) t1(a)
+WHERE EXISTS (
+    SELECT 1
+    FROM (VALUES (1), (2)) t2(a)
+    LEFT JOIN (VALUES (1)) t3(c) ON t2.a = t1.a
+)
+----
+1
+2
+
+query I rowsort
+SELECT *
+FROM (VALUES (1), (2)) t1(a)
+WHERE t1.a IN (
+    SELECT t2.a
+    FROM (VALUES (1), (2)) t2(a)
+    JOIN (VALUES (1)) t3(c) ON t2.a = t1.a
+)
+----
+1
+2
+
+query I rowsort
+SELECT (SELECT count(*)
+        FROM (VALUES (1), (2)) t2(a)
+        JOIN (VALUES (1)) t3(c) ON t2.a = t1.a)
+FROM (VALUES (1), (2)) t1(a)
+----
+1
+1
+
+query I rowsort
+SELECT *
+FROM (VALUES (1), (2)) t1(a)
+WHERE EXISTS (
+    SELECT 1
+    FROM (VALUES (1)) t2(a)
+    JOIN (VALUES (1)) t3(c) ON t1.a = 1
+)
+----
+1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

- fixes: #20462
- Correlated references in subquery plan nodes were not consistently tracked as outer columns.
- This caused execution failures such as `Unable to get field named "0"` during decorrelation.

## Changes

- Include correlated references from join `equi_conditions` and `non_equi_conditions`.
- Add a shared outer-column derivation helper for scalar-bearing plan nodes.
- Apply consistent tracking to aggregate, window/window-group, exchange, filter, eval-scalar, project-set, sort/window-partition, top-N, and UNION coercion expressions.
- Remap derived producer indexes and window expressions during decorrelation.
- Remap `Sort.window_partition` state instead of leaving it unsupported during column replacement.
- Keep correlated outer columns in window partitions so separate outer rows cannot share a window partition.
- Add direct relational-property invariant tests and execution/SQLLogicTest coverage.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation:

- `cargo fmt --all -- --check`
- `cargo check -p databend-common-sql`
- `cargo clippy -p databend-common-sql --all-targets -- -D warnings`
- `cargo test -p databend-common-sql --lib planner::plans::operator::tests --no-fail-fast`
- `cargo test -p databend-common-sql --lib planner::plans::join::tests --no-fail-fast`
- `cargo test -p databend-common-sql --test it optimizer:: --no-fail-fast` — 35 passed
- `cargo test -p databend-query --test it sql::exec::correlated_subquery_regression --no-fail-fast` — 3 passed
- `target/debug/databend-sqllogictests --handlers mysql --run_file correlated_join_condition.test --enable_sandbox --parallel 1` — 14 passed

Coverage includes correlated references in JOIN ON, aggregate GROUP BY, DISTINCT, window PARTITION BY, window ORDER BY, and window function arguments, using multiple outer rows.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other

## AI assistance

- AI usage: An AI coding agent investigated issue #20462, identified related outer-column tracking gaps, drafted the planner fixes and regression tests, updated the golden/SQL test coverage, and assisted with validation and PR preparation.
- Responsible human: @sundy-li
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20476)
<!-- Reviewable:end -->
