### PR TITLE
fix(query): handle early materialized CTE consumer completion

### DIFF
--- a/src/query/service/src/pipelines/processors/transforms/materialized_cte.rs
+++ b/src/query/service/src/pipelines/processors/transforms/materialized_cte.rs
@@ -213,13 +213,17 @@ impl MaterializedCteSink {
         Ok(())
     }
 
-    async fn send_payload(&self, payload: MaterializedCtePayload) -> Result<()> {
-        for sender in self.senders.iter() {
-            sender.send(payload.clone()).await.map_err(|_| {
-                ErrorCode::Internal("Failed to send blocks to materialized cte consumer")
-            })?;
+    async fn send_payload(&mut self, payload: MaterializedCtePayload) {
+        let mut index = 0;
+        while index < self.senders.len() {
+            if self.senders[index].send(payload.clone()).await.is_err() {
+                // A consumer can finish early (e.g. LIMIT), including while a
+                // bounded send is waiting. Other consumers still need this payload.
+                self.senders.remove(index);
+            } else {
+                index += 1;
+            }
         }
-        Ok(())
     }
 
     fn flush_spilling_blocks(&mut self) -> Result<()> {
@@ -263,6 +267,12 @@ impl Processor for MaterializedCteSink {
     }
 
     fn event(&mut self) -> Result<Event> {
+        self.senders.retain(|sender| !sender.is_closed());
+        if self.senders.is_empty() {
+            self.input.finish();
+            return Ok(Event::Finished);
+        }
+
         if !self.pending_payloads.is_empty() {
             self.input.set_not_need_data();
             return Ok(Event::Async);
@@ -311,14 +321,14 @@ impl Processor for MaterializedCteSink {
     #[async_backtrace::framed]
     async fn async_process(&mut self) -> Result<()> {
         while let Some(payload) = self.pending_payloads.pop_front() {
-            self.send_payload(payload).await?;
+            self.send_payload(payload).await;
         }
         Ok(())
     }
 }
 
 pub struct CTESource {
-    receiver: Receiver<MaterializedCtePayload>,
+    receiver: Option<Receiver<MaterializedCtePayload>>,
     output: Arc<OutputPort>,
     scan_progress: Arc<Progress>,
     received_payload: Option<MaterializedCtePayload>,
@@ -333,7 +343,7 @@ impl CTESource {
         receiver: Receiver<MaterializedCtePayload>,
     ) -> Result<ProcessorPtr> {
         Ok(ProcessorPtr::create(Box::new(Self {
-            receiver,
+            receiver: Some(receiver),
             output: output_port,
             scan_progress: ctx.get_scan_progress(),
             received_payload: None,
@@ -354,14 +364,12 @@ impl Processor for CTESource {
     }
 
     fn event(&mut self) -> Result<Event> {
-        if self.is_finished {
-            self.output.finish();
-            return Ok(Event::Finished);
-        }
-
-        if self.output.is_finished() {
+        if self.is_finished || self.output.is_finished() {
             self.is_finished = true;
-            self.receiver.close();
+            // Dropping the last source's receiver closes the consumer's channel.
+            // Other sources sharing this consumer can keep reading until then.
+            self.receiver = None;
+            self.output.finish();
             return Ok(Event::Finished);
         }
 
@@ -406,7 +414,7 @@ impl Processor for CTESource {
 
     #[async_backtrace::framed]
     async fn async_process(&mut self) -> Result<()> {
-        match self.receiver.recv().await {
+        match self.receiver.as_ref().unwrap().recv().await {
             Ok(payload) => self.received_payload = Some(payload),
             Err(_) => self.is_finished = true,
         }

--- a/tests/sqllogictests/suites/query/cte/materialized_cte_early_finish.test
+++ b/tests/sqllogictests/suites/query/cte/materialized_cte_early_finish.test
@@ -1,0 +1,84 @@
+# Regression for #20455. Run in standalone and cluster suites with multiple
+# blocks so LIMIT can finish while the shared CTE is still being produced.
+statement ok
+SET enable_auto_materialize_cte = 1
+
+statement ok
+SET max_threads = 2
+
+statement ok
+SET max_block_size = 1024
+
+statement ok
+SET materialized_cte_spilling_memory_ratio = 0
+
+# The limited row is unordered; check its range and cardinality, not its value.
+query TT rowsort
+WITH t AS (
+    SELECT number FROM numbers(1000000)
+)
+SELECT 'full', sum(number) = 499999500000 FROM t
+UNION ALL
+SELECT 'limited', count(*) = 1 AND sum(number) BETWEEN 0 AND 999999
+FROM (SELECT number FROM t LIMIT 1)
+----
+full true
+limited true
+
+# Reverse the branches to cover either consumer closing first.
+query TT rowsort
+WITH t AS (
+    SELECT number FROM numbers(1000000)
+)
+SELECT 'limited', count(*) = 1 AND sum(number) BETWEEN 0 AND 999999
+FROM (SELECT number FROM t LIMIT 1)
+UNION ALL
+SELECT 'full', sum(number) = 499999500000 FROM t
+----
+full true
+limited true
+
+# Both consumers may stop before the producer reaches the end.
+query IT rowsort
+WITH t AS (
+    SELECT number FROM numbers(1000000)
+)
+SELECT count(*), sum(number) BETWEEN 0 AND 999999
+FROM (SELECT number FROM t LIMIT 1)
+UNION ALL
+SELECT count(*), sum(number) BETWEEN 0 AND 1999998
+FROM (SELECT number FROM t LIMIT 2)
+----
+1 true
+2 true
+
+statement ok
+SET force_materialized_cte_spill = 1
+
+# More than one spill unit: early completion must also work with spilled payloads.
+query TT rowsort
+WITH t AS (
+    SELECT number FROM numbers(2000000)
+)
+SELECT 'full', sum(number) = 1999999000000 FROM t
+UNION ALL
+SELECT 'limited', count(*) = 1 AND sum(number) BETWEEN 0 AND 1999999
+FROM (SELECT number FROM t LIMIT 1)
+----
+full true
+limited true
+
+statement ok
+UNSET force_materialized_cte_spill
+
+statement ok
+UNSET materialized_cte_spilling_memory_ratio
+
+statement ok
+UNSET max_block_size
+
+statement ok
+UNSET max_threads
+
+statement ok
+UNSET enable_auto_materialize_cte

--- a/tests/sqllogictests/suites/query/cte/materialized_cte_early_finish.test
+++ b/tests/sqllogictests/suites/query/cte/materialized_cte_early_finish.test
@@ -13,7 +13,7 @@ statement ok
 SET materialized_cte_spilling_memory_ratio = 0
 
 # The limited row is unordered; check its range and cardinality, not its value.
-query TT rowsort
+query TB rowsort
 WITH t AS (
     SELECT number FROM numbers(1000000)
 )
@@ -22,11 +22,11 @@ UNION ALL
 SELECT 'limited', count(*) = 1 AND sum(number) BETWEEN 0 AND 999999
 FROM (SELECT number FROM t LIMIT 1)
 ----
-full true
-limited true
+full 1
+limited 1
 
 # Reverse the branches to cover either consumer closing first.
-query TT rowsort
+query TB rowsort
 WITH t AS (
     SELECT number FROM numbers(1000000)
 )
@@ -35,11 +35,11 @@ FROM (SELECT number FROM t LIMIT 1)
 UNION ALL
 SELECT 'full', sum(number) = 499999500000 FROM t
 ----
-full true
-limited true
+full 1
+limited 1
 
 # Both consumers may stop before the producer reaches the end.
-query IT rowsort
+query IB rowsort
 WITH t AS (
     SELECT number FROM numbers(1000000)
 )
@@ -49,14 +49,14 @@ UNION ALL
 SELECT count(*), sum(number) BETWEEN 0 AND 1999998
 FROM (SELECT number FROM t LIMIT 2)
 ----
-1 true
-2 true
+1 1
+2 1
 
 statement ok
 SET force_materialized_cte_spill = 1
 
 # More than one spill unit: early completion must also work with spilled payloads.
-query TT rowsort
+query TB rowsort
 WITH t AS (
     SELECT number FROM numbers(2000000)
 )
@@ -65,8 +65,8 @@ UNION ALL
 SELECT 'limited', count(*) = 1 AND sum(number) BETWEEN 0 AND 1999999
 FROM (SELECT number FROM t LIMIT 1)
 ----
-full true
-limited true
+full 1
+limited 1
 
 statement ok
 UNSET force_materialized_cte_spill


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

Fixes #20455.

A materialized CTE with multiple consumers can fail with `Failed to send blocks to materialized cte consumer` when one branch reaches `LIMIT` while another still needs data. Skip consumers whose channels have closed and stop upstream production when no consumers remain.

Each CTE source releases its receiver when it finishes. The channel closes only after the last source for that consumer exits, allowing other sources to continue reading.

## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test

Added `materialized_cte_early_finish.test` covering a limited consumer alongside a full scan in either branch order, all consumers finishing early, and forced CTE spilling. The full scans check the expected sums; limited branches check cardinality and value bounds without assuming row order.

Validation:
- `rustfmt --check --edition 2024 --config skip_children=true src/query/service/src/pipelines/processors/transforms/materialized_cte.rs`
- `git diff --cached --check`
- `cargo clippy -p databend-query --lib -- -D warnings` (passed)
- SQL regression cases have not been run locally.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)

## AI assistance

- AI usage: An AI coding agent assisted with the CTE lifecycle fix, SQL regression cases, and PR description.
- Responsible human: @dqhl76
- [x] The responsible human has read every line of this diff and can explain each change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/databend/20485)
<!-- Reviewable:end -->
