### PR TITLE
fix(storage): preserve change tracking correctness across counter resets

### DIFF
--- a/src/query/service/tests/it/storages/fuse/operations/logical_change_retry.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/logical_change_retry.rs
@@ -1,0 +1,189 @@
+// Copyright 2021 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use databend_common_catalog::session_type::SessionType;
+use databend_common_catalog::table::Table;
+use databend_common_expression::DataBlock;
+use databend_common_sql::Planner;
+use databend_common_storages_fuse::FuseTable;
+use databend_common_version::BUILD_INFO;
+use databend_query::interpreters::InterpreterFactory;
+use databend_query::sessions::Session;
+use databend_query::sessions::TableContextTableAccess;
+use databend_query::test_kits::TestFixture;
+use databend_storages_common_cache::CacheAccessor;
+use databend_storages_common_cache::CacheManager;
+use databend_storages_common_table_meta::meta::TableSnapshot;
+use futures::TryStreamExt;
+
+async fn execute(session: &Arc<Session>, sql: &str) -> anyhow::Result<()> {
+    let ctx = session.create_query_context(&BUILD_INFO).await?;
+    let (plan, _) = Planner::new(ctx.clone()).plan_sql(sql).await?;
+    InterpreterFactory::get(ctx.clone(), &plan)
+        .await?
+        .execute(ctx)
+        .await?
+        .try_collect::<Vec<DataBlock>>()
+        .await?;
+    Ok(())
+}
+
+async fn table(fixture: &TestFixture, name: &str) -> anyhow::Result<FuseTable> {
+    let ctx = fixture.new_query_ctx().await?;
+    let table = ctx
+        .get_table("default", &fixture.default_db_name(), name)
+        .await?;
+    Ok(FuseTable::try_from_table(table.as_ref())?.clone())
+}
+
+async fn totals(fixture: &TestFixture, name: &str) -> anyhow::Result<(u64, u64)> {
+    let snapshot = table(fixture, name)
+        .await?
+        .read_table_snapshot()
+        .await?
+        .unwrap();
+    let value = serde_json::to_value(snapshot.as_ref())?;
+    let counters = &value["logical_change_counters"];
+    // This is the raw cumulative interpretation used by pre-epoch readers.
+    Ok((
+        counters["updated_rows_total"].as_u64().unwrap(),
+        counters["deleted_rows_total"].as_u64().unwrap(),
+    ))
+}
+
+async fn make_epochless(fixture: &TestFixture, name: &str) -> anyhow::Result<()> {
+    let table = table(fixture, name).await?;
+    let location = table.snapshot_loc().unwrap();
+    let snapshot = table.read_table_snapshot().await?.unwrap();
+    let mut value = serde_json::to_value(snapshot.as_ref())?;
+    value["logical_change_counters"]
+        .as_object_mut()
+        .unwrap()
+        .remove("epoch");
+    let snapshot: TableSnapshot = serde_json::from_value(value)?;
+    // Test-only rewrite of the checkpoint: preserve data and totals, remove epoch.
+    table
+        .get_operator()
+        .write(&location, snapshot.to_bytes()?)
+        .await?;
+    if let Some(cache) = CacheManager::instance().get_table_snapshot_cache() {
+        cache.evict(&location);
+    }
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_epochless_transaction_conflict_preserves_complete_delta() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup().await?;
+    fixture.create_default_database().await?;
+    let name = "counter_retry";
+    let target = format!("{}.{}", fixture.default_db_name(), name);
+    fixture
+        .execute_command(&format!("CREATE TABLE {target}(id INT, v INT)"))
+        .await?;
+    fixture
+        .execute_command(&format!("INSERT INTO {target} VALUES (1,10),(2,20),(3,30)"))
+        .await?;
+    make_epochless(&fixture, name).await?;
+    let writer = fixture.new_session_with_type(SessionType::Dummy).await?;
+    let id = table(&fixture, name).await?.get_id();
+
+    // Each round has an actual metadata conflict: the transaction buffers its
+    // changes before a separate session commits an append to the same table.
+    for round in 0..2 {
+        let before = totals(&fixture, name).await?;
+        fixture.execute_command("BEGIN").await?;
+        fixture
+            .execute_command(&format!("UPDATE {target} SET v=v+1 WHERE id=1"))
+            .await?;
+        fixture
+            .execute_command(&format!("UPDATE {target} SET v=v+1 WHERE id=3"))
+            .await?;
+        let delete_id = if round == 0 { 2 } else { 100 };
+        fixture
+            .execute_command(&format!("DELETE FROM {target} WHERE id={delete_id}"))
+            .await?;
+        assert_eq!(
+            fixture
+                .default_session()
+                .txn_mgr()
+                .lock()
+                .logical_change_deltas()
+                .get(&id),
+            Some(&Some((2, 1)))
+        );
+        execute(
+            &writer,
+            &format!("INSERT INTO {target} VALUES ({},0)", 100 + round),
+        )
+        .await?;
+        fixture.execute_command("COMMIT").await?;
+        assert_eq!(totals(&fixture, name).await?, (before.0 + 2, before.1 + 1));
+        assert_eq!(
+            table(&fixture, name)
+                .await?
+                .read_table_snapshot()
+                .await?
+                .unwrap()
+                .summary
+                .row_count,
+            3
+        );
+        assert!(
+            fixture
+                .default_session()
+                .txn_mgr()
+                .lock()
+                .logical_change_deltas()
+                .is_empty()
+        );
+    }
+    // Keep internal bookkeeping assertions here: a SQL result alone cannot
+    // distinguish a known zero from missing counters after a successful retry.
+    let second_name = "counter_second";
+    let second = format!("{}.{}", fixture.default_db_name(), second_name);
+    fixture
+        .execute_command(&format!("CREATE TABLE {second}(id INT, v INT)"))
+        .await?;
+    fixture
+        .execute_command(&format!("INSERT INTO {second} VALUES (1,10),(2,20)"))
+        .await?;
+    let second_id = table(&fixture, second_name).await?.get_id();
+    for (sql, expected) in [
+        (format!("ANALYZE TABLE {target}"), vec![(id, (0, 0))]),
+        (
+            format!("INSERT ALL INTO {target} INTO {second} SELECT 9, 90"),
+            vec![(id, (0, 0)), (second_id, (0, 0))],
+        ),
+        (
+            format!("INSERT OVERWRITE ALL INTO {target} INTO {second} SELECT 9, 90"),
+            vec![(id, (0, 3)), (second_id, (0, 2))],
+        ),
+    ] {
+        fixture.execute_command("BEGIN").await?;
+        fixture.execute_command(&sql).await?;
+        let deltas = fixture
+            .default_session()
+            .txn_mgr()
+            .lock()
+            .logical_change_deltas();
+        for (table_id, delta) in expected {
+            assert_eq!(deltas.get(&table_id), Some(&Some(delta)), "{sql}");
+        }
+        fixture.execute_command("ROLLBACK").await?;
+    }
+    Ok(())
+}

--- a/src/query/service/tests/it/storages/fuse/operations/logical_change_retry.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/logical_change_retry.rs
@@ -101,9 +101,9 @@ async fn test_epochless_transaction_conflict_preserves_complete_delta() -> anyho
     let writer = fixture.new_session_with_type(SessionType::Dummy).await?;
     let id = table(&fixture, name).await?.get_id();
 
