### PR TITLE
refactor(storage): separate recluster sort and merge tasks

### DIFF
--- a/src/query/catalog/src/plan/partition.rs
+++ b/src/query/catalog/src/plan/partition.rs
@@ -455,6 +455,21 @@ impl ClusterLevelLogStats {
     }
 }
 
+/// Work performed by the row-sort stage of a recluster task.
+///
+/// Task plans are exchanged only between query processes running the same version;
+/// this enum is not part of persisted FUSE metadata.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum ReclusterTaskKind {
+    /// Establish row order. For ordinary linear FUSE tasks, the inputs are one
+    /// unordered block or a size-bounded group of small blocks. Other layouts
+    /// retain their layout-specific sorting and re-aggregation semantics.
+    SortBlocks,
+    /// Merge blocks already ordered by the current linear cluster key, without
+    /// sorting their rows again.
+    MergeBlocks,
+}
+
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct ReclusterTask {
     pub parts: Partitions,
@@ -467,9 +482,7 @@ pub struct ReclusterTask {
     /// Effective input levels under the current cluster key, not historical stored levels.
     #[serde(default)]
     pub input_level_stats: Vec<ClusterLevelLogStats>,
-    // All input blocks in this task are already ordered by the current cluster key.
-    #[serde(default)]
-    pub all_ordered: bool,
+    pub kind: ReclusterTaskKind,
     pub virtual_column_layout: Option<VirtualColumnLayout>,
 }
 

--- a/src/query/service/src/physical_plans/physical_recluster.rs
+++ b/src/query/service/src/physical_plans/physical_recluster.rs
@@ -24,6 +24,7 @@ use databend_common_catalog::plan::BlockMetaOptions;
 use databend_common_catalog::plan::DataSourceInfo;
 use databend_common_catalog::plan::DataSourcePlan;
 use databend_common_catalog::plan::ReclusterTask;
+use databend_common_catalog::plan::ReclusterTaskKind;
 use databend_common_catalog::table::Table;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
@@ -39,6 +40,7 @@ use databend_common_meta_app::schema::TableInfo;
 use databend_common_metrics::storage::metrics_inc_recluster_block_bytes_to_read;
 use databend_common_metrics::storage::metrics_inc_recluster_block_nums_to_read;
 use databend_common_metrics::storage::metrics_inc_recluster_row_nums_to_read;
+use databend_common_pipeline::core::Pipeline;
 use databend_common_pipeline::core::ProcessorPtr;
 use databend_common_pipeline::sources::EmptySource;
 use databend_common_pipeline_transforms::OrderedBlockCompactBuilder;
@@ -130,6 +132,11 @@ impl IPhysicalPlan for Recluster {
                 let table = FuseTable::try_from_table(table.as_ref())?;
 
                 let task = &self.tasks[0];
+                if task.parts.is_empty() {
+                    return Err(ErrorCode::Internal(
+                        "recluster task must have source blocks",
+                    ));
+                }
                 let settings = builder.ctx.get_settings();
                 // Execution-time guard: planning-time admission runs on the
                 // coordinator and cannot see this node's live memory pressure.
@@ -179,6 +186,7 @@ impl IPhysicalPlan for Recluster {
                     log::info!(
                         event = "recluster.input_planned",
                         table_id = table.get_id(),
+                        task_kind :? = task.kind,
                         input_levels :serde = task.input_level_stats;
                         "Recluster input planned"
                     );
@@ -239,8 +247,14 @@ impl IPhysicalPlan for Recluster {
                     .set_rows_per_block(rows_per_block)
                     .set_bytes_per_block(bytes_per_block);
 
+                if task.kind == ReclusterTaskKind::MergeBlocks && !cluster_stats_gen.is_linear() {
+                    return Err(ErrorCode::Internal(
+                        "MergeBlocks requires linear cluster keys",
+                    ));
+                }
+
                 if cluster_stats_gen.is_hilbert() {
-                    build_hilbert_layout_pipeline(
+                    Self::build_hilbert_layout_pipeline(
                         builder,
                         task,
                         &mut cluster_stats_gen,
@@ -249,7 +263,7 @@ impl IPhysicalPlan for Recluster {
                         max_threads,
                     )?;
                 } else {
-                    build_regular_layout_pipeline(
+                    Self::build_regular_layout_pipeline(
                         builder,
                         task,
                         &cluster_stats_gen,
@@ -319,144 +333,210 @@ impl IPhysicalPlan for Recluster {
     }
 }
 
-fn build_hilbert_layout_pipeline(
-    builder: &mut PipelineBuilder,
-    task: &ReclusterTask,
-    cluster_stats_gen: &mut ClusterStatsGenerator,
-    rows_per_block: usize,
-    compact_thresholds: BlockThresholds,
-    max_threads: usize,
-) -> Result<()> {
-    let dimension_offsets = cluster_stats_gen.hilbert_dimension_offsets()?;
-    let worker_count = builder.main_pipeline.output_len().max(1);
-    let target_blocks = task.total_rows.div_ceil(rows_per_block).max(1);
-    let num_collectors = max_threads
-        .min(target_blocks)
-        .clamp(1, u8::MAX as usize + 1);
-    let exchange = HilbertRangeExchange::create(
-        dimension_offsets,
-        task.total_rows,
-        worker_count,
-        num_collectors,
-    );
+impl Recluster {
+    fn build_hilbert_layout_pipeline(
+        builder: &mut PipelineBuilder,
+        task: &ReclusterTask,
+        cluster_stats_gen: &mut ClusterStatsGenerator,
+        rows_per_block: usize,
+        compact_thresholds: BlockThresholds,
+        max_threads: usize,
+    ) -> Result<()> {
+        let dimension_offsets = cluster_stats_gen.hilbert_dimension_offsets()?;
+        let worker_count = builder.main_pipeline.output_len().max(1);
+        let target_blocks = task.total_rows.div_ceil(rows_per_block).max(1);
+        let num_collectors = max_threads.min(target_blocks);
+        let num_collectors = num_collectors.clamp(1, u8::MAX as usize + 1);
+        let exchange = HilbertRangeExchange::create(
+            dimension_offsets,
+            task.total_rows,
+            worker_count,
+            num_collectors,
+        );
 
-    // The barrier uses the complete sort spill policy, including the sort-spill enable switch;
-    // the configured sort batch size controls each oldest-first spill unit.
-    let spiller = ReclusterSpiller::create(builder.ctx.clone())?;
+        // The barrier uses the complete sort spill policy, including the sort-spill enable switch;
+        // the configured sort batch size controls each oldest-first spill unit.
+        let spiller = ReclusterSpiller::create(builder.ctx.clone())?;
 
-    // Every input stream samples locally, then all streams replay against one immutable task-local
-    // weighted range plan.
-    let worker_id = AtomicUsize::new(0);
-    let range_exchange = exchange.clone();
-    builder.main_pipeline.add_transform(move |input, output| {
-        let id = worker_id.fetch_add(1, Ordering::Relaxed);
-        let memory_settings = spiller.memory_settings().clone();
-        Ok(ProcessorPtr::create(TransformHilbertCluster::<
-            ReclusterSpiller,
-        >::create(
-            input,
-            output,
-            exchange.clone(),
-            id,
-            spiller.clone(),
-            memory_settings,
-        )))
-    })?;
+        // Every input stream samples locally, then all streams replay against one immutable task-local
+        // weighted range plan.
+        let worker_id = AtomicUsize::new(0);
+        let range_exchange = exchange.clone();
+        let pipeline = &mut builder.main_pipeline;
+        pipeline.add_transform(move |input, output| {
+            let id = worker_id.fetch_add(1, Ordering::Relaxed);
+            let memory_settings = spiller.memory_settings().clone();
+            Ok(ProcessorPtr::create(TransformHilbertCluster::create(
+                input,
+                output,
+                exchange.clone(),
+                id,
+                spiller.clone(),
+                memory_settings,
+            )))
+        })?;
 
-    builder.main_pipeline.try_resize(num_collectors)?;
-    builder
-        .main_pipeline
-        .exchange(num_collectors, range_exchange)?;
+        pipeline.try_resize(num_collectors)?;
+        pipeline.exchange(num_collectors, range_exchange)?;
 
-    // Each collector owns a disjoint Hilbert-key interval. Sort only inside that interval, then
-    // compact locally so every output block covers a continuous key range without a global merge.
-    let mut sort_fields = cluster_stats_gen.out_fields.clone();
-    let hilbert_value_offset = sort_fields.len();
-    sort_fields.push(DataField::new(
-        "_task_hilbert_value",
-        DataType::Number(NumberDataType::UInt32),
-    ));
-    let sort_schema = DataSchemaRefExt::create(sort_fields);
-    let sort_desc = vec![SortColumnDescription {
-        offset: hilbert_value_offset,
-        asc: true,
-        nulls_first: false,
-    }];
-    SortPipelineBuilder::create(
-        builder.ctx.clone(),
-        sort_schema,
-        sort_desc.into(),
-        None,
-        builder.ctx.get_settings().get_enable_fixed_rows_sort()?,
-    )?
-    .with_block_size_hit(rows_per_block)
-    .build_local_full_sort_pipeline(&mut builder.main_pipeline, false)?;
+        // Each collector owns a disjoint Hilbert-key interval. Sort only inside that interval, then
+        // compact locally so every output block covers a continuous key range without a global merge.
+        let mut sort_fields = cluster_stats_gen.out_fields.clone();
+        let hilbert_value_offset = sort_fields.len();
+        sort_fields.push(DataField::new(
+            "_task_hilbert_value",
+            DataType::Number(NumberDataType::UInt32),
+        ));
+        let sort_schema = DataSchemaRefExt::create(sort_fields);
+        let sort_desc = vec![SortColumnDescription {
+            offset: hilbert_value_offset,
+            asc: true,
+            nulls_first: false,
+        }];
+        SortPipelineBuilder::create(
+            builder.ctx.clone(),
+            sort_schema,
+            sort_desc.into(),
+            None,
+            builder.ctx.get_settings().get_enable_fixed_rows_sort()?,
+        )?
+        .with_block_size_hit(rows_per_block)
+        .build_local_full_sort_pipeline(pipeline, false)?;
 
-    // The ordinary cluster statistics generator removes all trailing temporary columns before
-    // serialization; include the task-local Hilbert sort key.
-    cluster_stats_gen.extra_key_num += 1;
-    let extra_key_num = cluster_stats_gen.extra_key_num;
-    builder.main_pipeline.add_accumulating_transformer(move || {
-        OrderedBlockCompactBuilder::new(compact_thresholds, extra_key_num)
-    });
-    builder
-        .main_pipeline
-        .add_block_meta_transformer(|| TransformCompactBlock);
-    Ok(())
-}
+        // The ordinary cluster statistics generator removes all trailing temporary columns before
+        // serialization; include the task-local Hilbert sort key.
+        cluster_stats_gen.extra_key_num += 1;
+        let extra_key_num = cluster_stats_gen.extra_key_num;
+        pipeline.add_accumulating_transformer(move || {
+            OrderedBlockCompactBuilder::new(compact_thresholds, extra_key_num)
+        });
+        pipeline.add_block_meta_transformer(|| TransformCompactBlock);
+        Ok(())
+    }
 
-fn build_regular_layout_pipeline(
-    builder: &mut PipelineBuilder,
-    task: &ReclusterTask,
-    cluster_stats_gen: &ClusterStatsGenerator,
-    rows_per_block: usize,
-    compact_thresholds: BlockThresholds,
-    max_threads: usize,
-) -> Result<()> {
-    if let Some(vector_operator) = cluster_stats_gen.vector_operator() {
-        let vector_column_input_offset = vector_operator.vector_column_input_offset;
-        let dimension = vector_operator.info.dimension;
-        let distance_type = vector_operator.info.distance_type;
+    fn build_recluster_sort_pipeline(
+        kind: ReclusterTaskKind,
+        sort: SortPipelineBuilder,
+        pipeline: &mut Pipeline,
+    ) -> Result<()> {
+        match kind {
+            ReclusterTaskKind::SortBlocks => {
+                // Establish order in the input fragments, then merge them using the
+                // existing full-sort builder, including its spill support.
+                sort.build_full_sort_pipeline(pipeline, false)
+            }
+            ReclusterTaskKind::MergeBlocks => {
+                // Each source block is already ordered. A stream may contain several
+                // overlapping blocks, so retain local and cross-stream run merges,
+                // without sorting rows inside an input block.
+                sort.build_merge_sort_pipeline(pipeline, false, false)
+            }
+        }
+    }
+
+    fn build_regular_layout_pipeline(
+        builder: &mut PipelineBuilder,
+        task: &ReclusterTask,
+        cluster_stats_gen: &ClusterStatsGenerator,
+        rows_per_block: usize,
+        compact_thresholds: BlockThresholds,
+        max_threads: usize,
+    ) -> Result<()> {
+        if let Some(vector_operator) = cluster_stats_gen.vector_operator() {
+            let vector_column_input_offset = vector_operator.vector_column_input_offset;
+            let dimension = vector_operator.info.dimension;
+            let distance_type = vector_operator.info.distance_type;
+            builder.main_pipeline.try_resize(1)?;
+            builder.main_pipeline.add_accumulating_transformer(move || {
+                TransformVectorCluster::new(
+                    vector_column_input_offset,
+                    dimension,
+                    distance_type,
+                    rows_per_block,
+                )
+            });
+            builder.main_pipeline.try_resize(max_threads)?;
+        }
+
+        // Linear and vector clustering use their regular global row-sort pipeline.
+        let schema = DataSchemaRefExt::create(cluster_stats_gen.out_fields.clone());
+        let sort_descs = cluster_stats_gen.sort_descs();
+        let sort_pipeline_builder = SortPipelineBuilder::create(
+            builder.ctx.clone(),
+            schema,
+            sort_descs.into(),
+            None,
+            builder.ctx.get_settings().get_enable_fixed_rows_sort()?,
+        )?
+        .with_block_size_hit(rows_per_block);
+        Self::build_recluster_sort_pipeline(
+            task.kind,
+            sort_pipeline_builder,
+            &mut builder.main_pipeline,
+        )?;
+
         builder.main_pipeline.try_resize(1)?;
+        let extra_key_num = cluster_stats_gen.extra_key_num;
         builder.main_pipeline.add_accumulating_transformer(move || {
-            TransformVectorCluster::new(
-                vector_column_input_offset,
-                dimension,
-                distance_type,
-                rows_per_block,
-            )
+            OrderedBlockCompactBuilder::new(compact_thresholds, extra_key_num)
         });
         builder.main_pipeline.try_resize(max_threads)?;
+        builder
+            .main_pipeline
+            .add_block_meta_transformer(|| TransformCompactBlock);
+        Ok(())
     }
+}
 
-    // Linear and vector clustering use their regular global row-sort pipeline.
-    let schema = DataSchemaRefExt::create(cluster_stats_gen.out_fields.clone());
-    let sort_descs = cluster_stats_gen.sort_descs();
-    let skip_partial_sort = task.all_ordered && cluster_stats_gen.is_linear();
-    let sort_pipeline_builder = SortPipelineBuilder::create(
-        builder.ctx.clone(),
-        schema,
-        sort_descs.into(),
-        None,
-        builder.ctx.get_settings().get_enable_fixed_rows_sort()?,
-    )?
-    .with_block_size_hit(rows_per_block);
-    if !skip_partial_sort {
-        let partial_sort_descs = sort_pipeline_builder.sort_column_desc();
-        builder.main_pipeline.add_transformer(move || {
-            TransformSortPartial::new(LimitType::None, partial_sort_descs.clone())
-        });
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_kits::TestFixture;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_recluster_sort_pipeline_boundary() -> anyhow::Result<()> {
+        let fixture = TestFixture::setup().await?;
+        let ctx = fixture.new_query_ctx().await?;
+        for width in [1, 2] {
+            for kind in [
+                ReclusterTaskKind::SortBlocks,
+                ReclusterTaskKind::MergeBlocks,
+            ] {
+                let kind: ReclusterTaskKind = serde_json::from_str(&serde_json::to_string(&kind)?)?;
+                let schema = DataSchemaRefExt::create(vec![DataField::new(
+                    "k",
+                    DataType::Number(NumberDataType::Int32),
+                )]);
+                let sort = SortPipelineBuilder::create(
+                    ctx.clone(),
+                    schema,
+                    vec![SortColumnDescription {
+                        offset: 0,
+                        asc: true,
+                        nulls_first: false,
+                    }]
+                    .into(),
+                    None,
+                    false,
+                )?;
+                let mut pipeline = Pipeline::create();
+                pipeline.add_source(EmptySource::create, width)?;
+                Recluster::build_recluster_sort_pipeline(kind, sort, &mut pipeline)?;
+                let partial_sorts = pipeline
+                    .graph
+                    .node_weights()
+                    .filter(|node| unsafe { node.proc.name() }.contains("SortPartialTransform"))
+                    .count();
+                assert_eq!(
+                    partial_sorts,
+                    if kind == ReclusterTaskKind::SortBlocks {
+                        width
+                    } else {
+                        0
+                    }
+                );
+            }
+        }
+        Ok(())
     }
-    sort_pipeline_builder.build_merge_sort_pipeline(&mut builder.main_pipeline, false, false)?;
-
-    builder.main_pipeline.try_resize(1)?;
-    let extra_key_num = cluster_stats_gen.extra_key_num;
-    builder.main_pipeline.add_accumulating_transformer(move || {
-        OrderedBlockCompactBuilder::new(compact_thresholds, extra_key_num)
-    });
-    builder.main_pipeline.try_resize(max_threads)?;
-    builder
-        .main_pipeline
-        .add_block_meta_transformer(|| TransformCompactBlock);
-    Ok(())
 }

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
@@ -21,6 +21,9 @@ use databend_common_base::runtime::Runtime;
 use databend_common_catalog::plan::ClusterLevelLogStats;
 use databend_common_catalog::plan::PushDownInfo;
 use databend_common_catalog::plan::ReclusterParts;
+use databend_common_catalog::plan::ReclusterTask;
+use databend_common_catalog::plan::ReclusterTaskKind;
+use databend_common_catalog::table::Table;
 use databend_common_expression::BlockThresholds;
 use databend_common_expression::ColumnRef;
 use databend_common_expression::DataBlock;
@@ -39,6 +42,7 @@ use databend_common_storages_fuse::FUSE_OPT_KEY_BLOCK_PER_SEGMENT;
 use databend_common_storages_fuse::FUSE_OPT_KEY_ROW_PER_BLOCK;
 use databend_common_storages_fuse::FuseBlockPartInfo;
 use databend_common_storages_fuse::FuseTable;
+use databend_common_storages_fuse::io::MetaReaders;
 use databend_common_storages_fuse::io::MetaWriter;
 use databend_common_storages_fuse::io::TableMetaLocationGenerator;
 use databend_common_storages_fuse::operations::ReclusterFinalCarry;
@@ -55,6 +59,7 @@ use databend_query::sessions::TableContext;
 use databend_query::sessions::TableContextSettings;
 use databend_query::sessions::TableContextTableAccess;
 use databend_query::test_kits::*;
+use databend_storages_common_cache::LoadParams;
 use databend_storages_common_table_meta::meta;
 use databend_storages_common_table_meta::meta::BlockMeta;
 use databend_storages_common_table_meta::meta::ClusterKeyInfo;
@@ -812,8 +817,213 @@ async fn test_compacts_small_overlaps() -> anyhow::Result<()> {
     .await?;
     assert!(!parts.is_empty());
     assert_eq!(parts.tasks.len(), 1);
+    assert_eq!(parts.tasks[0].kind, ReclusterTaskKind::MergeBlocks);
     assert_eq!(task_part_counts(&parts), vec![3]);
 
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_recluster_task_kinds() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup().await?;
+    let ctx = fixture.new_query_ctx().await?;
+    ctx.get_settings().set_recluster_block_size(1000)?;
+    let operator = ctx.get_application_level_data_operator()?.operator();
+    let thresholds = BlockThresholds::new(1000, 100, 100, 10);
+    let locations = TableMetaLocationGenerator::new("_task_kinds".to_owned());
+
+    // The old cluster key has valid physical column statistics but does not
+    // certify row order under the current key. Include missing cluster stats too.
+    for (case, key_ids, rows, bytes, budget, expected) in [
+        ("ordered_small", vec![Some(1), Some(1)], 1, 1, 4, vec![(
+            ReclusterTaskKind::MergeBlocks,
+            2,
+        )]),
+        ("mixed_small", vec![Some(0), Some(1)], 1, 1, 4, vec![(
+            ReclusterTaskKind::SortBlocks,
+            2,
+        )]),
+        ("old_singleton", vec![Some(0)], 1000, 100, 4, vec![(
+            ReclusterTaskKind::SortBlocks,
+            1,
+        )]),
+        ("missing_singleton", vec![None], 1000, 100, 4, vec![(
+            ReclusterTaskKind::SortBlocks,
+            1,
+        )]),
+        (
+            "mixed_large",
+            vec![Some(0), None, Some(1), Some(1)],
+            1000,
+            100,
+            4,
+            vec![
+                (ReclusterTaskKind::MergeBlocks, 2),
+                (ReclusterTaskKind::SortBlocks, 1),
+                (ReclusterTaskKind::SortBlocks, 1),
+            ],
+        ),
+        (
+            "task_budget",
+            vec![Some(0), None, Some(0)],
+            1000,
+            100,
+            1,
+            vec![(ReclusterTaskKind::SortBlocks, 1)],
+        ),
+        ("over_memory", vec![Some(0)], 1000, 1001, 4, vec![]),
+    ] {
+        let mut blocks = Vec::new();
+        for key_id in key_ids {
+            let mut block = make_recluster_block(key_id.unwrap_or(0), 1, 100, 0, rows, bytes, 50);
+            let meta = Arc::make_mut(&mut block);
+            if key_id.is_none() {
+                meta.cluster_stats = None;
+            }
+            meta.col_stats.insert(
+                0,
+                ColumnStatistics::new(Scalar::from(1i32), Scalar::from(100i32), 0, bytes, None),
+            );
+            blocks.push(block);
+        }
+        let source_count = blocks.len();
+        let location =
+            write_recluster_segment(&operator, &locations, blocks, thresholds, 1).await?;
+        let (_, _, parts) = materialize_segment_locations_with_mode(
+            ctx.clone(),
+            operator.clone(),
+            vec![location],
+            thresholds,
+            1,
+            budget,
+            1000,
+            ReclusterMode::Conservative,
+        )
+        .await?;
+        let actual = parts
+            .tasks
+            .iter()
+            .map(|task| (task.kind, task.parts.len()))
+            .collect::<Vec<_>>();
+        assert_eq!(actual, expected, "{case}");
+        if !parts.is_empty() {
+            let rewritten = parts
+                .tasks
+                .iter()
+                .map(|task| task.parts.len())
+                .sum::<usize>();
+            assert_eq!(
+                rewritten + parts.remained_blocks.len(),
+                source_count,
+                "{case}"
+            );
+            let mut source_locations = HashSet::new();
+            for task in &parts.tasks {
+                let decoded: ReclusterTask = serde_json::from_slice(&serde_json::to_vec(task)?)?;
+                assert_eq!(decoded.kind, task.kind);
+                assert_eq!(decoded.parts, task.parts);
+                assert_eq!(decoded.total_rows, task.total_rows);
+                for part in &task.parts.partitions {
+                    let part = FuseBlockPartInfo::from_part(part)?;
+                    assert!(
+                        source_locations.insert(part.location.clone()),
+                        "duplicate source in {case}"
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sort_blocks_single_round_and_final() -> anyhow::Result<()> {
+    let fixture = TestFixture::setup().await?;
+    fixture.create_default_database().await?;
+    let name = format!(
+        "{}.{}",
+        fixture.default_db_name(),
+        fixture.default_table_name()
+    );
+    fixture
+        .execute_command(&format!(
+            "create table {name}(id int not null) row_per_block=3 block_per_segment=2"
+        ))
+        .await?;
+    // Two full blocks: the combined row count exceeds the small-group limit.
+    fixture
+        .execute_command(&format!(
+            "insert into {name} values (6),(1),(5),(3),(2),(4)"
+        ))
+        .await?;
+    fixture
+        .execute_command(&format!("alter table {name} cluster by(id)"))
+        .await?;
+    let ctx = fixture.new_query_ctx().await?;
+    ctx.get_settings().set_max_threads(1)?;
+    ctx.get_settings()
+        .set_setting("enable_distributed_recluster".to_owned(), "0".to_owned())?;
+    execute_command(ctx, &format!("alter table {name} recluster")).await?;
+
+    let table = fixture.latest_default_table().await?;
+    let fuse = FuseTable::try_from_table(table.as_ref())?;
+    let snapshot = fuse.read_table_snapshot().await?.unwrap();
+    let key_id = fuse.cluster_key_id().unwrap();
+    let mut ordered = 0;
+    let mut unordered = 0;
+    for location in &snapshot.segments {
+        let segment = MetaReaders::segment_info_reader(fuse.get_operator(), fuse.schema())
+            .read(&LoadParams {
+                location: location.0.clone(),
+                len_hint: None,
+                ver: location.1,
+                put_cache: false,
+            })
+            .await?;
+        for block in segment.block_metas()?.iter() {
+            if block
+                .cluster_stats
+                .as_ref()
+                .is_some_and(|stats| stats.cluster_key_id == key_id)
+            {
+                ordered += 1;
+            } else {
+                unordered += 1;
+            }
+        }
+    }
+    assert_eq!(
+        (ordered, unordered),
+        (1, 1),
+        "ordinary RECLUSTER must execute only one task round"
+    );
+
+    fixture
+        .execute_command(&format!("alter table {name} recluster final"))
+        .await?;
+    let table = fixture.latest_default_table().await?;
+    let fuse = FuseTable::try_from_table(table.as_ref())?;
+    let snapshot = fuse.read_table_snapshot().await?.unwrap();
+    assert_eq!(snapshot.summary.row_count, 6);
+    for location in &snapshot.segments {
+        let segment = MetaReaders::segment_info_reader(fuse.get_operator(), fuse.schema())
+            .read(&LoadParams {
+                location: location.0.clone(),
+                len_hint: None,
+                ver: location.1,
+                put_cache: false,
+            })
+            .await?;
+        assert!(segment.block_metas()?.iter().all(|block| {
+            block
+                .cluster_stats
+                .as_ref()
+                .is_some_and(|stats| stats.cluster_key_id == key_id)
+        }));
+    }
+    fixture
+        .execute_command(&format!("alter table {name} recluster final"))
+        .await?;
     Ok(())
 }
 

--- a/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
+++ b/src/query/service/tests/it/storages/fuse/operations/mutation/recluster_mutator.rs
@@ -1610,42 +1610,52 @@ async fn test_recluster_mutator_vector_mixed_key_overlap_selection() -> anyhow::
     )
     .await?;
 
-    let vector_cluster_info = VectorClusterInfo {
-        key_index: 1,
-        column_id: 1,
-        column_name: "embedding".to_string(),
-        dimension: 2,
-        distance_type: VectorDistanceType::L2,
-    };
-    let mutator = ReclusterMutator::new(
-        ctx,
-        data_accessor,
-        schema,
-        vec![test_cluster_key_expr(), test_vector_cluster_key_expr()],
-        1.0,
-        thresholds,
-        ClusterKeyInfo::new((cluster_key_id, "(c0)".to_string()), ClusterType::Linear),
-        0,
-        1,
-        ReclusterMode::Conservative,
-        Some(vector_cluster_info),
-    );
+    // Cover both the vector overlap strategy and the shared small-block shortcut,
+    // with current and obsolete cluster-key statistics. Vector inputs must never
+    // be split into scalar singleton sort tasks.
+    for (current_key_id, thresholds) in [
+        (cluster_key_id, thresholds),
+        (cluster_key_id + 1, thresholds),
+        (cluster_key_id, BlockThresholds::new(10000, 10000, 10000, 1)),
+    ] {
+        let vector_cluster_info = VectorClusterInfo {
+            key_index: 1,
+            column_id: 1,
+            column_name: "embedding".to_string(),
+            dimension: 2,
+            distance_type: VectorDistanceType::L2,
+        };
+        let mutator = ReclusterMutator::new(
+            ctx.clone(),
+            data_accessor.clone(),
+            schema.clone(),
+            vec![test_cluster_key_expr(), test_vector_cluster_key_expr()],
+            1.0,
+            thresholds,
+            ClusterKeyInfo::new((current_key_id, "(c0)".to_string()), ClusterType::Linear),
+            0,
+            1,
+            ReclusterMode::Conservative,
+            Some(vector_cluster_info),
+        );
 
-    let segment_windows = mutator.select_segments(&compact_segments, 8)?;
-    let vector_window = segment_windows
-        .into_iter()
-        .find(|window| {
-            window
-                .iter()
-                .map(|segment| segment.loc.segment_idx)
-                .collect::<HashSet<_>>()
-                == HashSet::from([0, 1])
-        })
-        .unwrap();
-    let (block_num, parts) = materialize_candidate_window(&mutator, vector_window, 1).await?;
-    assert_eq!(block_num, 2);
-    assert_eq!(parts.tasks.len(), 1);
-    assert_eq!(task_part_counts(&parts), vec![2]);
+        let segment_windows = mutator.select_segments(&compact_segments, 8)?;
+        let vector_window = segment_windows
+            .into_iter()
+            .find(|window| {
+                window
+                    .iter()
+                    .map(|segment| segment.loc.segment_idx)
+                    .collect::<HashSet<_>>()
+                    == HashSet::from([0, 1])
+            })
+            .unwrap();
+        let (block_num, parts) = materialize_candidate_window(&mutator, vector_window, 1).await?;
+        assert_eq!(block_num, 2);
+        assert_eq!(parts.tasks.len(), 1);
+        assert_eq!(parts.tasks[0].kind, ReclusterTaskKind::SortBlocks);
+        assert_eq!(task_part_counts(&parts), vec![2]);
+    }
 
     Ok(())
 }
@@ -1725,6 +1735,7 @@ async fn test_recluster_mutator_vector_only_overlap_selection() -> anyhow::Resul
     let (block_num, parts) = materialize_candidate_window(&mutator, vector_window, 1).await?;
     assert_eq!(block_num, 2);
     assert_eq!(parts.tasks.len(), 1);
+    assert_eq!(parts.tasks[0].kind, ReclusterTaskKind::SortBlocks);
     assert_eq!(task_part_counts(&parts), vec![2]);
 
     Ok(())

--- a/src/query/storages/fuse/src/operations/recluster/hilbert_recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster/hilbert_recluster.rs
@@ -268,6 +268,7 @@ impl ReclusterStrategy for HilbertReclusterStrategy {
                     .map(|local_idx| ordered_indices[local_idx])
                     .collect::<Vec<_>>();
                 tasks.push(task_candidate(
+                    self.supports_ordered_merge(),
                     group,
                     CandidateScore {
                         selected_total_bytes: task_bytes,

--- a/src/query/storages/fuse/src/operations/recluster/linear_recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster/linear_recluster.rs
@@ -40,6 +40,10 @@ use crate::statistics::RangeMaxTree;
 pub(crate) struct LinearReclusterStrategy;
 
 impl ReclusterStrategy for LinearReclusterStrategy {
+    fn supports_ordered_merge(&self) -> bool {
+        true
+    }
+
     fn select_segments(
         &self,
         properties: &ReclusterProperties,
@@ -200,7 +204,13 @@ impl ReclusterStrategy for LinearReclusterStrategy {
                 max_depth,
                 average_depth,
             };
-            candidates.push(task_candidate(group, score, &task_indices, blocks));
+            candidates.push(task_candidate(
+                self.supports_ordered_merge(),
+                group,
+                score,
+                &task_indices,
+                blocks,
+            ));
         };
 
         let mut candidates = Vec::new();

--- a/src/query/storages/fuse/src/operations/recluster/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/recluster/recluster_mutator.rs
@@ -23,6 +23,7 @@ use databend_common_base::runtime::Runtime;
 use databend_common_base::runtime::execute_futures_in_parallel;
 use databend_common_catalog::plan::ReclusterParts;
 use databend_common_catalog::plan::ReclusterTask;
+use databend_common_catalog::plan::ReclusterTaskKind;
 use databend_common_catalog::table::Table;
 use databend_common_catalog::table_context::TableContext;
 use databend_common_exception::ErrorCode;
@@ -408,7 +409,7 @@ impl ReclusterMutator {
                     selected_blocks: Vec::new(),
                     base_level: 0,
                     input_level_stats: Vec::new(),
-                    all_ordered: false,
+                    kind: ReclusterTaskKind::SortBlocks,
                 });
             } else {
                 return Ok(candidate_window);
@@ -582,6 +583,35 @@ impl ReclusterMutator {
                     }
                 }
 
+                if self.properties.split_sort_tasks {
+                    match candidate.kind {
+                        ReclusterTaskKind::MergeBlocks => {
+                            if block_metas.iter().any(|(_, meta)| {
+                                !meta.cluster_stats.as_ref().is_some_and(|stats| {
+                                    self.strategy
+                                        .can_reuse_cluster_stats(&self.properties, stats)
+                                })
+                            }) {
+                                return Err(ErrorCode::Internal(
+                                    "MergeBlocks requires sources ordered by the current cluster key",
+                                ));
+                            }
+                        }
+                        ReclusterTaskKind::SortBlocks => {
+                            if block_metas.len() > 1
+                                && !self
+                                    .properties
+                                    .block_thresholds
+                                    .check_for_compact(total_rows, total_bytes)
+                            {
+                                return Err(ErrorCode::Internal(
+                                    "multi-source SortBlocks exceeds the small-block group limits",
+                                ));
+                            }
+                        }
+                    }
+                }
+
                 let (stats, parts) = FuseTable::to_partitions(
                     Some(&self.schema),
                     &block_metas,
@@ -609,7 +639,10 @@ impl ReclusterMutator {
                     total_compressed,
                     level: candidate.base_level,
                     input_level_stats: candidate.input_level_stats.clone(),
-                    all_ordered: candidate.all_ordered,
+                    kind: match self.properties.cluster_key_info.cluster_type {
+                        ClusterType::Linear => candidate.kind,
+                        ClusterType::Hilbert => ReclusterTaskKind::SortBlocks,
+                    },
                     virtual_column_layout,
                 });
                 selected_block_count += block_metas.len() as u64;
@@ -691,7 +724,7 @@ impl ReclusterMutator {
     ) -> Result<Vec<ReclusterTaskCandidate>> {
         debug_assert!(task_budget > 0);
         let block_count = indices.len();
-        if block_count < 2 {
+        if block_count < 2 && !self.properties.split_sort_tasks {
             return Ok(Vec::new());
         }
         if block_count == 2
@@ -715,10 +748,11 @@ impl ReclusterMutator {
         // Physical small-block compaction intentionally takes precedence over strategy-specific
         // overlap depth gates. A compactable group is rewritten even when its strategy depth
         // is below the recluster threshold, so RECLUSTER also converges fragmented layouts.
-        if self
-            .properties
-            .block_thresholds
-            .check_for_compact(total_rows as usize, total_bytes as usize)
+        if block_count >= 2
+            && self
+                .properties
+                .block_thresholds
+                .check_for_compact(total_rows as usize, total_bytes as usize)
             && total_bytes as usize <= self.properties.memory_threshold
         {
             let score = CandidateScore {
@@ -729,6 +763,53 @@ impl ReclusterMutator {
             return Ok(vec![task_candidate(group, score, &indices, blocks)]);
         }
 
+        if self.properties.split_sort_tasks
+            && indices
+                .iter()
+                .any(|idx| matches!(blocks[*idx].stats, ReclusterBlockStats::Normalized(_)))
+        {
+            // A large mixed group is not a full-sort task. Establish order in each
+            // unordered block independently; only ordered blocks enter merge selection.
+            let (ordered, unordered): (Vec<_>, Vec<_>) = indices
+                .into_iter()
+                .partition(|idx| matches!(blocks[*idx].stats, ReclusterBlockStats::Original));
+            let mut candidates = match ordered.len() {
+                0 | 1 => Vec::new(),
+                _ => {
+                    // Reapply the small-group and level gates to the ordered subset.
+                    // All inputs are now ordered, so the helper cannot split again.
+                    self.build_recluster_task_candidates_for_indices(
+                        group,
+                        ordered,
+                        blocks,
+                        task_budget,
+                    )?
+                }
+            };
+            for idx in unordered {
+                let bytes = blocks[idx].meta.block_size as usize;
+                if bytes > self.properties.memory_threshold {
+                    continue;
+                }
+                candidates.push(task_candidate(
+                    group,
+                    CandidateScore {
+                        selected_total_bytes: bytes,
+                        max_depth: 1,
+                        average_depth: 1.0,
+                    },
+                    &[idx],
+                    blocks,
+                ));
+            }
+            candidates.sort_by(|left, right| right.score.cmp_desc(&left.score));
+            candidates.truncate(task_budget);
+            return Ok(candidates);
+        }
+
+        if block_count < 2 {
+            return Ok(Vec::new());
+        }
         self.strategy
             .fetch_task_candidates(&self.properties, group, &indices, blocks, task_budget)
     }

--- a/src/query/storages/fuse/src/operations/recluster/recluster_mutator.rs
+++ b/src/query/storages/fuse/src/operations/recluster/recluster_mutator.rs
@@ -639,10 +639,7 @@ impl ReclusterMutator {
                     total_compressed,
                     level: candidate.base_level,
                     input_level_stats: candidate.input_level_stats.clone(),
-                    kind: match self.properties.cluster_key_info.cluster_type {
-                        ClusterType::Linear => candidate.kind,
-                        ClusterType::Hilbert => ReclusterTaskKind::SortBlocks,
-                    },
+                    kind: candidate.kind,
                     virtual_column_layout,
                 });
                 selected_block_count += block_metas.len() as u64;
@@ -760,7 +757,13 @@ impl ReclusterMutator {
                 max_depth: block_count,
                 average_depth: block_count as f64,
             };
-            return Ok(vec![task_candidate(group, score, &indices, blocks)]);
+            return Ok(vec![task_candidate(
+                self.strategy.supports_ordered_merge(),
+                group,
+                score,
+                &indices,
+                blocks,
+            )]);
         }
 
         if self.properties.split_sort_tasks
@@ -792,6 +795,7 @@ impl ReclusterMutator {
                     continue;
                 }
                 candidates.push(task_candidate(
+                    self.strategy.supports_ordered_merge(),
                     group,
                     CandidateScore {
                         selected_total_bytes: bytes,

--- a/src/query/storages/fuse/src/operations/recluster/recluster_strategy.rs
+++ b/src/query/storages/fuse/src/operations/recluster/recluster_strategy.rs
@@ -120,7 +120,7 @@ impl ReclusterProperties {
             mode,
             depth_threshold,
             block_thresholds,
-            split_sort_tasks: cluster_key_info.cluster_type == ClusterType::Linear
+            split_sort_tasks: strategy.supports_ordered_merge()
                 && !is_materialized_view_engine(table.engine()),
             cluster_key_info,
             partition_key_count: table.partition_key_count(),
@@ -167,7 +167,7 @@ impl ReclusterProperties {
             mode,
             depth_threshold,
             block_thresholds,
-            split_sort_tasks: cluster_key_info.cluster_type == ClusterType::Linear,
+            split_sort_tasks: strategy.supports_ordered_merge(),
             cluster_key_info,
             partition_key_count,
             memory_threshold,
@@ -180,6 +180,13 @@ impl ReclusterProperties {
 
 /// Algorithm-specific behavior used by the recluster workflow.
 pub(crate) trait ReclusterStrategy: Send + Sync {
+    /// Only scalar linear clustering preserves source row order during merging.
+    /// The persisted ClusterType::Linear also covers vector clustering and is
+    /// not sufficient to select the merge-only execution path.
+    fn supports_ordered_merge(&self) -> bool {
+        false
+    }
+
     /// Select windows from a partition-local segment slice. ReclusterMutator performs partition
     /// grouping and filters segments without exact partition metadata before calling strategies.
     fn select_segments(
@@ -411,6 +418,7 @@ pub struct SelectedReclusterSegment {
 }
 
 pub(crate) fn task_candidate(
+    supports_ordered_merge: bool,
     group: ReclusterGroup,
     score: CandidateScore,
     task_indices: &[usize],
@@ -447,9 +455,10 @@ pub(crate) fn task_candidate(
         stats.block_size = stats.block_size.saturating_add(block.meta.block_size);
         stats.file_size = stats.file_size.saturating_add(block.meta.file_size);
     }
-    let kind = match task_indices
-        .iter()
-        .all(|idx| matches!(&blocks[*idx].stats, ReclusterBlockStats::Original))
+    let kind = match supports_ordered_merge
+        && task_indices
+            .iter()
+            .all(|idx| matches!(&blocks[*idx].stats, ReclusterBlockStats::Original))
     {
         true => ReclusterTaskKind::MergeBlocks,
         false => ReclusterTaskKind::SortBlocks,

--- a/src/query/storages/fuse/src/operations/recluster/recluster_strategy.rs
+++ b/src/query/storages/fuse/src/operations/recluster/recluster_strategy.rs
@@ -18,12 +18,15 @@ use std::fmt;
 use std::sync::Arc;
 
 use databend_common_catalog::plan::ClusterLevelLogStats;
+use databend_common_catalog::plan::ReclusterTaskKind;
+use databend_common_catalog::table::Table;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_expression::BlockThresholds;
 use databend_common_expression::Expr;
 use databend_common_expression::TableSchemaRef;
 use databend_common_expression::types::DataType;
+use databend_common_meta_app::schema::is_materialized_view_engine;
 use databend_common_sql::ClusterKeys;
 use databend_storages_common_table_meta::meta::BlockMeta;
 use databend_storages_common_table_meta::meta::ClusterKeyInfo;
@@ -62,6 +65,9 @@ pub(crate) struct ReclusterProperties {
     pub(crate) cluster_key_info: ClusterKeyInfo,
     pub(crate) partition_key_count: usize,
     pub(crate) memory_threshold: usize,
+    /// Split unordered linear inputs before overlap-based merge selection.
+    /// Materialized views retain their re-aggregation selection semantics.
+    pub(crate) split_sort_tasks: bool,
     pub(crate) prepared_cluster_key_exprs: Vec<PreparedClusterKeyExpr>,
     pub(crate) scalar_cluster_key_types: Vec<DataType>,
 }
@@ -114,6 +120,8 @@ impl ReclusterProperties {
             mode,
             depth_threshold,
             block_thresholds,
+            split_sort_tasks: cluster_key_info.cluster_type == ClusterType::Linear
+                && !is_materialized_view_engine(table.engine()),
             cluster_key_info,
             partition_key_count: table.partition_key_count(),
             memory_threshold,
@@ -159,6 +167,7 @@ impl ReclusterProperties {
             mode,
             depth_threshold,
             block_thresholds,
+            split_sort_tasks: cluster_key_info.cluster_type == ClusterType::Linear,
             cluster_key_info,
             partition_key_count,
             memory_threshold,
@@ -326,7 +335,7 @@ pub(crate) struct ReclusterTaskCandidate {
     pub(crate) selected_blocks: Vec<(usize, Vec<usize>)>,
     pub(crate) base_level: i32,
     pub(crate) input_level_stats: Vec<ClusterLevelLogStats>,
-    pub(crate) all_ordered: bool,
+    pub(crate) kind: ReclusterTaskKind,
 }
 
 impl ReclusterTaskCandidate {
@@ -438,15 +447,19 @@ pub(crate) fn task_candidate(
         stats.block_size = stats.block_size.saturating_add(block.meta.block_size);
         stats.file_size = stats.file_size.saturating_add(block.meta.file_size);
     }
-    let all_ordered = task_indices
+    let kind = match task_indices
         .iter()
-        .all(|idx| matches!(&blocks[*idx].stats, ReclusterBlockStats::Original));
+        .all(|idx| matches!(&blocks[*idx].stats, ReclusterBlockStats::Original))
+    {
+        true => ReclusterTaskKind::MergeBlocks,
+        false => ReclusterTaskKind::SortBlocks,
+    };
     ReclusterTaskCandidate {
         score,
         selected_blocks,
         base_level,
         input_level_stats: stats_by_level.into_values().collect(),
-        all_ordered,
+        kind,
     }
 }
 

--- a/src/query/storages/fuse/src/operations/recluster/recluster_table.rs
+++ b/src/query/storages/fuse/src/operations/recluster/recluster_table.rs
@@ -437,6 +437,7 @@ impl FuseTable {
                                 window_idx,
                                 task_idx,
                                 base_level = task.base_level,
+                                task_kind :? = task.kind,
                                 repack_only = task.is_repack_only(),
                                 max_depth = task.score.max_depth,
                                 avg_depth = task.score.average_depth,
@@ -603,6 +604,7 @@ impl FuseTable {
 
 #[cfg(test)]
 mod tests {
+    use databend_common_catalog::plan::ReclusterTaskKind;
     use databend_storages_common_table_meta::meta::SegmentInfo;
     use databend_storages_common_table_meta::meta::Statistics;
 
@@ -626,7 +628,7 @@ mod tests {
                 .collect(),
             base_level: 0,
             input_level_stats: Vec::new(),
-            all_ordered: false,
+            kind: ReclusterTaskKind::SortBlocks,
         }
     }
 

--- a/src/query/storages/fuse/src/operations/recluster/vector_recluster.rs
+++ b/src/query/storages/fuse/src/operations/recluster/vector_recluster.rs
@@ -365,6 +365,7 @@ impl ReclusterStrategy for VectorReclusterStrategy {
                 .map(|local_idx| indices[local_idx])
                 .collect::<Vec<_>>();
             candidates.push(task_candidate(
+                self.supports_ordered_merge(),
                 group,
                 CandidateScore {
                     selected_total_bytes: task_bytes,

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0008_fuse_optimize_table.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0008_fuse_optimize_table.test
@@ -513,13 +513,10 @@ select * exclude(timestamp) from clustering_information('db_09_0008','t10')
 ----
 (abs(a)) linear {"average_depth":2.75,"average_overlaps":2.0,"block_depth_histogram":{"00002":1,"00003":3},"constant_block_count":1,"max_depth":3,"p95_depth":3,"p99_depth":3,"total_block_count":4}
 
+# The pre-cluster-key block needs SortBlocks, while newer blocks can use
+# MergeBlocks. Ordinary RECLUSTER performs one round, not full convergence.
 statement ok
 alter table t10 recluster
-
-query T
-select info:average_depth from clustering_information('db_09_0008','t10')
-----
-1.0
 
 query I
 select count() from fuse_snapshot('db_09_0008', 't10')
@@ -527,9 +524,40 @@ select count() from fuse_snapshot('db_09_0008', 't10')
 6
 
 query I
-select count() from t10
+select a from t10 order by a
 ----
-9
+-8
+-7
+-6
+0
+1
+2
+3
+4
+5
+
+# FINAL continues with the remaining sort/merge work. Its number of commits
+# depends on task selection, so the single-round snapshot assertion is above.
+statement ok
+alter table t10 recluster final
+
+query T
+select info:average_depth from clustering_information('db_09_0008','t10')
+----
+1.0
+
+query I
+select a from t10 order by a
+----
+-8
+-7
+-6
+0
+1
+2
+3
+4
+5
 
 
 

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0055_recluster_task_kinds.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0055_recluster_task_kinds.test
@@ -1,0 +1,118 @@
+# SortBlocks establishes the current key order; MergeBlocks consumes ordered
+# blocks. Index construction and persisted FUSE formats are unchanged.
+statement ok
+create or replace database db_recluster_task_kinds
+
+statement ok
+use db_recluster_task_kinds
+
+statement ok
+set max_threads = 1
+
+statement ok
+create table t(k int, payload string) row_per_block=3 block_per_segment=2
+
+statement ok
+insert into t values (6, 'f'), (1, 'a'), (5, 'e'), (3, 'c'), (2, 'b'), (4, 'd')
+
+statement ok
+alter table t cluster by(k)
+
+# Ordinary recluster is still a single round; it need not finish both kinds.
+statement ok
+alter table t recluster
+
+query IT rowsort
+select * from t
+----
+1 a
+2 b
+3 c
+4 d
+5 e
+6 f
+
+statement ok
+alter table t recluster final
+
+query IT rowsort
+select * from t
+----
+1 a
+2 b
+3 c
+4 d
+5 e
+6 f
+
+# Already ordered small inputs may merge without reaching an overlap-depth gate.
+statement ok
+create table small(k int, payload string) cluster by(k) row_per_block=100
+
+statement ok
+insert into small values (1, 'a'), (3, 'c')
+
+statement ok
+insert into small values (2, 'b'), (4, 'd')
+
+statement ok
+alter table small recluster
+
+query IT rowsort
+select * from small
+----
+1 a
+2 b
+3 c
+4 d
+
+# Changing the key invalidates its ordering proof, not the data or indexes.
+statement ok
+alter table t cluster by(-k)
+
+statement ok
+insert into t values (NULL, 'n'), (2, 'duplicate'), (7, 'g')
+
+# Keep the existing spill path available to both task kinds.
+statement ok
+set force_sort_data_spill = 1
+
+statement ok
+set max_block_size = 2
+
+statement ok
+alter table t recluster final
+
+statement ok
+unset max_block_size
+
+statement ok
+unset force_sort_data_spill
+
+query IT rowsort
+select * from t
+----
+1 a
+2 b
+2 duplicate
+3 c
+4 d
+5 e
+6 f
+7 g
+NULL n
+
+# A second FINAL must terminate on the already processed layout.
+statement ok
+alter table t recluster final
+
+query III
+select count(), count(k), sum(k) from t
+----
+9 8 30
+
+statement ok
+unset max_threads
+
+statement ok
+drop database db_recluster_task_kinds

--- a/tests/sqllogictests/suites/mode/cluster/distributed_recluster.sql.test
+++ b/tests/sqllogictests/suites/mode/cluster/distributed_recluster.sql.test
@@ -27,6 +27,24 @@ alter table t_recluster recluster
 # ----
 # 1
 
+# Verify task-kind transport for ordered inputs.
+query I
+select count() from t_recluster
+----
+60
+
+# Invalidate the ordering proof and distribute SortBlocks tasks as well.
+statement ok
+alter table t_recluster cluster by(-a)
+
+statement ok
+alter table t_recluster recluster final
+
+query III
+select count(), min(a), max(a) from t_recluster
+----
+60 -9 10
+
 statement ok
 set enable_distributed_recluster = 0
 

--- a/tests/sqllogictests/suites/query/index/09_vector_index/09_0001_vector_recluster_task_kind.test
+++ b/tests/sqllogictests/suites/query/index/09_vector_index/09_0001_vector_recluster_task_kind.test
@@ -1,0 +1,59 @@
+# Vector keys use the persisted Linear cluster type, but require the vector
+# layout transform and full sort even when source cluster statistics are current.
+statement ok
+create or replace database vector_recluster_task_kind
+
+statement ok
+use vector_recluster_task_kind
+
+statement ok
+create table vectors(id int, embedding vector(2), vector index idx(embedding) distance='l2') cluster by(embedding) row_per_block=100
+
+statement ok
+insert into vectors values (1, [1, 0]), (2, [0, 1])
+
+statement ok
+insert into vectors values (3, [1, 0]), (4, [0, 1])
+
+statement ok
+alter table vectors recluster
+
+query II
+select count(), sum(id) from vectors
+----
+4 10
+
+statement ok
+create table mixed(id int, category int, embedding vector(2), vector index idx(embedding) distance='l2') cluster by(category, embedding) row_per_block=100
+
+statement ok
+insert into mixed values (1, 1, [1, 0]), (2, 1, [0, 1])
+
+statement ok
+insert into mixed values (3, 1, [1, 0]), (4, 1, [0, 1])
+
+statement ok
+alter table mixed recluster
+
+query II
+select count(), sum(id) from mixed
+----
+4 10
+
+# Obsolete key statistics must not send vector tasks through scalar splitting.
+statement ok
+alter table mixed cluster by(-category, embedding)
+
+statement ok
+insert into mixed values (5, 1, [1, 0]), (6, 1, [0, 1])
+
+statement ok
+alter table mixed recluster final
+
+query II
+select count(), sum(id) from mixed
+----
+6 21
+
+statement ok
+drop database vector_recluster_task_kind


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Separate recluster task semantics into `SortBlocks` and `MergeBlocks` instead of using `all_ordered` only to skip partial sorting in a mixed execution path.

- For ordinary linear FUSE tables, establish current-key order in individual unordered blocks, or in a size-bounded group of small blocks. Select ordered inputs separately for merge tasks.
- Keep the small-block shortcut as a selection condition, not a separate compaction task: ordered small inputs merge without partial sorting; bounded mixed inputs sort.
- Use a required task-kind enum and explicit pipeline dispatch. Keep pipeline construction helpers inside `impl Recluster`, with no redundant one-call wrappers.
- Preserve task/memory budgets, partition boundaries, segment claims, metadata-only repack, and the existing layout-specific behavior for Hilbert/vector and materialized-view reaggregation.
- Preserve ordinary RECLUSTER's single round and existing FINAL carry/continuation. Sorting outputs can be merged by subsequent rounds or statements.

### Scope and compatibility

Based on upstream/main at `18505dbe5e`. No inverted-index optimization, vertical executor, page-index changes, dependency updates, or persisted storage-format changes are included.

Query processes within a cluster run the same version, so the in-cluster task representation is changed directly without a cross-version fallback. Existing persisted cluster statistics, including missing or obsolete cluster-key statistics, remain readable.

Separating large unordered inputs can introduce an additional rewrite before a later merge; this PR makes the task boundary explicit and does not claim benchmarked performance gains.

## Tests

- [x] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Validation on macOS/aarch64 (commands using Python set `PYO3_PYTHON=/opt/homebrew/bin/python3.12` because the default local Python wrapper points to a removed environment):

- `cargo test -p databend-query --test it storages::fuse::operations::mutation::recluster_mutator -- --test-threads=1`: 29 passed.
- `cargo test -p databend-query --lib test_recluster_sort_pipeline_boundary -- --test-threads=1`: passed, rerun after final code cleanup; checks partial-sort presence/absence with one and two input streams.
- `cargo test -p databend-common-storages-fuse --lib operations::recluster:: -- --test-threads=1`: 7 passed.
- Standalone HTTP sqllogictests: 93 records passed across `09_0015_remote_alter_cluster_key.test`, `09_0016_remote_alter_recluster.test`, and the new `09_0055_recluster_task_kinds.test`.
- Three-query-node HTTP sqllogictests: 18 records passed in `distributed_recluster.sql.test`. Worker logs confirm both task kinds executed on remote nodes.
- `cargo build -p databend-binaries --bin databend-query`: passed.
- `cargo clippy -p databend-common-catalog -p databend-common-storages-fuse -p databend-query --lib --tests -- -D warnings`: passed; query clippy rerun after final cleanup.
- `cargo fmt --all -- --check` and `git diff --check`: passed.

New coverage includes mixed/ordered small groups, old or missing cluster statistics, single-source large sort tasks, task/memory budgets, preservation of unselected blocks, task serialization, ordinary single-round behavior, FINAL continuation, NULL/duplicate keys, and forced sort spill. Full workspace tests and benchmarks were not run.

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## AI assistance

- AI usage: An AI coding agent investigated recluster task boundaries, drafted the implementation and regression tests, ran local validation, and prepared this PR. The responsible human directed the design and reviewed the final diff, including follow-up code-organization and style changes.
- Responsible human: @zhang2014
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20482)
<!-- Reviewable:end -->