-    // Each round has an actual metadata conflict: the transaction buffers its
-    // changes before a separate session commits an append to the same table.
-    for round in 0..2 {
+    // The other session commits after this transaction buffers its mutations,
+    // forcing a metadata conflict at COMMIT.
+    {
         let before = totals(&fixture, name).await?;
         fixture.execute_command("BEGIN").await?;
         fixture
@@ -112,9 +112,8 @@ async fn test_epochless_transaction_conflict_preserves_complete_delta() -> anyho
         fixture
             .execute_command(&format!("UPDATE {target} SET v=v+1 WHERE id=3"))
             .await?;
-        let delete_id = if round == 0 { 2 } else { 100 };
         fixture
-            .execute_command(&format!("DELETE FROM {target} WHERE id={delete_id}"))
+            .execute_command(&format!("DELETE FROM {target} WHERE id=2"))
             .await?;
         assert_eq!(
             fixture
@@ -125,11 +124,7 @@ async fn test_epochless_transaction_conflict_preserves_complete_delta() -> anyho
                 .get(&id),
             Some(&Some((2, 1)))
         );
-        execute(
-            &writer,
-            &format!("INSERT INTO {target} VALUES ({},0)", 100 + round),
-        )
-        .await?;
+        execute(&writer, &format!("INSERT INTO {target} VALUES (100,0)")).await?;
         fixture.execute_command("COMMIT").await?;
         assert_eq!(totals(&fixture, name).await?, (before.0 + 2, before.1 + 1));
         assert_eq!(
@@ -151,39 +146,109 @@ async fn test_epochless_transaction_conflict_preserves_complete_delta() -> anyho
                 .is_empty()
         );
     }
-    // Keep internal bookkeeping assertions here: a SQL result alone cannot
-    // distinguish a known zero from missing counters after a successful retry.
-    let second_name = "counter_second";
-    let second = format!("{}.{}", fixture.default_db_name(), second_name);
-    fixture
-        .execute_command(&format!("CREATE TABLE {second}(id INT, v INT)"))
-        .await?;
-    fixture
-        .execute_command(&format!("INSERT INTO {second} VALUES (1,10),(2,20)"))
-        .await?;
-    let second_id = table(&fixture, second_name).await?.get_id();
-    for (sql, expected) in [
-        (format!("ANALYZE TABLE {target}"), vec![(id, (0, 0))]),
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_analyze_and_multi_table_retry_preserve_counters() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup().await?;
+    fixture.create_default_database().await?;
+    let writer = fixture.new_session_with_type(SessionType::Dummy).await?;
+    let db = fixture.default_db_name();
+    let names = ["counter_a", "counter_b"];
+    let mut ids = Vec::new();
+    for session in [fixture.default_session(), writer.clone()] {
+        execute(&session, "SET auto_compaction_imperfect_blocks_threshold=0").await?;
+        execute(&session, "SET enable_auto_analyze=0").await?;
+    }
+    for name in names {
+        let target = format!("{db}.{name}");
+        fixture
+            .execute_command(&format!("CREATE TABLE {target}(id INT, v INT)"))
+            .await?;
+        fixture
+            .execute_command(&format!("INSERT INTO {target} VALUES (1,10),(2,20),(3,30)"))
+            .await?;
+        fixture
+            .execute_command(&format!("UPDATE {target} SET v=11 WHERE id=1"))
+            .await?;
+        fixture
+            .execute_command(&format!("DELETE FROM {target} WHERE id=2"))
+            .await?;
+        assert_eq!(totals(&fixture, name).await?, (1, 1));
+        ids.push(table(&fixture, name).await?.get_id());
+    }
+
+    let a = format!("{db}.{}", names[0]);
+    let b = format!("{db}.{}", names[1]);
+    // Start with two rows per table. ANALYZE + concurrent append leaves three;
+    // INSERT ALL + concurrent append leaves five, which OVERWRITE removes.
+    for (statements, delta, expected_rows) in [
         (
-            format!("INSERT ALL INTO {target} INTO {second} SELECT 9, 90"),
-            vec![(id, (0, 0)), (second_id, (0, 0))],
+            vec![format!("ANALYZE TABLE {a}"), format!("ANALYZE TABLE {b}")],
+            (0, 0),
+            3,
         ),
         (
-            format!("INSERT OVERWRITE ALL INTO {target} INTO {second} SELECT 9, 90"),
-            vec![(id, (0, 3)), (second_id, (0, 2))],
+            vec![format!("INSERT ALL INTO {a} INTO {b} SELECT 9,90")],
+            (0, 0),
+            5,
+        ),
+        (
+            vec![format!(
+                "INSERT OVERWRITE ALL INTO {a} INTO {b} SELECT 9,90"
+            )],
+            (0, 5),
+            2,
         ),
     ] {
+        let mut before = Vec::new();
+        for name in names {
+            // Exercise each write path from an old, nonzero counter baseline.
+            make_epochless(&fixture, name).await?;
+            before.push(totals(&fixture, name).await?);
+        }
         fixture.execute_command("BEGIN").await?;
-        fixture.execute_command(&sql).await?;
+        for sql in &statements {
+            fixture.execute_command(sql).await?;
+        }
         let deltas = fixture
             .default_session()
             .txn_mgr()
             .lock()
             .logical_change_deltas();
-        for (table_id, delta) in expected {
-            assert_eq!(deltas.get(&table_id), Some(&Some(delta)), "{sql}");
+        for id in &ids {
+            assert_eq!(deltas.get(id), Some(&Some(delta)), "{statements:?}");
         }
-        fixture.execute_command("ROLLBACK").await?;
+        for name in names {
+            execute(&writer, &format!("INSERT INTO {db}.{name} VALUES (100,0)")).await?;
+        }
+        fixture.execute_command("COMMIT").await?;
+        for (index, name) in names.into_iter().enumerate() {
+            assert_eq!(
+                totals(&fixture, name).await?,
+                (before[index].0 + delta.0, before[index].1 + delta.1),
+                "persisted counters after retry: {statements:?}, {name}"
+            );
+            assert_eq!(
+                table(&fixture, name)
+                    .await?
+                    .read_table_snapshot()
+                    .await?
+                    .unwrap()
+                    .summary
+                    .row_count,
+                expected_rows
+            );
+        }
+        assert!(
+            fixture
+                .default_session()
+                .txn_mgr()
+                .lock()
+                .logical_change_deltas()
+                .is_empty()
+        );
     }
     Ok(())
 }

--- a/src/query/service/tests/it/storages/fuse/operations/mod.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mod.rs
@@ -17,6 +17,7 @@ mod alter_table;
 mod analyze;
 mod clustering;
 mod commit;
+mod logical_change_retry;
 
 mod create_or_replace_ownership_object;
 mod internal_column;

--- a/src/query/storages/common/session/src/transaction.rs
+++ b/src/query/storages/common/session/src/transaction.rs
@@ -78,6 +78,9 @@ pub struct TxnBuffer {
     stream_tables: HashMap<u64, StreamSnapshot>,
     need_purge_files: Vec<(StageInfo, Vec<String>)>,
     multi_table_insert_rows: HashMap<u64, u64>,
+    // Only successfully buffered writes contribute. Some((0, 0)) is a known
+    // insert-only delta; None means the transaction total overflowed.
+    logical_change_deltas: HashMap<u64, Option<(u64, u64)>>,
 
     // TODO doc this
     table_tnx_begin_timestamps: HashMap<u64, DateTime<Utc>>,
@@ -285,6 +288,29 @@ impl TxnManager {
 
     pub fn multi_table_insert_rows(&self) -> HashMap<u64, u64> {
         self.txn_buffer.multi_table_insert_rows.clone()
+    }
+
+    /// Record one successfully buffered write, never a candidate commit attempt.
+    /// This is independent of persisted counter epochs and snapshot resets.
+    pub fn add_logical_change_delta(&mut self, table_id: u64, delta: (u64, u64)) {
+        if !self.is_active() {
+            return;
+        }
+        let total = self
+            .txn_buffer
+            .logical_change_deltas
+            .entry(table_id)
+            .or_insert(Some((0, 0)));
+        *total = total.and_then(|(updated, deleted)| {
+            updated
+                .checked_add(delta.0)
+                .zip(deleted.checked_add(delta.1))
+        });
+    }
+
+    /// Freeze these totals before commit retries. Missing is not a known zero.
+    pub fn logical_change_deltas(&self) -> HashMap<u64, Option<(u64, u64)>> {
+        self.txn_buffer.logical_change_deltas.clone()
     }
 
     pub fn update_stream_metas(&mut self, reqs: &[UpdateStreamMetaReq]) {
@@ -508,6 +534,45 @@ mod tests {
         let (db, table) = TxnBuffer::parse_db_tbl_name("'db'.'tbl'");
         assert_eq!(db, "db");
         assert_eq!(table, "tbl");
+    }
+
+    #[test]
+    fn test_logical_deltas_accumulate_freeze_and_clear() {
+        let manager = TxnManager::init();
+        let mut txn = manager.lock();
+        txn.add_logical_change_delta(1, (9, 9));
+        assert!(txn.logical_change_deltas().is_empty());
+        txn.begin();
+        txn.add_logical_change_delta(1, (5, 0));
+        txn.add_logical_change_delta(1, (2, 3));
+        txn.add_logical_change_delta(2, (0, 0));
+        let frozen = txn.logical_change_deltas();
+        assert_eq!(frozen.get(&1), Some(&Some((7, 3))));
+        assert_eq!(frozen.get(&2), Some(&Some((0, 0))));
+        assert_eq!(frozen.get(&3), None);
+        txn.set_auto_commit();
+        assert_eq!(txn.logical_change_deltas(), frozen);
+        txn.clear();
+        assert!(txn.logical_change_deltas().is_empty());
+        assert_eq!(frozen.get(&1), Some(&Some((7, 3))));
+
+        txn.begin();
+        txn.add_logical_change_delta(1, (1, 2));
+        txn.force_set_fail();
+        assert!(txn.logical_change_deltas().is_empty());
+    }
+
+    #[test]
+    fn test_logical_delta_overflow_stays_unknown() {
+        let manager = TxnManager::init();
+        let mut txn = manager.lock();
+        txn.begin();
+        for (id, initial) in [(1, (u64::MAX, 0)), (2, (0, u64::MAX))] {
+            txn.add_logical_change_delta(id, initial);
+            txn.add_logical_change_delta(id, (1, 1));
+            txn.add_logical_change_delta(id, (0, 0));
+            assert_eq!(txn.logical_change_deltas().get(&id), Some(&None));
+        }
     }
 
     #[test]

--- a/src/query/storages/common/table_meta/src/meta/current/mod.rs
+++ b/src/query/storages/common/table_meta/src/meta/current/mod.rs
@@ -39,6 +39,7 @@ pub use v2::VirtualSegmentSchema;
 pub use v2::validate_segment_partition_statistics;
 pub use v2::widen_decimal_scalar;
 pub use v4::CompactSegmentInfo;
+pub use v4::LogicalChangeCounters;
 pub use v4::RawBlockMeta;
 pub use v4::SegmentInfo;
 pub use v4::TableSnapshot;

--- a/src/query/storages/common/table_meta/src/meta/v4/mod.rs
+++ b/src/query/storages/common/table_meta/src/meta/v4/mod.rs
@@ -19,6 +19,7 @@ mod table_snapshot_statistics;
 pub use segment::CompactSegmentInfo;
 pub use segment::RawBlockMeta;
 pub use segment::SegmentInfo;
+pub use snapshot::LogicalChangeCounters;
 pub use snapshot::TableSnapshot;
 pub use snapshot::TableSnapshotLite;
 pub use table_snapshot_statistics::TableSnapshotStatistics;

--- a/src/query/storages/common/table_meta/src/meta/v4/snapshot.rs
+++ b/src/query/storages/common/table_meta/src/meta/v4/snapshot.rs
@@ -349,6 +349,9 @@ impl TableSnapshot {
                 counters.deleted_rows_total = deleted;
             }
             _ => {
+                // Compatibility boundary: old counter-aware readers ignore epoch.
+                // Ordinary, non-overflowing writer handoffs preserve their totals;
+                // overflow resets are NOT safe for unrestricted mixed-version reads.
                 let epoch = self.prev_table_seq.filter(|seq| {
                     counters
                         .epoch

--- a/src/query/storages/common/table_meta/src/meta/v4/snapshot.rs
+++ b/src/query/storages/common/table_meta/src/meta/v4/snapshot.rs
@@ -594,93 +594,6 @@ mod tests {
     }
 
     #[test]
-    fn test_logical_change_counter_compatibility_boundary() {
-        let mut aware = snapshot_at(Some(10), None);
-        aware.add_logical_change_delta(17, 23);
-        let decoded = TableSnapshot::from_slice(&aware.to_bytes().unwrap()).unwrap();
-        let decoded_counters = decoded.logical_change_counters().unwrap();
-        assert_eq!(decoded_counters.updated_rows_total, 17);
-        assert_eq!(decoded_counters.deleted_rows_total, 23);
-        assert_eq!(decoded_counters.epoch, Some(10));
-
-        // A legacy writer drops the field entirely.
-        let legacy = strip_counters(&decoded);
-        assert!(legacy.logical_change_counters().is_none());
-
-        // Its counter-aware child restarts counting, but under a new identity so
-        // the restart stays detectable when endpoints are compared.
-        let first_aware = snapshot_at(Some(20), Some(Arc::new(legacy)));
-        let first_aware_counters = first_aware.logical_change_counters().unwrap();
-        assert_eq!(
-            first_aware_counters.delta_from(&decoded_counters).unwrap(),
-            None,
-            "counters from a restarted history must not be subtracted"
-        );
-
-        // A continuous descendant keeps the epoch and accumulates.
-        let mut continuous = snapshot_at(Some(30), Some(Arc::new(first_aware)));
-        continuous.add_logical_change_delta(2, 5);
-        assert_eq!(
-            continuous
-                .logical_change_counters()
-                .unwrap()
-                .delta_from(&first_aware_counters)
-                .unwrap(),
-            Some((2, 5))
-        );
-    }
-
-    #[test]
-    fn test_counters_without_epoch_are_unusable() {
-        // Written by the version that tracked counters but not their identity:
-        // the values are present but continuity is unprovable.
-        let mut aware = snapshot_at(Some(10), None);
-        aware.add_logical_change_delta(7, 9);
-        let mut value = serde_json::to_value(aware).unwrap();
-        value
-            .as_object_mut()
-            .unwrap()
-            .get_mut("logical_change_counters")
-            .unwrap()
-            .as_object_mut()
-            .unwrap()
-            .remove("epoch");
-        let epochless: TableSnapshot = serde_json::from_value(value).unwrap();
-        let epochless_counters = epochless.logical_change_counters().unwrap();
-        assert_eq!(epochless_counters.updated_rows_total, 7);
-        assert_eq!(epochless_counters.deleted_rows_total, 9);
-        assert_eq!(
-            epochless_counters.delta_from(&epochless_counters).unwrap(),
-            None
-        );
-
-        // A caller without a seq must preserve the totals too, but cannot
-        // identify the new history.
-        let unidentified = snapshot_at(None, Some(Arc::new(epochless.clone())));
-        let unidentified_counters = unidentified.logical_change_counters().unwrap();
-        assert_eq!(unidentified_counters.epoch, None);
-        assert_eq!(unidentified_counters.updated_rows_total, 7);
-        assert_eq!(unidentified_counters.deleted_rows_total, 9);
-
-        // Mint an epoch without resetting the totals used by older readers.
-        let healed = snapshot_at(Some(20), Some(Arc::new(epochless)));
-        let healed_counters = healed.logical_change_counters().unwrap();
-        assert_eq!(healed_counters.epoch, Some(20));
-        assert_eq!(healed_counters.updated_rows_total, 7);
-        assert_eq!(healed_counters.deleted_rows_total, 9);
-        assert_eq!(
-            healed_counters.delta_from(&healed_counters).unwrap(),
-            Some((0, 0))
-        );
-        // An epochless transaction base cannot prove whether earlier statements
-        // were lost in a reset, so retry must invalidate the merged counters.
-        assert_eq!(
-            healed_counters.delta_from(&epochless_counters).unwrap(),
-            None
-        );
-    }
-
-    #[test]
     fn test_epochless_writer_handoff_preserves_cumulative_totals() {
         // Model the older counter schema: unknown fields are discarded on read
         // and cannot be serialized back by an older writer.
@@ -705,7 +618,16 @@ mod tests {
             initial.add_logical_change_delta(base_updated, base_deleted);
             let base = old_writer(&initial, 0, 0);
             let base_counters = base.logical_change_counters().unwrap();
+            assert_eq!(base_counters.epoch, None);
+            assert_eq!(base_counters.delta_from(&base_counters).unwrap(), None);
             let old_latest = old_writer(&base, 1, 1);
+
+            // Missing seq must neither fabricate an epoch nor discard totals.
+            let unidentified = snapshot_at(None, Some(Arc::new(old_latest.clone())));
+            let counters = unidentified.logical_change_counters().unwrap();
+            assert_eq!(counters.epoch, None);
+            assert_eq!(counters.updated_rows_total, base_updated + 1);
+            assert_eq!(counters.deleted_rows_total, base_deleted + 1);
 
             let mut upgraded = snapshot_at(Some(20), Some(Arc::new(old_latest)));
             upgraded.add_logical_change_delta(2, 3);
@@ -821,27 +743,26 @@ mod tests {
     }
 
     #[test]
-    fn test_invalidated_counters_roundtrip_and_restart() {
-        let mut latest = snapshot_at(Some(10), None);
-        latest.add_logical_change_delta(7, 9);
-        let latest_counters = latest.logical_change_counters().unwrap();
-        let mut merged = snapshot_at(Some(20), Some(Arc::new(latest)));
-        merged.invalidate_logical_change_counters();
-        assert!(merged.logical_change_counters().is_none());
-        let merged = TableSnapshot::from_slice(&merged.to_bytes().unwrap()).unwrap();
-        assert!(merged.logical_change_counters().is_none());
-        let healed = snapshot_at(Some(30), Some(Arc::new(merged)));
-        let counters = healed.logical_change_counters().unwrap();
-        assert_eq!(counters.epoch, Some(30));
-        assert_eq!(counters.delta_from(&latest_counters).unwrap(), None);
-    }
+    fn test_absent_counters_roundtrip_and_restart() {
+        let mut base = snapshot_at(Some(10), None);
+        base.add_logical_change_delta(7, 9);
+        let base_counters = base.logical_change_counters().unwrap();
+        let mut invalidated = snapshot_at(Some(20), Some(Arc::new(base.clone())));
+        invalidated.invalidate_logical_change_counters();
 
-    #[test]
-    fn test_add_delta_does_not_resurrect_absent_counters() {
-        let mut legacy = strip_counters(&snapshot(None));
-        legacy.add_logical_change_delta(4, 6);
-        // Must stay absent: 4/6 are one operation's increments, not the table's
-        // cumulative totals.
-        assert!(legacy.logical_change_counters().is_none());
+        // Both a legacy writer and explicit invalidation produce unknown counters.
+        for mut absent in [strip_counters(&base), invalidated] {
+            absent.add_logical_change_delta(4, 6);
+            assert!(absent.logical_change_counters().is_none());
+            let decoded = TableSnapshot::from_slice(&absent.to_bytes().unwrap()).unwrap();
+            assert!(decoded.logical_change_counters().is_none());
+
+            let restarted = snapshot_at(Some(30), Some(Arc::new(decoded)));
+            let counters = restarted.logical_change_counters().unwrap();
+            assert_eq!(counters.epoch, Some(30));
+            assert_eq!(counters.updated_rows_total, 0);
+            assert_eq!(counters.deleted_rows_total, 0);
+            assert_eq!(counters.delta_from(&base_counters).unwrap(), None);
+        }
     }
 }

--- a/src/query/storages/common/table_meta/src/meta/v4/snapshot.rs
+++ b/src/query/storages/common/table_meta/src/meta/v4/snapshot.rs
@@ -106,24 +106,14 @@ pub struct TableSnapshot {
     logical_change_counters: Option<LogicalChangeCounters>,
 }
 
-/// Cumulative logical UPDATE and DELETE row counters, tagged with the identity
-/// of the counting history they belong to.
-///
-/// Counters restart from zero whenever a predecessor cannot prove continuity —
-/// a legacy writer that dropped the field, or a pre-v4 format snapshot. A
-/// restart is invisible in the values themselves, so each history is tagged
-/// with the table seq at which it began. Totals from two different histories
-/// are unrelated and must never be subtracted; use [`Self::delta_from`] and
-/// [`Self::increments_since`] rather than reading the totals directly.
+/// Cumulative UPDATE/DELETE counters. Only endpoints with the same known epoch
+/// are comparable; a legacy writer breaks continuity and starts a new epoch.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, FrozenAPI)]
 pub struct LogicalChangeCounters {
     updated_rows_total: u64,
     deleted_rows_total: u64,
-    /// Table seq at which this counting history began.
-    ///
-    /// `None` means the snapshot was written by a version that tracked
-    /// counters but not their identity, so continuity cannot be established.
-    /// Such counters are unusable until a later write mints an epoch.
+    /// Table seq used when starting this history, before committing its first
+    /// snapshot. Missing in older snapshots; `None` cannot prove continuity.
     #[serde(default)]
     epoch: Option<u64>,
 }
@@ -155,32 +145,17 @@ impl LogicalChangeCounters {
         Ok(Some((updated, deleted)))
     }
 
-    /// Increments accumulated by `self` on top of `base`, where `self` is known
-    /// to have been generated directly from `base`.
-    ///
-    /// Unlike [`Self::delta_from`] this always yields a value: when `base`
-    /// could not prove continuity, `self` started a fresh history from zero and
-    /// its totals already *are* the increments. Deciding that by epoch, rather
-    /// than by defaulting the base to zero, avoids subtracting the totals of an
-    /// unrelated history.
-    pub fn increments_since(&self, base: Option<&Self>) -> Result<(u64, u64)> {
-        let (base_updated, base_deleted) = base
-            .filter(|base| base.epoch.is_some() && base.epoch == self.epoch)
-            .map_or((0, 0), |base| {
-                (base.updated_rows_total, base.deleted_rows_total)
-            });
-        // Either same epoch (monotonic) or reduced to a zero base, so neither
-        // subtraction may underflow. Release builds disable overflow checks, so
-        // verify rather than wrap.
-        let updated = self
-            .updated_rows_total
-            .checked_sub(base_updated)
-            .ok_or_else(|| ErrorCode::Internal("logical updated row counter decreased"))?;
-        let deleted = self
-            .deleted_rows_total
-            .checked_sub(base_deleted)
-            .ok_or_else(|| ErrorCode::Internal("logical deleted row counter decreased"))?;
-        Ok((updated, deleted))
+    /// Extract this transaction's accumulated changes since its original base.
+    /// The transaction may contain multiple intermediate snapshots. A missing
+    /// or epochless base starts counting from zero; a known base must retain its
+    /// epoch throughout the transaction.
+    pub fn transaction_delta_from(&self, base: Option<&Self>) -> Result<(u64, u64)> {
+        match base.filter(|base| base.epoch.is_some()) {
+            Some(base) => self.delta_from(base)?.ok_or_else(|| {
+                ErrorCode::Internal("logical change counter epoch changed within transaction")
+            }),
+            None => Ok((self.updated_rows_total, self.deleted_rows_total)),
+        }
     }
 }
 
@@ -244,29 +219,19 @@ impl TableSnapshot {
         {
             summary.cluster_stats = None;
         }
-        // Inherit the predecessor's counting history only when it can be proven
-        // continuous. A predecessor whose counters are absent (legacy writer or
-        // pre-v4 format) or whose epoch is unknown leaves the accumulated totals
-        // unknowable, so counting restarts under a fresh identity instead of
-        // silently resuming from zero inside the old history.
-        let restarted = |epoch| LogicalChangeCounters {
-            updated_rows_total: 0,
-            deleted_rows_total: 0,
-            epoch,
-        };
-        let logical_change_counters = Some(match prev_snapshot.as_ref() {
-            // No predecessor at all: the table's counting history starts here
-            // and the totals really are zero, independent of any seq.
-            None => restarted(Some(prev_table_seq.unwrap_or(0))),
-            Some(prev) => match prev.logical_change_counters {
-                Some(counters) if counters.epoch.is_some() => counters,
-                // Restarting mid-history. Only provable when the table seq this
-                // restart commits against is known; without it the restart point
-                // is indistinguishable from the history it replaces, so leave it
-                // unknown and let readers fall back.
-                _ => restarted(prev_table_seq),
-            },
-        });
+        // Inherit a known history; otherwise restart using the current table seq.
+        // A missing seq stays unknown rather than inventing a shared epoch zero.
+        let logical_change_counters = Some(
+            prev_snapshot
+                .as_ref()
+                .and_then(|snapshot| snapshot.logical_change_counters)
+                .filter(|counters| counters.epoch.is_some())
+                .unwrap_or(LogicalChangeCounters {
+                    updated_rows_total: 0,
+                    deleted_rows_total: 0,
+                    epoch: prev_table_seq,
+                }),
+        );
         Ok(Self {
             format_version: TableSnapshot::VERSION,
             snapshot_id: uuid_from_date_time(snapshot_timestamp_adjusted),
@@ -389,21 +354,23 @@ impl TableSnapshot {
         self.logical_change_counters
     }
 
-    /// Adds one committed operation's logical UPDATE and DELETE increments.
-    ///
-    /// A no-op when the counters are absent: resurrecting them here would
-    /// present a single operation's increments as the table's cumulative totals,
-    /// and without an epoch they could not be compared anyway. Snapshots from
-    /// `try_new` always carry counters, so this only guards ones deserialized
-    /// from a legacy writer.
-    pub fn add_logical_change_delta(&mut self, updated_rows: u64, deleted_rows: u64) {
+    /// Add an operation's increments without resurrecting absent counters.
+    /// Overflow fails atomically: wrapping or saturating could hide later changes.
+    pub fn add_logical_change_delta(&mut self, updated_rows: u64, deleted_rows: u64) -> Result<()> {
         let Some(counters) = self.logical_change_counters.as_mut() else {
-            return;
+            return Ok(());
         };
-        // Release builds disable overflow checks. Saturate rather than wrap,
-        // since a wrapped total would later read as a counter decrease.
-        counters.updated_rows_total = counters.updated_rows_total.saturating_add(updated_rows);
-        counters.deleted_rows_total = counters.deleted_rows_total.saturating_add(deleted_rows);
+        let updated = counters
+            .updated_rows_total
+            .checked_add(updated_rows)
+            .ok_or_else(|| ErrorCode::Internal("logical updated row counter overflow"))?;
+        let deleted = counters
+            .deleted_rows_total
+            .checked_add(deleted_rows)
+            .ok_or_else(|| ErrorCode::Internal("logical deleted row counter overflow"))?;
+        counters.updated_rows_total = updated;
+        counters.deleted_rows_total = deleted;
+        Ok(())
     }
 }
 
@@ -626,7 +593,7 @@ mod tests {
     #[test]
     fn test_logical_change_counter_compatibility_boundary() {
         let mut aware = snapshot_at(Some(10), None);
-        aware.add_logical_change_delta(17, 23);
+        aware.add_logical_change_delta(17, 23).unwrap();
         let decoded = TableSnapshot::from_slice(&aware.to_bytes().unwrap()).unwrap();
         let decoded_counters = decoded.logical_change_counters().unwrap();
         // Same history: totals are directly comparable.
@@ -653,7 +620,7 @@ mod tests {
 
         // A continuous descendant keeps the epoch and accumulates.
         let mut continuous = snapshot_at(Some(30), Some(Arc::new(first_aware)));
-        continuous.add_logical_change_delta(2, 5);
+        continuous.add_logical_change_delta(2, 5).unwrap();
         assert_eq!(
             continuous
                 .logical_change_counters()
@@ -669,7 +636,7 @@ mod tests {
         // Written by the version that tracked counters but not their identity:
         // the values are present but continuity is unprovable.
         let mut aware = snapshot_at(Some(10), None);
-        aware.add_logical_change_delta(7, 9);
+        aware.add_logical_change_delta(7, 9).unwrap();
         let mut value = serde_json::to_value(aware).unwrap();
         value
             .as_object_mut()
@@ -696,16 +663,72 @@ mod tests {
         // Its totals restarted, so they are this write's own increments.
         assert_eq!(
             healed_counters
-                .increments_since(Some(&epochless_counters))
+                .transaction_delta_from(Some(&epochless_counters))
                 .unwrap(),
             (0, 0)
         );
     }
 
     #[test]
+    fn test_missing_seq_does_not_create_a_known_epoch() {
+        let base = snapshot(None);
+        let child = snapshot(Some(Arc::new(base.clone())));
+        let base_counters = base.logical_change_counters().unwrap();
+        assert!(base_counters.epoch.is_none());
+        assert_eq!(
+            child
+                .logical_change_counters()
+                .unwrap()
+                .delta_from(&base_counters)
+                .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn test_transaction_delta_requires_continuity_from_known_base() {
+        let mut base = snapshot_at(Some(10), None);
+        base.add_logical_change_delta(5, 3).unwrap();
+        let base_counters = base.logical_change_counters().unwrap();
+        let mut intermediate = snapshot_at(Some(11), Some(Arc::new(base)));
+        intermediate.add_logical_change_delta(2, 1).unwrap();
+        let mut latest = snapshot_at(Some(12), Some(Arc::new(intermediate)));
+        latest.add_logical_change_delta(3, 2).unwrap();
+        assert_eq!(
+            latest
+                .logical_change_counters()
+                .unwrap()
+                .transaction_delta_from(Some(&base_counters))
+                .unwrap(),
+            (5, 3)
+        );
+
+        for seq in [None, Some(20)] {
+            let unrelated = snapshot_at(seq, None).logical_change_counters().unwrap();
+            assert!(
+                unrelated
+                    .transaction_delta_from(Some(&base_counters))
+                    .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn test_counter_overflow_does_not_partially_update_totals() {
+        for (updated, deleted) in [(u64::MAX, 0), (0, u64::MAX)] {
+            let mut snapshot = snapshot_at(Some(10), None);
+            snapshot.add_logical_change_delta(updated, deleted).unwrap();
+            assert!(snapshot.add_logical_change_delta(1, 1).is_err());
+            let counters = snapshot.logical_change_counters().unwrap();
+            assert_eq!(counters.updated_rows_total, updated);
+            assert_eq!(counters.deleted_rows_total, deleted);
+        }
+    }
+
+    #[test]
     fn test_add_delta_does_not_resurrect_absent_counters() {
         let mut legacy = strip_counters(&snapshot(None));
-        legacy.add_logical_change_delta(4, 6);
+        legacy.add_logical_change_delta(4, 6).unwrap();
         // Must stay absent: 4/6 are one operation's increments, not the table's
         // cumulative totals.
         assert!(legacy.logical_change_counters().is_none());

--- a/src/query/storages/common/table_meta/src/meta/v4/snapshot.rs
+++ b/src/query/storages/common/table_meta/src/meta/v4/snapshot.rs
@@ -106,10 +106,82 @@ pub struct TableSnapshot {
     logical_change_counters: Option<LogicalChangeCounters>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, Default, FrozenAPI)]
-struct LogicalChangeCounters {
+/// Cumulative logical UPDATE and DELETE row counters, tagged with the identity
+/// of the counting history they belong to.
+///
+/// Counters restart from zero whenever a predecessor cannot prove continuity —
+/// a legacy writer that dropped the field, or a pre-v4 format snapshot. A
+/// restart is invisible in the values themselves, so each history is tagged
+/// with the table seq at which it began. Totals from two different histories
+/// are unrelated and must never be subtracted; use [`Self::delta_from`] and
+/// [`Self::increments_since`] rather than reading the totals directly.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, FrozenAPI)]
+pub struct LogicalChangeCounters {
     updated_rows_total: u64,
     deleted_rows_total: u64,
+    /// Table seq at which this counting history began.
+    ///
+    /// `None` means the snapshot was written by a version that tracked
+    /// counters but not their identity, so continuity cannot be established.
+    /// Such counters are unusable until a later write mints an epoch.
+    #[serde(default)]
+    epoch: Option<u64>,
+}
+
+impl LogicalChangeCounters {
+    /// UPDATE and DELETE rows committed between `base` and `self`.
+    ///
+    /// `Ok(None)` means the delta is unknowable and the caller must fall back
+    /// to endpoint/origin-based processing: either endpoint's identity is
+    /// unknown, or the two belong to different counting histories. Subtracting
+    /// across a restart would report the changes the restart hid as zero.
+    pub fn delta_from(&self, base: &Self) -> Result<Option<(u64, u64)>> {
+        let (Some(self_epoch), Some(base_epoch)) = (self.epoch, base.epoch) else {
+            return Ok(None);
+        };
+        if self_epoch != base_epoch {
+            return Ok(None);
+        }
+        // Monotonic within one epoch, so a decrease here is a broken invariant
+        // rather than a discontinuous history.
+        let updated = self
+            .updated_rows_total
+            .checked_sub(base.updated_rows_total)
+            .ok_or_else(|| ErrorCode::Internal("logical updated row counter decreased"))?;
+        let deleted = self
+            .deleted_rows_total
+            .checked_sub(base.deleted_rows_total)
+            .ok_or_else(|| ErrorCode::Internal("logical deleted row counter decreased"))?;
+        Ok(Some((updated, deleted)))
+    }
+
+    /// Increments accumulated by `self` on top of `base`, where `self` is known
+    /// to have been generated directly from `base`.
+    ///
+    /// Unlike [`Self::delta_from`] this always yields a value: when `base`
+    /// could not prove continuity, `self` started a fresh history from zero and
+    /// its totals already *are* the increments. Deciding that by epoch, rather
+    /// than by defaulting the base to zero, avoids subtracting the totals of an
+    /// unrelated history.
+    pub fn increments_since(&self, base: Option<&Self>) -> Result<(u64, u64)> {
+        let (base_updated, base_deleted) = base
+            .filter(|base| base.epoch.is_some() && base.epoch == self.epoch)
+            .map_or((0, 0), |base| {
+                (base.updated_rows_total, base.deleted_rows_total)
+            });
+        // Either same epoch (monotonic) or reduced to a zero base, so neither
+        // subtraction may underflow. Release builds disable overflow checks, so
+        // verify rather than wrap.
+        let updated = self
+            .updated_rows_total
+            .checked_sub(base_updated)
+            .ok_or_else(|| ErrorCode::Internal("logical updated row counter decreased"))?;
+        let deleted = self
+            .deleted_rows_total
+            .checked_sub(base_deleted)
+            .ok_or_else(|| ErrorCode::Internal("logical deleted row counter decreased"))?;
+        Ok((updated, deleted))
+    }
 }
 
 impl TableSnapshot {
@@ -172,12 +244,29 @@ impl TableSnapshot {
         {
             summary.cluster_stats = None;
         }
-        let logical_change_counters = Some(
-            prev_snapshot
-                .as_ref()
-                .and_then(|snapshot| snapshot.logical_change_counters)
-                .unwrap_or_default(),
-        );
+        // Inherit the predecessor's counting history only when it can be proven
+        // continuous. A predecessor whose counters are absent (legacy writer or
+        // pre-v4 format) or whose epoch is unknown leaves the accumulated totals
+        // unknowable, so counting restarts under a fresh identity instead of
+        // silently resuming from zero inside the old history.
+        let restarted = |epoch| LogicalChangeCounters {
+            updated_rows_total: 0,
+            deleted_rows_total: 0,
+            epoch,
+        };
+        let logical_change_counters = Some(match prev_snapshot.as_ref() {
+            // No predecessor at all: the table's counting history starts here
+            // and the totals really are zero, independent of any seq.
+            None => restarted(Some(prev_table_seq.unwrap_or(0))),
+            Some(prev) => match prev.logical_change_counters {
+                Some(counters) if counters.epoch.is_some() => counters,
+                // Restarting mid-history. Only provable when the table seq this
+                // restart commits against is known; without it the restart point
+                // is indistinguishable from the history it replaces, so leave it
+                // unknown and let readers fall back.
+                _ => restarted(prev_table_seq),
+            },
+        });
         Ok(Self {
             format_version: TableSnapshot::VERSION,
             snapshot_id: uuid_from_date_time(snapshot_timestamp_adjusted),
@@ -290,18 +379,31 @@ impl TableSnapshot {
         ensure_segments_unique(&self.segments)
     }
 
-    pub fn logical_change_counters(&self) -> Option<(u64, u64)> {
+    /// Cumulative logical change counters, or `None` when this snapshot was
+    /// written by a version that did not track them.
+    ///
+    /// The returned totals are only meaningful relative to another snapshot from
+    /// the same counting history; compare them via
+    /// [`LogicalChangeCounters::delta_from`] rather than reading them directly.
+    pub fn logical_change_counters(&self) -> Option<LogicalChangeCounters> {
         self.logical_change_counters
-            .map(|counters| (counters.updated_rows_total, counters.deleted_rows_total))
     }
 
     /// Adds one committed operation's logical UPDATE and DELETE increments.
+    ///
+    /// A no-op when the counters are absent: resurrecting them here would
+    /// present a single operation's increments as the table's cumulative totals,
+    /// and without an epoch they could not be compared anyway. Snapshots from
+    /// `try_new` always carry counters, so this only guards ones deserialized
+    /// from a legacy writer.
     pub fn add_logical_change_delta(&mut self, updated_rows: u64, deleted_rows: u64) {
-        let counters = self
-            .logical_change_counters
-            .get_or_insert_with(LogicalChangeCounters::default);
-        counters.updated_rows_total += updated_rows;
-        counters.deleted_rows_total += deleted_rows;
+        let Some(counters) = self.logical_change_counters.as_mut() else {
+            return;
+        };
+        // Release builds disable overflow checks. Saturate rather than wrap,
+        // since a wrapped total would later read as a counter decrease.
+        counters.updated_rows_total = counters.updated_rows_total.saturating_add(updated_rows);
+        counters.deleted_rows_total = counters.deleted_rows_total.saturating_add(deleted_rows);
     }
 }
 

--- a/src/query/storages/common/table_meta/src/meta/v4/snapshot.rs
+++ b/src/query/storages/common/table_meta/src/meta/v4/snapshot.rs
@@ -681,15 +681,23 @@ mod tests {
             .remove("epoch");
         let epochless: TableSnapshot = serde_json::from_value(value).unwrap();
         let epochless_counters = epochless.logical_change_counters().unwrap();
-        assert_eq!(epochless_counters.delta_from(&epochless_counters).unwrap(), None);
+        assert_eq!(
+            epochless_counters.delta_from(&epochless_counters).unwrap(),
+            None
+        );
 
         // The next write mints an epoch, so the table self-heals.
         let healed = snapshot_at(Some(20), Some(Arc::new(epochless)));
         let healed_counters = healed.logical_change_counters().unwrap();
-        assert_eq!(healed_counters.delta_from(&healed_counters).unwrap(), Some((0, 0)));
+        assert_eq!(
+            healed_counters.delta_from(&healed_counters).unwrap(),
+            Some((0, 0))
+        );
         // Its totals restarted, so they are this write's own increments.
         assert_eq!(
-            healed_counters.increments_since(Some(&epochless_counters)).unwrap(),
+            healed_counters
+                .increments_since(Some(&epochless_counters))
+                .unwrap(),
             (0, 0)
         );
     }

--- a/src/query/storages/common/table_meta/src/meta/v4/snapshot.rs
+++ b/src/query/storages/common/table_meta/src/meta/v4/snapshot.rs
@@ -102,18 +102,19 @@ pub struct TableSnapshot {
 
     /// Cumulative logical UPDATE and DELETE counters. `None` means this snapshot
     /// was written by a version that did not track logical changes.
+    // Also cleared by transaction retry when the complete delta is unknown.
     #[serde(default)]
     logical_change_counters: Option<LogicalChangeCounters>,
 }
 
 /// Cumulative UPDATE/DELETE counters. Only endpoints with the same known epoch
-/// are comparable; a legacy writer breaks continuity and starts a new epoch.
+/// are comparable. Legacy writes and overflow break continuity.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, FrozenAPI)]
 pub struct LogicalChangeCounters {
     updated_rows_total: u64,
     deleted_rows_total: u64,
     /// Table seq used when starting this history, before committing its first
-    /// snapshot. Missing in older snapshots; `None` cannot prove continuity.
+    /// snapshot. `None` means unknown: older snapshots or a reset without a fresh seq.
     #[serde(default)]
     epoch: Option<u64>,
 }
@@ -143,16 +144,6 @@ impl LogicalChangeCounters {
             .checked_sub(base.deleted_rows_total)
             .ok_or_else(|| ErrorCode::Internal("logical deleted row counter decreased"))?;
         Ok(Some((updated, deleted)))
-    }
-
-    /// Extract the transaction's complete delta only when its history is known
-    /// to be continuous. After a reset, totals may omit earlier statements.
-    /// Without a known base, a reset cannot be distinguished from initialization.
-    pub fn transaction_delta_from(&self, base: Option<&Self>) -> Result<Option<(u64, u64)>> {
-        match base {
-            Some(base) => self.delta_from(base),
-            None => Ok(None),
-        }
     }
 }
 
@@ -609,13 +600,9 @@ mod tests {
         aware.add_logical_change_delta(17, 23);
         let decoded = TableSnapshot::from_slice(&aware.to_bytes().unwrap()).unwrap();
         let decoded_counters = decoded.logical_change_counters().unwrap();
-        // Same history: totals are directly comparable.
-        assert_eq!(
-            decoded_counters
-                .delta_from(&aware.logical_change_counters().unwrap())
-                .unwrap(),
-            Some((0, 0))
-        );
+        assert_eq!(decoded_counters.updated_rows_total, 17);
+        assert_eq!(decoded_counters.deleted_rows_total, 23);
+        assert_eq!(decoded_counters.epoch, Some(10));
 
         // A legacy writer drops the field entirely.
         let legacy = strip_counters(&decoded);
@@ -676,9 +663,7 @@ mod tests {
         // An epochless transaction base cannot prove whether earlier statements
         // were lost in a reset, so retry must invalidate the merged counters.
         assert_eq!(
-            healed_counters
-                .transaction_delta_from(Some(&epochless_counters))
-                .unwrap(),
+            healed_counters.delta_from(&epochless_counters).unwrap(),
             None
         );
     }
@@ -700,7 +685,7 @@ mod tests {
     }
 
     #[test]
-    fn test_transaction_delta_requires_continuity_from_known_base() {
+    fn test_delta_across_intermediate_snapshots() {
         let mut base = snapshot_at(Some(10), None);
         base.add_logical_change_delta(5, 3);
         let base_counters = base.logical_change_counters().unwrap();
@@ -712,19 +697,14 @@ mod tests {
             latest
                 .logical_change_counters()
                 .unwrap()
-                .transaction_delta_from(Some(&base_counters))
+                .delta_from(&base_counters)
                 .unwrap(),
             Some((5, 3))
         );
 
         for seq in [None, Some(20)] {
             let unrelated = snapshot_at(seq, None).logical_change_counters().unwrap();
-            assert_eq!(
-                unrelated
-                    .transaction_delta_from(Some(&base_counters))
-                    .unwrap(),
-                None
-            );
+            assert_eq!(unrelated.delta_from(&base_counters).unwrap(), None);
         }
     }
 
@@ -741,12 +721,6 @@ mod tests {
             assert_eq!(counters.updated_rows_total, 1);
             assert_eq!(counters.deleted_rows_total, 2);
             assert_eq!(counters.delta_from(&base_counters).unwrap(), None);
-            assert_eq!(
-                counters
-                    .transaction_delta_from(Some(&base_counters))
-                    .unwrap(),
-                None
-            );
 
             let decoded = TableSnapshot::from_slice(&child.to_bytes().unwrap()).unwrap();
             let mut descendant = snapshot_at(Some(30), Some(Arc::new(decoded)));
@@ -759,12 +733,20 @@ mod tests {
                     .unwrap(),
                 Some((3, 4))
             );
+
+            // A second overflow at the same seq must not reuse epoch 20.
+            child.add_logical_change_delta(u64::MAX, u64::MAX);
+            let reset = child.logical_change_counters().unwrap();
+            assert_eq!(reset.epoch, None);
+            assert_eq!(reset.updated_rows_total, u64::MAX);
+            assert_eq!(reset.deleted_rows_total, u64::MAX);
+            assert_eq!(reset.delta_from(&counters).unwrap(), None);
         }
     }
 
     #[test]
     fn test_overflow_without_fresh_seq_stays_unknown() {
-        for seq in [None, Some(10)] {
+        for seq in [None, Some(9), Some(10)] {
             let mut base = snapshot_at(Some(10), None);
             base.add_logical_change_delta(u64::MAX, 0);
             let mut child = snapshot_at(seq, Some(Arc::new(base)));
@@ -773,12 +755,12 @@ mod tests {
             assert_eq!(counters.epoch, None);
             assert_eq!(counters.updated_rows_total, 1);
             assert_eq!(counters.deleted_rows_total, 2);
-            assert_eq!(counters.transaction_delta_from(None).unwrap(), None);
+            assert_eq!(counters.delta_from(&counters).unwrap(), None);
         }
     }
 
     #[test]
-    fn test_retry_with_unknown_delta_invalidates_latest_counters() {
+    fn test_invalidated_counters_roundtrip_and_restart() {
         let mut latest = snapshot_at(Some(10), None);
         latest.add_logical_change_delta(7, 9);
         let latest_counters = latest.logical_change_counters().unwrap();

--- a/src/query/storages/common/table_meta/src/meta/v4/snapshot.rs
+++ b/src/query/storages/common/table_meta/src/meta/v4/snapshot.rs
@@ -207,19 +207,18 @@ impl TableSnapshot {
         {
             summary.cluster_stats = None;
         }
-        // Inherit a known history; otherwise restart using the current table seq.
-        // A missing seq stays unknown rather than inventing a shared epoch zero.
-        let logical_change_counters = Some(
-            prev_snapshot
-                .as_ref()
-                .and_then(|snapshot| snapshot.logical_change_counters)
-                .filter(|counters| counters.epoch.is_some())
-                .unwrap_or(LogicalChangeCounters {
-                    updated_rows_total: 0,
-                    deleted_rows_total: 0,
-                    epoch: prev_table_seq,
-                }),
-        );
+        // Preserve existing totals even without an epoch: older readers still
+        // subtract them. Start a new identity, not new totals, at this boundary.
+        // Only an absent counter field starts from zero. A missing seq stays unknown.
+        let mut counters = prev_snapshot
+            .as_ref()
+            .and_then(|snapshot| snapshot.logical_change_counters)
+            .unwrap_or(LogicalChangeCounters {
+                updated_rows_total: 0,
+                deleted_rows_total: 0,
+                epoch: None,
+            });
+        counters.epoch = counters.epoch.or(prev_table_seq);
         Ok(Self {
             format_version: TableSnapshot::VERSION,
             snapshot_id: uuid_from_date_time(snapshot_timestamp_adjusted),
@@ -232,7 +231,7 @@ impl TableSnapshot {
             cluster_key_meta,
             cluster_type,
             table_statistics_location,
-            logical_change_counters,
+            logical_change_counters: Some(counters),
         })
     }
 
@@ -648,14 +647,27 @@ mod tests {
             .remove("epoch");
         let epochless: TableSnapshot = serde_json::from_value(value).unwrap();
         let epochless_counters = epochless.logical_change_counters().unwrap();
+        assert_eq!(epochless_counters.updated_rows_total, 7);
+        assert_eq!(epochless_counters.deleted_rows_total, 9);
         assert_eq!(
             epochless_counters.delta_from(&epochless_counters).unwrap(),
             None
         );
 
-        // The next write mints an epoch, so the table self-heals.
+        // A caller without a seq must preserve the totals too, but cannot
+        // identify the new history.
+        let unidentified = snapshot_at(None, Some(Arc::new(epochless.clone())));
+        let unidentified_counters = unidentified.logical_change_counters().unwrap();
+        assert_eq!(unidentified_counters.epoch, None);
+        assert_eq!(unidentified_counters.updated_rows_total, 7);
+        assert_eq!(unidentified_counters.deleted_rows_total, 9);
+
+        // Mint an epoch without resetting the totals used by older readers.
         let healed = snapshot_at(Some(20), Some(Arc::new(epochless)));
         let healed_counters = healed.logical_change_counters().unwrap();
+        assert_eq!(healed_counters.epoch, Some(20));
+        assert_eq!(healed_counters.updated_rows_total, 7);
+        assert_eq!(healed_counters.deleted_rows_total, 9);
         assert_eq!(
             healed_counters.delta_from(&healed_counters).unwrap(),
             Some((0, 0))
@@ -666,6 +678,55 @@ mod tests {
             healed_counters.delta_from(&epochless_counters).unwrap(),
             None
         );
+    }
+
+    #[test]
+    fn test_epochless_writer_handoff_preserves_cumulative_totals() {
+        // Model the older counter schema: unknown fields are discarded on read
+        // and cannot be serialized back by an older writer.
+        #[derive(Serialize, Deserialize)]
+        struct EpochlessCounters {
+            updated_rows_total: u64,
+            deleted_rows_total: u64,
+        }
+
+        fn old_writer(snapshot: &TableSnapshot, updated: u64, deleted: u64) -> TableSnapshot {
+            let mut value = serde_json::to_value(snapshot).unwrap();
+            let mut counters: EpochlessCounters =
+                serde_json::from_value(value["logical_change_counters"].clone()).unwrap();
+            counters.updated_rows_total += updated;
+            counters.deleted_rows_total += deleted;
+            value["logical_change_counters"] = serde_json::to_value(counters).unwrap();
+            serde_json::from_value(value).unwrap()
+        }
+
+        for (base_updated, base_deleted) in [(0, 0), (5, 3)] {
+            let mut initial = snapshot_at(Some(10), None);
+            initial.add_logical_change_delta(base_updated, base_deleted);
+            let base = old_writer(&initial, 0, 0);
+            let base_counters = base.logical_change_counters().unwrap();
+            let old_latest = old_writer(&base, 1, 1);
+
+            let mut upgraded = snapshot_at(Some(20), Some(Arc::new(old_latest)));
+            upgraded.add_logical_change_delta(2, 3);
+            let counters = upgraded.logical_change_counters().unwrap();
+            assert_eq!(counters.epoch, Some(20));
+            // An old reader ignores epoch and subtracts the totals directly.
+            assert_eq!(counters.updated_rows_total - base_updated, 3);
+            assert_eq!(counters.deleted_rows_total - base_deleted, 4);
+            assert_eq!(counters.delta_from(&base_counters).unwrap(), None);
+
+            // An older writer takes over again and drops the epoch. The next
+            // new writer must preserve its increments while assigning a new epoch.
+            let old_latest = old_writer(&upgraded, 4, 5);
+            let next = snapshot_at(Some(30), Some(Arc::new(old_latest)));
+            let decoded = TableSnapshot::from_slice(&next.to_bytes().unwrap()).unwrap();
+            let next_counters = decoded.logical_change_counters().unwrap();
+            assert_eq!(next_counters.epoch, Some(30));
+            assert_eq!(next_counters.updated_rows_total - base_updated, 7);
+            assert_eq!(next_counters.deleted_rows_total - base_deleted, 9);
+            assert_eq!(next_counters.delta_from(&counters).unwrap(), None);
+        }
     }
 
     #[test]

--- a/src/query/storages/common/table_meta/src/meta/v4/snapshot.rs
+++ b/src/query/storages/common/table_meta/src/meta/v4/snapshot.rs
@@ -594,8 +594,15 @@ mod tests {
     }
 
     fn snapshot(previous: Option<Arc<TableSnapshot>>) -> TableSnapshot {
+        snapshot_at(None, previous)
+    }
+
+    fn snapshot_at(
+        prev_table_seq: Option<u64>,
+        previous: Option<Arc<TableSnapshot>>,
+    ) -> TableSnapshot {
         TableSnapshot::try_new(
-            None,
+            prev_table_seq,
             previous,
             TableSchema::default(),
             Statistics::default(),
@@ -607,22 +614,92 @@ mod tests {
         .unwrap()
     }
 
-    #[test]
-    fn test_logical_change_counter_compatibility_boundary() {
-        let mut aware = snapshot(None);
-        aware.add_logical_change_delta(17, 23);
-        let decoded = TableSnapshot::from_slice(&aware.to_bytes().unwrap()).unwrap();
-        assert_eq!(decoded.logical_change_counters(), Some((17, 23)));
-
-        let mut legacy_value = serde_json::to_value(decoded).unwrap();
-        legacy_value
+    fn strip_counters(snapshot: &TableSnapshot) -> TableSnapshot {
+        let mut value = serde_json::to_value(snapshot.clone()).unwrap();
+        value
             .as_object_mut()
             .unwrap()
             .remove("logical_change_counters");
-        let legacy: TableSnapshot = serde_json::from_value(legacy_value).unwrap();
-        assert_eq!(legacy.logical_change_counters(), None);
+        serde_json::from_value(value).unwrap()
+    }
 
-        let first_aware = snapshot(Some(Arc::new(legacy)));
-        assert_eq!(first_aware.logical_change_counters(), Some((0, 0)));
+    #[test]
+    fn test_logical_change_counter_compatibility_boundary() {
+        let mut aware = snapshot_at(Some(10), None);
+        aware.add_logical_change_delta(17, 23);
+        let decoded = TableSnapshot::from_slice(&aware.to_bytes().unwrap()).unwrap();
+        let decoded_counters = decoded.logical_change_counters().unwrap();
+        // Same history: totals are directly comparable.
+        assert_eq!(
+            decoded_counters
+                .delta_from(&aware.logical_change_counters().unwrap())
+                .unwrap(),
+            Some((0, 0))
+        );
+
+        // A legacy writer drops the field entirely.
+        let legacy = strip_counters(&decoded);
+        assert!(legacy.logical_change_counters().is_none());
+
+        // Its counter-aware child restarts counting, but under a new identity so
+        // the restart stays detectable when endpoints are compared.
+        let first_aware = snapshot_at(Some(20), Some(Arc::new(legacy)));
+        let first_aware_counters = first_aware.logical_change_counters().unwrap();
+        assert_eq!(
+            first_aware_counters.delta_from(&decoded_counters).unwrap(),
+            None,
+            "counters from a restarted history must not be subtracted"
+        );
+
+        // A continuous descendant keeps the epoch and accumulates.
+        let mut continuous = snapshot_at(Some(30), Some(Arc::new(first_aware)));
+        continuous.add_logical_change_delta(2, 5);
+        assert_eq!(
+            continuous
+                .logical_change_counters()
+                .unwrap()
+                .delta_from(&first_aware_counters)
+                .unwrap(),
+            Some((2, 5))
+        );
+    }
+
+    #[test]
+    fn test_counters_without_epoch_are_unusable() {
+        // Written by the version that tracked counters but not their identity:
+        // the values are present but continuity is unprovable.
+        let mut aware = snapshot_at(Some(10), None);
+        aware.add_logical_change_delta(7, 9);
+        let mut value = serde_json::to_value(aware).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .get_mut("logical_change_counters")
+            .unwrap()
+            .as_object_mut()
+            .unwrap()
+            .remove("epoch");
+        let epochless: TableSnapshot = serde_json::from_value(value).unwrap();
+        let epochless_counters = epochless.logical_change_counters().unwrap();
+        assert_eq!(epochless_counters.delta_from(&epochless_counters).unwrap(), None);
+
+        // The next write mints an epoch, so the table self-heals.
+        let healed = snapshot_at(Some(20), Some(Arc::new(epochless)));
+        let healed_counters = healed.logical_change_counters().unwrap();
+        assert_eq!(healed_counters.delta_from(&healed_counters).unwrap(), Some((0, 0)));
+        // Its totals restarted, so they are this write's own increments.
+        assert_eq!(
+            healed_counters.increments_since(Some(&epochless_counters)).unwrap(),
+            (0, 0)
+        );
+    }
+
+    #[test]
+    fn test_add_delta_does_not_resurrect_absent_counters() {
+        let mut legacy = strip_counters(&snapshot(None));
+        legacy.add_logical_change_delta(4, 6);
+        // Must stay absent: 4/6 are one operation's increments, not the table's
+        // cumulative totals.
+        assert!(legacy.logical_change_counters().is_none());
     }
 }

--- a/src/query/storages/common/table_meta/src/meta/v4/snapshot.rs
+++ b/src/query/storages/common/table_meta/src/meta/v4/snapshot.rs
@@ -122,28 +122,21 @@ pub struct LogicalChangeCounters {
 impl LogicalChangeCounters {
     /// UPDATE and DELETE rows committed between `base` and `self`.
     ///
-    /// `Ok(None)` means the delta is unknowable and the caller must fall back
+    /// `None` means the delta is unknowable and the caller must fall back
     /// to endpoint/origin-based processing: either endpoint's identity is
-    /// unknown, or the two belong to different counting histories. Subtracting
-    /// across a restart would report the changes the restart hid as zero.
-    pub fn delta_from(&self, base: &Self) -> Result<Option<(u64, u64)>> {
-        let (Some(self_epoch), Some(base_epoch)) = (self.epoch, base.epoch) else {
-            return Ok(None);
-        };
-        if self_epoch != base_epoch {
-            return Ok(None);
+    /// unknown, the histories differ, or a counter decreases. A shared epoch
+    /// alone does not establish forward endpoint ordering.
+    pub fn delta_from(&self, base: &Self) -> Option<(u64, u64)> {
+        if self.epoch? != base.epoch? {
+            return None;
         }
-        // Monotonic within one epoch, so a decrease here is a broken invariant
-        // rather than a discontinuous history.
         let updated = self
             .updated_rows_total
-            .checked_sub(base.updated_rows_total)
-            .ok_or_else(|| ErrorCode::Internal("logical updated row counter decreased"))?;
+            .checked_sub(base.updated_rows_total)?;
         let deleted = self
             .deleted_rows_total
-            .checked_sub(base.deleted_rows_total)
-            .ok_or_else(|| ErrorCode::Internal("logical deleted row counter decreased"))?;
-        Ok(Some((updated, deleted)))
+            .checked_sub(base.deleted_rows_total)?;
+        Some((updated, deleted))
     }
 }
 
@@ -619,7 +612,7 @@ mod tests {
             let base = old_writer(&initial, 0, 0);
             let base_counters = base.logical_change_counters().unwrap();
             assert_eq!(base_counters.epoch, None);
-            assert_eq!(base_counters.delta_from(&base_counters).unwrap(), None);
+            assert_eq!(base_counters.delta_from(&base_counters), None);
             let old_latest = old_writer(&base, 1, 1);
 
             // Missing seq must neither fabricate an epoch nor discard totals.
@@ -636,7 +629,7 @@ mod tests {
             // An old reader ignores epoch and subtracts the totals directly.
             assert_eq!(counters.updated_rows_total - base_updated, 3);
             assert_eq!(counters.deleted_rows_total - base_deleted, 4);
-            assert_eq!(counters.delta_from(&base_counters).unwrap(), None);
+            assert_eq!(counters.delta_from(&base_counters), None);
 
             // An older writer takes over again and drops the epoch. The next
             // new writer must preserve its increments while assigning a new epoch.
@@ -647,7 +640,7 @@ mod tests {
             assert_eq!(next_counters.epoch, Some(30));
             assert_eq!(next_counters.updated_rows_total - base_updated, 7);
             assert_eq!(next_counters.deleted_rows_total - base_deleted, 9);
-            assert_eq!(next_counters.delta_from(&counters).unwrap(), None);
+            assert_eq!(next_counters.delta_from(&counters), None);
         }
     }
 
@@ -661,8 +654,7 @@ mod tests {
             child
                 .logical_change_counters()
                 .unwrap()
-                .delta_from(&base_counters)
-                .unwrap(),
+                .delta_from(&base_counters),
             None
         );
     }
@@ -680,14 +672,13 @@ mod tests {
             latest
                 .logical_change_counters()
                 .unwrap()
-                .delta_from(&base_counters)
-                .unwrap(),
+                .delta_from(&base_counters),
             Some((5, 3))
         );
 
         for seq in [None, Some(20)] {
             let unrelated = snapshot_at(seq, None).logical_change_counters().unwrap();
-            assert_eq!(unrelated.delta_from(&base_counters).unwrap(), None);
+            assert_eq!(unrelated.delta_from(&base_counters), None);
         }
     }
 
@@ -703,7 +694,7 @@ mod tests {
             assert_eq!(counters.epoch, Some(20));
             assert_eq!(counters.updated_rows_total, 1);
             assert_eq!(counters.deleted_rows_total, 2);
-            assert_eq!(counters.delta_from(&base_counters).unwrap(), None);
+            assert_eq!(counters.delta_from(&base_counters), None);
 
             let decoded = TableSnapshot::from_slice(&child.to_bytes().unwrap()).unwrap();
             let mut descendant = snapshot_at(Some(30), Some(Arc::new(decoded)));
@@ -712,8 +703,7 @@ mod tests {
                 descendant
                     .logical_change_counters()
                     .unwrap()
-                    .delta_from(&counters)
-                    .unwrap(),
+                    .delta_from(&counters),
                 Some((3, 4))
             );
 
@@ -723,7 +713,7 @@ mod tests {
             assert_eq!(reset.epoch, None);
             assert_eq!(reset.updated_rows_total, u64::MAX);
             assert_eq!(reset.deleted_rows_total, u64::MAX);
-            assert_eq!(reset.delta_from(&counters).unwrap(), None);
+            assert_eq!(reset.delta_from(&counters), None);
         }
     }
 
@@ -738,7 +728,7 @@ mod tests {
             assert_eq!(counters.epoch, None);
             assert_eq!(counters.updated_rows_total, 1);
             assert_eq!(counters.deleted_rows_total, 2);
-            assert_eq!(counters.delta_from(&counters).unwrap(), None);
+            assert_eq!(counters.delta_from(&counters), None);
         }
     }
 
@@ -762,7 +752,7 @@ mod tests {
             assert_eq!(counters.epoch, Some(30));
             assert_eq!(counters.updated_rows_total, 0);
             assert_eq!(counters.deleted_rows_total, 0);
-            assert_eq!(counters.delta_from(&base_counters).unwrap(), None);
+            assert_eq!(counters.delta_from(&base_counters), None);
         }
     }
 }

--- a/src/query/storages/common/table_meta/src/meta/v4/snapshot.rs
+++ b/src/query/storages/common/table_meta/src/meta/v4/snapshot.rs
@@ -145,16 +145,13 @@ impl LogicalChangeCounters {
         Ok(Some((updated, deleted)))
     }
 
-    /// Extract this transaction's accumulated changes since its original base.
-    /// The transaction may contain multiple intermediate snapshots. A missing
-    /// or epochless base starts counting from zero; a known base must retain its
-    /// epoch throughout the transaction.
-    pub fn transaction_delta_from(&self, base: Option<&Self>) -> Result<(u64, u64)> {
-        match base.filter(|base| base.epoch.is_some()) {
-            Some(base) => self.delta_from(base)?.ok_or_else(|| {
-                ErrorCode::Internal("logical change counter epoch changed within transaction")
-            }),
-            None => Ok((self.updated_rows_total, self.deleted_rows_total)),
+    /// Extract the transaction's complete delta only when its history is known
+    /// to be continuous. After a reset, totals may omit earlier statements.
+    /// Without a known base, a reset cannot be distinguished from initialization.
+    pub fn transaction_delta_from(&self, base: Option<&Self>) -> Result<Option<(u64, u64)>> {
+        match base {
+            Some(base) => self.delta_from(base),
+            None => Ok(None),
         }
     }
 }
@@ -344,8 +341,7 @@ impl TableSnapshot {
         ensure_segments_unique(&self.segments)
     }
 
-    /// Cumulative logical change counters, or `None` when this snapshot was
-    /// written by a version that did not track them.
+    /// Cumulative logical change counters, or `None` when absent or invalidated.
     ///
     /// The returned totals are only meaningful relative to another snapshot from
     /// the same counting history; compare them via
@@ -354,23 +350,40 @@ impl TableSnapshot {
         self.logical_change_counters
     }
 
-    /// Add an operation's increments without resurrecting absent counters.
-    /// Overflow fails atomically: wrapping or saturating could hide later changes.
-    pub fn add_logical_change_delta(&mut self, updated_rows: u64, deleted_rows: u64) -> Result<()> {
+    /// Add increments without resurrecting absent counters. On overflow, restart
+    /// both totals and retain this operation's increments. A reused/missing seq
+    /// cannot identify a fresh history (e.g. within a transaction), so use None.
+    pub fn add_logical_change_delta(&mut self, updated_rows: u64, deleted_rows: u64) {
         let Some(counters) = self.logical_change_counters.as_mut() else {
-            return Ok(());
+            return;
         };
-        let updated = counters
-            .updated_rows_total
-            .checked_add(updated_rows)
-            .ok_or_else(|| ErrorCode::Internal("logical updated row counter overflow"))?;
-        let deleted = counters
-            .deleted_rows_total
-            .checked_add(deleted_rows)
-            .ok_or_else(|| ErrorCode::Internal("logical deleted row counter overflow"))?;
-        counters.updated_rows_total = updated;
-        counters.deleted_rows_total = deleted;
-        Ok(())
+        match (
+            counters.updated_rows_total.checked_add(updated_rows),
+            counters.deleted_rows_total.checked_add(deleted_rows),
+        ) {
+            (Some(updated), Some(deleted)) => {
+                counters.updated_rows_total = updated;
+                counters.deleted_rows_total = deleted;
+            }
+            _ => {
+                let epoch = self.prev_table_seq.filter(|seq| {
+                    counters
+                        .epoch
+                        .is_some_and(|previous_epoch| *seq > previous_epoch)
+                });
+                *counters = LogicalChangeCounters {
+                    updated_rows_total: updated_rows,
+                    deleted_rows_total: deleted_rows,
+                    epoch,
+                };
+            }
+        }
+    }
+
+    /// Used when a transaction retry cannot recover its complete logical delta.
+    /// Do not inherit the latest snapshot's counters and omit the transaction.
+    pub fn invalidate_logical_change_counters(&mut self) {
+        self.logical_change_counters = None;
     }
 }
 
@@ -593,7 +606,7 @@ mod tests {
     #[test]
     fn test_logical_change_counter_compatibility_boundary() {
         let mut aware = snapshot_at(Some(10), None);
-        aware.add_logical_change_delta(17, 23).unwrap();
+        aware.add_logical_change_delta(17, 23);
         let decoded = TableSnapshot::from_slice(&aware.to_bytes().unwrap()).unwrap();
         let decoded_counters = decoded.logical_change_counters().unwrap();
         // Same history: totals are directly comparable.
@@ -620,7 +633,7 @@ mod tests {
 
         // A continuous descendant keeps the epoch and accumulates.
         let mut continuous = snapshot_at(Some(30), Some(Arc::new(first_aware)));
-        continuous.add_logical_change_delta(2, 5).unwrap();
+        continuous.add_logical_change_delta(2, 5);
         assert_eq!(
             continuous
                 .logical_change_counters()
@@ -636,7 +649,7 @@ mod tests {
         // Written by the version that tracked counters but not their identity:
         // the values are present but continuity is unprovable.
         let mut aware = snapshot_at(Some(10), None);
-        aware.add_logical_change_delta(7, 9).unwrap();
+        aware.add_logical_change_delta(7, 9);
         let mut value = serde_json::to_value(aware).unwrap();
         value
             .as_object_mut()
@@ -660,12 +673,13 @@ mod tests {
             healed_counters.delta_from(&healed_counters).unwrap(),
             Some((0, 0))
         );
-        // Its totals restarted, so they are this write's own increments.
+        // An epochless transaction base cannot prove whether earlier statements
+        // were lost in a reset, so retry must invalidate the merged counters.
         assert_eq!(
             healed_counters
                 .transaction_delta_from(Some(&epochless_counters))
                 .unwrap(),
-            (0, 0)
+            None
         );
     }
 
@@ -688,47 +702,101 @@ mod tests {
     #[test]
     fn test_transaction_delta_requires_continuity_from_known_base() {
         let mut base = snapshot_at(Some(10), None);
-        base.add_logical_change_delta(5, 3).unwrap();
+        base.add_logical_change_delta(5, 3);
         let base_counters = base.logical_change_counters().unwrap();
         let mut intermediate = snapshot_at(Some(11), Some(Arc::new(base)));
-        intermediate.add_logical_change_delta(2, 1).unwrap();
+        intermediate.add_logical_change_delta(2, 1);
         let mut latest = snapshot_at(Some(12), Some(Arc::new(intermediate)));
-        latest.add_logical_change_delta(3, 2).unwrap();
+        latest.add_logical_change_delta(3, 2);
         assert_eq!(
             latest
                 .logical_change_counters()
                 .unwrap()
                 .transaction_delta_from(Some(&base_counters))
                 .unwrap(),
-            (5, 3)
+            Some((5, 3))
         );
 
         for seq in [None, Some(20)] {
             let unrelated = snapshot_at(seq, None).logical_change_counters().unwrap();
-            assert!(
+            assert_eq!(
                 unrelated
                     .transaction_delta_from(Some(&base_counters))
-                    .is_err()
+                    .unwrap(),
+                None
             );
         }
     }
 
     #[test]
-    fn test_counter_overflow_does_not_partially_update_totals() {
+    fn test_counter_overflow_restarts_both_totals() {
         for (updated, deleted) in [(u64::MAX, 0), (0, u64::MAX)] {
-            let mut snapshot = snapshot_at(Some(10), None);
-            snapshot.add_logical_change_delta(updated, deleted).unwrap();
-            assert!(snapshot.add_logical_change_delta(1, 1).is_err());
-            let counters = snapshot.logical_change_counters().unwrap();
-            assert_eq!(counters.updated_rows_total, updated);
-            assert_eq!(counters.deleted_rows_total, deleted);
+            let mut base = snapshot_at(Some(10), None);
+            base.add_logical_change_delta(updated, deleted);
+            let base_counters = base.logical_change_counters().unwrap();
+            let mut child = snapshot_at(Some(20), Some(Arc::new(base)));
+            child.add_logical_change_delta(1, 2);
+            let counters = child.logical_change_counters().unwrap();
+            assert_eq!(counters.epoch, Some(20));
+            assert_eq!(counters.updated_rows_total, 1);
+            assert_eq!(counters.deleted_rows_total, 2);
+            assert_eq!(counters.delta_from(&base_counters).unwrap(), None);
+            assert_eq!(
+                counters
+                    .transaction_delta_from(Some(&base_counters))
+                    .unwrap(),
+                None
+            );
+
+            let decoded = TableSnapshot::from_slice(&child.to_bytes().unwrap()).unwrap();
+            let mut descendant = snapshot_at(Some(30), Some(Arc::new(decoded)));
+            descendant.add_logical_change_delta(3, 4);
+            assert_eq!(
+                descendant
+                    .logical_change_counters()
+                    .unwrap()
+                    .delta_from(&counters)
+                    .unwrap(),
+                Some((3, 4))
+            );
         }
+    }
+
+    #[test]
+    fn test_overflow_without_fresh_seq_stays_unknown() {
+        for seq in [None, Some(10)] {
+            let mut base = snapshot_at(Some(10), None);
+            base.add_logical_change_delta(u64::MAX, 0);
+            let mut child = snapshot_at(seq, Some(Arc::new(base)));
+            child.add_logical_change_delta(1, 2);
+            let counters = child.logical_change_counters().unwrap();
+            assert_eq!(counters.epoch, None);
+            assert_eq!(counters.updated_rows_total, 1);
+            assert_eq!(counters.deleted_rows_total, 2);
+            assert_eq!(counters.transaction_delta_from(None).unwrap(), None);
+        }
+    }
+
+    #[test]
+    fn test_retry_with_unknown_delta_invalidates_latest_counters() {
+        let mut latest = snapshot_at(Some(10), None);
+        latest.add_logical_change_delta(7, 9);
+        let latest_counters = latest.logical_change_counters().unwrap();
+        let mut merged = snapshot_at(Some(20), Some(Arc::new(latest)));
+        merged.invalidate_logical_change_counters();
+        assert!(merged.logical_change_counters().is_none());
+        let merged = TableSnapshot::from_slice(&merged.to_bytes().unwrap()).unwrap();
+        assert!(merged.logical_change_counters().is_none());
+        let healed = snapshot_at(Some(30), Some(Arc::new(merged)));
+        let counters = healed.logical_change_counters().unwrap();
+        assert_eq!(counters.epoch, Some(30));
+        assert_eq!(counters.delta_from(&latest_counters).unwrap(), None);
     }
 
     #[test]
     fn test_add_delta_does_not_resurrect_absent_counters() {
         let mut legacy = strip_counters(&snapshot(None));
-        legacy.add_logical_change_delta(4, 6).unwrap();
+        legacy.add_logical_change_delta(4, 6);
         // Must stay absent: 4/6 are one operation's increments, not the table's
         // cumulative totals.
         assert!(legacy.logical_change_counters().is_none());

--- a/src/query/storages/fuse/src/operations/analyze/analyze_state_sink.rs
+++ b/src/query/storages/fuse/src/operations/analyze/analyze_state_sink.rs
@@ -508,7 +508,15 @@ impl SinkAnalyzeState {
                 &None,
                 &table.operator,
             )
-            .await
+            .await?;
+        // ANALYZE bypasses the mutation sinks but still buffers a snapshot in an
+        // explicit transaction. Record a known zero so commit retries preserve
+        // the source's cumulative counters instead of treating them as missing.
+        self.ctx
+            .txn_mgr()
+            .lock()
+            .add_logical_change_delta(table.get_id(), (0, 0));
+        Ok(())
     }
 
     async fn commit_statistics_with_retry(&mut self) -> Result<()> {

--- a/src/query/storages/fuse/src/operations/changes.rs
+++ b/src/query/storages/fuse/src/operations/changes.rs
@@ -1001,4 +1001,86 @@ mod tests {
             0
         );
     }
+
+    /// A legacy writer between the two endpoints restarts the counters. The
+    /// endpoints then both read as zero, so the UPDATE/DELETE rows committed
+    /// before the restart must not be reported as "no changes" — that would
+    /// silently optimize a Standard stream into AppendOnly and drop them.
+    #[test]
+    fn test_restarted_counters_do_not_prove_absence_of_changes() {
+        // Stream created on a fresh table, so its base totals are zero.
+        let base = snapshot_at(Some(10), None, 3);
+
+        // UPDATE 1 row + DELETE 1 row while counters are tracked.
+        let mut mutated = snapshot_at(Some(11), Some(Arc::new(base.clone())), 2);
+        mutated.add_logical_change_delta(1, 1);
+        assert_eq!(
+            logical_change_delta(Some(&base), Some(&mutated)).unwrap(),
+            Some((1, 1)),
+            "within one history the delta is visible"
+        );
+
+        // A legacy writer publishes a snapshot without the counter field.
+        let legacy = strip_counters(&snapshot_at(Some(12), Some(Arc::new(mutated)), 3));
+        assert_eq!(
+            logical_change_delta(Some(&base), Some(&legacy)).unwrap(),
+            None,
+            "unknown latest counters must not yield a delta"
+        );
+
+        // A counter-aware writer follows, restarting the totals from zero.
+        let after_upgrade = snapshot_at(Some(13), Some(Arc::new(legacy)), 4);
+        assert_eq!(
+            logical_change_delta(Some(&base), Some(&after_upgrade)).unwrap(),
+            None,
+            "endpoints from different histories must not be subtracted"
+        );
+    }
+
+    /// Same history break, but the stream's base already carried non-zero
+    /// totals. Subtracting across the restart used to underflow and fail the
+    /// query; it must now degrade to an unknown delta instead.
+    #[test]
+    fn test_restarted_counters_below_base_do_not_error() {
+        let mut base = snapshot_at(Some(10), None, 10);
+        base.add_logical_change_delta(5, 3);
+
+        let legacy = strip_counters(&snapshot_at(Some(11), Some(Arc::new(base.clone())), 10));
+        let after_upgrade = snapshot_at(Some(12), Some(Arc::new(legacy)), 11);
+
+        assert_eq!(
+            logical_change_delta(Some(&base), Some(&after_upgrade)).unwrap(),
+            None
+        );
+        assert_eq!(
+            logical_change_rows(Some(&base), Some(&after_upgrade)).unwrap(),
+            None
+        );
+    }
+
+    /// The fix must not cost the optimization for streams created after the
+    /// break, otherwise every table with a legacy ancestor regresses.
+    #[test]
+    fn test_history_after_restart_is_still_comparable() {
+        let legacy = legacy_snapshot(10);
+        // First counter-aware write mints a fresh history.
+        let restarted = snapshot_at(Some(20), Some(Arc::new(legacy)), 10);
+        // A stream created here uses `restarted` as its base.
+        let mut later = snapshot_at(Some(21), Some(Arc::new(restarted.clone())), 9);
+        later.add_logical_change_delta(2, 3);
+
+        assert_eq!(
+            logical_change_delta(Some(&restarted), Some(&later)).unwrap(),
+            Some((2, 3)),
+            "descendants of a restart share its history"
+        );
+        assert_eq!(
+            logical_change_rows(Some(&restarted), Some(&later)).unwrap(),
+            Some(LogicalChangeRows {
+                inserted: 2,
+                updated: 2,
+                deleted: 3,
+            })
+        );
+    }
 }

--- a/src/query/storages/fuse/src/operations/changes.rs
+++ b/src/query/storages/fuse/src/operations/changes.rs
@@ -928,9 +928,17 @@ mod tests {
     use super::*;
 
     fn snapshot(rows: u64) -> TableSnapshot {
+        snapshot_at(None, None, rows)
+    }
+
+    fn snapshot_at(
+        prev_table_seq: Option<u64>,
+        previous: Option<Arc<TableSnapshot>>,
+        rows: u64,
+    ) -> TableSnapshot {
         TableSnapshot::try_new(
-            None,
-            None,
+            prev_table_seq,
+            previous,
             TableSchema::default(),
             Statistics {
                 row_count: rows,
@@ -944,14 +952,17 @@ mod tests {
         .unwrap()
     }
 
-    fn legacy_snapshot(rows: u64) -> TableSnapshot {
-        let snapshot = snapshot(rows);
-        let mut value = serde_json::to_value(snapshot).unwrap();
+    fn strip_counters(snapshot: &TableSnapshot) -> TableSnapshot {
+        let mut value = serde_json::to_value(snapshot.clone()).unwrap();
         value
             .as_object_mut()
             .unwrap()
             .remove("logical_change_counters");
         serde_json::from_value(value).unwrap()
+    }
+
+    fn legacy_snapshot(rows: u64) -> TableSnapshot {
+        strip_counters(&snapshot(rows))
     }
 
     #[test]

--- a/src/query/storages/fuse/src/operations/changes.rs
+++ b/src/query/storages/fuse/src/operations/changes.rs
@@ -1007,60 +1007,39 @@ mod tests {
         assert_eq!(logical_change_rows(None, Some(&restarted)).unwrap(), None);
     }
 
-    /// A legacy writer between the two endpoints restarts the counters. The
-    /// endpoints then both read as zero, so the UPDATE/DELETE rows committed
-    /// before the restart must not be reported as "no changes" — that would
-    /// silently optimize a Standard stream into AppendOnly and drop them.
+    /// A restart must neither look like zero changes (zero base counters) nor
+    /// cause subtraction underflow (nonzero base counters).
     #[test]
-    fn test_restarted_counters_do_not_prove_absence_of_changes() {
-        // Stream created on a fresh table, so its base totals are zero.
-        let base = snapshot_at(Some(10), None, 3);
+    fn test_restarted_counters_fall_back() {
+        for (updated, deleted) in [(0, 0), (5, 3)] {
+            let mut base = snapshot_at(Some(10), None, 3);
+            base.add_logical_change_delta(updated, deleted);
 
-        // UPDATE 1 row + DELETE 1 row while counters are tracked.
-        let mut mutated = snapshot_at(Some(11), Some(Arc::new(base.clone())), 2);
-        mutated.add_logical_change_delta(1, 1);
-        assert_eq!(
-            logical_change_delta(Some(&base), Some(&mutated)).unwrap(),
-            Some((1, 1)),
-            "within one history the delta is visible"
-        );
+            let mut mutated = snapshot_at(Some(11), Some(Arc::new(base.clone())), 2);
+            mutated.add_logical_change_delta(1, 1);
+            assert_eq!(
+                logical_change_delta(Some(&base), Some(&mutated)).unwrap(),
+                Some((1, 1)),
+                "within one history the delta is visible"
+            );
 
-        // A legacy writer publishes a snapshot without the counter field.
-        let legacy = strip_counters(&snapshot_at(Some(12), Some(Arc::new(mutated)), 3));
-        assert_eq!(
-            logical_change_delta(Some(&base), Some(&legacy)).unwrap(),
-            None,
-            "unknown latest counters must not yield a delta"
-        );
+            let legacy = strip_counters(&snapshot_at(Some(12), Some(Arc::new(mutated)), 3));
+            assert_eq!(
+                logical_change_delta(Some(&base), Some(&legacy)).unwrap(),
+                None
+            );
 
-        // A counter-aware writer follows, restarting the totals from zero.
-        let after_upgrade = snapshot_at(Some(13), Some(Arc::new(legacy)), 4);
-        assert_eq!(
-            logical_change_delta(Some(&base), Some(&after_upgrade)).unwrap(),
-            None,
-            "endpoints from different histories must not be subtracted"
-        );
-    }
-
-    /// Same history break, but the stream's base already carried non-zero
-    /// totals. Subtracting across the restart used to underflow and fail the
-    /// query; it must now degrade to an unknown delta instead.
-    #[test]
-    fn test_restarted_counters_below_base_do_not_error() {
-        let mut base = snapshot_at(Some(10), None, 10);
-        base.add_logical_change_delta(5, 3);
-
-        let legacy = strip_counters(&snapshot_at(Some(11), Some(Arc::new(base.clone())), 10));
-        let after_upgrade = snapshot_at(Some(12), Some(Arc::new(legacy)), 11);
-
-        assert_eq!(
-            logical_change_delta(Some(&base), Some(&after_upgrade)).unwrap(),
-            None
-        );
-        assert_eq!(
-            logical_change_rows(Some(&base), Some(&after_upgrade)).unwrap(),
-            None
-        );
+            let after_upgrade = snapshot_at(Some(13), Some(Arc::new(legacy)), 4);
+            assert_eq!(
+                logical_change_delta(Some(&base), Some(&after_upgrade)).unwrap(),
+                None,
+                "different histories must fall back, base=({updated}, {deleted})"
+            );
+            assert_eq!(
+                logical_change_rows(Some(&base), Some(&after_upgrade)).unwrap(),
+                None
+            );
+        }
     }
 
     /// The fix must not cost the optimization for streams created after the

--- a/src/query/storages/fuse/src/operations/changes.rs
+++ b/src/query/storages/fuse/src/operations/changes.rs
@@ -253,7 +253,7 @@ impl FuseTable {
                     return Ok(StreamMode::Standard);
                 };
                 let base_snapshot = self.changes_read_offset_snapshot(base_location).await?;
-                if logical_change_delta(Some(&base_snapshot), Some(&latest_snapshot))?
+                if logical_change_delta(Some(&base_snapshot), Some(&latest_snapshot))
                     .is_some_and(|delta| delta == (0, 0))
                 {
                     Ok(StreamMode::AppendOnly)
@@ -728,34 +728,24 @@ pub(crate) struct LogicalChangeRows {
     deleted: u64,
 }
 
-/// UPDATE and DELETE rows committed between the two endpoints.
-///
-/// `None` means the delta is unknowable and the caller must fall back to
-/// endpoint/origin-based processing rather than treating it as "no changes".
+/// Compare only endpoints with known, continuous counters. An empty base does
+/// not establish the start of a potentially restarted counting history.
 fn logical_change_delta(
     base: Option<&TableSnapshot>,
     latest: Option<&TableSnapshot>,
-) -> Result<Option<(u64, u64)>> {
-    let Some(latest_counters) = latest.and_then(TableSnapshot::logical_change_counters) else {
-        return Ok(None);
-    };
-    match base {
-        Some(snapshot) => {
-            let Some(base_counters) = snapshot.logical_change_counters() else {
-                return Ok(None);
-            };
-            latest_counters.delta_from(&base_counters)
-        }
-        // A restarted history need not cover the full range from an empty base.
-        None => Ok(None),
-    }
+) -> Option<(u64, u64)> {
+    let base_counters = base?.logical_change_counters()?;
+    let latest_counters = latest?.logical_change_counters()?;
+    latest_counters.delta_from(&base_counters)
 }
 
+/// Estimate logical rows only when both endpoints have comparable counters.
+/// Missing or discontinuous history must fall back to endpoint processing.
 fn logical_change_rows(
     base: Option<&TableSnapshot>,
     latest: Option<&TableSnapshot>,
 ) -> Result<Option<LogicalChangeRows>> {
-    let Some((updated, deleted)) = logical_change_delta(base, latest)? else {
+    let Some((updated, deleted)) = logical_change_delta(base, latest) else {
         return Ok(None);
     };
     let base_rows = base.map_or(0, |snapshot| snapshot.summary.row_count);
@@ -982,12 +972,20 @@ mod tests {
             })
         );
 
-        let mut newer_base = snapshot_at(Some(12), Some(Arc::new(latest.clone())), 10);
-        newer_base.add_logical_change_delta(3, 0);
-        assert!(logical_change_rows(Some(&newer_base), Some(&latest)).is_err());
+        // Either counter decreasing makes the delta unknown, even in one epoch.
+        for (updated, deleted) in [(3, 0), (0, 3)] {
+            let mut newer_base = snapshot_at(Some(12), Some(Arc::new(latest.clone())), 10);
+            newer_base.add_logical_change_delta(updated, deleted);
+            assert_eq!(logical_change_delta(Some(&newer_base), Some(&latest)), None);
+            assert_eq!(
+                logical_change_rows(Some(&newer_base), Some(&latest)).unwrap(),
+                None
+            );
+        }
 
-        let base = snapshot(10);
-        let mut updated = snapshot(10);
+        // Preserve upstream's estimate coverage with endpoints in one epoch.
+        let base = snapshot_at(Some(20), None, 10);
+        let mut updated = snapshot_at(Some(21), Some(Arc::new(base.clone())), 10);
         updated.add_logical_change_delta(2, 0);
         assert_eq!(
             estimate_change_rows(Some(&base), &updated, &StreamMode::Standard).unwrap(),
@@ -1003,7 +1001,7 @@ mod tests {
     fn test_no_base_does_not_trust_partial_history() {
         let legacy = legacy_snapshot(10);
         let restarted = snapshot_at(Some(20), Some(Arc::new(legacy)), 11);
-        assert_eq!(logical_change_delta(None, Some(&restarted)).unwrap(), None);
+        assert_eq!(logical_change_delta(None, Some(&restarted)), None);
         assert_eq!(logical_change_rows(None, Some(&restarted)).unwrap(), None);
     }
 
@@ -1018,26 +1016,23 @@ mod tests {
             let mut mutated = snapshot_at(Some(11), Some(Arc::new(base.clone())), 2);
             mutated.add_logical_change_delta(1, 1);
             assert_eq!(
-                logical_change_delta(Some(&base), Some(&mutated)).unwrap(),
+                logical_change_delta(Some(&base), Some(&mutated)),
                 Some((1, 1)),
                 "within one history the delta is visible"
             );
 
             let legacy = strip_counters(&snapshot_at(Some(12), Some(Arc::new(mutated)), 3));
-            assert_eq!(
-                logical_change_delta(Some(&base), Some(&legacy)).unwrap(),
-                None
-            );
+            assert_eq!(logical_change_delta(Some(&base), Some(&legacy)), None);
 
             let after_upgrade = snapshot_at(Some(13), Some(Arc::new(legacy)), 4);
             assert_eq!(
-                logical_change_delta(Some(&base), Some(&after_upgrade)).unwrap(),
+                logical_change_delta(Some(&base), Some(&after_upgrade)),
                 None,
                 "different histories must fall back, base=({updated}, {deleted})"
             );
             assert_eq!(
                 logical_change_rows(Some(&base), Some(&after_upgrade)).unwrap(),
-                None
+                None,
             );
         }
     }
@@ -1054,9 +1049,8 @@ mod tests {
         later.add_logical_change_delta(2, 3);
 
         assert_eq!(
-            logical_change_delta(Some(&restarted), Some(&later)).unwrap(),
-            Some((2, 3)),
-            "descendants of a restart share its history"
+            logical_change_delta(Some(&restarted), Some(&later)),
+            Some((2, 3))
         );
         assert_eq!(
             logical_change_rows(Some(&restarted), Some(&later)).unwrap(),

--- a/src/query/storages/fuse/src/operations/changes.rs
+++ b/src/query/storages/fuse/src/operations/changes.rs
@@ -967,7 +967,7 @@ mod tests {
         let legacy = legacy_snapshot(10);
         let base = snapshot_at(Some(10), None, 10);
         let mut latest = snapshot_at(Some(11), Some(Arc::new(base.clone())), 9);
-        latest.add_logical_change_delta(2, 3).unwrap();
+        latest.add_logical_change_delta(2, 3);
 
         assert_eq!(
             logical_change_rows(Some(&legacy), Some(&latest)).unwrap(),
@@ -983,7 +983,7 @@ mod tests {
         );
 
         let mut newer_base = snapshot_at(Some(12), Some(Arc::new(latest.clone())), 10);
-        newer_base.add_logical_change_delta(3, 0).unwrap();
+        newer_base.add_logical_change_delta(3, 0);
         assert!(logical_change_rows(Some(&newer_base), Some(&latest)).is_err());
 
         let base = snapshot(10);
@@ -1018,7 +1018,7 @@ mod tests {
 
         // UPDATE 1 row + DELETE 1 row while counters are tracked.
         let mut mutated = snapshot_at(Some(11), Some(Arc::new(base.clone())), 2);
-        mutated.add_logical_change_delta(1, 1).unwrap();
+        mutated.add_logical_change_delta(1, 1);
         assert_eq!(
             logical_change_delta(Some(&base), Some(&mutated)).unwrap(),
             Some((1, 1)),
@@ -1048,7 +1048,7 @@ mod tests {
     #[test]
     fn test_restarted_counters_below_base_do_not_error() {
         let mut base = snapshot_at(Some(10), None, 10);
-        base.add_logical_change_delta(5, 3).unwrap();
+        base.add_logical_change_delta(5, 3);
 
         let legacy = strip_counters(&snapshot_at(Some(11), Some(Arc::new(base.clone())), 10));
         let after_upgrade = snapshot_at(Some(12), Some(Arc::new(legacy)), 11);
@@ -1072,7 +1072,7 @@ mod tests {
         let restarted = snapshot_at(Some(20), Some(Arc::new(legacy)), 10);
         // A stream created here uses `restarted` as its base.
         let mut later = snapshot_at(Some(21), Some(Arc::new(restarted.clone())), 9);
-        later.add_logical_change_delta(2, 3).unwrap();
+        later.add_logical_change_delta(2, 3);
 
         assert_eq!(
             logical_change_delta(Some(&restarted), Some(&later)).unwrap(),

--- a/src/query/storages/fuse/src/operations/changes.rs
+++ b/src/query/storages/fuse/src/operations/changes.rs
@@ -728,32 +728,30 @@ pub(crate) struct LogicalChangeRows {
     deleted: u64,
 }
 
+/// UPDATE and DELETE rows committed between the two endpoints.
+///
+/// `None` means the delta is unknowable and the caller must fall back to
+/// endpoint/origin-based processing rather than treating it as "no changes".
 fn logical_change_delta(
     base: Option<&TableSnapshot>,
     latest: Option<&TableSnapshot>,
 ) -> Result<Option<(u64, u64)>> {
-    let Some((latest_updated, latest_deleted)) =
-        latest.and_then(TableSnapshot::logical_change_counters)
-    else {
+    let Some(latest_counters) = latest.and_then(TableSnapshot::logical_change_counters) else {
         return Ok(None);
     };
-    let (base_updated, base_deleted) = match base {
+    match base {
         Some(snapshot) => {
-            let Some(counters) = snapshot.logical_change_counters() else {
+            let Some(base_counters) = snapshot.logical_change_counters() else {
                 return Ok(None);
             };
-            counters
+            latest_counters.delta_from(&base_counters)
         }
-        None => (0, 0),
-    };
-
-    let updated = latest_updated
-        .checked_sub(base_updated)
-        .ok_or_else(|| ErrorCode::Internal("logical updated row counter decreased"))?;
-    let deleted = latest_deleted
-        .checked_sub(base_deleted)
-        .ok_or_else(|| ErrorCode::Internal("logical deleted row counter decreased"))?;
-    Ok(Some((updated, deleted)))
+        // Without a base endpoint the delta only feeds row-count estimates. A
+        // restarted history makes the totals cover less than the table's whole
+        // life, which can understate an estimate but cannot affect the
+        // correctness of stream results.
+        None => latest_counters.increments_since(None).map(Some),
+    }
 }
 
 fn logical_change_rows(

--- a/src/query/storages/fuse/src/operations/changes.rs
+++ b/src/query/storages/fuse/src/operations/changes.rs
@@ -746,11 +746,8 @@ fn logical_change_delta(
             };
             latest_counters.delta_from(&base_counters)
         }
-        // Without a base endpoint the delta only feeds row-count estimates. A
-        // restarted history makes the totals cover less than the table's whole
-        // life, which can understate an estimate but cannot affect the
-        // correctness of stream results.
-        None => latest_counters.increments_since(None).map(Some),
+        // A restarted history need not cover the full range from an empty base.
+        None => Ok(None),
     }
 }
 
@@ -968,9 +965,9 @@ mod tests {
     #[test]
     fn test_logical_change_rows() {
         let legacy = legacy_snapshot(10);
-        let base = snapshot(10);
-        let mut latest = snapshot(9);
-        latest.add_logical_change_delta(2, 3);
+        let base = snapshot_at(Some(10), None, 10);
+        let mut latest = snapshot_at(Some(11), Some(Arc::new(base.clone())), 9);
+        latest.add_logical_change_delta(2, 3).unwrap();
 
         assert_eq!(
             logical_change_rows(Some(&legacy), Some(&latest)).unwrap(),
@@ -985,8 +982,8 @@ mod tests {
             })
         );
 
-        let mut newer_base = snapshot(10);
-        newer_base.add_logical_change_delta(3, 0);
+        let mut newer_base = snapshot_at(Some(12), Some(Arc::new(latest.clone())), 10);
+        newer_base.add_logical_change_delta(3, 0).unwrap();
         assert!(logical_change_rows(Some(&newer_base), Some(&latest)).is_err());
 
         let base = snapshot(10);
@@ -1002,6 +999,14 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_no_base_does_not_trust_partial_history() {
+        let legacy = legacy_snapshot(10);
+        let restarted = snapshot_at(Some(20), Some(Arc::new(legacy)), 11);
+        assert_eq!(logical_change_delta(None, Some(&restarted)).unwrap(), None);
+        assert_eq!(logical_change_rows(None, Some(&restarted)).unwrap(), None);
+    }
+
     /// A legacy writer between the two endpoints restarts the counters. The
     /// endpoints then both read as zero, so the UPDATE/DELETE rows committed
     /// before the restart must not be reported as "no changes" — that would
@@ -1013,7 +1018,7 @@ mod tests {
 
         // UPDATE 1 row + DELETE 1 row while counters are tracked.
         let mut mutated = snapshot_at(Some(11), Some(Arc::new(base.clone())), 2);
-        mutated.add_logical_change_delta(1, 1);
+        mutated.add_logical_change_delta(1, 1).unwrap();
         assert_eq!(
             logical_change_delta(Some(&base), Some(&mutated)).unwrap(),
             Some((1, 1)),
@@ -1043,7 +1048,7 @@ mod tests {
     #[test]
     fn test_restarted_counters_below_base_do_not_error() {
         let mut base = snapshot_at(Some(10), None, 10);
-        base.add_logical_change_delta(5, 3);
+        base.add_logical_change_delta(5, 3).unwrap();
 
         let legacy = strip_counters(&snapshot_at(Some(11), Some(Arc::new(base.clone())), 10));
         let after_upgrade = snapshot_at(Some(12), Some(Arc::new(legacy)), 11);
@@ -1067,7 +1072,7 @@ mod tests {
         let restarted = snapshot_at(Some(20), Some(Arc::new(legacy)), 10);
         // A stream created here uses `restarted` as its base.
         let mut later = snapshot_at(Some(21), Some(Arc::new(restarted.clone())), 9);
-        later.add_logical_change_delta(2, 3);
+        later.add_logical_change_delta(2, 3).unwrap();
 
         assert_eq!(
             logical_change_delta(Some(&restarted), Some(&later)).unwrap(),

--- a/src/query/storages/fuse/src/operations/common/generators/snapshot_generator.rs
+++ b/src/query/storages/fuse/src/operations/common/generators/snapshot_generator.rs
@@ -71,7 +71,7 @@ pub trait SnapshotGenerator {
             table_stats_gen,
         )?;
         let (updated_rows, deleted_rows) = self.logical_change_delta(&previous);
-        snapshot.add_logical_change_delta(updated_rows, deleted_rows)?;
+        snapshot.add_logical_change_delta(updated_rows, deleted_rows);
         decorate_snapshot(&mut snapshot, txn_mgr, previous, table_info.ident.table_id)?;
         Ok(snapshot)
     }

--- a/src/query/storages/fuse/src/operations/common/generators/snapshot_generator.rs
+++ b/src/query/storages/fuse/src/operations/common/generators/snapshot_generator.rs
@@ -71,7 +71,7 @@ pub trait SnapshotGenerator {
             table_stats_gen,
         )?;
         let (updated_rows, deleted_rows) = self.logical_change_delta(&previous);
-        snapshot.add_logical_change_delta(updated_rows, deleted_rows);
+        snapshot.add_logical_change_delta(updated_rows, deleted_rows)?;
         decorate_snapshot(&mut snapshot, txn_mgr, previous, table_info.ident.table_id)?;
         Ok(snapshot)
     }

--- a/src/query/storages/fuse/src/operations/common/processors/multi_table_insert_commit.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/multi_table_insert_commit.rs
@@ -105,6 +105,7 @@ impl AsyncSink for CommitMultiTableInsert {
         let mut hlls = HashMap::with_capacity(self.commit_metas.len());
         let mut top_ns = HashMap::with_capacity(self.commit_metas.len());
         let mut imperfect_counts = HashMap::with_capacity(self.commit_metas.len());
+        let mut logical_deltas = HashMap::with_capacity(self.commit_metas.len());
         let insert_rows = std::mem::take(&mut self.insert_rows);
         for (table_id, commit_meta) in std::mem::take(&mut self.commit_metas).into_iter() {
             let table = self.tables.get(&table_id).unwrap();
@@ -113,7 +114,7 @@ impl AsyncSink for CommitMultiTableInsert {
             let mut snapshot_generator = AppendGenerator::new(self.ctx.clone(), self.overwrite);
             snapshot_generator.set_conflict_resolve_context(commit_meta.conflict_resolve_context);
             if table.is_temp() {
-                let (req, imperfect_count) = build_update_temp_table_req(
+                let prepared = build_update_temp_table_req(
                     table.as_ref(),
                     &snapshot_generator,
                     self.ctx.txn_mgr(),
@@ -123,10 +124,11 @@ impl AsyncSink for CommitMultiTableInsert {
                     &commit_meta.top_n,
                 )
                 .await?;
-                update_temp_tables.push(req);
-                imperfect_counts.insert(table_id, imperfect_count);
+                update_temp_tables.push(prepared.update);
+                logical_deltas.insert(table_id, prepared.logical_delta);
+                imperfect_counts.insert(table_id, prepared.imperfect_count);
             } else {
-                let (req, imperfect_count) = build_update_table_meta_req(
+                let prepared = build_update_table_meta_req(
                     table.as_ref(),
                     &snapshot_generator,
                     self.ctx.txn_mgr(),
@@ -136,8 +138,9 @@ impl AsyncSink for CommitMultiTableInsert {
                     &commit_meta.top_n,
                 )
                 .await?;
-                update_table_metas.push((req, table.get_table_info().clone()));
-                imperfect_counts.insert(table_id, imperfect_count);
+                update_table_metas.push((prepared.update, table.get_table_info().clone()));
+                logical_deltas.insert(table_id, prepared.logical_delta);
+                imperfect_counts.insert(table_id, prepared.imperfect_count);
             }
             snapshot_generators.insert(table_id, snapshot_generator);
             top_ns.insert(table_id, commit_meta.top_n);
@@ -221,6 +224,9 @@ impl AsyncSink for CommitMultiTableInsert {
                     let mut txn_mgr = txn_mgr.lock();
                     if txn_mgr.is_active() {
                         txn_mgr.add_multi_table_insert_rows(insert_rows.clone());
+                        for (&table_id, &delta) in &logical_deltas {
+                            txn_mgr.add_logical_change_delta(table_id, delta);
+                        }
                     }
                 }
 
@@ -251,7 +257,7 @@ impl AsyncSink for CommitMultiTableInsert {
                             .await?;
                         for (req, _) in update_table_metas.iter_mut() {
                             if req.table_id == tid {
-                                let (new_req, imperfect_count) = build_update_table_meta_req(
+                                let prepared = build_update_table_meta_req(
                                     table.as_ref(),
                                     snapshot_generators.get(&tid).unwrap(),
                                     self.ctx.txn_mgr(),
@@ -261,8 +267,9 @@ impl AsyncSink for CommitMultiTableInsert {
                                     top_ns.get(&tid).unwrap(),
                                 )
                                 .await?;
-                                *req = new_req;
-                                imperfect_counts.insert(tid, imperfect_count);
+                                *req = prepared.update;
+                                imperfect_counts.insert(tid, prepared.imperfect_count);
+                                logical_deltas.insert(tid, prepared.logical_delta);
                                 break;
                             }
                         }
@@ -345,6 +352,14 @@ fn build_temp_update_multi_table_meta_req(
     }
 }
 
+/// A prepared metadata update and the bookkeeping for that exact candidate.
+struct PreparedTableCommit<T> {
+    update: T,
+    imperfect_count: u64,
+    /// Logical UPDATE/DELETE increments, recorded only after successful commit.
+    logical_delta: (u64, u64),
+}
+
 async fn build_update_temp_table_req(
     table: &dyn Table,
     snapshot_generator: &AppendGenerator,
@@ -353,9 +368,9 @@ async fn build_update_temp_table_req(
     insert_hll: &BlockHLL,
     insert_rows: u64,
     insert_top_n: &BlockTopN,
-) -> Result<(UpdateTempTableReq, u64)> {
+) -> Result<PreparedTableCommit<UpdateTempTableReq>> {
     let table_info = table.get_table_info();
-    let (new_table_meta, imperfect_count) = write_new_snapshot_and_build_table_meta(
+    let prepared = write_new_snapshot_and_build_table_meta(
         table,
         snapshot_generator,
         txn_mgr,
@@ -366,15 +381,16 @@ async fn build_update_temp_table_req(
     )
     .await?;
 
-    Ok((
-        UpdateTempTableReq {
+    Ok(PreparedTableCommit {
+        update: UpdateTempTableReq {
             table_id: table_info.ident.table_id,
-            new_table_meta,
+            new_table_meta: prepared.update,
             copied_files: Default::default(),
             desc: table_info.desc.clone(),
         },
-        imperfect_count,
-    ))
+        imperfect_count: prepared.imperfect_count,
+        logical_delta: prepared.logical_delta,
+    })
 }
 
 async fn build_update_table_meta_req(
@@ -385,9 +401,9 @@ async fn build_update_table_meta_req(
     insert_hll: &BlockHLL,
     insert_rows: u64,
     insert_top_n: &BlockTopN,
-) -> Result<(UpdateTableMetaReq, u64)> {
+) -> Result<PreparedTableCommit<UpdateTableMetaReq>> {
     let fuse_table = FuseTable::try_from_table(table)?;
-    let (new_table_meta, imperfect_count) = write_new_snapshot_and_build_table_meta(
+    let prepared = write_new_snapshot_and_build_table_meta(
         table,
         snapshot_generator,
         txn_mgr,
@@ -403,11 +419,15 @@ async fn build_update_table_meta_req(
     let req = UpdateTableMetaReq {
         table_id,
         seq: MatchSeq::Exact(table_version),
-        new_table_meta,
+        new_table_meta: prepared.update,
         base_snapshot_location: fuse_table.snapshot_loc(),
         lvt_check: None,
     };
-    Ok((req, imperfect_count))
+    Ok(PreparedTableCommit {
+        update: req,
+        imperfect_count: prepared.imperfect_count,
+        logical_delta: prepared.logical_delta,
+    })
 }
 
 async fn write_new_snapshot_and_build_table_meta(
@@ -418,7 +438,7 @@ async fn write_new_snapshot_and_build_table_meta(
     insert_hll: &BlockHLL,
     insert_rows: u64,
     insert_top_n: &BlockTopN,
-) -> Result<(TableMeta, u64)> {
+) -> Result<PreparedTableCommit<TableMeta>> {
     let fuse_table = FuseTable::try_from_table(table)?;
     let previous = fuse_table.read_table_snapshot().await?;
     // Match single-table commits: transaction commits may collapse intermediate snapshot
@@ -435,6 +455,7 @@ async fn write_new_snapshot_and_build_table_meta(
         .await?;
     let mut table_statistics = table_stats_gen.take_table_statistics();
     let table_info = table.get_table_info();
+    let logical_delta = snapshot_generator.logical_change_delta(&previous);
     let snapshot = snapshot_generator.generate_new_snapshot(
         table_info,
         fuse_table.cluster_key_info(),
@@ -460,10 +481,11 @@ async fn write_new_snapshot_and_build_table_meta(
             .await?;
     }
 
-    Ok((
-        FuseTable::build_new_table_meta(&fuse_table.table_info.meta, &location, &snapshot),
+    Ok(PreparedTableCommit {
+        update: FuseTable::build_new_table_meta(&fuse_table.table_info.meta, &location, &snapshot),
         imperfect_count,
-    ))
+        logical_delta,
+    })
 }
 
 #[cfg(test)]

--- a/src/query/storages/fuse/src/operations/common/processors/sink_commit.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/sink_commit.rs
@@ -86,6 +86,7 @@ enum State {
         table_info: TableInfo,
     },
     TryCommit {
+        logical_delta: (u64, u64),
         data: Vec<u8>,
         snapshot: TableSnapshot,
         table_info: TableInfo,
@@ -509,6 +510,7 @@ where F: SnapshotGenerator + Send + Sync + 'static
                 // therefore, we can safely proceed.
 
                 let mut table_statistics = table_stats_gen.take_table_statistics();
+                let logical_delta = self.snapshot_gen.logical_change_delta(&previous);
                 match self.snapshot_gen.generate_new_snapshot(
                     &table_info,
                     cluster_key_info,
@@ -523,6 +525,7 @@ where F: SnapshotGenerator + Send + Sync + 'static
                             &snapshot,
                         );
                         self.state = State::TryCommit {
+                            logical_delta,
                             data: snapshot.to_bytes()?,
                             snapshot,
                             table_info,
@@ -630,6 +633,7 @@ where F: SnapshotGenerator + Send + Sync + 'static
                 }
             }
             State::TryCommit {
+                logical_delta,
                 data,
                 snapshot,
                 table_info,
@@ -724,6 +728,10 @@ where F: SnapshotGenerator + Send + Sync + 'static
 
                 match commit_result {
                     Ok(_) => {
+                        self.ctx
+                            .txn_mgr()
+                            .lock()
+                            .add_logical_change_delta(table_info.ident.table_id, logical_delta);
                         set_compaction_num_block_hint(
                             self.ctx.as_ref(),
                             &table_info,

--- a/src/query/storages/fuse/src/retry/commit.rs
+++ b/src/query/storages/fuse/src/retry/commit.rs
@@ -328,6 +328,9 @@ async fn try_rebuild_req(
             None,
             table_meta_timestamps,
         )?;
+        // Missing/overflowed bookkeeping must not become a trusted zero. This
+        // fallback protects epoch-aware readers, not unrestricted old-reader
+        // mixed mode: an older writer may recreate zero counters afterward.
         match logical_delta {
             Some((updated, deleted)) => merged_snapshot.add_logical_change_delta(updated, deleted),
             None => merged_snapshot.invalidate_logical_change_counters(),

--- a/src/query/storages/fuse/src/retry/commit.rs
+++ b/src/query/storages/fuse/src/retry/commit.rs
@@ -222,10 +222,8 @@ async fn try_rebuild_req(
                 ErrorCode::Internal(format!("Missing original snapshot for table {}", tid))
             })?
             .clone();
-        // `new_snapshot` is generated directly from `base_snapshot`, so this
-        // transaction's own increments are the difference between the two. When
-        // the base could not prove counter continuity, `new_snapshot` started a
-        // fresh history and its totals already are those increments.
+        // Recover all changes accumulated by this transaction from its original
+        // base, including any intermediate snapshots.
         let new_counters = new_snapshot
             .as_ref()
             .and_then(|snapshot| snapshot.logical_change_counters())
@@ -234,7 +232,7 @@ async fn try_rebuild_req(
             .as_ref()
             .and_then(|snapshot| snapshot.logical_change_counters());
         let (logical_updated_rows, logical_deleted_rows) =
-            new_counters.increments_since(base_counters.as_ref())?;
+            new_counters.transaction_delta_from(base_counters.as_ref())?;
 
         let s = merge_statistics(
             new_snapshot.summary(),
@@ -333,7 +331,7 @@ async fn try_rebuild_req(
             None,
             table_meta_timestamps,
         )?;
-        merged_snapshot.add_logical_change_delta(logical_updated_rows, logical_deleted_rows);
+        merged_snapshot.add_logical_change_delta(logical_updated_rows, logical_deleted_rows)?;
         merged_snapshot.ensure_segments_unique()?;
 
         // write snapshot

--- a/src/query/storages/fuse/src/retry/commit.rs
+++ b/src/query/storages/fuse/src/retry/commit.rs
@@ -226,13 +226,14 @@ async fn try_rebuild_req(
         // base, including any intermediate snapshots.
         let new_counters = new_snapshot
             .as_ref()
-            .and_then(|snapshot| snapshot.logical_change_counters())
-            .ok_or_else(|| ErrorCode::Internal("new snapshot lacks logical change counters"))?;
+            .and_then(|snapshot| snapshot.logical_change_counters());
         let base_counters = base_snapshot
             .as_ref()
             .and_then(|snapshot| snapshot.logical_change_counters());
-        let (logical_updated_rows, logical_deleted_rows) =
-            new_counters.transaction_delta_from(base_counters.as_ref())?;
+        let logical_delta = match new_counters {
+            Some(counters) => counters.transaction_delta_from(base_counters.as_ref())?,
+            None => None,
+        };
 
         let s = merge_statistics(
             new_snapshot.summary(),
@@ -331,7 +332,10 @@ async fn try_rebuild_req(
             None,
             table_meta_timestamps,
         )?;
-        merged_snapshot.add_logical_change_delta(logical_updated_rows, logical_deleted_rows)?;
+        match logical_delta {
+            Some((updated, deleted)) => merged_snapshot.add_logical_change_delta(updated, deleted),
+            None => merged_snapshot.invalidate_logical_change_counters(),
+        }
         merged_snapshot.ensure_segments_unique()?;
 
         // write snapshot

--- a/src/query/storages/fuse/src/retry/commit.rs
+++ b/src/query/storages/fuse/src/retry/commit.rs
@@ -230,9 +230,11 @@ async fn try_rebuild_req(
         let base_counters = base_snapshot
             .as_ref()
             .and_then(|snapshot| snapshot.logical_change_counters());
-        let logical_delta = match new_counters {
-            Some(counters) => counters.transaction_delta_from(base_counters.as_ref())?,
-            None => None,
+        // A reset can discard changes from earlier statements. Only comparable
+        // endpoints prove the full transaction delta; otherwise invalidate below.
+        let logical_delta = match (new_counters, base_counters) {
+            (Some(new), Some(base)) => new.delta_from(&base)?,
+            _ => None,
         };
 
         let s = merge_statistics(

--- a/src/query/storages/fuse/src/retry/commit.rs
+++ b/src/query/storages/fuse/src/retry/commit.rs
@@ -57,6 +57,9 @@ pub async fn commit_with_backoff(
     // Also cache the original snapshots for statistics merging.
     let (table_segments_diffs, table_original_snapshots) =
         compute_table_segments_diffs(ctx.clone(), &req).await?;
+    // Snapshot counters may lack epochs or restart. Retry the same complete
+    // transaction delta, recorded only after each write was successfully buffered.
+    let logical_deltas = ctx.txn_mgr().lock().logical_change_deltas();
 
     loop {
         let ret = catalog
@@ -80,6 +83,7 @@ pub async fn commit_with_backoff(
             update_failed_tbls,
             &table_segments_diffs,
             &table_original_snapshots,
+            &logical_deltas,
         )
         .await?;
     }
@@ -157,6 +161,7 @@ async fn try_rebuild_req(
     update_failed_tbls: Vec<(u64, u64, TableMeta)>,
     table_segments_diffs: &HashMap<u64, SegmentsDiff>,
     table_original_snapshots: &HashMap<u64, Option<Arc<TableSnapshot>>>,
+    logical_deltas: &HashMap<u64, Option<(u64, u64)>>,
 ) -> Result<()> {
     info!(
         "try_rebuild_req: update_failed_tbls={:?}",
@@ -222,20 +227,9 @@ async fn try_rebuild_req(
                 ErrorCode::Internal(format!("Missing original snapshot for table {}", tid))
             })?
             .clone();
-        // Recover all changes accumulated by this transaction from its original
-        // base, including any intermediate snapshots.
-        let new_counters = new_snapshot
-            .as_ref()
-            .and_then(|snapshot| snapshot.logical_change_counters());
-        let base_counters = base_snapshot
-            .as_ref()
-            .and_then(|snapshot| snapshot.logical_change_counters());
-        // A reset can discard changes from earlier statements. Only comparable
-        // endpoints prove the full transaction delta; otherwise invalidate below.
-        let logical_delta = match (new_counters, base_counters) {
-            (Some(new), Some(base)) => new.delta_from(&base)?,
-            _ => None,
-        };
+        // Missing/overflowed transaction bookkeeping is unknown, not zero.
+        // In particular, an epochless base no longer invalidates a known delta.
+        let logical_delta = logical_deltas.get(&tid).copied().flatten();
 
         let s = merge_statistics(
             new_snapshot.summary(),

--- a/src/query/storages/fuse/src/retry/commit.rs
+++ b/src/query/storages/fuse/src/retry/commit.rs
@@ -222,18 +222,19 @@ async fn try_rebuild_req(
                 ErrorCode::Internal(format!("Missing original snapshot for table {}", tid))
             })?
             .clone();
-        // `new_snapshot` is generated directly from `base_snapshot`. A legacy
-        // base has no counters, while its counter-aware child starts from zero.
-        let (new_updated_rows, new_deleted_rows) = new_snapshot
+        // `new_snapshot` is generated directly from `base_snapshot`, so this
+        // transaction's own increments are the difference between the two. When
+        // the base could not prove counter continuity, `new_snapshot` started a
+        // fresh history and its totals already are those increments.
+        let new_counters = new_snapshot
             .as_ref()
             .and_then(|snapshot| snapshot.logical_change_counters())
             .ok_or_else(|| ErrorCode::Internal("new snapshot lacks logical change counters"))?;
-        let (base_updated_rows, base_deleted_rows) = base_snapshot
+        let base_counters = base_snapshot
             .as_ref()
-            .and_then(|snapshot| snapshot.logical_change_counters())
-            .unwrap_or_default();
-        let logical_updated_rows = new_updated_rows - base_updated_rows;
-        let logical_deleted_rows = new_deleted_rows - base_deleted_rows;
+            .and_then(|snapshot| snapshot.logical_change_counters());
+        let (logical_updated_rows, logical_deleted_rows) =
+            new_counters.increments_since(base_counters.as_ref())?;
 
         let s = merge_statistics(
             new_snapshot.summary(),

--- a/tests/sqllogictests/src/client/mod.rs
+++ b/tests/sqllogictests/src/client/mod.rs
@@ -23,7 +23,6 @@ use std::fmt;
 pub use http_client::HttpClient;
 pub use mysql_client::MySQLClient;
 use rand::Rng;
-use rand::distributions::Alphanumeric;
 use regex::Regex;
 use sqllogictest::DBOutput;
 pub use ttc_client::TTCClient;
@@ -82,13 +81,9 @@ impl Client {
         }
     }
 
-    // Create sandbox tenant and create default database for the tenant
-    pub async fn create_sandbox(&mut self) -> Result<()> {
-        let sandbox_name: String = rand::thread_rng()
-            .sample_iter(&Alphanumeric)
-            .take(7)
-            .map(char::from)
-            .collect();
+    // Join the runner-selected sandbox and initialize its default database.
+    // Connections in one file share a tenant, not session or transaction state.
+    pub async fn init_sandbox(&mut self, sandbox_name: &str) -> Result<()> {
         self.query(format!("set sandbox_tenant = \'{sandbox_name}\'").as_str())
             .await?;
         self.query("create database if not exists default").await?;

--- a/tests/sqllogictests/src/main.rs
+++ b/tests/sqllogictests/src/main.rs
@@ -22,6 +22,7 @@ use client::TTCClient;
 use futures_util::StreamExt;
 use futures_util::stream;
 use rand::Rng;
+use rand::distributions::Alphanumeric;
 use sqllogictest::DBOutput;
 use sqllogictest::Location;
 use sqllogictest::QueryExpect;
@@ -223,9 +224,25 @@ async fn run_hybrid_client(
     Ok(())
 }
 
+// Allocate once per file execution, not per connection or derived from its path.
+// Re-running the same file in another CI job also gets an independent random name.
+fn new_sandbox_name(enabled: bool) -> Option<String> {
+    enabled.then(|| {
+        rand::thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(16)
+            .map(char::from)
+            .collect()
+    })
+}
+
 // Create new databend with client type
 #[async_recursion::async_recursion(#[recursive::recursive])]
-async fn create_databend(client_type: &ClientType, filename: &str) -> Result<Databend> {
+async fn create_databend(
+    client_type: &ClientType,
+    filename: &str,
+    sandbox_name: Option<&str>,
+) -> Result<Databend> {
     let mut client: Client;
     let args = SqlLogicTestArgs::parse();
     match client_type {
@@ -259,14 +276,14 @@ async fn create_databend(client_type: &ClientType, filename: &str) -> Result<Dat
                 acc += s;
 
                 if acc >= r {
-                    return create_databend(t.as_ref(), filename).await;
+                    return create_databend(t.as_ref(), filename, sandbox_name).await;
                 }
             }
             unreachable!()
         }
     }
-    if args.enable_sandbox {
-        client.create_sandbox().await?;
+    if let Some(sandbox_name) = sandbox_name {
+        client.init_sandbox(sandbox_name).await?;
     }
     if args.debug {
         client.enable_debug();
@@ -318,8 +335,10 @@ async fn run_suits(args: SqlLogicTestArgs, client_type: ClientType) -> Result<()
 
             let col_separator = " ";
             let validator = default_validator;
-            let mut runner =
-                Runner::new(|| async { create_databend(&client_type, &file_name).await });
+            let sandbox_name = new_sandbox_name(args.enable_sandbox);
+            let mut runner = Runner::new(|| async {
+                create_databend(&client_type, &file_name, sandbox_name.as_deref()).await
+            });
             // todo: The behavior of normalizer for multi line string is incorrect
             runner
                 .update_test_file(
@@ -421,11 +440,15 @@ async fn run_file_async(
     let start = Instant::now();
 
     let mut error_records = vec![];
-    let no_fail_fast = SqlLogicTestArgs::parse().no_fail_fast;
+    let args = SqlLogicTestArgs::parse();
+    let no_fail_fast = args.no_fail_fast;
+    let sandbox_name = new_sandbox_name(args.enable_sandbox);
     let records = parse_file(&filename).unwrap();
     let filename = filename.as_ref().to_str().unwrap();
 
-    let mut runner = Runner::new(|| async { create_databend(client_type, filename).await });
+    let mut runner = Runner::new(|| async {
+        create_databend(client_type, filename, sandbox_name.as_deref()).await
+    });
     for record in records.into_iter() {
         if let Record::Halt { .. } = record {
             break;

--- a/tests/sqllogictests/suites/query/logical_change_retry.test
+++ b/tests/sqllogictests/suites/query/logical_change_retry.test
@@ -1,0 +1,187 @@
+# Named connections share the file's sandbox, but retain independent sessions.
+# `connection` applies only to the immediately following statement/query.
+# Default connection = transaction A; writer = independently committing B.
+# No sleeps or client retries: B commits after A has buffered a stale version.
+
+statement ok
+CREATE DATABASE logical_change_retry
+
+statement ok
+USE logical_change_retry
+
+connection writer
+statement ok
+USE logical_change_retry
+
+# Disable maintenance hooks to keep concurrent appends from rewriting base segments.
+statement ok
+SET auto_compaction_imperfect_blocks_threshold = 0
+
+statement ok
+SET enable_auto_analyze = 0
+
+connection writer
+statement ok
+SET auto_compaction_imperfect_blocks_threshold = 0
+
+connection writer
+statement ok
+SET enable_auto_analyze = 0
+
+statement ok
+CREATE TABLE t1(id INT)
+
+statement ok
+CREATE TABLE t2(id INT)
+
+statement ok
+INSERT INTO t1 VALUES (1), (2)
+
+statement ok
+INSERT INTO t2 VALUES (1), (2)
+
+# ANALYZE buffers metadata without logical changes; concurrent append forces rebasing.
+statement ok
+BEGIN
+
+statement ok
+ANALYZE TABLE t1
+
+connection writer
+statement ok
+INSERT INTO t1 VALUES (3)
+
+statement ok
+COMMIT
+
+query I
+SELECT id FROM t1 ORDER BY id
+----
+1
+2
+3
+
+# Multi-table INSERT preserves its own rows and the concurrent append.
+statement ok
+BEGIN
+
+statement ok
+INSERT ALL INTO t1 INTO t2 SELECT 4
+
+connection writer
+statement ok
+INSERT INTO t2 VALUES (5)
+
+statement ok
+COMMIT
+
+query I
+SELECT id FROM t1 ORDER BY id
+----
+1
+2
+3
+4
+
+query I
+SELECT id FROM t2 ORDER BY id
+----
+1
+2
+4
+5
+
+# OVERWRITE replaces original segments; B's appended segment survives the merge.
+statement ok
+BEGIN
+
+statement ok
+INSERT OVERWRITE ALL INTO t1 INTO t2 SELECT 9
+
+connection writer
+statement ok
+INSERT INTO t2 VALUES (6)
+
+statement ok
+COMMIT
+
+query I
+SELECT id FROM t1 ORDER BY id
+----
+9
+
+query I
+SELECT id FROM t2 ORDER BY id
+----
+6
+9
+
+# Multiple single-table mutations are applied exactly once on retry.
+statement ok
+BEGIN
+
+statement ok
+UPDATE t2 SET id = 60 WHERE id = 6
+
+statement ok
+DELETE FROM t2 WHERE id = 9
+
+connection writer
+statement ok
+INSERT INTO t2 VALUES (7)
+
+statement ok
+COMMIT
+
+query I
+SELECT id FROM t2 ORDER BY id
+----
+7
+60
+
+statement ok
+BEGIN
+
+statement ok
+DELETE FROM t2
+
+statement ok
+ROLLBACK
+
+query I
+SELECT id FROM t2 ORDER BY id
+----
+7
+60
+
+# Reuse A after rollback; the discarded transaction must not affect this commit.
+statement ok
+BEGIN
+
+statement ok
+INSERT INTO t2 VALUES (8)
+
+connection writer
+statement ok
+INSERT INTO t2 VALUES (10)
+
+statement ok
+COMMIT
+
+query I
+SELECT id FROM t2 ORDER BY id
+----
+7
+8
+10
+60
+
+connection writer
+statement ok
+USE default
+
+statement ok
+USE default
+
+statement ok
+DROP DATABASE logical_change_retry

--- a/tests/sqllogictests/suites/query/logical_change_retry.test
+++ b/tests/sqllogictests/suites/query/logical_change_retry.test
@@ -1,7 +1,6 @@
 # Named connections share the file's sandbox, but retain independent sessions.
 # `connection` applies only to the immediately following statement/query.
-# Default connection = transaction A; writer = independently committing B.
-# No sleeps or client retries: B commits after A has buffered a stale version.
+# ANALYZE and multi-table counter assertions live in the Rust integration test.
 
 statement ok
 CREATE DATABASE logical_change_retry
@@ -13,7 +12,7 @@ connection writer
 statement ok
 USE logical_change_retry
 
-# Disable maintenance hooks to keep concurrent appends from rewriting base segments.
+# Keep the concurrent append from rewriting the transaction's base segments.
 statement ok
 SET auto_compaction_imperfect_blocks_threshold = 0
 
@@ -29,112 +28,30 @@ statement ok
 SET enable_auto_analyze = 0
 
 statement ok
-CREATE TABLE t1(id INT)
+CREATE TABLE t(id INT)
 
 statement ok
-CREATE TABLE t2(id INT)
+INSERT INTO t VALUES (6), (9)
 
-statement ok
-INSERT INTO t1 VALUES (1), (2)
-
-statement ok
-INSERT INTO t2 VALUES (1), (2)
-
-# ANALYZE buffers metadata without logical changes; concurrent append forces rebasing.
+# B commits after A buffers mutations, forcing a version conflict without sleeps.
 statement ok
 BEGIN
 
 statement ok
-ANALYZE TABLE t1
+UPDATE t SET id = 60 WHERE id = 6
+
+statement ok
+DELETE FROM t WHERE id = 9
 
 connection writer
 statement ok
-INSERT INTO t1 VALUES (3)
+INSERT INTO t VALUES (7)
 
 statement ok
 COMMIT
 
 query I
-SELECT id FROM t1 ORDER BY id
-----
-1
-2
-3
-
-# Multi-table INSERT preserves its own rows and the concurrent append.
-statement ok
-BEGIN
-
-statement ok
-INSERT ALL INTO t1 INTO t2 SELECT 4
-
-connection writer
-statement ok
-INSERT INTO t2 VALUES (5)
-
-statement ok
-COMMIT
-
-query I
-SELECT id FROM t1 ORDER BY id
-----
-1
-2
-3
-4
-
-query I
-SELECT id FROM t2 ORDER BY id
-----
-1
-2
-4
-5
-
-# OVERWRITE replaces original segments; B's appended segment survives the merge.
-statement ok
-BEGIN
-
-statement ok
-INSERT OVERWRITE ALL INTO t1 INTO t2 SELECT 9
-
-connection writer
-statement ok
-INSERT INTO t2 VALUES (6)
-
-statement ok
-COMMIT
-
-query I
-SELECT id FROM t1 ORDER BY id
-----
-9
-
-query I
-SELECT id FROM t2 ORDER BY id
-----
-6
-9
-
-# Multiple single-table mutations are applied exactly once on retry.
-statement ok
-BEGIN
-
-statement ok
-UPDATE t2 SET id = 60 WHERE id = 6
-
-statement ok
-DELETE FROM t2 WHERE id = 9
-
-connection writer
-statement ok
-INSERT INTO t2 VALUES (7)
-
-statement ok
-COMMIT
-
-query I
-SELECT id FROM t2 ORDER BY id
+SELECT id FROM t ORDER BY id
 ----
 7
 60
@@ -143,33 +60,33 @@ statement ok
 BEGIN
 
 statement ok
-DELETE FROM t2
+DELETE FROM t
 
 statement ok
 ROLLBACK
 
 query I
-SELECT id FROM t2 ORDER BY id
+SELECT id FROM t ORDER BY id
 ----
 7
 60
 
-# Reuse A after rollback; the discarded transaction must not affect this commit.
+# Reuse A after rollback; discarded writes must not affect this commit.
 statement ok
 BEGIN
 
 statement ok
-INSERT INTO t2 VALUES (8)
+INSERT INTO t VALUES (8)
 
 connection writer
 statement ok
-INSERT INTO t2 VALUES (10)
+INSERT INTO t VALUES (10)
 
 statement ok
 COMMIT
 
 query I
-SELECT id FROM t2 ORDER BY id
+SELECT id FROM t ORDER BY id
 ----
 7
 8


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Prevent discontinuous logical change counters from being interpreted as evidence that no UPDATE or DELETE occurred.

Previously, a legacy writer could drop the counters, and a newer writer would restart them from zero. Comparing that snapshot with an earlier zero-valued checkpoint could incorrectly optimize Standard changes into AppendOnly, omitting DELETE rows and UPDATE pairs. A nonzero checkpoint could instead cause a counter-decrease error.

This affects Standard Streams and the shared changes paths used by materialized view refresh and hybrid reads. Incorrect AppendOnly selection can cause an MV to append changes when it should merge, rebuild, or fall back to live computation.

### Changes

- Add an optional table-seq-based `epoch` to `LogicalChangeCounters`. Compare counters only when both endpoints have the same known epoch; otherwise use the existing conservative fallback paths.
- Preserve existing cumulative totals when upgrading a snapshot that has counters but no epoch. Assign a new epoch without resetting those totals, avoiding a reset visible to older counter-aware readers.
- Initialize totals to zero when there are no predecessor counters. Descendants within the newly established epoch can use the optimization again; it is not permanently disabled for the table.
- On counter overflow, restart both totals with the current operation's increments. Use a fresh table seq as the epoch when available; otherwise mark the epoch unknown.
- Transaction retry must apply the complete per-table transaction delta, not infer it solely from snapshot epochs. The local follow-up records deltas after successful buffering, reuses them across retries, and registers ANALYZE as a known zero delta. Missing or overflowed bookkeeping still invalidates the merged counters; unknown increments must not be treated as zero.

Unknown history may make non-aggregate MV refreshes use MERGE, aggregate refreshes rebuild, and stale MV reads fall back to live computation. These are conservative execution paths rather than evidence of an empty delta.

### Compatibility

The optional field is compatible with the existing named MessagePack snapshot encoding: older readers ignore it, and newer readers default a missing epoch to unknown.

The compatibility scope is ordinary upgrades and non-overflowing writer handoffs. This is not a guarantee of unrestricted mixed-version safety. Older counter-aware readers ignore epochs: overflow resets, transaction-delta overflow, or invalidation caused by missing bookkeeping can still break the cumulative history they rely on. These exceptional paths require all counter consumers to understand epochs before they can be considered safe.

### Follow-up validation

Local follow-up changes (not yet pushed) add:

- A Rust integration case for an epochless checkpoint, actual transaction conflicts, cumulative-counter checks, and internal zero/overwrite-delta registration.
- A sqllogictest using named connections for ANALYZE, multi-table INSERT/OVERWRITE, UPDATE/DELETE conflicts, and rollback/session reuse. Connections in the same test file share one sandbox tenant in both normal and --complete modes; independent sessions force version conflicts without sleeps or client-side retries.

These tests have not been compiled or executed. The sqllogictest checks SQL-visible results, not legacy-reader counter semantics. The Rust case exercises conflicts in separate transactions; repeated conflicts within one COMMIT and a full old/new-binary compatibility run remain unverified.

Closes #20480.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_


## Type of change

- [ ] Documentation Update
- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent analysed the issue, traced the four affected sites, and drafted
  this description.
- Responsible human: @zhyass
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20481)
<!-- Reviewable:end -->
